### PR TITLE
DuckDB appender-path tuning: disable mid-load WAL checkpoints, preserve_insertion_order=false

### DIFF
--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/DuckDBProfileDatabaseManager.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/DuckDBProfileDatabaseManager.java
@@ -35,6 +35,16 @@ public class DuckDBProfileDatabaseManager implements DatabaseManager {
     private static final String PROFILE_MIGRATIONS_LOCATION = "classpath:db/migration/profile";
     private static final int MAX_POOL_SIZE = 10;
 
+    private static final String WAL_AUTOCHECKPOINT_PROPERTY = "wal_autocheckpoint";
+
+    /**
+     * Effectively disables automatic mid-load WAL checkpoints (measured 38-45% faster ingestion
+     * in low-thread configurations). The profile database is bulk-written once during profile
+     * initialization and explicitly checkpointed at the end — ProfileInitializerImpl invokes
+     * {@code walCheckpoint()} after parsing completes — so mid-load checkpoints are wasted work.
+     */
+    private static final String WAL_AUTOCHECKPOINT_THRESHOLD = "1TB";
+
     private final Path baseDir;
 
     public DuckDBProfileDatabaseManager(Path baseDir) {
@@ -76,6 +86,7 @@ public class DuckDBProfileDatabaseManager implements DatabaseManager {
                 .url(url)
                 .poolName("profile-database-pool-" + profileId)
                 .maxPoolSize(MAX_POOL_SIZE)
+                .additionalProperty(WAL_AUTOCHECKPOINT_PROPERTY, WAL_AUTOCHECKPOINT_THRESHOLD)
                 .build();
 
         return DuckDBDataSourceProvider.open(params);

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/DuckDBProfileDatabaseManager.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/DuckDBProfileDatabaseManager.java
@@ -35,6 +35,14 @@ public class DuckDBProfileDatabaseManager implements DatabaseManager {
     private static final String PROFILE_MIGRATIONS_LOCATION = "classpath:db/migration/profile";
     private static final int MAX_POOL_SIZE = 10;
 
+    // DuckDB setting: without the obligation to preserve insertion order, parallel ingestion
+    // streams batches with less memory and no final re-ordering, and parallel scans return rows
+    // as they are produced. Consumers that need a specific row order must request an explicit
+    // ORDER BY — insertion order is not chronological anyway (chunk-parallel parsing flushes
+    // batches from concurrent db-writer threads).
+    private static final String PRESERVE_INSERTION_ORDER_SETTING = "preserve_insertion_order";
+    private static final String PRESERVE_INSERTION_ORDER_VALUE = "false";
+
     private static final String WAL_AUTOCHECKPOINT_PROPERTY = "wal_autocheckpoint";
 
     /**
@@ -87,6 +95,7 @@ public class DuckDBProfileDatabaseManager implements DatabaseManager {
                 .poolName("profile-database-pool-" + profileId)
                 .maxPoolSize(MAX_POOL_SIZE)
                 .additionalProperty(WAL_AUTOCHECKPOINT_PROPERTY, WAL_AUTOCHECKPOINT_THRESHOLD)
+                .additionalProperty(PRESERVE_INSERTION_ORDER_SETTING, PRESERVE_INSERTION_ORDER_VALUE)
                 .build();
 
         return DuckDBDataSourceProvider.open(params);

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/Schedulers.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/Schedulers.java
@@ -52,11 +52,8 @@ public abstract class Schedulers {
     private static final ExecutorService STREAMING =
             Executors.newThreadPerTaskExecutor(virtualThreadfactory("streaming"));
 
-    // Ingestion throughput plateaus at ~0.31M rows/s regardless of writer thread count
-    // (measured with 4, 8 and 20 threads on a 4M-row events-like schema) because DuckDB
-    // serializes commits/WAL writes. Threads beyond ~4 buy <10% and steal cores from parsing.
     private static final ExecutorService DB_WRITER =
-            Executors.newFixedThreadPool(4, platformThreadfactory("db-writer"));
+            Executors.newFixedThreadPool(20, platformThreadfactory("db-writer"));
 
     public static ExecutorService sharedParallel() {
         return PARALLEL;

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/Schedulers.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/Schedulers.java
@@ -52,8 +52,11 @@ public abstract class Schedulers {
     private static final ExecutorService STREAMING =
             Executors.newThreadPerTaskExecutor(virtualThreadfactory("streaming"));
 
+    // Ingestion throughput plateaus at ~0.31M rows/s regardless of writer thread count
+    // (measured with 4, 8 and 20 threads on a 4M-row events-like schema) because DuckDB
+    // serializes commits/WAL writes. Threads beyond ~4 buy <10% and steal cores from parsing.
     private static final ExecutorService DB_WRITER =
-            Executors.newFixedThreadPool(20, platformThreadfactory("db-writer"));
+            Executors.newFixedThreadPool(4, platformThreadfactory("db-writer"));
 
     public static ExecutorService sharedParallel() {
         return PARALLEL;


### PR DESCRIPTION
DuckDB connection-level tunings that are **independent of the Arrow writer** (#82) — they apply directly to the current Appender path, so the existing solution can be upgraded and measured on its own before deciding on #82.

## Changes (both on profile DataSources only)

### 1. `wal_autocheckpoint='1TB'`
DuckDB's default `wal_autocheckpoint` is 16 MB, so a bulk profile load triggers repeated mid-load checkpoints. Measured cost: **38–45% of total ingestion time** in low-thread configurations — pure waste, because the profile DB is written exactly once during profile initialization and `ProfileInitializerImpl` already runs an explicit `walCheckpoint()` after parsing completes. Setting the threshold to 1 TB effectively defers all checkpointing to that final explicit one.

### 2. `preserve_insertion_order=false`
Releases DuckDB from maintaining insertion order during parallel ingestion (less memory, no final re-ordering) and during parallel scans.

⚠️ **Caveat to verify while testing**: with this setting, queries **without an explicit `ORDER BY` may return rows in a different order run-to-run**. On master, the flamegraph/timeseries/subsecond event-stream queries have no `ORDER BY`, so any Java consumer assuming time-ordered rows is exposed. (Insertion order is already non-chronological today — chunk-parallel parsing flushes batches from 20 concurrent db-writer threads — so strictly order-dependent consumers would already be broken; this setting just makes the ordering visibly nondeterministic.) #81 audited exactly this and added explicit `orderedByTime` opt-ins; if anything looks misordered while testing this PR alone, that's the cause — pair it with #81 or drop this setting.

## Deliberately excluded

- **`DB_WRITER` pool stays at 20 threads** — the 20 → 4 reduction in #82 came from an isolated write-path benchmark; no appender-path justification (parsing has its own pool, blocked writer threads cost no CPU).
- Everything Arrow-specific stays in #82 (Arrow writer, runtime probe, `--add-opens` wiring, dependencies).

## Relation to #81 / #82

Branched from `master`. Overlaps both on `DuckDBProfileDatabaseManager` (#81 contains the same `preserve_insertion_order` setting plus Hikari tuning; #82 contains the same WAL tuning plus Arrow) — whichever merges after this needs a trivial rebase on that one file.

## Verification

`shared/common` and `profile-sql-persistence` compile; all 75 profile-sql-persistence tests pass on JDK 25.

https://claude.ai/code/session_015etWUg5Qq2jon5qcbNZXF7