### PR TITLE
Fix NumberFormatException due to locale-sensitive String format

### DIFF
--- a/service/profile-guardian/src/main/java/pbouda/jeffrey/profile/guardian/guard/TraversableGuard.java
+++ b/service/profile-guardian/src/main/java/pbouda/jeffrey/profile/guardian/guard/TraversableGuard.java
@@ -26,6 +26,8 @@ import pbouda.jeffrey.profile.guardian.preconditions.Preconditions;
 import pbouda.jeffrey.profile.guardian.traverse.*;
 
 import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -39,6 +41,7 @@ import static pbouda.jeffrey.profile.guardian.traverse.Next.NOT_STARTED;
  * processing is marked as DONE.
  */
 public abstract class TraversableGuard extends AbstractTraversable implements Guard {
+    private static final MathContext PRECISION_CONTEXT = new MathContext(2, RoundingMode.HALF_UP);
 
     private final String guardName;
     private final ProfileInfo profileInfo;
@@ -131,7 +134,7 @@ public abstract class TraversableGuard extends AbstractTraversable implements Gu
         double ratioResult = totalValue != 0 ? (double) observedValue / totalValue : 0;
         Severity severity = ratioResult > threshold ? Severity.WARNING : Severity.OK;
 
-        BigDecimal matchedInPercent = new BigDecimal(String.format("%.2f", ratioResult * 100));
+        BigDecimal matchedInPercent = new BigDecimal(ratioResult * 100, PRECISION_CONTEXT);
         return new Result(severity, totalValue, observedValue, ratioResult, matchedInPercent, threshold, frames);
     }
 


### PR DESCRIPTION
I'm encountering exceptions like this:
```
11:35:15.480 ERROR [http-nio-8585-exec-8] o.a.c.c.C.[.[.[.[.j.r.JerseyConfig] - Servlet.service() for servlet [pbouda.jeffrey.resources.JerseyConfig] in context with path [] threw exception [java.lang.NumberFormatException: Character , is neither a decimal digit number, decimal point, nor "e" notation exponential mark.] with root cause 
java.lang.NumberFormatException: Character , is neither a decimal digit number, decimal point, nor "e" notation exponential mark.
        at java.base/java.math.BigDecimal.<init>(BigDecimal.java:608)
        at java.base/java.math.BigDecimal.<init>(BigDecimal.java:497)
        at java.base/java.math.BigDecimal.<init>(BigDecimal.java:903)
        at pbouda.jeffrey.profile.guardian.guard.TraversableGuard.evaluateFrames(TraversableGuard.java:134)
        at pbouda.jeffrey.profile.guardian.guard.TraversableGuard.result(TraversableGuard.java:154)
        ...
```

This is caused by the locale-sensitive `String.format` call. Instead of using a fixed locale, I decided to use a MathContext matching the `String.format` rounding behavior with the same precision.

I sadly wasn't able to test the change, as building using `mvn clean package` in the main directory and then running `java -jar build/build-app/target/jeffrey.jar` results in an exception due to the logger setup being broken. Not sure if I'm doing something wrong there.