### PR TITLE
Add G1 and ZGC collector deep-dive pages under Garbage Collection

### DIFF
--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/GarbageCollectionController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/GarbageCollectionController.java
@@ -30,8 +30,10 @@ import cafe.jeffrey.profile.manager.GarbageCollectionManager;
 import cafe.jeffrey.profile.manager.model.gc.GCOverviewData;
 import cafe.jeffrey.profile.manager.model.gc.GCTimeseriesType;
 import cafe.jeffrey.profile.manager.model.gc.configuration.GCConfigurationData;
+import cafe.jeffrey.profile.manager.model.gc.g1.G1AnalysisData;
 import cafe.jeffrey.profile.manager.model.gc.tuning.IhopData;
 import cafe.jeffrey.profile.manager.model.gc.tuning.TenuringData;
+import cafe.jeffrey.profile.manager.model.gc.zgc.ZgcAnalysisData;
 import cafe.jeffrey.timeseries.TimeseriesData;
 
 @RestController
@@ -76,6 +78,18 @@ public class GarbageCollectionController {
     public IhopData ihop(@PathVariable("profileId") String profileId) {
         LOG.debug("Fetching G1 IHOP data");
         return mgr(profileId).ihop();
+    }
+
+    @GetMapping("/g1")
+    public G1AnalysisData g1Analysis(@PathVariable("profileId") String profileId) {
+        LOG.debug("Fetching G1 deep-dive analysis");
+        return mgr(profileId).g1Analysis();
+    }
+
+    @GetMapping("/zgc")
+    public ZgcAnalysisData zgcAnalysis(@PathVariable("profileId") String profileId) {
+        LOG.debug("Fetching ZGC deep-dive analysis");
+        return mgr(profileId).zgcAnalysis();
     }
 
     private GarbageCollectionManager mgr(String profileId) {

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/GarbageCollectionControllerTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/GarbageCollectionControllerTest.java
@@ -27,6 +27,10 @@ import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
 import cafe.jeffrey.profile.manager.GarbageCollectionManager;
 import cafe.jeffrey.profile.manager.ProfileManager;
 import cafe.jeffrey.profile.manager.model.gc.GCTimeseriesType;
+import cafe.jeffrey.profile.manager.model.gc.g1.G1AnalysisData;
+import cafe.jeffrey.profile.manager.model.gc.g1.G1AnalysisData.G1Header;
+import cafe.jeffrey.profile.manager.model.gc.zgc.ZgcAnalysisData;
+import cafe.jeffrey.profile.manager.model.gc.zgc.ZgcAnalysisData.ZgcHeader;
 import cafe.jeffrey.shared.common.exception.Exceptions;
 import cafe.jeffrey.timeseries.TimeseriesData;
 
@@ -59,6 +63,42 @@ class GarbageCollectionControllerTest {
 
         assertThat(mvc.get().uri("/api/internal/profiles/p-1/gc/timeseries?timeseriesType=COUNT"))
                 .hasStatusOk();
+    }
+
+    @Test
+    void getsG1Analysis() {
+        when(resolver.resolve("p-1")).thenReturn(profileManager);
+        when(profileManager.gcManager()).thenReturn(gcManager);
+        when(gcManager.g1Analysis()).thenReturn(emptyG1Analysis());
+
+        MockMvcTester mvc = mockMvcTesterFor(new GarbageCollectionController(resolver));
+
+        assertThat(mvc.get().uri("/api/internal/profiles/p-1/gc/g1")).hasStatusOk();
+    }
+
+    @Test
+    void getsZgcAnalysis() {
+        when(resolver.resolve("p-1")).thenReturn(profileManager);
+        when(profileManager.gcManager()).thenReturn(gcManager);
+        when(gcManager.zgcAnalysis()).thenReturn(emptyZgcAnalysis());
+
+        MockMvcTester mvc = mockMvcTesterFor(new GarbageCollectionController(resolver));
+
+        assertThat(mvc.get().uri("/api/internal/profiles/p-1/gc/zgc")).hasStatusOk();
+    }
+
+    private static G1AnalysisData emptyG1Analysis() {
+        return new G1AnalysisData(
+                new G1Header(0, 0, 0, 0, 0, 0, 0, 0, 0),
+                List.of(), TimeseriesData.empty(), List.of(), List.of(), List.of(),
+                TimeseriesData.empty(), List.of(), List.of(), List.of());
+    }
+
+    private static ZgcAnalysisData emptyZgcAnalysis() {
+        return new ZgcAnalysisData(
+                new ZgcHeader(0, 0, 0, 0, 0, 0, 0),
+                TimeseriesData.empty(), List.of(), List.of(), List.of(),
+                TimeseriesData.empty(), List.of(), List.of());
     }
 
     @Test

--- a/jeffrey-microscope/pages-microscope/src/components/gc/G1RegionHeatmap.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/gc/G1RegionHeatmap.vue
@@ -1,0 +1,190 @@
+<template>
+  <div class="region-heatmap">
+    <div v-if="snapshots.length === 0">
+      <EmptyState
+        icon="bi-grid-3x3"
+        title="No region snapshots"
+        description="Enable jdk.G1HeapRegionInformation in the recording to see the per-region heap layout."
+      />
+    </div>
+    <div v-else>
+      <div class="heatmap-toolbar">
+        <div class="snapshot-selector" v-if="snapshots.length > 1">
+          <label class="selector-label">Snapshot</label>
+          <input
+            type="range"
+            min="0"
+            :max="snapshots.length - 1"
+            v-model.number="selectedIndex"
+            class="snapshot-range"
+          />
+          <span class="selector-value">
+            {{
+              FormattingService.formatDuration2Units(selectedSnapshot.timeOffsetMillis * 1_000_000)
+            }}
+          </span>
+        </div>
+        <div class="legend">
+          <span v-for="bucket in legendBuckets" :key="bucket.label" class="legend-item">
+            <span class="legend-swatch" :style="{ background: bucket.color }"></span>
+            {{ bucket.label }}
+          </span>
+        </div>
+      </div>
+
+      <div class="region-grid">
+        <div
+          v-for="cell in selectedSnapshot.regions"
+          :key="cell.index"
+          class="region-cell"
+          :style="{ background: colorForType(cell.type) }"
+          :title="`#${cell.index} · ${cell.type} · ${FormattingService.formatBytes(cell.usedBytes)} used`"
+        ></div>
+      </div>
+
+      <div class="region-summary">
+        <Badge
+          v-for="bucket in legendBuckets"
+          :key="bucket.label"
+          :key-label="bucket.label"
+          :value="countForBucket(bucket.label)"
+          variant="secondary"
+          size="s"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import Badge from '@/components/Badge.vue';
+import EmptyState from '@/components/EmptyState.vue';
+import FormattingService from '@/services/FormattingService';
+import type { RegionSnapshot } from '@/services/api/model/G1AnalysisData';
+
+const props = defineProps<{
+  snapshots: RegionSnapshot[];
+}>();
+
+const selectedIndex = ref(0);
+
+watch(
+  () => props.snapshots,
+  () => {
+    selectedIndex.value = props.snapshots.length > 0 ? props.snapshots.length - 1 : 0;
+  },
+  { immediate: true }
+);
+
+const selectedSnapshot = computed<RegionSnapshot>(
+  () => props.snapshots[selectedIndex.value] ?? { timeOffsetMillis: 0, regions: [] }
+);
+
+interface LegendBucket {
+  label: string;
+  color: string;
+  matches: (type: string) => boolean;
+}
+
+const legendBuckets: LegendBucket[] = [
+  { label: 'Eden', color: 'var(--color-primary)', matches: t => t.includes('Eden') },
+  { label: 'Survivor', color: 'var(--color-success)', matches: t => t.includes('Survivor') },
+  { label: 'Old', color: 'var(--color-purple)', matches: t => t.includes('Old') },
+  { label: 'Humongous', color: 'var(--color-danger)', matches: t => t.includes('Humongous') },
+  { label: 'Archive', color: 'var(--color-warning)', matches: t => t.includes('Archive') },
+  { label: 'Free', color: 'var(--color-border)', matches: t => t.includes('Free') }
+];
+
+const colorForType = (type: string): string => {
+  const bucket = legendBuckets.find(b => b.matches(type ?? ''));
+  return bucket ? bucket.color : 'var(--color-text-light)';
+};
+
+const countForBucket = (label: string): number => {
+  const bucket = legendBuckets.find(b => b.label === label);
+  if (!bucket) {
+    return 0;
+  }
+  return selectedSnapshot.value.regions.filter(cell => bucket.matches(cell.type ?? '')).length;
+};
+</script>
+
+<style scoped>
+.heatmap-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.snapshot-selector {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.selector-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: var(--color-text-muted);
+}
+
+.snapshot-range {
+  width: 200px;
+}
+
+.selector-value {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-dark);
+}
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.72rem;
+  color: var(--color-text-muted);
+}
+
+.legend-swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: var(--radius-sm);
+  display: inline-block;
+}
+
+.region-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(10px, 1fr));
+  gap: 2px;
+  padding: 0.75rem;
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.region-cell {
+  aspect-ratio: 1 / 1;
+  border-radius: var(--radius-sm);
+  cursor: help;
+}
+
+.region-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+</style>

--- a/jeffrey-microscope/pages-microscope/src/router/index.ts
+++ b/jeffrey-microscope/pages-microscope/src/router/index.ts
@@ -140,6 +140,18 @@ const profileChildRoutes = [
     meta: { layout: 'profile' }
   },
   {
+    path: 'garbage-collection/g1',
+    name: 'profile-garbage-collection-g1',
+    component: () => import('@/views/profiles/detail/ProfileGCG1.vue'),
+    meta: { layout: 'profile' }
+  },
+  {
+    path: 'garbage-collection/zgc',
+    name: 'profile-garbage-collection-zgc',
+    component: () => import('@/views/profiles/detail/ProfileGCZgc.vue'),
+    meta: { layout: 'profile' }
+  },
+  {
     path: 'class-loading',
     name: 'profile-class-loading',
     component: () => import('@/views/profiles/detail/ProfileClassLoading.vue'),

--- a/jeffrey-microscope/pages-microscope/src/services/api/ProfileGCClient.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/ProfileGCClient.ts
@@ -22,6 +22,8 @@ import GCConfigurationData from '@/services/api/model/GCConfigurationData';
 import GCTimeseriesType from '@/services/api/model/GCTimeseriesType';
 import TimeseriesData from '@/services/timeseries/model/TimeseriesData';
 import type { IhopData, TenuringData } from '@/services/api/model/GCTuningModels';
+import type G1AnalysisData from '@/services/api/model/G1AnalysisData';
+import type ZgcAnalysisData from '@/services/api/model/ZgcAnalysisData';
 
 export default class ProfileGCClient extends BaseProfileClient {
   constructor(profileId: string) {
@@ -46,5 +48,13 @@ export default class ProfileGCClient extends BaseProfileClient {
 
   public getIhop(): Promise<IhopData> {
     return this.get<IhopData>('/ihop');
+  }
+
+  public getG1Analysis(): Promise<G1AnalysisData> {
+    return this.get<G1AnalysisData>('/g1');
+  }
+
+  public getZgcAnalysis(): Promise<ZgcAnalysisData> {
+    return this.get<ZgcAnalysisData>('/zgc');
   }
 }

--- a/jeffrey-microscope/pages-microscope/src/services/api/model/G1AnalysisData.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/model/G1AnalysisData.ts
@@ -1,0 +1,93 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type TimeseriesData from '@/services/timeseries/model/TimeseriesData';
+import type { MmuEntry } from '@/services/api/model/GCTuningModels';
+
+export interface G1Header {
+  youngCount: number;
+  mixedCount: number;
+  fullCount: number;
+  totalPauseNanos: number;
+  avgPauseNanos: number;
+  maxPauseNanos: number;
+  p99PauseNanos: number;
+  evacuationFailureCount: number;
+  regionCount: number;
+}
+
+export interface PausePhase {
+  name: string;
+  level: number;
+  count: number;
+  totalNanos: number;
+  maxNanos: number;
+  avgNanos: number;
+}
+
+export interface RegionCell {
+  index: number;
+  type: string;
+  usedBytes: number;
+}
+
+export interface RegionSnapshot {
+  timeOffsetMillis: number;
+  regions: RegionCell[];
+}
+
+export interface EvacuationEntry {
+  gcId: number;
+  cSetRegions: number;
+  cSetUsedBefore: number;
+  cSetUsedAfter: number;
+  allocationRegions: number;
+  bytesCopied: number;
+  regionsFreed: number;
+}
+
+export interface EvacuationFailure {
+  gcId: number;
+  count: number;
+}
+
+export interface SystemGcEntry {
+  timeOffsetMillis: number;
+  durationNanos: number;
+  invokedConcurrent: boolean;
+}
+
+export interface GcLockerEntry {
+  timeOffsetMillis: number;
+  durationNanos: number;
+  lockCount: number;
+  stallCount: number;
+}
+
+export default interface G1AnalysisData {
+  header: G1Header;
+  pausePhases: PausePhase[];
+  regionComposition: TimeseriesData;
+  regionSnapshots: RegionSnapshot[];
+  evacuations: EvacuationEntry[];
+  evacuationFailures: EvacuationFailure[];
+  ihopTimeline: TimeseriesData;
+  mmu: MmuEntry[];
+  systemGcs: SystemGcEntry[];
+  gcLockers: GcLockerEntry[];
+}

--- a/jeffrey-microscope/pages-microscope/src/services/api/model/ZgcAnalysisData.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/model/ZgcAnalysisData.ts
@@ -1,0 +1,73 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type TimeseriesData from '@/services/timeseries/model/TimeseriesData';
+
+export interface ZgcHeader {
+  youngCycles: number;
+  oldCycles: number;
+  stallCount: number;
+  totalStallNanos: number;
+  maxStallNanos: number;
+  pagesAllocatedBytes: number;
+  uncommittedBytes: number;
+}
+
+export interface StallType {
+  type: string;
+  count: number;
+  totalNanos: number;
+  maxNanos: number;
+}
+
+export interface StallSite {
+  threadName: string;
+  count: number;
+  totalNanos: number;
+}
+
+export interface ZCycle {
+  gcId: number;
+  generation: string;
+  durationNanos: number;
+  tenuringThreshold: number;
+}
+
+export interface ZUncommitEntry {
+  timeOffsetMillis: number;
+  uncommittedBytes: number;
+  durationNanos: number;
+}
+
+export interface ZRelocationEntry {
+  timeOffsetMillis: number;
+  total: number;
+  empty: number;
+  relocate: number;
+}
+
+export default interface ZgcAnalysisData {
+  header: ZgcHeader;
+  stallTimeline: TimeseriesData;
+  stallTypes: StallType[];
+  stallSites: StallSite[];
+  cycles: ZCycle[];
+  pageAllocation: TimeseriesData;
+  uncommits: ZUncommitEntry[];
+  relocations: ZRelocationEntry[];
+}

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/ProfileDetail.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/ProfileDetail.vue
@@ -360,6 +360,22 @@
                           <i class="bi bi-gear"></i>
                           <span>Configuration</span>
                         </router-link>
+                        <router-link
+                          :to="`/profiles/${profileId}/garbage-collection/g1`"
+                          class="nav-item nav-subitem"
+                          active-class="active"
+                        >
+                          <i class="bi bi-diagram-3"></i>
+                          <span>G1 Analysis</span>
+                        </router-link>
+                        <router-link
+                          :to="`/profiles/${profileId}/garbage-collection/zgc`"
+                          class="nav-item nav-subitem"
+                          active-class="active"
+                        >
+                          <i class="bi bi-cpu"></i>
+                          <span>ZGC Analysis</span>
+                        </router-link>
                       </div>
                     </div>
                     <router-link

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileGCG1.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileGCG1.vue
@@ -1,0 +1,451 @@
+<template>
+  <LoadingState v-if="loading" message="Loading G1 analysis..." />
+
+  <ErrorState v-else-if="error" message="Failed to load G1 analysis" />
+
+  <div v-else>
+    <PageHeader
+      title="G1 Analysis"
+      description="Deep-dive into G1 behaviour: pause anatomy, heap regions, evacuation and concurrent marking"
+      icon="bi-diagram-3"
+    />
+
+    <EmptyState
+      v-if="!hasData"
+      icon="bi-diagram-3"
+      title="No G1 events in this recording"
+      description="This profile was not produced with G1, or the G1 JFR events were not enabled."
+    />
+
+    <div v-else>
+      <div class="mb-4">
+        <StatsTable :metrics="metrics" />
+      </div>
+
+      <TabBar v-model="activeTab" :tabs="tabs" class="mb-3" />
+
+      <!-- Pause Phases -->
+      <div v-show="activeTab === 'phases'">
+        <ChartDescription
+          shows="Where each G1 pause spends its time, aggregated by sub-phase"
+          use-case="Find the dominant pause cost — Object Copy (evacuation), remembered-set work, or reference processing"
+        />
+        <div class="table-responsive">
+          <table class="table table-sm table-hover mb-0">
+            <thead>
+              <tr>
+                <th>Phase</th>
+                <th>Level</th>
+                <th class="text-end">Count</th>
+                <th class="text-end">Total</th>
+                <th class="text-end">Avg</th>
+                <th class="text-end">Max</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="phase in data!.pausePhases" :key="`${phase.level}-${phase.name}`">
+                <td>{{ phase.name }}</td>
+                <td><Badge :value="levelLabel(phase.level)" variant="secondary" size="s" /></td>
+                <td class="text-end">{{ FormattingService.formatNumber(phase.count) }}</td>
+                <td class="text-end">
+                  {{ FormattingService.formatDuration2Units(phase.totalNanos) }}
+                </td>
+                <td class="text-end">
+                  {{ FormattingService.formatDuration2Units(phase.avgNanos) }}
+                </td>
+                <td class="text-end">
+                  {{ FormattingService.formatDuration2Units(phase.maxNanos) }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <EmptyState
+          v-if="data!.pausePhases.length === 0"
+          icon="bi-bar-chart-steps"
+          title="No pause-phase events"
+          description="Enable jdk.GCPhasePause* events in the recording for the phase breakdown."
+        />
+      </div>
+
+      <!-- Heap Regions -->
+      <div v-show="activeTab === 'regions'">
+        <ChartDescription
+          shows="Heap-region composition over time and the per-region layout at each snapshot"
+          use-case="Spot humongous-allocation pressure and how Eden/Survivor/Old occupancy evolves"
+        />
+        <TimeSeriesChart
+          :primary-data="edenData"
+          :secondary-data="survivorData"
+          :tertiary-data="oldData"
+          primary-title="Eden"
+          secondary-title="Survivor"
+          tertiary-title="Old"
+          :primary-axis-type="AxisFormatType.BYTES"
+          :secondary-axis-type="AxisFormatType.BYTES"
+          :tertiary-axis-type="AxisFormatType.BYTES"
+          :visible-minutes="60"
+          primary-color="#4285F4"
+          secondary-color="#34A853"
+          tertiary-color="#8E44AD"
+          :stacked="true"
+        />
+        <h6 class="section-title mt-4">Region Layout</h6>
+        <G1RegionHeatmap :snapshots="data!.regionSnapshots" />
+      </div>
+
+      <!-- Evacuation -->
+      <div v-show="activeTab === 'evacuation'">
+        <ChartDescription
+          shows="Per-collection evacuation cost and to-space exhaustion (evacuation failures)"
+          use-case="Evacuation failures are the usual cause of surprise Full GCs and pause spikes"
+        />
+        <div v-if="data!.evacuationFailures.length > 0" class="alert-banner mb-3">
+          <i class="bi bi-exclamation-triangle-fill"></i>
+          {{ data!.header.evacuationFailureCount }} evacuation failure(s) detected across
+          {{ data!.evacuationFailures.length }} collection(s) — G1 ran out of to-space.
+        </div>
+        <div class="table-responsive">
+          <table class="table table-sm table-hover mb-0">
+            <thead>
+              <tr>
+                <th>GC Id</th>
+                <th class="text-end">CSet Regions</th>
+                <th class="text-end">Used Before</th>
+                <th class="text-end">Used After</th>
+                <th class="text-end">Bytes Copied</th>
+                <th class="text-end">Regions Freed</th>
+                <th class="text-end">Failures</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="ev in data!.evacuations" :key="ev.gcId">
+                <td>{{ ev.gcId }}</td>
+                <td class="text-end">{{ FormattingService.formatNumber(ev.cSetRegions) }}</td>
+                <td class="text-end">{{ FormattingService.formatBytes(ev.cSetUsedBefore) }}</td>
+                <td class="text-end">{{ FormattingService.formatBytes(ev.cSetUsedAfter) }}</td>
+                <td class="text-end">{{ FormattingService.formatBytes(ev.bytesCopied) }}</td>
+                <td class="text-end">{{ FormattingService.formatNumber(ev.regionsFreed) }}</td>
+                <td class="text-end">
+                  <Badge
+                    v-if="failureCount(ev.gcId) > 0"
+                    :value="failureCount(ev.gcId)"
+                    variant="danger"
+                    size="s"
+                  />
+                  <span v-else>-</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <EmptyState
+          v-if="data!.evacuations.length === 0"
+          icon="bi-box-arrow-right"
+          title="No evacuation events"
+          description="Enable jdk.EvacuationInformation in the recording."
+        />
+      </div>
+
+      <!-- Marking (IHOP / MMU) -->
+      <div v-show="activeTab === 'marking'">
+        <ChartDescription
+          shows="Adaptive IHOP threshold vs old-generation occupancy"
+          use-case="When occupancy crosses the threshold, G1 starts a concurrent marking cycle — verify marking keeps up with allocation"
+        />
+        <TimeSeriesChart
+          :primary-data="ihopThresholdData"
+          :secondary-data="ihopOccupancyData"
+          primary-title="IHOP Threshold"
+          secondary-title="Old Gen Occupancy"
+          :primary-axis-type="AxisFormatType.BYTES"
+          :secondary-axis-type="AxisFormatType.BYTES"
+          :visible-minutes="60"
+          primary-color="#FBBC04"
+          secondary-color="#EA4335"
+        />
+        <h6 class="section-title mt-4">Pause-Target Adherence (MMU)</h6>
+        <div class="table-responsive">
+          <table class="table table-sm table-hover mb-0">
+            <thead>
+              <tr>
+                <th>GC Id</th>
+                <th class="text-end">GC Time</th>
+                <th class="text-end">Pause Target</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="m in data!.mmu" :key="m.gcId">
+                <td>{{ m.gcId }}</td>
+                <td class="text-end">
+                  {{ FormattingService.formatDuration2Units(m.gcTimeNanos) }}
+                </td>
+                <td class="text-end">
+                  {{ FormattingService.formatDuration2Units(m.pauseTargetNanos) }}
+                </td>
+                <td>
+                  <Badge
+                    :value="m.gcTimeNanos > m.pauseTargetNanos ? 'Missed' : 'Met'"
+                    :variant="m.gcTimeNanos > m.pauseTargetNanos ? 'danger' : 'success'"
+                    size="s"
+                  />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <EmptyState v-if="data!.mmu.length === 0" icon="bi-clock-history" title="No MMU events" />
+      </div>
+
+      <!-- Anomalies -->
+      <div v-show="activeTab === 'anomalies'">
+        <ChartDescription
+          shows="Explicit System.gc() calls and GC-locker stalls"
+          use-case="Explicit GCs are usually a bug; GC-locker stalls delay collection while threads sit in JNI critical sections"
+        />
+        <h6 class="section-title">Explicit GC Calls (System.gc())</h6>
+        <div class="table-responsive">
+          <table class="table table-sm table-hover mb-0">
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th class="text-end">Duration</th>
+                <th>Concurrent</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(sg, i) in data!.systemGcs" :key="i">
+                <td>
+                  {{ FormattingService.formatDuration2Units(sg.timeOffsetMillis * 1_000_000) }}
+                </td>
+                <td class="text-end">
+                  {{ FormattingService.formatDuration2Units(sg.durationNanos) }}
+                </td>
+                <td>
+                  <Badge
+                    :value="sg.invokedConcurrent ? 'Yes' : 'No'"
+                    :variant="sg.invokedConcurrent ? 'info' : 'warning'"
+                    size="s"
+                  />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <EmptyState
+          v-if="data!.systemGcs.length === 0"
+          icon="bi-check-circle"
+          title="No explicit System.gc() calls"
+        />
+
+        <h6 class="section-title mt-4">GC Locker Stalls</h6>
+        <div class="table-responsive">
+          <table class="table table-sm table-hover mb-0">
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th class="text-end">Duration</th>
+                <th class="text-end">Threads in Critical Section</th>
+                <th class="text-end">Threads Stalled</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(gl, i) in data!.gcLockers" :key="i">
+                <td>
+                  {{ FormattingService.formatDuration2Units(gl.timeOffsetMillis * 1_000_000) }}
+                </td>
+                <td class="text-end">
+                  {{ FormattingService.formatDuration2Units(gl.durationNanos) }}
+                </td>
+                <td class="text-end">{{ FormattingService.formatNumber(gl.lockCount) }}</td>
+                <td class="text-end">{{ FormattingService.formatNumber(gl.stallCount) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <EmptyState
+          v-if="data!.gcLockers.length === 0"
+          icon="bi-check-circle"
+          title="No GC-locker stalls"
+        />
+      </div>
+
+      <!-- About -->
+      <div v-show="activeTab === 'about'">
+        <ConfigurationSection title="How G1 Analysis Works" icon="bi-info-circle">
+          <p class="about-text">
+            G1 splits the heap into equal-sized regions that play the role of Eden, Survivor, Old or
+            Humongous. Collections evacuate live objects out of a collection set; running out of
+            to-space triggers an <strong>evacuation failure</strong> and, often, a Full GC. A
+            concurrent marking cycle starts when old-generation occupancy crosses the adaptive
+            <strong>IHOP</strong> threshold. This page reconstructs that behaviour from the
+            G1-specific JFR events: pause-phase anatomy, region composition and layout, evacuation
+            cost and failures, IHOP/MMU marking behaviour, and explicit-GC / GC-locker anomalies.
+          </p>
+        </ConfigurationSection>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { useRoute } from 'vue-router';
+
+import PageHeader from '@/components/layout/PageHeader.vue';
+import StatsTable from '@/components/StatsTable.vue';
+import TabBar from '@/components/TabBar.vue';
+import TimeSeriesChart from '@/components/TimeSeriesChart.vue';
+import ChartDescription from '@/components/ChartDescription.vue';
+import ConfigurationSection from '@/components/ConfigurationSection.vue';
+import LoadingState from '@/components/LoadingState.vue';
+import ErrorState from '@/components/ErrorState.vue';
+import EmptyState from '@/components/EmptyState.vue';
+import Badge from '@/components/Badge.vue';
+import G1RegionHeatmap from '@/components/gc/G1RegionHeatmap.vue';
+import ProfileGCClient from '@/services/api/ProfileGCClient';
+import FormattingService from '@/services/FormattingService';
+import AxisFormatType from '@/services/timeseries/AxisFormatType';
+import type G1AnalysisData from '@/services/api/model/G1AnalysisData';
+
+const route = useRoute();
+
+const loading = ref(true);
+const error = ref<string | null>(null);
+const data = ref<G1AnalysisData>();
+
+const tabs = [
+  { id: 'phases', label: 'Pause Phases', icon: 'bar-chart-steps' },
+  { id: 'regions', label: 'Heap Regions', icon: 'grid-3x3' },
+  { id: 'evacuation', label: 'Evacuation', icon: 'box-arrow-right' },
+  { id: 'marking', label: 'IHOP & Marking', icon: 'graph-up' },
+  { id: 'anomalies', label: 'Anomalies', icon: 'exclamation-triangle' },
+  { id: 'about', label: 'About', icon: 'info-circle' }
+];
+const activeTab = ref(tabs[0].id);
+
+const hasData = computed(() => {
+  const h = data.value?.header;
+  if (!h) {
+    return false;
+  }
+  return h.youngCount > 0 || h.mixedCount > 0 || h.fullCount > 0 || h.regionCount > 0;
+});
+
+const edenData = computed(() => data.value?.regionComposition.series?.[0]?.data ?? []);
+const survivorData = computed(() => data.value?.regionComposition.series?.[1]?.data ?? []);
+const oldData = computed(() => data.value?.regionComposition.series?.[2]?.data ?? []);
+const ihopThresholdData = computed(() => data.value?.ihopTimeline.series?.[0]?.data ?? []);
+const ihopOccupancyData = computed(() => data.value?.ihopTimeline.series?.[1]?.data ?? []);
+
+const failureByGcId = computed(() => {
+  const map = new Map<number, number>();
+  for (const failure of data.value?.evacuationFailures ?? []) {
+    map.set(failure.gcId, failure.count);
+  }
+  return map;
+});
+
+const failureCount = (gcId: number): number => failureByGcId.value.get(gcId) ?? 0;
+
+const levelLabel = (level: number): string => {
+  if (level < 0) {
+    return 'Parallel';
+  }
+  if (level === 0) {
+    return 'Pause';
+  }
+  return `Level ${level}`;
+};
+
+const metrics = computed(() => {
+  const h = data.value?.header;
+  if (!h) {
+    return [];
+  }
+  return [
+    {
+      icon: 'recycle',
+      title: 'Collections',
+      value: FormattingService.formatNumber(h.youngCount + h.mixedCount + h.fullCount),
+      variant: 'highlight' as const,
+      breakdown: [
+        { label: 'Young', value: FormattingService.formatNumber(h.youngCount) },
+        { label: 'Mixed', value: FormattingService.formatNumber(h.mixedCount) },
+        { label: 'Full', value: FormattingService.formatNumber(h.fullCount) }
+      ]
+    },
+    {
+      icon: 'clock',
+      title: 'Pause Time',
+      value: FormattingService.formatDuration2Units(h.totalPauseNanos),
+      variant: 'info' as const,
+      breakdown: [
+        { label: 'Avg', value: FormattingService.formatDuration2Units(h.avgPauseNanos) },
+        { label: 'P99', value: FormattingService.formatDuration2Units(h.p99PauseNanos) },
+        { label: 'Max', value: FormattingService.formatDuration2Units(h.maxPauseNanos) }
+      ]
+    },
+    {
+      icon: 'exclamation-triangle',
+      title: 'Evacuation Failures',
+      value: FormattingService.formatNumber(h.evacuationFailureCount),
+      variant: h.evacuationFailureCount > 0 ? ('danger' as const) : ('success' as const)
+    },
+    {
+      icon: 'grid-3x3',
+      title: 'Heap Regions',
+      value: FormattingService.formatNumber(h.regionCount),
+      variant: 'warning' as const
+    }
+  ];
+});
+
+const loadData = async () => {
+  try {
+    loading.value = true;
+    error.value = null;
+    const client = new ProfileGCClient(route.params.profileId as string);
+    data.value = await client.getG1Analysis();
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Unknown error occurred';
+    console.error('Error loading G1 analysis:', err);
+  } finally {
+    loading.value = false;
+  }
+};
+
+onMounted(loadData);
+</script>
+
+<style scoped>
+.section-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: var(--color-text-muted);
+  margin-bottom: 0.5rem;
+}
+
+.about-text {
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: var(--color-dark);
+  margin: 0;
+}
+
+.alert-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-danger);
+  border-radius: var(--radius-md);
+  color: var(--color-danger);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+</style>

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileGCZgc.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileGCZgc.vue
@@ -1,0 +1,367 @@
+<template>
+  <LoadingState v-if="loading" message="Loading ZGC analysis..." />
+
+  <ErrorState v-else-if="error" message="Failed to load ZGC analysis" />
+
+  <div v-else>
+    <PageHeader
+      title="ZGC Analysis"
+      description="Deep-dive into ZGC behaviour: allocation stalls, generational cycles, pages and relocation"
+      icon="bi-cpu"
+    />
+
+    <EmptyState
+      v-if="!hasData"
+      icon="bi-cpu"
+      title="No ZGC events in this recording"
+      description="This profile was not produced with ZGC, or the ZGC JFR events were not enabled."
+    />
+
+    <div v-else>
+      <div class="mb-4">
+        <StatsTable :metrics="metrics" />
+      </div>
+
+      <TabBar v-model="activeTab" :tabs="tabs" class="mb-3" />
+
+      <!-- Allocation Stalls -->
+      <div v-show="activeTab === 'stalls'">
+        <ChartDescription
+          shows="Allocation-stall count and total stall time per second"
+          use-case="Allocation stalls are the only place ZGC pauses become visible to application threads — the top low-latency signal"
+        />
+        <TimeSeriesChart
+          :primary-data="stallCountData"
+          :secondary-data="stallTimeData"
+          primary-title="Allocation Stalls"
+          secondary-title="Stall Time"
+          :primary-axis-type="AxisFormatType.NUMBER"
+          :secondary-axis-type="AxisFormatType.DURATION_IN_NANOS"
+          :independent-secondary-axis="true"
+          :visible-minutes="60"
+          primary-color="#EA4335"
+          secondary-color="#FBBC04"
+        />
+
+        <div class="row mt-4">
+          <div class="col-lg-5">
+            <h6 class="section-title">Stalls by Page Type</h6>
+            <div class="table-responsive">
+              <table class="table table-sm table-hover mb-0">
+                <thead>
+                  <tr>
+                    <th>Type</th>
+                    <th class="text-end">Count</th>
+                    <th class="text-end">Total</th>
+                    <th class="text-end">Max</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="st in data!.stallTypes" :key="st.type">
+                    <td><Badge :value="st.type" variant="secondary" size="s" /></td>
+                    <td class="text-end">{{ FormattingService.formatNumber(st.count) }}</td>
+                    <td class="text-end">
+                      {{ FormattingService.formatDuration2Units(st.totalNanos) }}
+                    </td>
+                    <td class="text-end">
+                      {{ FormattingService.formatDuration2Units(st.maxNanos) }}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <EmptyState
+              v-if="data!.stallTypes.length === 0"
+              icon="bi-check-circle"
+              title="No allocation stalls"
+            />
+          </div>
+          <div class="col-lg-7">
+            <h6 class="section-title">Top Stalling Threads</h6>
+            <div class="table-responsive">
+              <table class="table table-sm table-hover mb-0">
+                <thead>
+                  <tr>
+                    <th>Thread</th>
+                    <th class="text-end">Stalls</th>
+                    <th class="text-end">Total Stall Time</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="site in data!.stallSites" :key="site.threadName">
+                    <td>{{ site.threadName }}</td>
+                    <td class="text-end">{{ FormattingService.formatNumber(site.count) }}</td>
+                    <td class="text-end">
+                      {{ FormattingService.formatDuration2Units(site.totalNanos) }}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <EmptyState
+              v-if="data!.stallSites.length === 0"
+              icon="bi-check-circle"
+              title="No stalling threads"
+            />
+          </div>
+        </div>
+      </div>
+
+      <!-- Cycles -->
+      <div v-show="activeTab === 'cycles'">
+        <ChartDescription
+          shows="Generational ZGC collection cycles (young and old)"
+          use-case="Confirm collection frequency and the tenuring threshold driving promotion to the old generation"
+        />
+        <div class="table-responsive">
+          <table class="table table-sm table-hover mb-0">
+            <thead>
+              <tr>
+                <th>GC Id</th>
+                <th>Generation</th>
+                <th class="text-end">Duration</th>
+                <th class="text-end">Tenuring Threshold</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="cycle in data!.cycles" :key="`${cycle.generation}-${cycle.gcId}`">
+                <td>{{ cycle.gcId }}</td>
+                <td>
+                  <Badge
+                    :value="cycle.generation"
+                    :variant="cycle.generation === 'Old' ? 'warning' : 'info'"
+                    size="s"
+                  />
+                </td>
+                <td class="text-end">
+                  {{ FormattingService.formatDuration2Units(cycle.durationNanos) }}
+                </td>
+                <td class="text-end">
+                  {{ cycle.generation === 'Young' ? cycle.tenuringThreshold : '-' }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <EmptyState
+          v-if="data!.cycles.length === 0"
+          icon="bi-recycle"
+          title="No ZGC cycles recorded"
+        />
+      </div>
+
+      <!-- Pages & Memory -->
+      <div v-show="activeTab === 'pages'">
+        <ChartDescription
+          shows="Page-allocation throughput over time"
+          use-case="High sustained page allocation with stalls indicates the collector cannot keep up with the allocation rate"
+        />
+        <TimeSeriesChart
+          :primary-data="pageAllocationData"
+          primary-title="Page Allocation"
+          :primary-axis-type="AxisFormatType.BYTES"
+          :visible-minutes="60"
+          primary-color="#4285F4"
+        />
+        <h6 class="section-title mt-4">Uncommitted Memory (returned to OS)</h6>
+        <div class="table-responsive">
+          <table class="table table-sm table-hover mb-0">
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th class="text-end">Uncommitted</th>
+                <th class="text-end">Duration</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(u, i) in data!.uncommits" :key="i">
+                <td>
+                  {{ FormattingService.formatDuration2Units(u.timeOffsetMillis * 1_000_000) }}
+                </td>
+                <td class="text-end">{{ FormattingService.formatBytes(u.uncommittedBytes) }}</td>
+                <td class="text-end">
+                  {{ FormattingService.formatDuration2Units(u.durationNanos) }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <EmptyState
+          v-if="data!.uncommits.length === 0"
+          icon="bi-arrow-down-circle"
+          title="No uncommit events"
+        />
+      </div>
+
+      <!-- Relocation -->
+      <div v-show="activeTab === 'relocation'">
+        <ChartDescription
+          shows="Relocation-set composition per cycle (pages)"
+          use-case="Large relocation sets increase concurrent work; empty pages are reclaimed without relocation"
+        />
+        <div class="table-responsive">
+          <table class="table table-sm table-hover mb-0">
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th class="text-end">Total Pages</th>
+                <th class="text-end">Empty Pages</th>
+                <th class="text-end">Relocated Pages</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(r, i) in data!.relocations" :key="i">
+                <td>
+                  {{ FormattingService.formatDuration2Units(r.timeOffsetMillis * 1_000_000) }}
+                </td>
+                <td class="text-end">{{ FormattingService.formatNumber(r.total) }}</td>
+                <td class="text-end">{{ FormattingService.formatNumber(r.empty) }}</td>
+                <td class="text-end">{{ FormattingService.formatNumber(r.relocate) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <EmptyState
+          v-if="data!.relocations.length === 0"
+          icon="bi-arrows-move"
+          title="No relocation-set events"
+        />
+      </div>
+
+      <!-- About -->
+      <div v-show="activeTab === 'about'">
+        <ConfigurationSection title="How ZGC Analysis Works" icon="bi-info-circle">
+          <p class="about-text">
+            ZGC is a concurrent, region-based collector whose pauses are sub-millisecond. The signal
+            that matters for latency is the <strong>allocation stall</strong>: when the application
+            allocates faster than ZGC can reclaim memory, mutator threads are stalled until a page
+            is available. This page surfaces stalls, generational young/old cycles, page-allocation
+            throughput, memory returned to the OS, and relocation-set sizes.
+          </p>
+        </ConfigurationSection>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { useRoute } from 'vue-router';
+
+import PageHeader from '@/components/layout/PageHeader.vue';
+import StatsTable from '@/components/StatsTable.vue';
+import TabBar from '@/components/TabBar.vue';
+import TimeSeriesChart from '@/components/TimeSeriesChart.vue';
+import ChartDescription from '@/components/ChartDescription.vue';
+import ConfigurationSection from '@/components/ConfigurationSection.vue';
+import LoadingState from '@/components/LoadingState.vue';
+import ErrorState from '@/components/ErrorState.vue';
+import EmptyState from '@/components/EmptyState.vue';
+import Badge from '@/components/Badge.vue';
+import ProfileGCClient from '@/services/api/ProfileGCClient';
+import FormattingService from '@/services/FormattingService';
+import AxisFormatType from '@/services/timeseries/AxisFormatType';
+import type ZgcAnalysisData from '@/services/api/model/ZgcAnalysisData';
+
+const route = useRoute();
+
+const loading = ref(true);
+const error = ref<string | null>(null);
+const data = ref<ZgcAnalysisData>();
+
+const tabs = [
+  { id: 'stalls', label: 'Allocation Stalls', icon: 'exclamation-octagon' },
+  { id: 'cycles', label: 'GC Cycles', icon: 'recycle' },
+  { id: 'pages', label: 'Pages & Memory', icon: 'hdd-stack' },
+  { id: 'relocation', label: 'Relocation', icon: 'arrows-move' },
+  { id: 'about', label: 'About', icon: 'info-circle' }
+];
+const activeTab = ref(tabs[0].id);
+
+const hasData = computed(() => {
+  const h = data.value?.header;
+  if (!h) {
+    return false;
+  }
+  return h.stallCount > 0 || h.youngCycles > 0 || h.oldCycles > 0;
+});
+
+const stallCountData = computed(() => data.value?.stallTimeline.series?.[0]?.data ?? []);
+const stallTimeData = computed(() => data.value?.stallTimeline.series?.[1]?.data ?? []);
+const pageAllocationData = computed(() => data.value?.pageAllocation.series?.[0]?.data ?? []);
+
+const metrics = computed(() => {
+  const h = data.value?.header;
+  if (!h) {
+    return [];
+  }
+  return [
+    {
+      icon: 'recycle',
+      title: 'Collection Cycles',
+      value: FormattingService.formatNumber(h.youngCycles + h.oldCycles),
+      variant: 'highlight' as const,
+      breakdown: [
+        { label: 'Young', value: FormattingService.formatNumber(h.youngCycles) },
+        { label: 'Old', value: FormattingService.formatNumber(h.oldCycles) }
+      ]
+    },
+    {
+      icon: 'exclamation-octagon',
+      title: 'Allocation Stalls',
+      value: FormattingService.formatNumber(h.stallCount),
+      variant: 'danger' as const,
+      breakdown: [
+        { label: 'Total', value: FormattingService.formatDuration2Units(h.totalStallNanos) },
+        { label: 'Max', value: FormattingService.formatDuration2Units(h.maxStallNanos) }
+      ]
+    },
+    {
+      icon: 'hdd-stack',
+      title: 'Pages Allocated',
+      value: FormattingService.formatBytes(h.pagesAllocatedBytes),
+      variant: 'info' as const
+    },
+    {
+      icon: 'arrow-down-circle',
+      title: 'Memory Uncommitted',
+      value: FormattingService.formatBytes(h.uncommittedBytes),
+      variant: 'success' as const
+    }
+  ];
+});
+
+const loadData = async () => {
+  try {
+    loading.value = true;
+    error.value = null;
+    const client = new ProfileGCClient(route.params.profileId as string);
+    data.value = await client.getZgcAnalysis();
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Unknown error occurred';
+    console.error('Error loading ZGC analysis:', err);
+  } finally {
+    loading.value = false;
+  }
+};
+
+onMounted(loadData);
+</script>
+
+<style scoped>
+.section-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: var(--color-text-muted);
+  margin-bottom: 0.5rem;
+}
+
+.about-text {
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: var(--color-dark);
+  margin: 0;
+}
+</style>

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/GarbageCollectionManager.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/GarbageCollectionManager.java
@@ -23,8 +23,10 @@ import cafe.jeffrey.shared.common.model.ProfileInfo;
 import cafe.jeffrey.profile.manager.model.gc.GCTimeseriesType;
 import cafe.jeffrey.profile.manager.model.gc.configuration.GCConfigurationData;
 import cafe.jeffrey.profile.manager.model.gc.GCOverviewData;
+import cafe.jeffrey.profile.manager.model.gc.g1.G1AnalysisData;
 import cafe.jeffrey.profile.manager.model.gc.tuning.IhopData;
 import cafe.jeffrey.profile.manager.model.gc.tuning.TenuringData;
+import cafe.jeffrey.profile.manager.model.gc.zgc.ZgcAnalysisData;
 import cafe.jeffrey.timeseries.TimeseriesData;
 
 import java.util.function.Function;
@@ -56,4 +58,20 @@ public interface GarbageCollectionManager {
      * Collectors without IHOP produce an empty timeline.
      */
     IhopData ihop();
+
+    /**
+     * G1-specific deep-dive: pause-phase anatomy ({@code jdk.GCPhasePause*}), heap-region
+     * composition and per-region snapshots ({@code jdk.G1HeapSummary}, {@code jdk.G1HeapRegionInformation}),
+     * evacuation cost and to-space exhaustion ({@code jdk.EvacuationInformation}/{@code EvacuationFailed}),
+     * IHOP/MMU marking behaviour, plus explicit-GC and GC-locker anomalies. Non-G1 recordings
+     * produce an empty result.
+     */
+    G1AnalysisData g1Analysis();
+
+    /**
+     * ZGC-specific deep-dive: allocation stalls ({@code jdk.ZAllocationStall}), young/old cycles,
+     * page-allocation throughput, uncommit and relocation activity. Non-ZGC recordings produce an
+     * empty result.
+     */
+    ZgcAnalysisData zgcAnalysis();
 }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/GarbageCollectionManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/GarbageCollectionManagerImpl.java
@@ -31,13 +31,18 @@ import cafe.jeffrey.profile.manager.model.gc.GCGenerationTimeseriesBuilder;
 import cafe.jeffrey.profile.manager.model.gc.GCOverviewData;
 import cafe.jeffrey.profile.manager.model.gc.GCTimeseriesType;
 import cafe.jeffrey.profile.manager.model.gc.configuration.GCConfigurationData;
+import cafe.jeffrey.profile.manager.model.gc.g1.G1AnalysisBuilder;
+import cafe.jeffrey.profile.manager.model.gc.g1.G1AnalysisData;
 import cafe.jeffrey.profile.manager.model.gc.tuning.G1MmuBuilder;
 import cafe.jeffrey.profile.manager.model.gc.tuning.GcCpuTimesBuilder;
 import cafe.jeffrey.profile.manager.model.gc.tuning.IhopData;
+import cafe.jeffrey.profile.manager.model.gc.tuning.IhopData.MmuEntry;
 import cafe.jeffrey.profile.manager.model.gc.tuning.IhopTimeseriesBuilder;
 import cafe.jeffrey.profile.manager.model.gc.tuning.ReferenceStatsBuilder;
 import cafe.jeffrey.profile.manager.model.gc.tuning.TenuringData;
 import cafe.jeffrey.profile.manager.model.gc.tuning.TenuringDistributionBuilder;
+import cafe.jeffrey.profile.manager.model.gc.zgc.ZgcAnalysisBuilder;
+import cafe.jeffrey.profile.manager.model.gc.zgc.ZgcAnalysisData;
 import cafe.jeffrey.provider.profile.api.RecordBuilder;
 import cafe.jeffrey.provider.profile.api.EventQueryConfigurer;
 import cafe.jeffrey.provider.profile.api.ProfileEventRepository;
@@ -194,5 +199,70 @@ public class GarbageCollectionManagerImpl implements GarbageCollectionManager {
         var mmu = eventStreamRepository.genericStreaming(mmuConfigurer, new G1MmuBuilder(MAX_GC_CPU_ENTRIES));
 
         return new IhopData(ihopTimeline, cpuTimes, mmu);
+    }
+
+    @Override
+    public G1AnalysisData g1Analysis() {
+        RelativeTimeRange timeRange = new RelativeTimeRange(profileInfo.profilingStartEnd());
+
+        EventQueryConfigurer configurer = new EventQueryConfigurer()
+                .withEventTypes(List.of(
+                        Type.GARBAGE_COLLECTION,
+                        Type.G1_GARBAGE_COLLECTION,
+                        Type.GC_PHASE_PAUSE,
+                        Type.GC_PHASE_PAUSE_LEVEL_1,
+                        Type.GC_PHASE_PAUSE_LEVEL_2,
+                        Type.GC_PHASE_PAUSE_LEVEL_3,
+                        Type.GC_PHASE_PAUSE_LEVEL_4,
+                        Type.GC_PHASE_PARALLEL,
+                        Type.G1_HEAP_SUMMARY,
+                        Type.G1_HEAP_REGION_INFORMATION,
+                        Type.EVACUATION_INFORMATION,
+                        Type.EVACUATION_FAILED,
+                        Type.SYSTEM_GC,
+                        Type.GC_LOCKER))
+                .withJsonFields();
+        G1AnalysisData base = eventStreamRepository.genericStreaming(configurer, new G1AnalysisBuilder(timeRange));
+
+        EventQueryConfigurer ihopConfigurer = new EventQueryConfigurer()
+                .withEventType(Type.G1_ADAPTIVE_IHOP)
+                .withJsonFields();
+        TimeseriesData ihopTimeline =
+                eventStreamRepository.genericStreaming(ihopConfigurer, new IhopTimeseriesBuilder(timeRange));
+
+        EventQueryConfigurer mmuConfigurer = new EventQueryConfigurer()
+                .withEventType(Type.G1_MMU)
+                .withJsonFields();
+        List<MmuEntry> mmu = eventStreamRepository.genericStreaming(mmuConfigurer, new G1MmuBuilder(MAX_GC_CPU_ENTRIES));
+
+        return new G1AnalysisData(
+                base.header(),
+                base.pausePhases(),
+                base.regionComposition(),
+                base.regionSnapshots(),
+                base.evacuations(),
+                base.evacuationFailures(),
+                ihopTimeline,
+                mmu,
+                base.systemGcs(),
+                base.gcLockers());
+    }
+
+    @Override
+    public ZgcAnalysisData zgcAnalysis() {
+        RelativeTimeRange timeRange = new RelativeTimeRange(profileInfo.profilingStartEnd());
+
+        EventQueryConfigurer configurer = new EventQueryConfigurer()
+                .withEventTypes(List.of(
+                        Type.Z_ALLOCATION_STALL,
+                        Type.Z_YOUNG_GARBAGE_COLLECTION,
+                        Type.Z_OLD_GARBAGE_COLLECTION,
+                        Type.Z_PAGE_ALLOCATION,
+                        Type.Z_UNCOMMIT,
+                        Type.Z_RELOCATION_SET))
+                .withJsonFields()
+                .withThreads();
+
+        return eventStreamRepository.genericStreaming(configurer, new ZgcAnalysisBuilder(timeRange));
     }
 }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/gc/g1/G1AnalysisBuilder.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/gc/g1/G1AnalysisBuilder.java
@@ -1,0 +1,352 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.gc.g1;
+
+import org.eclipse.collections.impl.map.mutable.primitive.LongLongHashMap;
+import tools.jackson.databind.node.ObjectNode;
+import cafe.jeffrey.profile.manager.model.gc.g1.G1AnalysisData.EvacuationEntry;
+import cafe.jeffrey.profile.manager.model.gc.g1.G1AnalysisData.EvacuationFailure;
+import cafe.jeffrey.profile.manager.model.gc.g1.G1AnalysisData.G1Header;
+import cafe.jeffrey.profile.manager.model.gc.g1.G1AnalysisData.GcLockerEntry;
+import cafe.jeffrey.profile.manager.model.gc.g1.G1AnalysisData.PausePhase;
+import cafe.jeffrey.profile.manager.model.gc.g1.G1AnalysisData.RegionCell;
+import cafe.jeffrey.profile.manager.model.gc.g1.G1AnalysisData.RegionSnapshot;
+import cafe.jeffrey.profile.manager.model.gc.g1.G1AnalysisData.SystemGcEntry;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.provider.profile.api.RecordBuilder;
+import cafe.jeffrey.shared.common.Json;
+import cafe.jeffrey.shared.common.model.EventTypeName;
+import cafe.jeffrey.shared.common.model.time.RelativeTimeRange;
+import cafe.jeffrey.timeseries.SingleSerie;
+import cafe.jeffrey.timeseries.TimeseriesData;
+import cafe.jeffrey.timeseries.TimeseriesUtils;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.function.ToLongFunction;
+
+/**
+ * Single-pass aggregator over the full G1 event set that produces {@link G1AnalysisData}. The
+ * stream mixes many event types (see {@code GarbageCollectionManagerImpl.g1Analysis}); each is
+ * routed by {@link GenericRecord#type()}.
+ */
+public class G1AnalysisBuilder implements RecordBuilder<GenericRecord, G1AnalysisData> {
+
+    private static final String GC_ID_FIELD = "gcId";
+    private static final String NAME_FIELD = "name";
+    private static final String TYPE_FIELD = "type";
+    private static final String SUM_OF_PAUSES_FIELD = "sumOfPauses";
+    private static final String WHEN_FIELD = "when";
+    private static final String EDEN_USED_FIELD = "edenUsedSize";
+    private static final String SURVIVOR_USED_FIELD = "survivorUsedSize";
+    private static final String OLD_USED_FIELD = "oldGenUsedSize";
+    private static final String NUMBER_OF_REGIONS_FIELD = "numberOfRegions";
+    private static final String INDEX_FIELD = "index";
+    private static final String USED_FIELD = "used";
+    private static final String CSET_REGIONS_FIELD = "cSetRegions";
+    private static final String CSET_USED_BEFORE_FIELD = "cSetUsedBefore";
+    private static final String CSET_USED_AFTER_FIELD = "cSetUsedAfter";
+    private static final String ALLOCATION_REGIONS_FIELD = "allocationRegions";
+    private static final String BYTES_COPIED_FIELD = "bytesCopied";
+    private static final String REGIONS_FREED_FIELD = "regionsFreed";
+    private static final String INVOKED_CONCURRENT_FIELD = "invokedConcurrent";
+    private static final String LOCK_COUNT_FIELD = "lockCount";
+    private static final String STALL_COUNT_FIELD = "stallCount";
+
+    private static final String WHEN_AFTER_GC = "After GC";
+    private static final String MIXED_TYPE = "Mixed";
+    private static final String FULL_MARKER = "full";
+
+    private static final String EDEN_SERIES = "Eden";
+    private static final String SURVIVOR_SERIES = "Survivor";
+    private static final String OLD_SERIES = "Old";
+    private static final long CARRY_FORWARD_MARK = 0L;
+
+    private static final int MAX_PAUSE_PHASES = 25;
+    private static final int MAX_REGION_SNAPSHOTS = 8;
+    private static final int MAX_REGIONS_PER_SNAPSHOT = 4096;
+    private static final int MAX_EVACUATIONS = 200;
+    private static final int MAX_SYSTEM_GCS = 200;
+    private static final int MAX_GC_LOCKERS = 200;
+
+    private static final class PhaseAcc {
+        private final int level;
+        private long count;
+        private long total;
+        private long max;
+
+        private PhaseAcc(int level) {
+            this.level = level;
+        }
+
+        private void add(long nanos) {
+            count++;
+            total += nanos;
+            max = Math.max(max, nanos);
+        }
+    }
+
+    private final Map<Long, String> gcNames = new HashMap<>();
+    private final Map<Long, Long> gcPauseNanos = new HashMap<>();
+    private final Map<Long, String> g1Types = new HashMap<>();
+    private final Map<String, PhaseAcc> phases = new HashMap<>();
+    private final LongLongHashMap edenSeries;
+    private final LongLongHashMap survivorSeries;
+    private final LongLongHashMap oldSeries;
+    private final TreeMap<Long, List<RegionCell>> regionSnapshots = new TreeMap<>();
+    private final List<EvacuationEntry> evacuations = new ArrayList<>();
+    private final Map<Long, Long> evacuationFailures = new HashMap<>();
+    private final List<SystemGcEntry> systemGcs = new ArrayList<>();
+    private final List<GcLockerEntry> gcLockers = new ArrayList<>();
+    private int regionCount;
+
+    public G1AnalysisBuilder(RelativeTimeRange timeRange) {
+        this.edenSeries = TimeseriesUtils.initWithZeros(timeRange);
+        this.survivorSeries = TimeseriesUtils.initWithZeros(timeRange);
+        this.oldSeries = TimeseriesUtils.initWithZeros(timeRange);
+    }
+
+    @Override
+    public void onRecord(GenericRecord record) {
+        ObjectNode fields = record.jsonFields();
+        String type = record.type().code();
+        switch (type) {
+            case EventTypeName.GARBAGE_COLLECTION -> onGarbageCollection(fields);
+            case EventTypeName.G1_GARBAGE_COLLECTION -> onG1GarbageCollection(fields);
+            case EventTypeName.GC_PHASE_PAUSE -> addPhase(fields, record, 0);
+            case EventTypeName.GC_PHASE_PAUSE_LEVEL_1 -> addPhase(fields, record, 1);
+            case EventTypeName.GC_PHASE_PAUSE_LEVEL_2 -> addPhase(fields, record, 2);
+            case EventTypeName.GC_PHASE_PAUSE_LEVEL_3 -> addPhase(fields, record, 3);
+            case EventTypeName.GC_PHASE_PAUSE_LEVEL_4 -> addPhase(fields, record, 4);
+            case EventTypeName.GC_PHASE_PARALLEL -> addPhase(fields, record, -1);
+            case EventTypeName.G1_HEAP_SUMMARY -> onHeapSummary(fields, record);
+            case EventTypeName.G1_HEAP_REGION_INFORMATION -> onRegionInformation(fields, record);
+            case EventTypeName.EVACUATION_INFORMATION -> onEvacuationInformation(fields);
+            case EventTypeName.EVACUATION_FAILED -> onEvacuationFailed(fields);
+            case EventTypeName.SYSTEM_GC -> onSystemGc(fields, record);
+            case EventTypeName.GC_LOCKER -> onGcLocker(fields, record);
+            default -> {
+                // Unrelated event in the combined stream; ignore.
+            }
+        }
+    }
+
+    private void onGarbageCollection(ObjectNode fields) {
+        long gcId = Json.readLong(fields, GC_ID_FIELD);
+        if (gcId < 0) {
+            return;
+        }
+        gcNames.put(gcId, Json.readString(fields, NAME_FIELD));
+        gcPauseNanos.put(gcId, Math.max(0, Json.readLong(fields, SUM_OF_PAUSES_FIELD)));
+    }
+
+    private void onG1GarbageCollection(ObjectNode fields) {
+        long gcId = Json.readLong(fields, GC_ID_FIELD);
+        if (gcId >= 0) {
+            g1Types.put(gcId, Json.readString(fields, TYPE_FIELD));
+        }
+    }
+
+    private void addPhase(ObjectNode fields, GenericRecord record, int level) {
+        String name = Json.readString(fields, NAME_FIELD);
+        if (name == null) {
+            return;
+        }
+        phases.computeIfAbsent(name, key -> new PhaseAcc(level)).add(record.duration().toNanos());
+    }
+
+    private void onHeapSummary(ObjectNode fields, GenericRecord record) {
+        int regions = Json.readInt(fields, NUMBER_OF_REGIONS_FIELD);
+        if (regions > regionCount) {
+            regionCount = regions;
+        }
+        if (!WHEN_AFTER_GC.equals(Json.readString(fields, WHEN_FIELD))) {
+            return;
+        }
+        long seconds = record.timestampFromStart().toSeconds();
+        accumulateMax(edenSeries, seconds, Json.readLong(fields, EDEN_USED_FIELD));
+        accumulateMax(survivorSeries, seconds, Json.readLong(fields, SURVIVOR_USED_FIELD));
+        accumulateMax(oldSeries, seconds, Json.readLong(fields, OLD_USED_FIELD));
+    }
+
+    private static void accumulateMax(LongLongHashMap series, long seconds, long value) {
+        if (value >= 0) {
+            series.updateValue(seconds, 0, existing -> Math.max(existing, value));
+        }
+    }
+
+    private void onRegionInformation(ObjectNode fields, GenericRecord record) {
+        long bucket = record.timestampFromStart().toMillis();
+        int index = Json.readInt(fields, INDEX_FIELD);
+        String type = Json.readString(fields, TYPE_FIELD);
+        long used = Math.max(0, Json.readLong(fields, USED_FIELD));
+        regionSnapshots.computeIfAbsent(bucket, key -> new ArrayList<>())
+                .add(new RegionCell(index, type, used));
+    }
+
+    private void onEvacuationInformation(ObjectNode fields) {
+        long gcId = Json.readLong(fields, GC_ID_FIELD);
+        if (gcId < 0) {
+            return;
+        }
+        evacuations.add(new EvacuationEntry(
+                gcId,
+                Math.max(0, Json.readInt(fields, CSET_REGIONS_FIELD)),
+                Math.max(0, Json.readLong(fields, CSET_USED_BEFORE_FIELD)),
+                Math.max(0, Json.readLong(fields, CSET_USED_AFTER_FIELD)),
+                Math.max(0, Json.readInt(fields, ALLOCATION_REGIONS_FIELD)),
+                Math.max(0, Json.readLong(fields, BYTES_COPIED_FIELD)),
+                Math.max(0, Json.readInt(fields, REGIONS_FREED_FIELD))));
+    }
+
+    private void onEvacuationFailed(ObjectNode fields) {
+        long gcId = Json.readLong(fields, GC_ID_FIELD);
+        if (gcId >= 0) {
+            evacuationFailures.merge(gcId, 1L, Long::sum);
+        }
+    }
+
+    private void onSystemGc(ObjectNode fields, GenericRecord record) {
+        systemGcs.add(new SystemGcEntry(
+                record.timestampFromStart().toMillis(),
+                record.duration().toNanos(),
+                Json.readBoolean(fields, INVOKED_CONCURRENT_FIELD)));
+    }
+
+    private void onGcLocker(ObjectNode fields, GenericRecord record) {
+        gcLockers.add(new GcLockerEntry(
+                record.timestampFromStart().toMillis(),
+                record.duration().toNanos(),
+                Math.max(0, Json.readInt(fields, LOCK_COUNT_FIELD)),
+                Math.max(0, Json.readInt(fields, STALL_COUNT_FIELD))));
+    }
+
+    @Override
+    public G1AnalysisData build() {
+        return new G1AnalysisData(
+                buildHeader(),
+                buildPhases(),
+                buildComposition(),
+                buildSnapshots(),
+                capByGcId(evacuations, EvacuationEntry::gcId, MAX_EVACUATIONS),
+                buildEvacuationFailures(),
+                TimeseriesData.empty(),
+                List.of(),
+                capByOffset(systemGcs, SystemGcEntry::timeOffsetMillis, MAX_SYSTEM_GCS),
+                capByOffset(gcLockers, GcLockerEntry::timeOffsetMillis, MAX_GC_LOCKERS));
+    }
+
+    private G1Header buildHeader() {
+        long young = 0;
+        long mixed = 0;
+        long full = 0;
+        List<Long> pauses = new ArrayList<>(gcPauseNanos.size());
+        for (Map.Entry<Long, Long> entry : gcPauseNanos.entrySet()) {
+            long gcId = entry.getKey();
+            pauses.add(entry.getValue());
+            String name = gcNames.get(gcId);
+            if (name != null && name.toLowerCase().contains(FULL_MARKER)) {
+                full++;
+            } else if (MIXED_TYPE.equalsIgnoreCase(g1Types.get(gcId))) {
+                mixed++;
+            } else {
+                young++;
+            }
+        }
+        pauses.sort(Comparator.naturalOrder());
+        long total = pauses.stream().mapToLong(Long::longValue).sum();
+        long max = pauses.isEmpty() ? 0 : pauses.getLast();
+        long avg = pauses.isEmpty() ? 0 : total / pauses.size();
+        long p99 = percentile(pauses, 99);
+        long failures = evacuationFailures.values().stream().mapToLong(Long::longValue).sum();
+        return new G1Header(young, mixed, full, total, avg, max, p99, failures, regionCount);
+    }
+
+    private static long percentile(List<Long> sortedAscending, int percentile) {
+        if (sortedAscending.isEmpty()) {
+            return 0;
+        }
+        int index = (int) Math.ceil(percentile / 100.0 * sortedAscending.size()) - 1;
+        return sortedAscending.get(Math.max(0, Math.min(index, sortedAscending.size() - 1)));
+    }
+
+    private List<PausePhase> buildPhases() {
+        return phases.entrySet().stream()
+                .map(entry -> {
+                    PhaseAcc acc = entry.getValue();
+                    long avg = acc.count == 0 ? 0 : acc.total / acc.count;
+                    return new PausePhase(entry.getKey(), acc.level, acc.count, acc.total, acc.max, avg);
+                })
+                .sorted(Comparator.comparingLong(PausePhase::totalNanos).reversed())
+                .limit(MAX_PAUSE_PHASES)
+                .toList();
+    }
+
+    private TimeseriesData buildComposition() {
+        SingleSerie eden = TimeseriesUtils.buildSerie(EDEN_SERIES, edenSeries);
+        SingleSerie survivor = TimeseriesUtils.buildSerie(SURVIVOR_SERIES, survivorSeries);
+        SingleSerie old = TimeseriesUtils.buildSerie(OLD_SERIES, oldSeries);
+        TimeseriesUtils.remapTimeseriesBySteps(eden, CARRY_FORWARD_MARK);
+        TimeseriesUtils.remapTimeseriesBySteps(survivor, CARRY_FORWARD_MARK);
+        TimeseriesUtils.remapTimeseriesBySteps(old, CARRY_FORWARD_MARK);
+        return new TimeseriesData(eden, survivor, old);
+    }
+
+    private List<RegionSnapshot> buildSnapshots() {
+        List<RegionSnapshot> result = new ArrayList<>();
+        for (Map.Entry<Long, List<RegionCell>> entry : regionSnapshots.descendingMap().entrySet()) {
+            if (result.size() >= MAX_REGION_SNAPSHOTS) {
+                break;
+            }
+            List<RegionCell> cells = entry.getValue();
+            cells.sort(Comparator.comparingInt(RegionCell::index));
+            if (cells.size() > MAX_REGIONS_PER_SNAPSHOT) {
+                cells = cells.subList(0, MAX_REGIONS_PER_SNAPSHOT);
+            }
+            result.add(new RegionSnapshot(entry.getKey(), List.copyOf(cells)));
+        }
+        result.sort(Comparator.comparingLong(RegionSnapshot::timeOffsetMillis));
+        return result;
+    }
+
+    private List<EvacuationFailure> buildEvacuationFailures() {
+        return evacuationFailures.entrySet().stream()
+                .map(entry -> new EvacuationFailure(entry.getKey(), entry.getValue()))
+                .sorted(Comparator.comparingLong(EvacuationFailure::gcId).reversed())
+                .toList();
+    }
+
+    private static <T> List<T> capByGcId(List<T> entries, ToLongFunction<T> gcId, int max) {
+        return entries.stream()
+                .sorted(Comparator.comparingLong(gcId).reversed())
+                .limit(max)
+                .toList();
+    }
+
+    private static <T> List<T> capByOffset(List<T> entries, ToLongFunction<T> offset, int max) {
+        return entries.stream()
+                .sorted(Comparator.comparingLong(offset).reversed())
+                .limit(max)
+                .toList();
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/gc/g1/G1AnalysisData.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/gc/g1/G1AnalysisData.java
@@ -1,0 +1,98 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.gc.g1;
+
+import cafe.jeffrey.profile.manager.model.gc.tuning.IhopData.MmuEntry;
+import cafe.jeffrey.timeseries.TimeseriesData;
+
+import java.util.List;
+
+/**
+ * G1 collector deep-dive insight built from the full set of G1-specific JFR events. Gives an
+ * exact picture of how G1 behaves: pause anatomy, heap-region composition, evacuation cost and
+ * failures, and concurrent-marking (IHOP/MMU) behaviour.
+ *
+ * @param header            high-level counters (young/mixed/full pauses, pause statistics, region count)
+ * @param pausePhases       per-phase pause breakdown ({@code jdk.GCPhasePause(Level1..4)}, {@code jdk.GCPhaseParallel})
+ * @param regionComposition Eden/Survivor/Old used-bytes over time ({@code jdk.G1HeapSummary})
+ * @param regionSnapshots   per-snapshot region grid for the heatmap ({@code jdk.G1HeapRegionInformation})
+ * @param evacuations       per-collection evacuation cost ({@code jdk.EvacuationInformation})
+ * @param evacuationFailures to-space-exhaustion events per collection ({@code jdk.EvacuationFailed})
+ * @param ihopTimeline      IHOP threshold vs old-gen occupancy ({@code jdk.G1AdaptiveIHOP})
+ * @param mmu               pause-target adherence per collection ({@code jdk.G1MMU})
+ * @param systemGcs         explicit {@code System.gc()} invocations ({@code jdk.SystemGC})
+ * @param gcLockers         JNI-critical-section GC stalls ({@code jdk.GCLocker})
+ */
+public record G1AnalysisData(
+        G1Header header,
+        List<PausePhase> pausePhases,
+        TimeseriesData regionComposition,
+        List<RegionSnapshot> regionSnapshots,
+        List<EvacuationEntry> evacuations,
+        List<EvacuationFailure> evacuationFailures,
+        TimeseriesData ihopTimeline,
+        List<MmuEntry> mmu,
+        List<SystemGcEntry> systemGcs,
+        List<GcLockerEntry> gcLockers) {
+
+    public record G1Header(
+            long youngCount,
+            long mixedCount,
+            long fullCount,
+            long totalPauseNanos,
+            long avgPauseNanos,
+            long maxPauseNanos,
+            long p99PauseNanos,
+            long evacuationFailureCount,
+            int regionCount) {
+    }
+
+    /**
+     * Aggregated pause sub-phase. {@code level} is the nesting depth (0 = top-level
+     * {@code jdk.GCPhasePause}, 1..4 = {@code GCPhasePauseLevelN}; -1 = per-worker
+     * {@code jdk.GCPhaseParallel}).
+     */
+    public record PausePhase(String name, int level, long count, long totalNanos, long maxNanos, long avgNanos) {
+    }
+
+    public record RegionSnapshot(long timeOffsetMillis, List<RegionCell> regions) {
+    }
+
+    public record RegionCell(int index, String type, long usedBytes) {
+    }
+
+    public record EvacuationEntry(
+            long gcId,
+            int cSetRegions,
+            long cSetUsedBefore,
+            long cSetUsedAfter,
+            int allocationRegions,
+            long bytesCopied,
+            int regionsFreed) {
+    }
+
+    public record EvacuationFailure(long gcId, long count) {
+    }
+
+    public record SystemGcEntry(long timeOffsetMillis, long durationNanos, boolean invokedConcurrent) {
+    }
+
+    public record GcLockerEntry(long timeOffsetMillis, long durationNanos, int lockCount, int stallCount) {
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/gc/zgc/ZgcAnalysisBuilder.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/gc/zgc/ZgcAnalysisBuilder.java
@@ -1,0 +1,234 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.gc.zgc;
+
+import org.eclipse.collections.impl.map.mutable.primitive.LongLongHashMap;
+import tools.jackson.databind.node.ObjectNode;
+import cafe.jeffrey.jfrparser.api.type.JfrThread;
+import cafe.jeffrey.profile.manager.model.gc.zgc.ZgcAnalysisData.StallSite;
+import cafe.jeffrey.profile.manager.model.gc.zgc.ZgcAnalysisData.StallType;
+import cafe.jeffrey.profile.manager.model.gc.zgc.ZgcAnalysisData.ZCycle;
+import cafe.jeffrey.profile.manager.model.gc.zgc.ZgcAnalysisData.ZgcHeader;
+import cafe.jeffrey.profile.manager.model.gc.zgc.ZgcAnalysisData.ZRelocationEntry;
+import cafe.jeffrey.profile.manager.model.gc.zgc.ZgcAnalysisData.ZUncommitEntry;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.provider.profile.api.RecordBuilder;
+import cafe.jeffrey.shared.common.Json;
+import cafe.jeffrey.shared.common.model.EventTypeName;
+import cafe.jeffrey.shared.common.model.time.RelativeTimeRange;
+import cafe.jeffrey.timeseries.SingleSerie;
+import cafe.jeffrey.timeseries.TimeseriesData;
+import cafe.jeffrey.timeseries.TimeseriesUtils;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.ToLongFunction;
+
+/**
+ * Single-pass aggregator over the ZGC event set producing {@link ZgcAnalysisData}.
+ */
+public class ZgcAnalysisBuilder implements RecordBuilder<GenericRecord, ZgcAnalysisData> {
+
+    private static final String GC_ID_FIELD = "gcId";
+    private static final String TYPE_FIELD = "type";
+    private static final String SIZE_FIELD = "size";
+    private static final String TENURING_THRESHOLD_FIELD = "tenuringThreshold";
+    private static final String UNCOMMITTED_FIELD = "uncommitted";
+    private static final String TOTAL_FIELD = "total";
+    private static final String EMPTY_FIELD = "empty";
+    private static final String RELOCATE_FIELD = "relocate";
+
+    private static final String GENERATION_YOUNG = "Young";
+    private static final String GENERATION_OLD = "Old";
+    private static final String UNKNOWN_THREAD = "unknown";
+
+    private static final String STALL_COUNT_SERIES = "Allocation Stalls";
+    private static final String STALL_TIME_SERIES = "Stall Time";
+    private static final String PAGE_ALLOCATION_SERIES = "Page Allocation";
+
+    private static final int MAX_STALL_SITES = 50;
+    private static final int MAX_CYCLES = 200;
+    private static final int MAX_UNCOMMITS = 200;
+    private static final int MAX_RELOCATIONS = 200;
+
+    private static final class StallAcc {
+        private long count;
+        private long total;
+        private long max;
+
+        private void add(long nanos) {
+            count++;
+            total += nanos;
+            max = Math.max(max, nanos);
+        }
+    }
+
+    private final LongLongHashMap stallCountSeries;
+    private final LongLongHashMap stallTimeSeries;
+    private final LongLongHashMap pageAllocationSeries;
+    private final Map<String, StallAcc> stallsByType = new HashMap<>();
+    private final Map<String, StallAcc> stallsByThread = new HashMap<>();
+    private final List<ZCycle> cycles = new ArrayList<>();
+    private final List<ZUncommitEntry> uncommits = new ArrayList<>();
+    private final List<ZRelocationEntry> relocations = new ArrayList<>();
+    private long youngCycles;
+    private long oldCycles;
+    private long stallCount;
+    private long totalStallNanos;
+    private long maxStallNanos;
+    private long pagesAllocatedBytes;
+    private long uncommittedBytes;
+
+    public ZgcAnalysisBuilder(RelativeTimeRange timeRange) {
+        this.stallCountSeries = TimeseriesUtils.initWithZeros(timeRange);
+        this.stallTimeSeries = TimeseriesUtils.initWithZeros(timeRange);
+        this.pageAllocationSeries = TimeseriesUtils.initWithZeros(timeRange);
+    }
+
+    @Override
+    public void onRecord(GenericRecord record) {
+        ObjectNode fields = record.jsonFields();
+        switch (record.type().code()) {
+            case EventTypeName.Z_ALLOCATION_STALL -> onAllocationStall(fields, record);
+            case EventTypeName.Z_YOUNG_GARBAGE_COLLECTION -> onYoungCollection(fields, record);
+            case EventTypeName.Z_OLD_GARBAGE_COLLECTION -> onOldCollection(fields, record);
+            case EventTypeName.Z_PAGE_ALLOCATION -> onPageAllocation(fields, record);
+            case EventTypeName.Z_UNCOMMIT -> onUncommit(fields, record);
+            case EventTypeName.Z_RELOCATION_SET -> onRelocationSet(fields, record);
+            default -> {
+                // Unrelated event in the combined stream; ignore.
+            }
+        }
+    }
+
+    private void onAllocationStall(ObjectNode fields, GenericRecord record) {
+        long nanos = record.duration().toNanos();
+        long seconds = record.timestampFromStart().toSeconds();
+        stallCountSeries.addToValue(seconds, 1);
+        stallTimeSeries.addToValue(seconds, nanos);
+
+        stallCount++;
+        totalStallNanos += nanos;
+        maxStallNanos = Math.max(maxStallNanos, nanos);
+
+        String type = Json.readString(fields, TYPE_FIELD);
+        stallsByType.computeIfAbsent(type == null ? UNKNOWN_THREAD : type, key -> new StallAcc()).add(nanos);
+
+        JfrThread thread = record.thread();
+        String threadName = thread == null || thread.name() == null ? UNKNOWN_THREAD : thread.name();
+        stallsByThread.computeIfAbsent(threadName, key -> new StallAcc()).add(nanos);
+    }
+
+    private void onYoungCollection(ObjectNode fields, GenericRecord record) {
+        long gcId = Json.readLong(fields, GC_ID_FIELD);
+        if (gcId < 0) {
+            return;
+        }
+        youngCycles++;
+        cycles.add(new ZCycle(
+                gcId,
+                GENERATION_YOUNG,
+                record.duration().toNanos(),
+                Math.max(0, Json.readInt(fields, TENURING_THRESHOLD_FIELD))));
+    }
+
+    private void onOldCollection(ObjectNode fields, GenericRecord record) {
+        long gcId = Json.readLong(fields, GC_ID_FIELD);
+        if (gcId < 0) {
+            return;
+        }
+        oldCycles++;
+        cycles.add(new ZCycle(gcId, GENERATION_OLD, record.duration().toNanos(), 0));
+    }
+
+    private void onPageAllocation(ObjectNode fields, GenericRecord record) {
+        long size = Math.max(0, Json.readLong(fields, SIZE_FIELD));
+        pagesAllocatedBytes += size;
+        pageAllocationSeries.addToValue(record.timestampFromStart().toSeconds(), size);
+    }
+
+    private void onUncommit(ObjectNode fields, GenericRecord record) {
+        long bytes = Math.max(0, Json.readLong(fields, UNCOMMITTED_FIELD));
+        uncommittedBytes += bytes;
+        uncommits.add(new ZUncommitEntry(
+                record.timestampFromStart().toMillis(), bytes, record.duration().toNanos()));
+    }
+
+    private void onRelocationSet(ObjectNode fields, GenericRecord record) {
+        relocations.add(new ZRelocationEntry(
+                record.timestampFromStart().toMillis(),
+                Math.max(0, Json.readLong(fields, TOTAL_FIELD)),
+                Math.max(0, Json.readLong(fields, EMPTY_FIELD)),
+                Math.max(0, Json.readLong(fields, RELOCATE_FIELD))));
+    }
+
+    @Override
+    public ZgcAnalysisData build() {
+        ZgcHeader header = new ZgcHeader(
+                youngCycles, oldCycles, stallCount, totalStallNanos, maxStallNanos,
+                pagesAllocatedBytes, uncommittedBytes);
+
+        SingleSerie countSerie = TimeseriesUtils.buildSerie(STALL_COUNT_SERIES, stallCountSeries);
+        SingleSerie timeSerie = TimeseriesUtils.buildSerie(STALL_TIME_SERIES, stallTimeSeries);
+        SingleSerie pageSerie = TimeseriesUtils.buildSerie(PAGE_ALLOCATION_SERIES, pageAllocationSeries);
+
+        return new ZgcAnalysisData(
+                header,
+                new TimeseriesData(countSerie, timeSerie),
+                buildStallTypes(),
+                buildStallSites(),
+                capByGcId(cycles, ZCycle::gcId, MAX_CYCLES),
+                new TimeseriesData(pageSerie),
+                capByOffset(uncommits, ZUncommitEntry::timeOffsetMillis, MAX_UNCOMMITS),
+                capByOffset(relocations, ZRelocationEntry::timeOffsetMillis, MAX_RELOCATIONS));
+    }
+
+    private List<StallType> buildStallTypes() {
+        return stallsByType.entrySet().stream()
+                .map(entry -> new StallType(
+                        entry.getKey(), entry.getValue().count, entry.getValue().total, entry.getValue().max))
+                .sorted(Comparator.comparingLong(StallType::totalNanos).reversed())
+                .toList();
+    }
+
+    private List<StallSite> buildStallSites() {
+        return stallsByThread.entrySet().stream()
+                .map(entry -> new StallSite(entry.getKey(), entry.getValue().count, entry.getValue().total))
+                .sorted(Comparator.comparingLong(StallSite::totalNanos).reversed())
+                .limit(MAX_STALL_SITES)
+                .toList();
+    }
+
+    private static <T> List<T> capByGcId(List<T> entries, ToLongFunction<T> gcId, int max) {
+        return entries.stream()
+                .sorted(Comparator.comparingLong(gcId).reversed())
+                .limit(max)
+                .toList();
+    }
+
+    private static <T> List<T> capByOffset(List<T> entries, ToLongFunction<T> offset, int max) {
+        return entries.stream()
+                .sorted(Comparator.comparingLong(offset).reversed())
+                .limit(max)
+                .toList();
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/gc/zgc/ZgcAnalysisData.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/gc/zgc/ZgcAnalysisData.java
@@ -1,0 +1,73 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.gc.zgc;
+
+import cafe.jeffrey.timeseries.TimeseriesData;
+
+import java.util.List;
+
+/**
+ * ZGC (generational) deep-dive insight built from the ZGC-specific JFR events. The headline
+ * signal is allocation stalls — the only place where the otherwise-concurrent collector becomes
+ * visible to application threads.
+ *
+ * @param header        high-level counters (cycles, allocation-stall totals, pages, uncommit)
+ * @param stallTimeline allocation-stall count and total stall time per second ({@code jdk.ZAllocationStall})
+ * @param stallTypes    stall breakdown by page type (Small/Medium/Large)
+ * @param stallSites    stalling threads ranked by total stall time
+ * @param cycles        young/old collection cycles ({@code jdk.ZYoungGarbageCollection}, {@code jdk.ZOldGarbageCollection})
+ * @param pageAllocation page-allocation throughput over time ({@code jdk.ZPageAllocation})
+ * @param uncommits     memory returned to the OS ({@code jdk.ZUncommit})
+ * @param relocations   relocation-set sizes per cycle ({@code jdk.ZRelocationSet})
+ */
+public record ZgcAnalysisData(
+        ZgcHeader header,
+        TimeseriesData stallTimeline,
+        List<StallType> stallTypes,
+        List<StallSite> stallSites,
+        List<ZCycle> cycles,
+        TimeseriesData pageAllocation,
+        List<ZUncommitEntry> uncommits,
+        List<ZRelocationEntry> relocations) {
+
+    public record ZgcHeader(
+            long youngCycles,
+            long oldCycles,
+            long stallCount,
+            long totalStallNanos,
+            long maxStallNanos,
+            long pagesAllocatedBytes,
+            long uncommittedBytes) {
+    }
+
+    public record StallType(String type, long count, long totalNanos, long maxNanos) {
+    }
+
+    public record StallSite(String threadName, long count, long totalNanos) {
+    }
+
+    public record ZCycle(long gcId, String generation, long durationNanos, int tenuringThreshold) {
+    }
+
+    public record ZUncommitEntry(long timeOffsetMillis, long uncommittedBytes, long durationNanos) {
+    }
+
+    public record ZRelocationEntry(long timeOffsetMillis, long total, long empty, long relocate) {
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/gc/g1/G1AnalysisBuilderTest.java
+++ b/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/gc/g1/G1AnalysisBuilderTest.java
@@ -1,0 +1,181 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.gc.g1;
+
+import tools.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import cafe.jeffrey.profile.manager.model.gc.g1.G1AnalysisData.PausePhase;
+import cafe.jeffrey.profile.manager.model.gc.g1.G1AnalysisData.RegionSnapshot;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.shared.common.Json;
+import cafe.jeffrey.shared.common.model.Type;
+import cafe.jeffrey.shared.common.model.time.RelativeTimeRange;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("G1AnalysisBuilder")
+class G1AnalysisBuilderTest {
+
+    private static final Instant START = Instant.parse("2024-01-01T00:00:00Z");
+
+    private static GenericRecord rec(Type type, long secondsFromStart, long durationNanos, ObjectNode fields) {
+        return new GenericRecord(
+                type, "label", START,
+                Duration.ofSeconds(secondsFromStart), Duration.ofNanos(durationNanos),
+                null, null, 0L, 0L, fields);
+    }
+
+    private static G1AnalysisBuilder newBuilder() {
+        return new G1AnalysisBuilder(new RelativeTimeRange(0, 10_000));
+    }
+
+    private static ObjectNode gc(long gcId, String name, long sumOfPauses) {
+        ObjectNode node = Json.createObject();
+        node.put("gcId", gcId);
+        node.put("name", name);
+        node.put("sumOfPauses", sumOfPauses);
+        return node;
+    }
+
+    private static ObjectNode g1gc(long gcId, String type) {
+        ObjectNode node = Json.createObject();
+        node.put("gcId", gcId);
+        node.put("type", type);
+        return node;
+    }
+
+    private static ObjectNode phase(String name) {
+        ObjectNode node = Json.createObject();
+        node.put("name", name);
+        return node;
+    }
+
+    @Test
+    @DisplayName("Classifies collections into young, mixed and full with pause statistics")
+    void classifiesCollections() {
+        G1AnalysisBuilder builder = newBuilder();
+        builder.onRecord(rec(Type.GARBAGE_COLLECTION, 1, 0, gc(0, "G1New", 1_000_000)));
+        builder.onRecord(rec(Type.G1_GARBAGE_COLLECTION, 1, 0, g1gc(0, "Normal")));
+        builder.onRecord(rec(Type.GARBAGE_COLLECTION, 2, 0, gc(1, "G1New", 3_000_000)));
+        builder.onRecord(rec(Type.G1_GARBAGE_COLLECTION, 2, 0, g1gc(1, "Mixed")));
+        builder.onRecord(rec(Type.GARBAGE_COLLECTION, 3, 0, gc(2, "G1Full", 9_000_000)));
+
+        var header = builder.build().header();
+
+        assertEquals(1, header.youngCount());
+        assertEquals(1, header.mixedCount());
+        assertEquals(1, header.fullCount());
+        assertEquals(13_000_000, header.totalPauseNanos());
+        assertEquals(9_000_000, header.maxPauseNanos());
+    }
+
+    @Test
+    @DisplayName("Aggregates pause sub-phases by name, sorted by total time descending")
+    void aggregatesPausePhases() {
+        G1AnalysisBuilder builder = newBuilder();
+        builder.onRecord(rec(Type.GC_PHASE_PAUSE, 1, 5_000_000, phase("Pause")));
+        builder.onRecord(rec(Type.GC_PHASE_PAUSE_LEVEL_1, 1, 2_000_000, phase("Object Copy")));
+        builder.onRecord(rec(Type.GC_PHASE_PAUSE_LEVEL_1, 1, 2_000_000, phase("Object Copy")));
+
+        List<PausePhase> phases = builder.build().pausePhases();
+
+        assertEquals("Pause", phases.getFirst().name());
+        PausePhase objectCopy = phases.stream()
+                .filter(p -> p.name().equals("Object Copy"))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(2, objectCopy.count());
+        assertEquals(4_000_000, objectCopy.totalNanos());
+        assertEquals(1, objectCopy.level());
+    }
+
+    @Test
+    @DisplayName("Counts evacuation failures per gcId")
+    void countsEvacuationFailures() {
+        G1AnalysisBuilder builder = newBuilder();
+        builder.onRecord(rec(Type.EVACUATION_FAILED, 1, 0, gcIdOnly(2)));
+        builder.onRecord(rec(Type.EVACUATION_FAILED, 1, 0, gcIdOnly(2)));
+        builder.onRecord(rec(Type.EVACUATION_FAILED, 2, 0, gcIdOnly(5)));
+
+        G1AnalysisData data = builder.build();
+
+        assertEquals(3, data.header().evacuationFailureCount());
+        assertEquals(2, data.evacuationFailures().size());
+        assertEquals(5, data.evacuationFailures().getFirst().gcId());
+        assertEquals(1, data.evacuationFailures().getFirst().count());
+    }
+
+    @Test
+    @DisplayName("Groups region-information events into a per-timestamp snapshot")
+    void groupsRegionSnapshots() {
+        G1AnalysisBuilder builder = newBuilder();
+        builder.onRecord(rec(Type.G1_HEAP_REGION_INFORMATION, 1, 0, region(1, "Old", 20)));
+        builder.onRecord(rec(Type.G1_HEAP_REGION_INFORMATION, 1, 0, region(0, "Eden", 10)));
+
+        List<RegionSnapshot> snapshots = builder.build().regionSnapshots();
+
+        assertEquals(1, snapshots.size());
+        assertEquals(2, snapshots.getFirst().regions().size());
+        assertEquals(0, snapshots.getFirst().regions().getFirst().index());
+    }
+
+    @Test
+    @DisplayName("Builds Eden/Survivor/Old composition from the After-GC heap summary")
+    void buildsComposition() {
+        G1AnalysisBuilder builder = newBuilder();
+        ObjectNode summary = Json.createObject();
+        summary.put("when", "After GC");
+        summary.put("edenUsedSize", 100L);
+        summary.put("survivorUsedSize", 50L);
+        summary.put("oldGenUsedSize", 200L);
+        summary.put("numberOfRegions", 10);
+        builder.onRecord(rec(Type.G1_HEAP_SUMMARY, 2, 0, summary));
+
+        G1AnalysisData data = builder.build();
+
+        assertEquals(10, data.header().regionCount());
+        assertEquals("Eden", data.regionComposition().series().getFirst().name());
+        long maxEden = data.regionComposition().series().getFirst().data().stream()
+                .mapToLong(point -> point.get(1))
+                .max()
+                .orElse(0);
+        assertTrue(maxEden >= 100, "Eden series should carry the After-GC used size");
+    }
+
+    private static ObjectNode gcIdOnly(long gcId) {
+        ObjectNode node = Json.createObject();
+        node.put("gcId", gcId);
+        return node;
+    }
+
+    private static ObjectNode region(int index, String type, long used) {
+        ObjectNode node = Json.createObject();
+        node.put("index", index);
+        node.put("type", type);
+        node.put("used", used);
+        return node;
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/gc/zgc/ZgcAnalysisBuilderTest.java
+++ b/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/gc/zgc/ZgcAnalysisBuilderTest.java
@@ -1,0 +1,122 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.gc.zgc;
+
+import tools.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import cafe.jeffrey.profile.manager.model.gc.zgc.ZgcAnalysisData.StallType;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.shared.common.Json;
+import cafe.jeffrey.shared.common.model.Type;
+import cafe.jeffrey.shared.common.model.time.RelativeTimeRange;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DisplayName("ZgcAnalysisBuilder")
+class ZgcAnalysisBuilderTest {
+
+    private static final Instant START = Instant.parse("2024-01-01T00:00:00Z");
+
+    private static GenericRecord rec(Type type, long secondsFromStart, long durationNanos, ObjectNode fields) {
+        return new GenericRecord(
+                type, "label", START,
+                Duration.ofSeconds(secondsFromStart), Duration.ofNanos(durationNanos),
+                null, null, 0L, 0L, fields);
+    }
+
+    private static ZgcAnalysisBuilder newBuilder() {
+        return new ZgcAnalysisBuilder(new RelativeTimeRange(0, 10_000));
+    }
+
+    private static ObjectNode stall(String type, long size) {
+        ObjectNode node = Json.createObject();
+        node.put("type", type);
+        node.put("size", size);
+        return node;
+    }
+
+    @Test
+    @DisplayName("Aggregates allocation stalls into totals and per-type buckets")
+    void aggregatesStalls() {
+        ZgcAnalysisBuilder builder = newBuilder();
+        builder.onRecord(rec(Type.Z_ALLOCATION_STALL, 1, 1_000_000, stall("Small", 2048)));
+        builder.onRecord(rec(Type.Z_ALLOCATION_STALL, 1, 3_000_000, stall("Small", 2048)));
+        builder.onRecord(rec(Type.Z_ALLOCATION_STALL, 2, 2_000_000, stall("Medium", 32768)));
+
+        ZgcAnalysisData data = builder.build();
+
+        assertEquals(3, data.header().stallCount());
+        assertEquals(6_000_000, data.header().totalStallNanos());
+        assertEquals(3_000_000, data.header().maxStallNanos());
+
+        List<StallType> types = data.stallTypes();
+        assertEquals("Small", types.getFirst().type());
+        assertEquals(2, types.getFirst().count());
+        assertEquals(4_000_000, types.getFirst().totalNanos());
+    }
+
+    @Test
+    @DisplayName("Counts young and old generational cycles")
+    void countsCycles() {
+        ZgcAnalysisBuilder builder = newBuilder();
+        ObjectNode young = Json.createObject();
+        young.put("gcId", 0L);
+        young.put("tenuringThreshold", 5);
+        builder.onRecord(rec(Type.Z_YOUNG_GARBAGE_COLLECTION, 1, 500_000, young));
+
+        ObjectNode old = Json.createObject();
+        old.put("gcId", 1L);
+        builder.onRecord(rec(Type.Z_OLD_GARBAGE_COLLECTION, 2, 700_000, old));
+
+        ZgcAnalysisData data = builder.build();
+
+        assertEquals(1, data.header().youngCycles());
+        assertEquals(1, data.header().oldCycles());
+        assertEquals(2, data.cycles().size());
+    }
+
+    @Test
+    @DisplayName("Sums page-allocation bytes and uncommitted memory")
+    void sumsPagesAndUncommit() {
+        ZgcAnalysisBuilder builder = newBuilder();
+        builder.onRecord(rec(Type.Z_PAGE_ALLOCATION, 1, 0, sizeField(2048)));
+        builder.onRecord(rec(Type.Z_PAGE_ALLOCATION, 1, 0, sizeField(4096)));
+
+        ObjectNode uncommit = Json.createObject();
+        uncommit.put("uncommitted", 1_000_000L);
+        builder.onRecord(rec(Type.Z_UNCOMMIT, 2, 0, uncommit));
+
+        ZgcAnalysisData data = builder.build();
+
+        assertEquals(6144, data.header().pagesAllocatedBytes());
+        assertEquals(1_000_000, data.header().uncommittedBytes());
+        assertEquals(1, data.uncommits().size());
+    }
+
+    private static ObjectNode sizeField(long size) {
+        ObjectNode node = Json.createObject();
+        node.put("size", size);
+        return node;
+    }
+}

--- a/jeffrey-pages/src/router/index.ts
+++ b/jeffrey-pages/src/router/index.ts
@@ -208,6 +208,16 @@ const routes: RouteRecordRaw[] = [
         component: () => import('@/views/docs/microscope/profiles/ProfileGarbageCollectionPage.vue')
       },
       {
+        path: 'microscope/profiles/garbage-collection/g1',
+        name: 'DocsProfilesG1Analysis',
+        component: () => import('@/views/docs/microscope/profiles/ProfileG1AnalysisPage.vue')
+      },
+      {
+        path: 'microscope/profiles/garbage-collection/zgc',
+        name: 'DocsProfilesZgcAnalysis',
+        component: () => import('@/views/docs/microscope/profiles/ProfileZgcAnalysisPage.vue')
+      },
+      {
         path: 'microscope/profiles/class-loading',
         name: 'DocsProfilesClassLoading',
         component: () => import('@/views/docs/microscope/profiles/ProfileClassLoadingPage.vue')

--- a/jeffrey-pages/src/views/docs/microscope/profiles/ProfileG1AnalysisPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/profiles/ProfileG1AnalysisPage.vue
@@ -1,0 +1,88 @@
+<!--
+  - Jeffrey
+  - Copyright (C) 2026 Petr Bouda
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as published by
+  - the Free Software Foundation, either version 3 of the License, or
+  - (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import DocsCallout from '@/components/docs/DocsCallout.vue';
+import DocsNavFooter from '@/components/docs/DocsNavFooter.vue';
+import DocsPageHeader from '@/components/docs/DocsPageHeader.vue';
+import { useDocHeadings } from '@/composables/useDocHeadings';
+
+const { setHeadings } = useDocHeadings();
+
+const headings = [
+  { id: 'overview', text: 'Overview', level: 2 },
+  { id: 'pause-phases', text: 'Pause Phases', level: 2 },
+  { id: 'heap-regions', text: 'Heap Regions', level: 2 },
+  { id: 'evacuation', text: 'Evacuation', level: 2 },
+  { id: 'marking', text: 'IHOP & Marking', level: 2 },
+  { id: 'anomalies', text: 'Anomalies', level: 2 }
+];
+
+onMounted(() => {
+  setHeadings(headings);
+});
+</script>
+
+<template>
+  <article class="docs-article">
+    <DocsPageHeader title="G1 Analysis" icon="bi bi-diagram-3" />
+
+    <div class="docs-content">
+      <p>The G1 Analysis page is a collector-specific deep dive that reconstructs exactly how the G1 garbage collector behaved during the recording. It complements the general Garbage Collection page by reading the full set of G1-specific JFR events. The page shows an empty state when the recording was not produced with G1.</p>
+
+      <h2 id="overview">Overview</h2>
+      <p>A header strip surfaces the headline numbers — young / mixed / full collection counts, total / average / p99 / max pause time, the number of evacuation failures, and the heap-region count — so you can judge G1 health before drilling into a tab.</p>
+
+      <DocsCallout type="tip">
+        <strong>Where to start:</strong> open <em>Pause Phases</em> to see what dominates pause time, then <em>Evacuation</em> if you see evacuation failures — they are the usual cause of surprise Full GCs.
+      </DocsCallout>
+
+      <h2 id="pause-phases">Pause Phases</h2>
+      <p>Every G1 pause is split into sub-phases (External Root Scan, Update/Scan Remembered Sets, Object Copy, Termination, Reference Processing, Choose CSet, …) from <code>jdk.GCPhasePause</code> and its nested <code>GCPhasePauseLevel1–4</code> events, plus per-worker <code>jdk.GCPhaseParallel</code>. The table aggregates each phase by total, average and max time so you can tell whether copy cost, remembered-set work, or reference processing dominates.</p>
+
+      <h2 id="heap-regions">Heap Regions</h2>
+      <p>A stacked timeseries shows Eden / Survivor / Old used bytes over time from <code>jdk.G1HeapSummary</code>. Below it, a per-region <strong>heatmap</strong> built from <code>jdk.G1HeapRegionInformation</code> renders every region as a coloured cell (Eden, Survivor, Old, Humongous, Archive, Free), with a snapshot scrubber to step through time. Humongous regions stand out immediately — a common G1 footgun for objects larger than half a region.</p>
+
+      <DocsCallout type="info">
+        The per-region heatmap requires <code>jdk.G1HeapRegionInformation</code>, which is verbose and disabled in most default settings. When it is absent the page falls back to the aggregate composition timeseries.
+      </DocsCallout>
+
+      <h2 id="evacuation">Evacuation</h2>
+      <p>Per-collection evacuation cost from <code>jdk.EvacuationInformation</code> — collection-set regions, used-before / used-after, bytes copied, and regions freed. <strong>Evacuation failures</strong> (to-space exhaustion) from <code>jdk.EvacuationFailed</code> are counted per collection and flagged with a banner; they explain surprise Full GCs and pause spikes.</p>
+
+      <h2 id="marking">IHOP &amp; Marking</h2>
+      <p>The adaptive IHOP threshold vs. current old-generation occupancy over time (<code>jdk.G1AdaptiveIHOP</code>) — when occupancy crosses the threshold, G1 starts a concurrent marking cycle. A pause-target adherence table (<code>jdk.G1MMU</code>) flags collections whose GC time exceeded the configured pause target, telling you whether G1 is meeting its <code>MaxGCPauseMillis</code> goal.</p>
+
+      <h2 id="anomalies">Anomalies</h2>
+      <p>Two tables surface behaviour that usually indicates a problem: explicit <code>System.gc()</code> calls (<code>jdk.SystemGC</code>, including whether they ran concurrently) and GC-locker stalls (<code>jdk.GCLocker</code>), where threads sitting in JNI critical sections delayed collection.</p>
+
+      <DocsCallout type="info">
+        <strong>Read the JFR canonical event list:</strong> the
+        <a href="https://sap.github.io/jfrevents/" target="_blank" rel="noopener">SAP JFR Events catalog</a>
+        documents every G1 event the JDK emits, including the exact field names used here.
+      </DocsCallout>
+    </div>
+
+    <DocsNavFooter />
+  </article>
+</template>
+
+<style scoped>
+@import '@/views/docs/docs-page.css';
+</style>

--- a/jeffrey-pages/src/views/docs/microscope/profiles/ProfileZgcAnalysisPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/profiles/ProfileZgcAnalysisPage.vue
@@ -1,0 +1,80 @@
+<!--
+  - Jeffrey
+  - Copyright (C) 2026 Petr Bouda
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as published by
+  - the Free Software Foundation, either version 3 of the License, or
+  - (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import DocsCallout from '@/components/docs/DocsCallout.vue';
+import DocsNavFooter from '@/components/docs/DocsNavFooter.vue';
+import DocsPageHeader from '@/components/docs/DocsPageHeader.vue';
+import { useDocHeadings } from '@/composables/useDocHeadings';
+
+const { setHeadings } = useDocHeadings();
+
+const headings = [
+  { id: 'overview', text: 'Overview', level: 2 },
+  { id: 'allocation-stalls', text: 'Allocation Stalls', level: 2 },
+  { id: 'cycles', text: 'GC Cycles', level: 2 },
+  { id: 'pages', text: 'Pages & Memory', level: 2 },
+  { id: 'relocation', text: 'Relocation', level: 2 }
+];
+
+onMounted(() => {
+  setHeadings(headings);
+});
+</script>
+
+<template>
+  <article class="docs-article">
+    <DocsPageHeader title="ZGC Analysis" icon="bi bi-cpu" />
+
+    <div class="docs-content">
+      <p>The ZGC Analysis page is a collector-specific deep dive into the generational ZGC collector. Because ZGC is concurrent and its stop-the-world pauses are sub-millisecond, the signal that actually matters for latency is the <strong>allocation stall</strong> — and that is where this page starts. It shows an empty state when the recording was not produced with ZGC.</p>
+
+      <h2 id="overview">Overview</h2>
+      <p>A header strip surfaces young / old cycle counts, allocation-stall count with total and max stall time, total bytes of pages allocated, and memory uncommitted back to the OS.</p>
+
+      <h2 id="allocation-stalls">Allocation Stalls</h2>
+      <p>When the application allocates faster than ZGC can reclaim memory, mutator threads are stalled until a page becomes available. This tab plots stall count and total stall time per second (<code>jdk.ZAllocationStall</code>), and breaks stalls down by page type (Small / Medium / Large) and by the threads that stalled the most. Sustained stalls mean the collector cannot keep up with the allocation rate.</p>
+
+      <DocsCallout type="tip">
+        <strong>Where to start:</strong> if you are chasing latency on ZGC, this is the first tab to open — ordinary GC pauses will look tiny, but allocation stalls show the real application impact.
+      </DocsCallout>
+
+      <h2 id="cycles">GC Cycles</h2>
+      <p>Generational ZGC runs separate young and old collections. This tab lists each cycle (<code>jdk.ZYoungGarbageCollection</code>, <code>jdk.ZOldGarbageCollection</code>) with its duration, generation, and — for young cycles — the tenuring threshold that drives promotion to the old generation.</p>
+
+      <h2 id="pages">Pages &amp; Memory</h2>
+      <p>Page-allocation throughput over time (<code>jdk.ZPageAllocation</code>) shows how hard the allocator is working; high sustained allocation alongside stalls confirms the collector is behind. A table of uncommit events (<code>jdk.ZUncommit</code>) shows memory returned to the operating system.</p>
+
+      <h2 id="relocation">Relocation</h2>
+      <p>Relocation-set composition per cycle (<code>jdk.ZRelocationSet</code>) — total, empty, and relocated pages. Empty pages are reclaimed without relocation; large relocation sets increase the amount of concurrent copying work.</p>
+
+      <DocsCallout type="info">
+        <strong>Read the JFR canonical event list:</strong> the
+        <a href="https://sap.github.io/jfrevents/" target="_blank" rel="noopener">SAP JFR Events catalog</a>
+        documents every ZGC event the JDK emits, including the exact field names used here.
+      </DocsCallout>
+    </div>
+
+    <DocsNavFooter />
+  </article>
+</template>
+
+<style scoped>
+@import '@/views/docs/docs-page.css';
+</style>

--- a/jeffrey-pages/src/views/docs/microscope/profiles/ProfilesPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/profiles/ProfilesPage.vue
@@ -121,7 +121,7 @@ const folderStructure = `$JEFFREY_HOME/
         <DocsFeatureCard
           icon="bi bi-bar-chart-line"
           title="Memory & Garbage Collection"
-          description="Pause distribution, throughput / overhead, longest-pause table with cause attribution, concurrent cycles, and a searchable reference for every GC pause type — see the GC analysis page."
+          description="Pause distribution, throughput / overhead, longest-pause table with cause attribution, concurrent cycles, and a searchable reference for every GC pause type — plus collector-specific G1 and ZGC deep-dive pages."
         />
         <DocsFeatureCard
           icon="bi bi-lightning"
@@ -199,6 +199,10 @@ const folderStructure = `$JEFFREY_HOME/
         <router-link to="/docs/microscope/profiles/guardian">Read the Guardian reference &rarr;</router-link>
         &nbsp;·&nbsp;
         <router-link to="/docs/microscope/profiles/garbage-collection">Read the GC analysis reference &rarr;</router-link>
+        &nbsp;·&nbsp;
+        <router-link to="/docs/microscope/profiles/garbage-collection/g1">Read the G1 analysis reference &rarr;</router-link>
+        &nbsp;·&nbsp;
+        <router-link to="/docs/microscope/profiles/garbage-collection/zgc">Read the ZGC analysis reference &rarr;</router-link>
         &nbsp;·&nbsp;
         <router-link to="/docs/microscope/profiles/class-loading">Read the class-loading reference &rarr;</router-link>
         &nbsp;·&nbsp;

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/EventTypeName.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/EventTypeName.java
@@ -69,6 +69,28 @@ public abstract class EventTypeName {
     public static final String G1_BASIC_IHOP = "jdk.G1BasicIHOP";
     public static final String G1_MMU = "jdk.G1MMU";
 
+    // G1 deep-dive events
+    public static final String G1_HEAP_REGION_INFORMATION = "jdk.G1HeapRegionInformation";
+    public static final String G1_HEAP_REGION_TYPE_CHANGE = "jdk.G1HeapRegionTypeChange";
+    public static final String EVACUATION_INFORMATION = "jdk.EvacuationInformation";
+    public static final String EVACUATION_FAILED = "jdk.EvacuationFailed";
+    public static final String GC_PHASE_PAUSE = "jdk.GCPhasePause";
+    public static final String GC_PHASE_PAUSE_LEVEL_1 = "jdk.GCPhasePauseLevel1";
+    public static final String GC_PHASE_PAUSE_LEVEL_2 = "jdk.GCPhasePauseLevel2";
+    public static final String GC_PHASE_PAUSE_LEVEL_3 = "jdk.GCPhasePauseLevel3";
+    public static final String GC_PHASE_PAUSE_LEVEL_4 = "jdk.GCPhasePauseLevel4";
+    public static final String GC_PHASE_PARALLEL = "jdk.GCPhaseParallel";
+    public static final String SYSTEM_GC = "jdk.SystemGC";
+    public static final String GC_LOCKER = "jdk.GCLocker";
+
+    // ZGC deep-dive events
+    public static final String Z_ALLOCATION_STALL = "jdk.ZAllocationStall";
+    public static final String Z_PAGE_ALLOCATION = "jdk.ZPageAllocation";
+    public static final String Z_RELOCATION_SET = "jdk.ZRelocationSet";
+    public static final String Z_RELOCATION_SET_GROUP = "jdk.ZRelocationSetGroup";
+    public static final String Z_UNCOMMIT = "jdk.ZUncommit";
+    public static final String Z_THREAD_PHASE = "jdk.ZThreadPhase";
+
     public static final String YOUNG_GENERATION_CONFIGURATION = "jdk.YoungGenerationConfiguration";
     public static final String COMPILER_CONFIGURATION = "jdk.CompilerConfiguration";
     public static final String JVM_INFORMATION = "jdk.JVMInformation";

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/Type.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/Type.java
@@ -78,6 +78,28 @@ public record Type(String code, boolean calculated) {
     public static final Type G1_ADAPTIVE_IHOP = new Type(EventTypeName.G1_ADAPTIVE_IHOP);
     public static final Type G1_BASIC_IHOP = new Type(EventTypeName.G1_BASIC_IHOP);
     public static final Type G1_MMU = new Type(EventTypeName.G1_MMU);
+
+    // G1 deep-dive events
+    public static final Type G1_HEAP_REGION_INFORMATION = new Type(EventTypeName.G1_HEAP_REGION_INFORMATION);
+    public static final Type G1_HEAP_REGION_TYPE_CHANGE = new Type(EventTypeName.G1_HEAP_REGION_TYPE_CHANGE);
+    public static final Type EVACUATION_INFORMATION = new Type(EventTypeName.EVACUATION_INFORMATION);
+    public static final Type EVACUATION_FAILED = new Type(EventTypeName.EVACUATION_FAILED);
+    public static final Type GC_PHASE_PAUSE = new Type(EventTypeName.GC_PHASE_PAUSE);
+    public static final Type GC_PHASE_PAUSE_LEVEL_1 = new Type(EventTypeName.GC_PHASE_PAUSE_LEVEL_1);
+    public static final Type GC_PHASE_PAUSE_LEVEL_2 = new Type(EventTypeName.GC_PHASE_PAUSE_LEVEL_2);
+    public static final Type GC_PHASE_PAUSE_LEVEL_3 = new Type(EventTypeName.GC_PHASE_PAUSE_LEVEL_3);
+    public static final Type GC_PHASE_PAUSE_LEVEL_4 = new Type(EventTypeName.GC_PHASE_PAUSE_LEVEL_4);
+    public static final Type GC_PHASE_PARALLEL = new Type(EventTypeName.GC_PHASE_PARALLEL);
+    public static final Type SYSTEM_GC = new Type(EventTypeName.SYSTEM_GC);
+    public static final Type GC_LOCKER = new Type(EventTypeName.GC_LOCKER);
+
+    // ZGC deep-dive events
+    public static final Type Z_ALLOCATION_STALL = new Type(EventTypeName.Z_ALLOCATION_STALL);
+    public static final Type Z_PAGE_ALLOCATION = new Type(EventTypeName.Z_PAGE_ALLOCATION);
+    public static final Type Z_RELOCATION_SET = new Type(EventTypeName.Z_RELOCATION_SET);
+    public static final Type Z_RELOCATION_SET_GROUP = new Type(EventTypeName.Z_RELOCATION_SET_GROUP);
+    public static final Type Z_UNCOMMIT = new Type(EventTypeName.Z_UNCOMMIT);
+    public static final Type Z_THREAD_PHASE = new Type(EventTypeName.Z_THREAD_PHASE);
     public static final Type YOUNG_GENERATION_CONFIGURATION = new Type(EventTypeName.YOUNG_GENERATION_CONFIGURATION);
     public static final Type COMPILER_CONFIGURATION = new Type(EventTypeName.COMPILER_CONFIGURATION);
     public static final Type JVM_INFORMATION = new Type(EventTypeName.JVM_INFORMATION);
@@ -224,6 +246,24 @@ public record Type(String code, boolean calculated) {
                 G1_ADAPTIVE_IHOP,
                 G1_BASIC_IHOP,
                 G1_MMU,
+                G1_HEAP_REGION_INFORMATION,
+                G1_HEAP_REGION_TYPE_CHANGE,
+                EVACUATION_INFORMATION,
+                EVACUATION_FAILED,
+                GC_PHASE_PAUSE,
+                GC_PHASE_PAUSE_LEVEL_1,
+                GC_PHASE_PAUSE_LEVEL_2,
+                GC_PHASE_PAUSE_LEVEL_3,
+                GC_PHASE_PAUSE_LEVEL_4,
+                GC_PHASE_PARALLEL,
+                SYSTEM_GC,
+                GC_LOCKER,
+                Z_ALLOCATION_STALL,
+                Z_PAGE_ALLOCATION,
+                Z_RELOCATION_SET,
+                Z_RELOCATION_SET_GROUP,
+                Z_UNCOMMIT,
+                Z_THREAD_PHASE,
                 YOUNG_GENERATION_CONFIGURATION,
                 COMPILER_CONFIGURATION,
                 JVM_INFORMATION,


### PR DESCRIPTION
## Summary

Adds two collector-specific deep-dive pages under the **Garbage Collection** section that use the full set of G1/ZGC JFR events to show exactly how each collector behaves. Each page detects the active collector and shows an `EmptyState` when the recording isn't from that collector.

### G1 Analysis (`/garbage-collection/g1`)
Tabs: **Pause Phases** (per-sub-phase breakdown from `GCPhasePause(Level1–4)` + `GCPhaseParallel`), **Heap Regions** (Eden/Survivor/Old composition timeseries + a per-region heatmap from `G1HeapRegionInformation` with a snapshot scrubber), **Evacuation** (`EvacuationInformation` cost + `EvacuationFailed` to-space exhaustion), **IHOP & Marking** (`G1AdaptiveIHOP` threshold vs occupancy + `G1MMU` pause-target adherence), **Anomalies** (`SystemGC`, `GCLocker`).

### ZGC Analysis (`/garbage-collection/zgc`)
Tabs: **Allocation Stalls** (`ZAllocationStall` count/duration + per-type + stalling threads — the headline low-latency signal), **GC Cycles** (`ZYoung/OldGarbageCollection` + tenuring threshold), **Pages & Memory** (`ZPageAllocation`, `ZUncommit`), **Relocation** (`ZRelocationSet`).

## Implementation
- **Event constants**: registered all G1/ZGC events in `Type`/`EventTypeName` (field names verified against the JDK's own `jfr metadata`).
- **Backend**: two composite `RecordBuilder`s (`G1AnalysisBuilder`, `ZgcAnalysisBuilder`) + DTO records, exposed via two new methods on the existing `GarbageCollectionManager` and `/gc/g1` + `/gc/zgc` controller endpoints (reusing the existing factory — no new manager wiring).
- **Frontend**: `ProfileGCG1.vue` / `ProfileGCZgc.vue`, a token-based CSS-grid `G1RegionHeatmap`, client methods, TS models, routes, sidebar entries.
- **Docs**: G1 and ZGC reference pages in `jeffrey-pages`.

## Tests
- `G1AnalysisBuilderTest` / `ZgcAnalysisBuilderTest` (aggregation logic), and two new `GarbageCollectionControllerTest` cases for `/gc/g1` and `/gc/zgc`.

## Verification
- Frontend (`pages-microscope`): ESLint clean, Vite build passes; docs (`jeffrey-pages`) build passes.
- Backend was **not** compiled in the authoring environment (only JDK 21 available; the project targets `--release 25`). Field names are taken from authoritative JFR metadata; please run `mvn -pl jeffrey-microscope/profiles/profile-management,jeffrey-microscope/core-microscope -am test` in CI.

## Notes
- The parser stores nested JFR structs as `toString()` blobs, so `EvacuationFailed` is used as a per-gcId failure **count** and the struct-shaped `G1Evacuation*Statistics` (PLAB) events are intentionally left for a follow-up that needs a small parser change.
- Worth one end-to-end pass against a real G1/ZGC recording to confirm rendered values (field names are verified; runtime output isn't).

https://claude.ai/code/session_019PNnPZQ2oSTUGrEjFfsE4x

---
_Generated by [Claude Code](https://claude.ai/code/session_019PNnPZQ2oSTUGrEjFfsE4x)_