### PR TITLE
Upgrade Spring Boot to 4.1.0, refresh dependencies, and move to JUnit 6

### DIFF
--- a/jeffrey-microscope/profiles/ai-config/src/main/java/cafe/jeffrey/profile/ai/config/AiChatModelConfiguration.java
+++ b/jeffrey-microscope/profiles/ai-config/src/main/java/cafe/jeffrey/profile/ai/config/AiChatModelConfiguration.java
@@ -18,6 +18,8 @@
 
 package cafe.jeffrey.profile.ai.config;
 
+import com.openai.client.OpenAIClient;
+import io.micrometer.observation.ObservationRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.anthropic.AnthropicChatModel;
@@ -28,10 +30,13 @@ import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.ai.openai.OpenAiChatOptions;
-import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.ai.openai.setup.OpenAiSetup;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
+
+import java.time.Duration;
+import java.util.List;
 
 /**
  * Manual configuration of Spring AI ChatModel and ChatClient beans.
@@ -48,6 +53,9 @@ import org.springframework.context.annotation.Bean;
 public class AiChatModelConfiguration {
 
     private static final Logger LOG = LoggerFactory.getLogger(AiChatModelConfiguration.class);
+
+    private static final Duration OPENAI_CLIENT_TIMEOUT = Duration.ofMinutes(10);
+    private static final int OPENAI_CLIENT_MAX_RETRIES = 2;
 
     @Bean
     public ChatModel chatModel(
@@ -89,18 +97,32 @@ public class AiChatModelConfiguration {
     private ChatModel createOpenAiChatModel(String apiKey, String modelName, int maxTokens) {
         LOG.info("Creating OpenAI ChatModel: model={} maxTokens={}", modelName, maxTokens);
 
-        OpenAiApi api = OpenAiApi.builder()
-                .apiKey(apiKey)
-                .build();
+        OpenAIClient client = OpenAiSetup.setupSyncClient(
+                null,                       // baseUrl (default OpenAI endpoint)
+                apiKey,                     // apiKey
+                null,                       // credential
+                null,                       // azureDeploymentName
+                null,                       // azureOpenAiServiceVersion
+                null,                       // organizationId
+                false,                      // isAzure
+                false,                      // isGitHubModels
+                modelName,                  // modelName
+                OPENAI_CLIENT_TIMEOUT,      // timeout
+                OPENAI_CLIENT_MAX_RETRIES,  // maxRetries
+                null,                       // proxy
+                null,                       // customHeaders
+                ObservationRegistry.NOOP,   // observationRegistry
+                null,                       // meterRegistry
+                List.of());                 // httpClientCustomizers
 
         OpenAiChatOptions options = OpenAiChatOptions.builder()
                 .model(modelName)
-                .maxTokens(maxTokens)
+                .maxCompletionTokens(maxTokens)
                 .build();
 
         return OpenAiChatModel.builder()
-                .openAiApi(api)
-                .defaultOptions(options)
+                .openAiClient(client)
+                .options(options)
                 .toolCallingManager(ToolCallingManager.builder().build())
                 .build();
     }

--- a/jeffrey-microscope/profiles/pom.xml
+++ b/jeffrey-microscope/profiles/pom.xml
@@ -56,7 +56,7 @@
     <properties>
         <eclipse-collections.version>13.0.0</eclipse-collections.version>
         <flightrecorder.version>9.1.2</flightrecorder.version>
-        <junit.version>5.13.4</junit.version>
+        <junit.version>5.14.4</junit.version>
         <hdrhistogram.version>2.2.2</hdrhistogram.version>
     </properties>
 

--- a/jeffrey-microscope/profiles/pom.xml
+++ b/jeffrey-microscope/profiles/pom.xml
@@ -56,7 +56,7 @@
     <properties>
         <eclipse-collections.version>13.0.0</eclipse-collections.version>
         <flightrecorder.version>9.1.2</flightrecorder.version>
-        <junit.version>5.14.4</junit.version>
+        <junit.version>6.0.3</junit.version>
         <hdrhistogram.version>2.2.2</hdrhistogram.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,19 +44,19 @@
         <picocli.version>4.7.7</picocli.version>
         <typesafe-config.version>1.4.6</typesafe-config.version>
         <lz4.version>1.11.0</lz4.version>
-        <junit.version>5.14.3</junit.version>
+        <junit.version>5.14.4</junit.version>
         <uuid-creator.version>6.1.1</uuid-creator.version>
         <jeffrey-events.version>0.11.0</jeffrey-events.version>
-        <spring-boot.version>4.0.5</spring-boot.version>
-        <spring-ai.version>2.0.0-M4</spring-ai.version>
-        <duckdb.version>1.5.2.0</duckdb.version>
+        <spring-boot.version>4.1.0</spring-boot.version>
+        <spring-ai.version>2.0.0-RC2</spring-ai.version>
+        <duckdb.version>1.5.3.0</duckdb.version>
         <flyway.version>10.24.0</flyway.version>
         <!-- flyway-core upgraded ahead of flyway-database-duckdb (which has no 12.x release).
-             12.4.0 brings Jackson 3.x (tools.jackson.*), eliminating the legacy Jackson 2.x dependency tree. -->
-        <flyway-core.version>12.4.0</flyway-core.version>
-        <grpc.version>1.80.0</grpc.version>
-        <netty.version>4.2.12.Final</netty.version>
-        <protobuf.version>4.34.1</protobuf.version>
+             12.x brings Jackson 3.x (tools.jackson.*), eliminating the legacy Jackson 2.x dependency tree. -->
+        <flyway-core.version>12.8.1</flyway-core.version>
+        <grpc.version>1.81.0</grpc.version>
+        <netty.version>4.2.15.Final</netty.version>
+        <protobuf.version>4.35.0</protobuf.version>
         <antlr4.version>4.13.2</antlr4.version>
         <!-- Vendored async-profiler Java API (span-api branch), served from the in-repo lib/m2 repository. -->
         <async-profiler.version>4.4-span</async-profiler.version>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <picocli.version>4.7.7</picocli.version>
         <typesafe-config.version>1.4.6</typesafe-config.version>
         <lz4.version>1.11.0</lz4.version>
-        <junit.version>5.14.4</junit.version>
+        <junit.version>6.0.3</junit.version>
         <uuid-creator.version>6.1.1</uuid-creator.version>
         <jeffrey-events.version>0.11.0</jeffrey-events.version>
         <spring-boot.version>4.1.0</spring-boot.version>

--- a/shared/server-api/pom.xml
+++ b/shared/server-api/pom.xml
@@ -31,8 +31,8 @@
     <artifactId>server-api</artifactId>
 
     <properties>
-        <grpc.version>1.72.0</grpc.version>
-        <protobuf.version>4.30.2</protobuf.version>
+        <grpc.version>1.81.0</grpc.version>
+        <protobuf.version>4.35.0</protobuf.version>
         <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>
     </properties>
 


### PR DESCRIPTION
## Summary

Upgrades Spring Boot to **4.1.0** and refreshes the surrounding dependency set to current versions, then moves the test stack to **JUnit 6** (which Spring Boot 4.1 mandates).

## Dependency upgrades

| Dependency | From | To |
|---|---|---|
| Spring Boot | 4.0.5 | **4.1.0** |
| Spring AI | 2.0.0-M4 | **2.0.0-RC2** |
| gRPC | 1.80.0 | **1.81.0** |
| Protobuf | 4.34.1 | **4.35.0** |
| Netty | 4.2.12.Final | **4.2.15.Final** |
| DuckDB JDBC | 1.5.2.0 | **1.5.3.0** |
| flyway-core | 12.4.0 | **12.8.1** |
| JUnit | 5.14.x | **6.0.3** |

Also fixed two drifting overrides:
- `shared/server-api` proto toolchain was lagging at grpc 1.72.0 / protobuf 4.30.2 → aligned to **1.81.0 / 4.35.0** so generated stubs match the runtime.
- `jeffrey-microscope/profiles` had junit pinned independently → aligned with root.

`flyway-database-duckdb` stays at 10.24.0 (still its latest). The vendored `jeffrey-jib` fork keeps its own JUnit 5 pin — it's independent of the Spring stack.

## Spring AI RC2 — API rewrite

RC2 reworked `spring-ai-openai`, so `AiChatModelConfiguration` was updated:
- `OpenAiApi.builder()` was **removed** → the client is now built via `OpenAiSetup.setupSyncClient(...)`.
- `OpenAiChatModel.Builder`: `openAiApi(...)`/`defaultOptions(...)` → `openAiClient(...)`/`options(...)`.
- `.maxTokens` → `.maxCompletionTokens` (the current OpenAI field).
- The Anthropic path needed no changes.

## JUnit 6

Spring Boot 4.1 manages `junit-jupiter` at **6.0.3** and mandates JUnit 6; the explicit pins were holding the project on 5.x. Lifting them to 6.0.3 keeps junit-platform aligned with what spring-test 7 was tested against.

Verified safe for this repo:
- Java 25 ≫ the new Java 17 baseline.
- No removed JUnit 6 APIs are used; no `@CsvSource` tests.
- The `@DuckDBTest` extension API and the `shared.test` JPMS module name (`org.junit.jupiter.api`) are unchanged in 6.0.3.
- Mockito (5.23.0, Spring-Boot-managed, unpinned) is JUnit 6 compatible.

## Verification

This environment only has Java 21 (project requires Java 25), so the full reactor build / test suite was **not** run here. Verification performed:
- All new versions and the protoc/grpc executables resolve from Maven Central.
- Every Spring AI method signature used was checked with `javap` against the actual RC2 jars; `AiChatModelConfiguration` was compiled standalone against the RC2 classpath (clean).
- JUnit 6.0.3 extension interfaces and JPMS module name verified against the jar.

**A CI / Java-25 `mvn verify` is recommended as the final confirmation**, particularly for the Spring Boot 4.0→4.1 jump across the wider codebase.

> Note: one pre-existing deprecation warning remains — `toolCallingManager(...)` is deprecated-for-removal in Spring AI RC2 (on both model builders). Still functional; worth revisiting if a future Spring AI release removes it.

https://claude.ai/code/session_01QTnu2smfQXsZQi2jGgTXkg

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTnu2smfQXsZQi2jGgTXkg)_