### PR TITLE
Add Virtual Threads (Project Loom) dashboard

### DIFF
--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/VirtualThreadController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/VirtualThreadController.java
@@ -1,0 +1,52 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.microscope.core.web.controllers.profile;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
+import cafe.jeffrey.profile.manager.VirtualThreadManager;
+import cafe.jeffrey.profile.manager.model.virtualthread.VirtualThreadData;
+
+@RestController
+@RequestMapping("/api/internal/profiles/{profileId}/virtual-threads")
+public class VirtualThreadController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(VirtualThreadController.class);
+
+    private final ProfileManagerResolver resolver;
+
+    public VirtualThreadController(ProfileManagerResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    @GetMapping
+    public VirtualThreadData virtualThreadData(@PathVariable("profileId") String profileId) {
+        LOG.debug("Fetching virtual-thread dashboard data");
+        return mgr(profileId).virtualThreadData();
+    }
+
+    private VirtualThreadManager mgr(String profileId) {
+        return resolver.resolve(profileId).virtualThreadManager();
+    }
+}

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/VirtualThreadControllerTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/VirtualThreadControllerTest.java
@@ -1,0 +1,84 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.microscope.core.web.controllers.profile;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
+import cafe.jeffrey.profile.manager.ProfileManager;
+import cafe.jeffrey.profile.manager.VirtualThreadManager;
+import cafe.jeffrey.profile.manager.model.virtualthread.VirtualThreadData;
+import cafe.jeffrey.profile.manager.model.virtualthread.VirtualThreadData.VtHeader;
+import cafe.jeffrey.shared.common.exception.Exceptions;
+import cafe.jeffrey.timeseries.TimeseriesData;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static cafe.jeffrey.microscope.core.web.MockMvcSupport.mockMvcTesterFor;
+
+@ExtendWith(MockitoExtension.class)
+class VirtualThreadControllerTest {
+
+    @Mock
+    ProfileManagerResolver resolver;
+
+    @Mock
+    ProfileManager profileManager;
+
+    @Mock
+    VirtualThreadManager virtualThreadManager;
+
+    @Test
+    void getsVirtualThreadData() {
+        when(resolver.resolve("p-1")).thenReturn(profileManager);
+        when(profileManager.virtualThreadManager()).thenReturn(virtualThreadManager);
+        when(virtualThreadManager.virtualThreadData()).thenReturn(emptyData());
+
+        MockMvcTester mvc = mockMvcTesterFor(new VirtualThreadController(resolver));
+
+        assertThat(mvc.get().uri("/api/internal/profiles/p-1/virtual-threads")).hasStatusOk();
+    }
+
+    @Test
+    void profileNotFoundReturns404() {
+        when(resolver.resolve("ghost")).thenThrow(Exceptions.profileNotFound("ghost"));
+
+        MockMvcTester mvc = mockMvcTesterFor(new VirtualThreadController(resolver));
+
+        assertThat(mvc.get().uri("/api/internal/profiles/ghost/virtual-threads"))
+                .hasStatus(404)
+                .bodyJson()
+                .extractingPath("$.code").asString().isEqualTo("PROFILE_NOT_FOUND");
+    }
+
+    private static VirtualThreadData emptyData() {
+        return new VirtualThreadData(
+                new VtHeader(0, 0, 0, 0, 0, 0, 0),
+                TimeseriesData.empty(),
+                List.of(),
+                List.of(),
+                List.of(),
+                TimeseriesData.empty());
+    }
+}

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/VirtualThreadControllerTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/VirtualThreadControllerTest.java
@@ -79,6 +79,7 @@ class VirtualThreadControllerTest {
                 List.of(),
                 List.of(),
                 List.of(),
+                List.of(),
                 TimeseriesData.empty());
     }
 }

--- a/jeffrey-microscope/pages-microscope/src/router/index.ts
+++ b/jeffrey-microscope/pages-microscope/src/router/index.ts
@@ -98,6 +98,12 @@ const profileChildRoutes = [
     meta: { layout: 'profile' }
   },
   {
+    path: 'virtual-threads',
+    name: 'profile-virtual-threads',
+    component: () => import('@/views/profiles/detail/ProfileVirtualThreads.vue'),
+    meta: { layout: 'profile' }
+  },
+  {
     path: 'jit-compilation',
     name: 'profile-jit-compilation',
     component: () => import('@/views/profiles/detail/ProfileJitCompilation.vue'),

--- a/jeffrey-microscope/pages-microscope/src/services/EventTypes.test.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/EventTypes.test.ts
@@ -39,6 +39,11 @@ describe('EventTypes', () => {
       expect(EventTypes.isWallClock('other')).toBe(false);
     });
 
+    it('isVirtualThreadPinned', () => {
+      expect(EventTypes.isVirtualThreadPinned('jdk.VirtualThreadPinned')).toBe(true);
+      expect(EventTypes.isVirtualThreadPinned('other')).toBe(false);
+    });
+
     it('isExecutionEventType', () => {
       expect(EventTypes.isExecutionEventType('jdk.ExecutionSample')).toBe(true);
       expect(EventTypes.isExecutionEventType('other')).toBe(false);
@@ -79,6 +84,7 @@ describe('EventTypes', () => {
       expect(EventTypes.isBlockingEventType('jdk.JavaMonitorEnter')).toBe(true);
       expect(EventTypes.isBlockingEventType('jdk.JavaMonitorWait')).toBe(true);
       expect(EventTypes.isBlockingEventType('jdk.ThreadPark')).toBe(true);
+      expect(EventTypes.isBlockingEventType('jdk.VirtualThreadPinned')).toBe(true);
       expect(EventTypes.isBlockingEventType('jdk.ExecutionSample')).toBe(false);
     });
 
@@ -86,6 +92,7 @@ describe('EventTypes', () => {
       expect(EventTypes.isDifferential('jdk.JavaMonitorEnter')).toBe(true);
       expect(EventTypes.isDifferential('jdk.JavaMonitorWait')).toBe(true);
       expect(EventTypes.isDifferential('jdk.ThreadPark')).toBe(true);
+      expect(EventTypes.isDifferential('jdk.VirtualThreadPinned')).toBe(true);
       expect(EventTypes.isDifferential('jdk.ExecutionSample')).toBe(false);
     });
   });

--- a/jeffrey-microscope/pages-microscope/src/services/EventTypes.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/EventTypes.ts
@@ -28,6 +28,7 @@ export default class EventTypes {
   static JAVA_MONITOR_ENTER = 'jdk.JavaMonitorEnter';
   static JAVA_MONITOR_WAIT = 'jdk.JavaMonitorWait';
   static THREAD_PARK = 'jdk.ThreadPark';
+  static VIRTUAL_THREAD_PINNED = 'jdk.VirtualThreadPinned';
   static WALL_CLOCK = 'profiler.WallClockSample';
   static NATIVE_MALLOC_ALLOCATION = 'profiler.Malloc';
   static NATIVE_LEAK = 'jeffrey.NativeLeak';
@@ -56,6 +57,10 @@ export default class EventTypes {
     return code === this.THREAD_PARK;
   }
 
+  static isVirtualThreadPinned(code: string) {
+    return code === this.VIRTUAL_THREAD_PINNED;
+  }
+
   static isWallClock(code: string) {
     return code === this.WALL_CLOCK;
   }
@@ -69,11 +74,21 @@ export default class EventTypes {
   }
 
   static isBlockingEventType(code: string) {
-    return this.isJavaMonitorEnter(code) || this.isJavaMonitorWait(code) || this.isThreadPark(code);
+    return (
+      this.isJavaMonitorEnter(code) ||
+      this.isJavaMonitorWait(code) ||
+      this.isThreadPark(code) ||
+      this.isVirtualThreadPinned(code)
+    );
   }
 
   static isDifferential(code: string) {
-    return this.isJavaMonitorEnter(code) || this.isJavaMonitorWait(code) || this.isThreadPark(code);
+    return (
+      this.isJavaMonitorEnter(code) ||
+      this.isJavaMonitorWait(code) ||
+      this.isThreadPark(code) ||
+      this.isVirtualThreadPinned(code)
+    );
   }
 
   static isExecutionEventType(code: string) {

--- a/jeffrey-microscope/pages-microscope/src/services/api/ProfileVirtualThreadsClient.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/ProfileVirtualThreadsClient.ts
@@ -1,0 +1,30 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import BaseProfileClient from '@/services/api/BaseProfileClient';
+import type VirtualThreadData from '@/services/api/model/VirtualThreadModels';
+
+export default class ProfileVirtualThreadsClient extends BaseProfileClient {
+  constructor(profileId: string) {
+    super(profileId, 'virtual-threads');
+  }
+
+  public getData(): Promise<VirtualThreadData> {
+    return this.get<VirtualThreadData>('');
+  }
+}

--- a/jeffrey-microscope/pages-microscope/src/services/api/model/VirtualThreadModels.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/model/VirtualThreadModels.ts
@@ -1,0 +1,56 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type TimeseriesData from '@/services/timeseries/model/TimeseriesData';
+
+export interface VtHeader {
+  pinningCount: number;
+  totalPinnedNanos: number;
+  maxPinnedNanos: number;
+  submitFailedCount: number;
+  startedCount: number;
+  endedCount: number;
+  peakLiveCount: number;
+}
+
+export interface DurationBucket {
+  label: string;
+  count: number;
+}
+
+export interface PinnedThreadStat {
+  threadName: string;
+  count: number;
+  totalNanos: number;
+  maxNanos: number;
+}
+
+export interface SubmitFailure {
+  timeOffsetMillis: number;
+  threadName: string;
+  exceptionMessage: string;
+}
+
+export default interface VirtualThreadData {
+  header: VtHeader;
+  pinningTimeline: TimeseriesData;
+  pinningDistribution: DurationBucket[];
+  topPinnedThreads: PinnedThreadStat[];
+  submitFailures: SubmitFailure[];
+  lifecycle: TimeseriesData;
+}

--- a/jeffrey-microscope/pages-microscope/src/services/api/model/VirtualThreadModels.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/model/VirtualThreadModels.ts
@@ -40,6 +40,13 @@ export interface PinnedThreadStat {
   maxNanos: number;
 }
 
+export interface PinningReasonStat {
+  reason: string;
+  count: number;
+  totalNanos: number;
+  maxNanos: number;
+}
+
 export interface SubmitFailure {
   timeOffsetMillis: number;
   threadName: string;
@@ -51,6 +58,7 @@ export default interface VirtualThreadData {
   pinningTimeline: TimeseriesData;
   pinningDistribution: DurationBucket[];
   topPinnedThreads: PinnedThreadStat[];
+  pinningReasons: PinningReasonStat[];
   submitFailures: SubmitFailure[];
   lifecycle: TimeseriesData;
 }

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/ProfileDetail.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/ProfileDetail.vue
@@ -284,6 +284,14 @@
                       <i class="bi bi-clock-history"></i>
                       <span>Timeline</span>
                     </router-link>
+                    <router-link
+                      :to="`/profiles/${profileId}/virtual-threads`"
+                      class="nav-item"
+                      active-class="active"
+                    >
+                      <i class="bi bi-pin-angle"></i>
+                      <span>Virtual Threads</span>
+                    </router-link>
                   </div>
                 </div>
 

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileVirtualThreads.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileVirtualThreads.vue
@@ -97,6 +97,42 @@
           </div>
         </div>
 
+        <div class="row mt-4">
+          <div class="col-12">
+            <h6 class="section-title">Pinning by Reason</h6>
+            <div class="table-responsive">
+              <table class="table table-sm table-hover mb-0">
+                <thead>
+                  <tr>
+                    <th>Reason</th>
+                    <th class="text-end">Incidents</th>
+                    <th class="text-end">Total Pinned</th>
+                    <th class="text-end">Max Pinned</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="(r, i) in data!.pinningReasons" :key="i">
+                    <td>{{ r.reason }}</td>
+                    <td class="text-end">{{ FormattingService.formatNumber(r.count) }}</td>
+                    <td class="text-end">
+                      {{ FormattingService.formatDuration2Units(r.totalNanos) }}
+                    </td>
+                    <td class="text-end">
+                      {{ FormattingService.formatDuration2Units(r.maxNanos) }}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <EmptyState
+              v-if="data!.pinningReasons.length === 0"
+              icon="bi-check-circle"
+              title="No pinning recorded"
+              description="The pinnedReason field is reported by JDK 26+ recordings."
+            />
+          </div>
+        </div>
+
         <p class="hint mt-3">
           <i class="bi bi-lightbulb"></i>
           To see <em>where</em> the pinning happens, open the weighted

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileVirtualThreads.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileVirtualThreads.vue
@@ -1,0 +1,314 @@
+<template>
+  <LoadingState v-if="loading" message="Loading virtual-thread analysis..." />
+
+  <ErrorState v-else-if="error" message="Failed to load virtual-thread analysis" />
+
+  <div v-else>
+    <PageHeader
+      title="Virtual Threads"
+      description="Project Loom diagnostics: carrier pinning, submit failures, and thread lifecycle"
+      icon="bi-pin-angle"
+    />
+
+    <EmptyState
+      v-if="!hasData"
+      icon="bi-pin-angle"
+      title="No virtual-thread events in this recording"
+      description="This profile contains no virtual-thread pinning, submit-failure, or lifecycle events."
+    />
+
+    <div v-else>
+      <div class="mb-4">
+        <StatsTable :metrics="metrics" />
+      </div>
+
+      <TabBar v-model="activeTab" :tabs="tabs" class="mb-3" />
+
+      <!-- Pinning -->
+      <div v-show="activeTab === 'pinning'">
+        <ChartDescription
+          shows="Pinning occurrences and total pinned time per second"
+          use-case="Pinning ties a virtual thread to its carrier and serializes work — the top Loom scalability footgun"
+        />
+        <TimeSeriesChart
+          :primary-data="pinningCountData"
+          :secondary-data="pinningTimeData"
+          primary-title="Pinning Events"
+          secondary-title="Pinned Time"
+          :primary-axis-type="AxisFormatType.NUMBER"
+          :secondary-axis-type="AxisFormatType.DURATION_IN_NANOS"
+          :independent-secondary-axis="true"
+          :visible-minutes="60"
+          primary-color="#EA4335"
+          secondary-color="#FBBC04"
+        />
+
+        <div class="row mt-4">
+          <div class="col-lg-5">
+            <h6 class="section-title">Pinning Duration Distribution</h6>
+            <div class="table-responsive">
+              <table class="table table-sm table-hover mb-0">
+                <thead>
+                  <tr>
+                    <th>Duration</th>
+                    <th class="text-end">Incidents</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="bucket in data!.pinningDistribution" :key="bucket.label">
+                    <td>{{ bucket.label }}</td>
+                    <td class="text-end">{{ FormattingService.formatNumber(bucket.count) }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+          <div class="col-lg-7">
+            <h6 class="section-title">Top Pinned Virtual Threads</h6>
+            <div class="table-responsive">
+              <table class="table table-sm table-hover mb-0">
+                <thead>
+                  <tr>
+                    <th>Virtual Thread</th>
+                    <th class="text-end">Incidents</th>
+                    <th class="text-end">Total Pinned</th>
+                    <th class="text-end">Max Pinned</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="(t, i) in data!.topPinnedThreads" :key="i">
+                    <td>{{ t.threadName }}</td>
+                    <td class="text-end">{{ FormattingService.formatNumber(t.count) }}</td>
+                    <td class="text-end">
+                      {{ FormattingService.formatDuration2Units(t.totalNanos) }}
+                    </td>
+                    <td class="text-end">
+                      {{ FormattingService.formatDuration2Units(t.maxNanos) }}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <EmptyState
+              v-if="data!.topPinnedThreads.length === 0"
+              icon="bi-check-circle"
+              title="No pinning recorded"
+            />
+          </div>
+        </div>
+
+        <p class="hint mt-3">
+          <i class="bi bi-lightbulb"></i>
+          To see <em>where</em> the pinning happens, open the weighted
+          <strong>jdk.VirtualThreadPinned</strong> flamegraph in the Visualization → Flamegraphs
+          section.
+        </p>
+      </div>
+
+      <!-- Submit Failures -->
+      <div v-show="activeTab === 'submit-failures'">
+        <ChartDescription
+          shows="Virtual threads that failed to be submitted to a carrier"
+          use-case="Submit failures usually indicate carrier-pool rejection, executor shutdown, or a scheduling bug"
+        />
+        <div class="table-responsive">
+          <table class="table table-sm table-hover mb-0">
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th>Virtual Thread</th>
+                <th>Exception</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(f, i) in data!.submitFailures" :key="i">
+                <td>
+                  {{ FormattingService.formatDuration2Units(f.timeOffsetMillis * 1_000_000) }}
+                </td>
+                <td>{{ f.threadName }}</td>
+                <td>{{ f.exceptionMessage }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <EmptyState
+          v-if="data!.submitFailures.length === 0"
+          icon="bi-check-circle"
+          title="No submit failures"
+          description="No jdk.VirtualThreadSubmitFailed events were recorded."
+        />
+      </div>
+
+      <!-- Lifecycle -->
+      <div v-show="activeTab === 'lifecycle'">
+        <ChartDescription
+          shows="Virtual-thread creation, completion, and the derived live count over time"
+          use-case="A live count that climbs without bound signals a virtual-thread leak; spikes signal runaway spawning"
+        />
+        <TimeSeriesChart
+          v-if="hasLifecycle"
+          :primary-data="startedData"
+          :secondary-data="endedData"
+          :tertiary-data="liveData"
+          primary-title="Started"
+          secondary-title="Ended"
+          tertiary-title="Live"
+          :primary-axis-type="AxisFormatType.NUMBER"
+          :secondary-axis-type="AxisFormatType.NUMBER"
+          :tertiary-axis-type="AxisFormatType.NUMBER"
+          :visible-minutes="60"
+          primary-color="#34A853"
+          secondary-color="#9AA0A6"
+          tertiary-color="#4285F4"
+        />
+        <EmptyState
+          v-else
+          icon="bi-activity"
+          title="No lifecycle events"
+          description="Enable jdk.VirtualThreadStart and jdk.VirtualThreadEnd in the recording to see creation/completion and live-count trends (disabled by default and high-volume)."
+        />
+      </div>
+
+      <!-- About -->
+      <div v-show="activeTab === 'about'">
+        <ConfigurationSection title="How Virtual Thread Analysis Works" icon="bi-info-circle">
+          <p class="about-text">
+            Virtual threads (Project Loom) run many lightweight threads on a small pool of carrier
+            threads. The signal that matters most for throughput is <strong>pinning</strong>: when a
+            virtual thread cannot unmount from its carrier (e.g. inside a native frame), it blocks
+            the carrier and defeats the scalability benefit. This page surfaces pinning over time,
+            by duration, and by thread; <strong>submit failures</strong> (a functionality/bug
+            signal); and, when enabled, the virtual-thread <strong>lifecycle</strong> for leak and
+            spawn-rate analysis.
+          </p>
+        </ConfigurationSection>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { useRoute } from 'vue-router';
+
+import PageHeader from '@/components/layout/PageHeader.vue';
+import StatsTable from '@/components/StatsTable.vue';
+import TabBar from '@/components/TabBar.vue';
+import TimeSeriesChart from '@/components/TimeSeriesChart.vue';
+import ChartDescription from '@/components/ChartDescription.vue';
+import ConfigurationSection from '@/components/ConfigurationSection.vue';
+import LoadingState from '@/components/LoadingState.vue';
+import ErrorState from '@/components/ErrorState.vue';
+import EmptyState from '@/components/EmptyState.vue';
+import ProfileVirtualThreadsClient from '@/services/api/ProfileVirtualThreadsClient';
+import FormattingService from '@/services/FormattingService';
+import AxisFormatType from '@/services/timeseries/AxisFormatType';
+import type VirtualThreadData from '@/services/api/model/VirtualThreadModels';
+
+const route = useRoute();
+
+const loading = ref(true);
+const error = ref<string | null>(null);
+const data = ref<VirtualThreadData>();
+
+const tabs = [
+  { id: 'pinning', label: 'Pinning', icon: 'pin-angle' },
+  { id: 'submit-failures', label: 'Submit Failures', icon: 'exclamation-octagon' },
+  { id: 'lifecycle', label: 'Lifecycle', icon: 'activity' },
+  { id: 'about', label: 'About', icon: 'info-circle' }
+];
+const activeTab = ref(tabs[0].id);
+
+const hasData = computed(() => {
+  const h = data.value?.header;
+  if (!h) {
+    return false;
+  }
+  return h.pinningCount > 0 || h.submitFailedCount > 0 || h.startedCount > 0;
+});
+
+const hasLifecycle = computed(() => (data.value?.header.startedCount ?? 0) > 0);
+
+const pinningCountData = computed(() => data.value?.pinningTimeline.series?.[0]?.data ?? []);
+const pinningTimeData = computed(() => data.value?.pinningTimeline.series?.[1]?.data ?? []);
+const startedData = computed(() => data.value?.lifecycle.series?.[0]?.data ?? []);
+const endedData = computed(() => data.value?.lifecycle.series?.[1]?.data ?? []);
+const liveData = computed(() => data.value?.lifecycle.series?.[2]?.data ?? []);
+
+const metrics = computed(() => {
+  const h = data.value?.header;
+  if (!h) {
+    return [];
+  }
+  return [
+    {
+      icon: 'pin-angle',
+      title: 'Pinning Events',
+      value: FormattingService.formatNumber(h.pinningCount),
+      variant: 'danger' as const,
+      breakdown: [
+        { label: 'Total', value: FormattingService.formatDuration2Units(h.totalPinnedNanos) },
+        { label: 'Max', value: FormattingService.formatDuration2Units(h.maxPinnedNanos) }
+      ]
+    },
+    {
+      icon: 'exclamation-octagon',
+      title: 'Submit Failures',
+      value: FormattingService.formatNumber(h.submitFailedCount),
+      variant: h.submitFailedCount > 0 ? ('warning' as const) : ('success' as const)
+    },
+    {
+      icon: 'activity',
+      title: 'Peak Live',
+      value: FormattingService.formatNumber(h.peakLiveCount),
+      variant: 'highlight' as const,
+      breakdown: [
+        { label: 'Started', value: FormattingService.formatNumber(h.startedCount) },
+        { label: 'Ended', value: FormattingService.formatNumber(h.endedCount) }
+      ]
+    }
+  ];
+});
+
+const loadData = async () => {
+  try {
+    loading.value = true;
+    error.value = null;
+    const client = new ProfileVirtualThreadsClient(route.params.profileId as string);
+    data.value = await client.getData();
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Unknown error occurred';
+    console.error('Error loading virtual-thread analysis:', err);
+  } finally {
+    loading.value = false;
+  }
+};
+
+onMounted(loadData);
+</script>
+
+<style scoped>
+.section-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: var(--color-text-muted);
+  margin-bottom: 0.5rem;
+}
+
+.about-text {
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: var(--color-dark);
+  margin: 0;
+}
+
+.hint {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+</style>

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/configuration/ProfileFactoriesConfiguration.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/configuration/ProfileFactoriesConfiguration.java
@@ -140,6 +140,7 @@ public class ProfileFactoriesConfiguration {
             SystemResourcesManager.Factory systemResourcesFactory,
             VmOperationManager.Factory vmOperationFactory,
             BlockingManager.Factory blockingFactory,
+            VirtualThreadManager.Factory virtualThreadFactory,
             IoManager.Factory ioFactory,
             AllocationManager.Factory allocationFactory,
             LeakCandidatesManager.Factory leakCandidatesFactory,
@@ -160,6 +161,7 @@ public class ProfileFactoriesConfiguration {
                 systemResourcesFactory,
                 vmOperationFactory,
                 blockingFactory,
+                virtualThreadFactory,
                 ioFactory,
                 allocationFactory,
                 leakCandidatesFactory,
@@ -592,6 +594,17 @@ public class ProfileFactoriesConfiguration {
             return new BlockingManagerImpl(
                     profileInfo,
                     profileRepositories.newEventRepository(profileDb),
+                    profileRepositories.newEventStreamRepository(profileDb));
+        };
+    }
+
+    @Bean
+    public VirtualThreadManager.Factory virtualThreadManagerFactory() {
+
+        return profileInfo -> {
+            DataSource profileDb = databaseManagerResolver.open(profileInfo);
+            return new VirtualThreadManagerImpl(
+                    profileInfo,
                     profileRepositories.newEventStreamRepository(profileDb));
         };
     }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/DiffFlamegraphManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/DiffFlamegraphManagerImpl.java
@@ -39,7 +39,8 @@ public class DiffFlamegraphManagerImpl implements FlamegraphManager {
             Type.METHOD_TRACE,
             Type.OBJECT_ALLOCATION_SAMPLE,
             Type.OBJECT_ALLOCATION_IN_NEW_TLAB,
-            Type.OBJECT_ALLOCATION_OUTSIDE_TLAB);
+            Type.OBJECT_ALLOCATION_OUTSIDE_TLAB,
+            Type.VIRTUAL_THREAD_PINNED);
 
     private final ProfileEventTypeRepository primaryEventTypeRepository;
     private final ProfileEventTypeRepository secondaryEventTypeRepository;

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/PrimaryFlamegraphManager.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/PrimaryFlamegraphManager.java
@@ -47,7 +47,8 @@ public class PrimaryFlamegraphManager implements FlamegraphManager {
             Type.THREAD_PARK,
             Type.THREAD_SLEEP,
             Type.JAVA_MONITOR_ENTER,
-            Type.JAVA_MONITOR_WAIT);
+            Type.JAVA_MONITOR_WAIT,
+            Type.VIRTUAL_THREAD_PINNED);
 
     private final ProfileEventTypeRepository eventTypeRepository;
     private final DbBasedFlamegraphGenerator generator;

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/ProfileManager.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/ProfileManager.java
@@ -77,6 +77,8 @@ public interface ProfileManager {
 
     BlockingManager blockingManager();
 
+    VirtualThreadManager virtualThreadManager();
+
     IoManager ioManager();
 
     AllocationManager allocationManager();

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/ProfileManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/ProfileManagerImpl.java
@@ -167,6 +167,11 @@ public class ProfileManagerImpl implements ProfileManager {
     }
 
     @Override
+    public VirtualThreadManager virtualThreadManager() {
+        return registry.jvmInsight().virtualThread().apply(profileInfo);
+    }
+
+    @Override
     public IoManager ioManager() {
         return registry.jvmInsight().io().apply(profileInfo);
     }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/VirtualThreadManager.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/VirtualThreadManager.java
@@ -1,0 +1,43 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager;
+
+import cafe.jeffrey.profile.manager.model.virtualthread.VirtualThreadData;
+import cafe.jeffrey.shared.common.model.ProfileInfo;
+
+import java.util.function.Function;
+
+/**
+ * Virtual-thread (Project Loom) insight for a single profile: pinning
+ * ({@code jdk.VirtualThreadPinned}), carrier-submit failures ({@code jdk.VirtualThreadSubmitFailed}),
+ * and thread lifecycle ({@code jdk.VirtualThreadStart}/{@code jdk.VirtualThreadEnd}). The lifecycle
+ * events are disabled by default, so consumers must handle an empty lifecycle.
+ */
+public interface VirtualThreadManager {
+
+    @FunctionalInterface
+    interface Factory extends Function<ProfileInfo, VirtualThreadManager> {
+    }
+
+    /**
+     * Composite virtual-thread dashboard data: pinning timeline/distribution/top-threads,
+     * submit failures, and the lifecycle timeline.
+     */
+    VirtualThreadData virtualThreadData();
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/VirtualThreadManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/VirtualThreadManagerImpl.java
@@ -80,6 +80,7 @@ public class VirtualThreadManagerImpl implements VirtualThreadManager {
                 pinning.timeline(),
                 pinning.distribution(),
                 pinning.topThreads(),
+                pinning.reasons(),
                 submitFailures,
                 lifecycle.timeline());
     }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/VirtualThreadManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/VirtualThreadManagerImpl.java
@@ -1,0 +1,86 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager;
+
+import cafe.jeffrey.profile.manager.model.virtualthread.VirtualThreadData;
+import cafe.jeffrey.profile.manager.model.virtualthread.VirtualThreadData.SubmitFailure;
+import cafe.jeffrey.profile.manager.model.virtualthread.VirtualThreadData.VtHeader;
+import cafe.jeffrey.profile.manager.model.virtualthread.VtLifecycleBuilder;
+import cafe.jeffrey.profile.manager.model.virtualthread.VtPinningBuilder;
+import cafe.jeffrey.profile.manager.model.virtualthread.VtSubmitFailedBuilder;
+import cafe.jeffrey.provider.profile.api.EventQueryConfigurer;
+import cafe.jeffrey.provider.profile.api.ProfileEventStreamRepository;
+import cafe.jeffrey.shared.common.model.ProfileInfo;
+import cafe.jeffrey.shared.common.model.Type;
+import cafe.jeffrey.shared.common.model.time.RelativeTimeRange;
+
+import java.util.List;
+
+public class VirtualThreadManagerImpl implements VirtualThreadManager {
+
+    private static final int MAX_TOP_THREADS = 100;
+    private static final int MAX_SUBMIT_FAILURES = 200;
+
+    private final ProfileInfo profileInfo;
+    private final ProfileEventStreamRepository eventStreamRepository;
+
+    public VirtualThreadManagerImpl(
+            ProfileInfo profileInfo,
+            ProfileEventStreamRepository eventStreamRepository) {
+        this.profileInfo = profileInfo;
+        this.eventStreamRepository = eventStreamRepository;
+    }
+
+    @Override
+    public VirtualThreadData virtualThreadData() {
+        RelativeTimeRange timeRange = new RelativeTimeRange(profileInfo.profilingStartEnd());
+
+        VtPinningBuilder.Result pinning = eventStreamRepository.genericStreaming(
+                new EventQueryConfigurer().withEventType(Type.VIRTUAL_THREAD_PINNED).withJsonFields(),
+                new VtPinningBuilder(timeRange, MAX_TOP_THREADS));
+
+        List<SubmitFailure> submitFailures = eventStreamRepository.genericStreaming(
+                new EventQueryConfigurer().withEventType(Type.VIRTUAL_THREAD_SUBMIT_FAILED).withJsonFields(),
+                new VtSubmitFailedBuilder(MAX_SUBMIT_FAILURES));
+
+        VtLifecycleBuilder.Result lifecycle = eventStreamRepository.genericStreaming(
+                new EventQueryConfigurer()
+                        .withEventTypes(List.of(Type.VIRTUAL_THREAD_START, Type.VIRTUAL_THREAD_END))
+                        .withJsonFields()
+                        .orderedByTime(),
+                new VtLifecycleBuilder(timeRange));
+
+        VtHeader header = new VtHeader(
+                pinning.count(),
+                pinning.totalNanos(),
+                pinning.maxNanos(),
+                submitFailures.size(),
+                lifecycle.started(),
+                lifecycle.ended(),
+                lifecycle.peakLive());
+
+        return new VirtualThreadData(
+                header,
+                pinning.timeline(),
+                pinning.distribution(),
+                pinning.topThreads(),
+                submitFailures,
+                lifecycle.timeline());
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/virtualthread/VirtualThreadData.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/virtualthread/VirtualThreadData.java
@@ -29,6 +29,7 @@ import java.util.List;
  * @param pinningTimeline     pinning occurrences and total pinned time per second ({@code jdk.VirtualThreadPinned})
  * @param pinningDistribution pinning incidents bucketed by duration
  * @param topPinnedThreads    virtual threads ranked by total pinned time
+ * @param pinningReasons      pinning incidents grouped by reported reason ({@code pinnedReason}, JDK 26+)
  * @param submitFailures      carrier-submit failures ({@code jdk.VirtualThreadSubmitFailed})
  * @param lifecycle           per-second started / ended / live counts
  *                            ({@code jdk.VirtualThreadStart}/{@code jdk.VirtualThreadEnd}); empty unless enabled
@@ -38,6 +39,7 @@ public record VirtualThreadData(
         TimeseriesData pinningTimeline,
         List<DurationBucket> pinningDistribution,
         List<PinnedThreadStat> topPinnedThreads,
+        List<PinningReasonStat> pinningReasons,
         List<SubmitFailure> submitFailures,
         TimeseriesData lifecycle) {
 
@@ -55,6 +57,9 @@ public record VirtualThreadData(
     }
 
     public record PinnedThreadStat(String threadName, long count, long totalNanos, long maxNanos) {
+    }
+
+    public record PinningReasonStat(String reason, long count, long totalNanos, long maxNanos) {
     }
 
     public record SubmitFailure(long timeOffsetMillis, String threadName, String exceptionMessage) {

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/virtualthread/VirtualThreadData.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/virtualthread/VirtualThreadData.java
@@ -1,0 +1,62 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.virtualthread;
+
+import cafe.jeffrey.timeseries.TimeseriesData;
+
+import java.util.List;
+
+/**
+ * Virtual-thread insight for a single profile, built from the Loom JFR events.
+ *
+ * @param header             headline counters (pinning, submit failures, lifecycle)
+ * @param pinningTimeline     pinning occurrences and total pinned time per second ({@code jdk.VirtualThreadPinned})
+ * @param pinningDistribution pinning incidents bucketed by duration
+ * @param topPinnedThreads    virtual threads ranked by total pinned time
+ * @param submitFailures      carrier-submit failures ({@code jdk.VirtualThreadSubmitFailed})
+ * @param lifecycle           per-second started / ended / live counts
+ *                            ({@code jdk.VirtualThreadStart}/{@code jdk.VirtualThreadEnd}); empty unless enabled
+ */
+public record VirtualThreadData(
+        VtHeader header,
+        TimeseriesData pinningTimeline,
+        List<DurationBucket> pinningDistribution,
+        List<PinnedThreadStat> topPinnedThreads,
+        List<SubmitFailure> submitFailures,
+        TimeseriesData lifecycle) {
+
+    public record VtHeader(
+            long pinningCount,
+            long totalPinnedNanos,
+            long maxPinnedNanos,
+            long submitFailedCount,
+            long startedCount,
+            long endedCount,
+            long peakLiveCount) {
+    }
+
+    public record DurationBucket(String label, long count) {
+    }
+
+    public record PinnedThreadStat(String threadName, long count, long totalNanos, long maxNanos) {
+    }
+
+    public record SubmitFailure(long timeOffsetMillis, String threadName, String exceptionMessage) {
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/virtualthread/VtLifecycleBuilder.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/virtualthread/VtLifecycleBuilder.java
@@ -1,0 +1,91 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.virtualthread;
+
+import org.eclipse.collections.impl.map.mutable.primitive.LongLongHashMap;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.provider.profile.api.RecordBuilder;
+import cafe.jeffrey.shared.common.model.EventTypeName;
+import cafe.jeffrey.shared.common.model.time.RelativeTimeRange;
+import cafe.jeffrey.timeseries.SingleSerie;
+import cafe.jeffrey.timeseries.TimeseriesData;
+import cafe.jeffrey.timeseries.TimeseriesUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Builds the virtual-thread lifecycle timeline from {@code jdk.VirtualThreadStart} and
+ * {@code jdk.VirtualThreadEnd}: per-second creation and completion counts, plus a derived
+ * running <em>live</em> count (cumulative starts minus ends) that exposes virtual-thread leaks
+ * and runaway spawning. These events are disabled by default, so the result is empty unless the
+ * recording explicitly enabled them.
+ */
+public class VtLifecycleBuilder implements RecordBuilder<GenericRecord, VtLifecycleBuilder.Result> {
+
+    public record Result(TimeseriesData timeline, long started, long ended, long peakLive) {
+    }
+
+    private static final String STARTED_SERIES = "Started";
+    private static final String ENDED_SERIES = "Ended";
+    private static final String LIVE_SERIES = "Live";
+
+    private final LongLongHashMap startsSeries;
+    private final LongLongHashMap endsSeries;
+    private long started;
+    private long ended;
+
+    public VtLifecycleBuilder(RelativeTimeRange timeRange) {
+        this.startsSeries = TimeseriesUtils.initWithZeros(timeRange);
+        this.endsSeries = TimeseriesUtils.initWithZeros(timeRange);
+    }
+
+    @Override
+    public void onRecord(GenericRecord record) {
+        long seconds = record.timestampFromStart().toSeconds();
+        if (EventTypeName.VIRTUAL_THREAD_START.equals(record.type().code())) {
+            startsSeries.addToValue(seconds, 1);
+            started++;
+        } else if (EventTypeName.VIRTUAL_THREAD_END.equals(record.type().code())) {
+            endsSeries.addToValue(seconds, 1);
+            ended++;
+        }
+    }
+
+    @Override
+    public Result build() {
+        SingleSerie startsSerie = TimeseriesUtils.buildSerie(STARTED_SERIES, startsSeries);
+        SingleSerie endsSerie = TimeseriesUtils.buildSerie(ENDED_SERIES, endsSeries);
+
+        // The two series share the same sorted second keys; prefix-sum (starts - ends) gives the live count.
+        List<List<Long>> startsData = startsSerie.data();
+        List<List<Long>> endsData = endsSerie.data();
+        List<List<Long>> liveData = new ArrayList<>(startsData.size());
+        long running = 0;
+        long peakLive = 0;
+        for (int i = 0; i < startsData.size(); i++) {
+            running += startsData.get(i).get(1) - endsData.get(i).get(1);
+            peakLive = Math.max(peakLive, running);
+            liveData.add(List.of(startsData.get(i).get(0), Math.max(0, running)));
+        }
+
+        TimeseriesData timeline = new TimeseriesData(startsSerie, endsSerie, new SingleSerie(LIVE_SERIES, liveData));
+        return new Result(timeline, started, ended, peakLive);
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/virtualthread/VtPinningBuilder.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/virtualthread/VtPinningBuilder.java
@@ -1,0 +1,142 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.virtualthread;
+
+import org.eclipse.collections.impl.map.mutable.primitive.LongLongHashMap;
+import cafe.jeffrey.profile.manager.model.virtualthread.VirtualThreadData.DurationBucket;
+import cafe.jeffrey.profile.manager.model.virtualthread.VirtualThreadData.PinnedThreadStat;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.provider.profile.api.RecordBuilder;
+import cafe.jeffrey.shared.common.Json;
+import cafe.jeffrey.shared.common.model.time.RelativeTimeRange;
+import cafe.jeffrey.timeseries.SingleSerie;
+import cafe.jeffrey.timeseries.TimeseriesData;
+import cafe.jeffrey.timeseries.TimeseriesUtils;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Aggregates {@code jdk.VirtualThreadPinned} events into per-second timelines, a duration
+ * distribution, and per-thread totals.
+ */
+public class VtPinningBuilder implements RecordBuilder<GenericRecord, VtPinningBuilder.Result> {
+
+    public record Result(
+            long count,
+            long totalNanos,
+            long maxNanos,
+            TimeseriesData timeline,
+            List<DurationBucket> distribution,
+            List<PinnedThreadStat> topThreads) {
+    }
+
+    private static final String EVENT_THREAD_FIELD = "eventThread";
+    private static final String UNKNOWN_THREAD = "unknown";
+    private static final String COUNT_SERIES = "Pinning Events";
+    private static final String TIME_SERIES = "Pinned Time";
+
+    // Bucket upper bounds (exclusive) in nanos, paired with labels; the final bucket catches the rest.
+    private static final long[] BUCKET_BOUNDS_NANOS = {
+            50_000_000L, 100_000_000L, 500_000_000L, 1_000_000_000L};
+    private static final String[] BUCKET_LABELS = {
+            "< 50 ms", "50–100 ms", "100–500 ms", "500 ms–1 s", "≥ 1 s"};
+
+    private static final class ThreadAcc {
+        private long count;
+        private long total;
+        private long max;
+
+        private void add(long nanos) {
+            count++;
+            total += nanos;
+            max = Math.max(max, nanos);
+        }
+    }
+
+    private final int maxThreads;
+    private final LongLongHashMap countSeries;
+    private final LongLongHashMap timeSeries;
+    private final long[] bucketCounts = new long[BUCKET_LABELS.length];
+    private final Map<String, ThreadAcc> byThread = new HashMap<>();
+    private long count;
+    private long totalNanos;
+    private long maxNanos;
+
+    public VtPinningBuilder(RelativeTimeRange timeRange, int maxThreads) {
+        if (maxThreads <= 0) {
+            throw new IllegalArgumentException("maxThreads must be positive: " + maxThreads);
+        }
+        this.maxThreads = maxThreads;
+        this.countSeries = TimeseriesUtils.initWithZeros(timeRange);
+        this.timeSeries = TimeseriesUtils.initWithZeros(timeRange);
+    }
+
+    @Override
+    public void onRecord(GenericRecord record) {
+        Duration duration = record.duration();
+        long nanos = duration == null ? 0 : Math.max(0, duration.toNanos());
+        long seconds = record.timestampFromStart().toSeconds();
+
+        countSeries.addToValue(seconds, 1);
+        timeSeries.addToValue(seconds, nanos);
+
+        count++;
+        totalNanos += nanos;
+        maxNanos = Math.max(maxNanos, nanos);
+        bucketCounts[bucketIndex(nanos)]++;
+
+        String thread = Json.readString(record.jsonFields(), EVENT_THREAD_FIELD);
+        byThread.computeIfAbsent(thread == null ? UNKNOWN_THREAD : thread, key -> new ThreadAcc()).add(nanos);
+    }
+
+    private static int bucketIndex(long nanos) {
+        for (int i = 0; i < BUCKET_BOUNDS_NANOS.length; i++) {
+            if (nanos < BUCKET_BOUNDS_NANOS[i]) {
+                return i;
+            }
+        }
+        return BUCKET_LABELS.length - 1;
+    }
+
+    @Override
+    public Result build() {
+        SingleSerie countSerie = TimeseriesUtils.buildSerie(COUNT_SERIES, countSeries);
+        SingleSerie timeSerie = TimeseriesUtils.buildSerie(TIME_SERIES, timeSeries);
+
+        List<DurationBucket> distribution = new ArrayList<>(BUCKET_LABELS.length);
+        for (int i = 0; i < BUCKET_LABELS.length; i++) {
+            distribution.add(new DurationBucket(BUCKET_LABELS[i], bucketCounts[i]));
+        }
+
+        List<PinnedThreadStat> topThreads = byThread.entrySet().stream()
+                .map(entry -> new PinnedThreadStat(
+                        entry.getKey(), entry.getValue().count, entry.getValue().total, entry.getValue().max))
+                .sorted(Comparator.comparingLong(PinnedThreadStat::totalNanos).reversed())
+                .limit(maxThreads)
+                .toList();
+
+        return new Result(count, totalNanos, maxNanos, new TimeseriesData(countSerie, timeSerie),
+                distribution, topThreads);
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/virtualthread/VtPinningBuilder.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/virtualthread/VtPinningBuilder.java
@@ -21,6 +21,7 @@ package cafe.jeffrey.profile.manager.model.virtualthread;
 import org.eclipse.collections.impl.map.mutable.primitive.LongLongHashMap;
 import cafe.jeffrey.profile.manager.model.virtualthread.VirtualThreadData.DurationBucket;
 import cafe.jeffrey.profile.manager.model.virtualthread.VirtualThreadData.PinnedThreadStat;
+import cafe.jeffrey.profile.manager.model.virtualthread.VirtualThreadData.PinningReasonStat;
 import cafe.jeffrey.provider.profile.api.GenericRecord;
 import cafe.jeffrey.provider.profile.api.RecordBuilder;
 import cafe.jeffrey.shared.common.Json;
@@ -48,11 +49,14 @@ public class VtPinningBuilder implements RecordBuilder<GenericRecord, VtPinningB
             long maxNanos,
             TimeseriesData timeline,
             List<DurationBucket> distribution,
-            List<PinnedThreadStat> topThreads) {
+            List<PinnedThreadStat> topThreads,
+            List<PinningReasonStat> reasons) {
     }
 
     private static final String EVENT_THREAD_FIELD = "eventThread";
+    private static final String PINNED_REASON_FIELD = "pinnedReason";
     private static final String UNKNOWN_THREAD = "unknown";
+    private static final String UNKNOWN_REASON = "unknown";
     private static final String COUNT_SERIES = "Pinning Events";
     private static final String TIME_SERIES = "Pinned Time";
 
@@ -79,6 +83,7 @@ public class VtPinningBuilder implements RecordBuilder<GenericRecord, VtPinningB
     private final LongLongHashMap timeSeries;
     private final long[] bucketCounts = new long[BUCKET_LABELS.length];
     private final Map<String, ThreadAcc> byThread = new HashMap<>();
+    private final Map<String, ThreadAcc> byReason = new HashMap<>();
     private long count;
     private long totalNanos;
     private long maxNanos;
@@ -108,6 +113,10 @@ public class VtPinningBuilder implements RecordBuilder<GenericRecord, VtPinningB
 
         String thread = Json.readString(record.jsonFields(), EVENT_THREAD_FIELD);
         byThread.computeIfAbsent(thread == null ? UNKNOWN_THREAD : thread, key -> new ThreadAcc()).add(nanos);
+
+        String reason = Json.readString(record.jsonFields(), PINNED_REASON_FIELD);
+        byReason.computeIfAbsent(reason == null || reason.isBlank() ? UNKNOWN_REASON : reason,
+                key -> new ThreadAcc()).add(nanos);
     }
 
     private static int bucketIndex(long nanos) {
@@ -136,7 +145,13 @@ public class VtPinningBuilder implements RecordBuilder<GenericRecord, VtPinningB
                 .limit(maxThreads)
                 .toList();
 
+        List<PinningReasonStat> reasons = byReason.entrySet().stream()
+                .map(entry -> new PinningReasonStat(
+                        entry.getKey(), entry.getValue().count, entry.getValue().total, entry.getValue().max))
+                .sorted(Comparator.comparingLong(PinningReasonStat::totalNanos).reversed())
+                .toList();
+
         return new Result(count, totalNanos, maxNanos, new TimeseriesData(countSerie, timeSerie),
-                distribution, topThreads);
+                distribution, topThreads, reasons);
     }
 }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/virtualthread/VtSubmitFailedBuilder.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/virtualthread/VtSubmitFailedBuilder.java
@@ -1,0 +1,64 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.virtualthread;
+
+import cafe.jeffrey.profile.manager.model.virtualthread.VirtualThreadData.SubmitFailure;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.provider.profile.api.RecordBuilder;
+import cafe.jeffrey.shared.common.Json;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Collects {@code jdk.VirtualThreadSubmitFailed} events — a virtual thread that could not be
+ * submitted to its carrier pool (carrier-pool rejection, executor shutdown, …). Most recent first.
+ */
+public class VtSubmitFailedBuilder implements RecordBuilder<GenericRecord, List<SubmitFailure>> {
+
+    private static final String EVENT_THREAD_FIELD = "eventThread";
+    private static final String EXCEPTION_MESSAGE_FIELD = "exceptionMessage";
+
+    private final int maxEntries;
+    private final List<SubmitFailure> failures = new ArrayList<>();
+
+    public VtSubmitFailedBuilder(int maxEntries) {
+        if (maxEntries <= 0) {
+            throw new IllegalArgumentException("maxEntries must be positive: " + maxEntries);
+        }
+        this.maxEntries = maxEntries;
+    }
+
+    @Override
+    public void onRecord(GenericRecord record) {
+        failures.add(new SubmitFailure(
+                record.timestampFromStart().toMillis(),
+                Json.readString(record.jsonFields(), EVENT_THREAD_FIELD),
+                Json.readString(record.jsonFields(), EXCEPTION_MESSAGE_FIELD)));
+    }
+
+    @Override
+    public List<SubmitFailure> build() {
+        return failures.stream()
+                .sorted(Comparator.comparingLong(SubmitFailure::timeOffsetMillis).reversed())
+                .limit(maxEntries)
+                .toList();
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/registry/JvmInsightFactories.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/registry/JvmInsightFactories.java
@@ -35,6 +35,7 @@ import cafe.jeffrey.profile.manager.JITCompilationManager;
 import cafe.jeffrey.profile.manager.JITDeoptimizationManager;
 import cafe.jeffrey.profile.manager.SpanManager;
 import cafe.jeffrey.profile.manager.ThreadManager;
+import cafe.jeffrey.profile.manager.VirtualThreadManager;
 import cafe.jeffrey.profile.manager.VmOperationManager;
 
 public record JvmInsightFactories(
@@ -52,6 +53,7 @@ public record JvmInsightFactories(
         SystemResourcesManager.Factory systemResources,
         VmOperationManager.Factory vmOperation,
         BlockingManager.Factory blocking,
+        VirtualThreadManager.Factory virtualThread,
         IoManager.Factory io,
         AllocationManager.Factory allocation,
         LeakCandidatesManager.Factory leakCandidates,

--- a/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/virtualthread/VirtualThreadBuildersTest.java
+++ b/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/virtualthread/VirtualThreadBuildersTest.java
@@ -1,0 +1,140 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.virtualthread;
+
+import tools.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import cafe.jeffrey.profile.manager.model.virtualthread.VirtualThreadData.DurationBucket;
+import cafe.jeffrey.profile.manager.model.virtualthread.VirtualThreadData.PinnedThreadStat;
+import cafe.jeffrey.profile.manager.model.virtualthread.VirtualThreadData.SubmitFailure;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.shared.common.Json;
+import cafe.jeffrey.shared.common.model.Type;
+import cafe.jeffrey.shared.common.model.time.RelativeTimeRange;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DisplayName("Virtual-thread builders")
+class VirtualThreadBuildersTest {
+
+    private static final Instant START = Instant.parse("2024-01-01T00:00:00Z");
+    private static final long MS = 1_000_000L;
+
+    private static GenericRecord rec(Type type, long secondsFromStart, long durationNanos, ObjectNode fields) {
+        return new GenericRecord(
+                type, "label", START,
+                Duration.ofSeconds(secondsFromStart), Duration.ofNanos(durationNanos),
+                null, null, 0L, 0L, fields);
+    }
+
+    private static ObjectNode pinned(String thread) {
+        ObjectNode node = Json.createObject();
+        node.put("eventThread", thread);
+        return node;
+    }
+
+    @Nested
+    @DisplayName("VtPinningBuilder")
+    class Pinning {
+
+        @Test
+        @DisplayName("Aggregates pinning totals, duration buckets and top threads")
+        void aggregates() {
+            VtPinningBuilder builder = new VtPinningBuilder(new RelativeTimeRange(0, 10_000), 10);
+            builder.onRecord(rec(Type.VIRTUAL_THREAD_PINNED, 1, 30 * MS, pinned("vt-1")));
+            builder.onRecord(rec(Type.VIRTUAL_THREAD_PINNED, 1, 60 * MS, pinned("vt-1")));
+            builder.onRecord(rec(Type.VIRTUAL_THREAD_PINNED, 2, 200 * MS, pinned("vt-2")));
+
+            VtPinningBuilder.Result result = builder.build();
+
+            assertEquals(3, result.count());
+            assertEquals(290 * MS, result.totalNanos());
+            assertEquals(200 * MS, result.maxNanos());
+
+            assertEquals(1, bucket(result.distribution(), "< 50 ms"));
+            assertEquals(1, bucket(result.distribution(), "50–100 ms"));
+            assertEquals(1, bucket(result.distribution(), "100–500 ms"));
+
+            List<PinnedThreadStat> top = result.topThreads();
+            assertEquals("vt-2", top.getFirst().threadName());
+            assertEquals(200 * MS, top.getFirst().totalNanos());
+            assertEquals("vt-1", top.get(1).threadName());
+            assertEquals(2, top.get(1).count());
+            assertEquals("Pinning Events", result.timeline().series().getFirst().name());
+        }
+
+        private long bucket(List<DurationBucket> distribution, String label) {
+            return distribution.stream()
+                    .filter(b -> b.label().equals(label))
+                    .mapToLong(DurationBucket::count)
+                    .findFirst()
+                    .orElseThrow();
+        }
+    }
+
+    @Nested
+    @DisplayName("VtLifecycleBuilder")
+    class Lifecycle {
+
+        @Test
+        @DisplayName("Counts starts/ends and derives the peak live count")
+        void countsAndPeak() {
+            VtLifecycleBuilder builder = new VtLifecycleBuilder(new RelativeTimeRange(0, 10_000));
+            builder.onRecord(rec(Type.VIRTUAL_THREAD_START, 1, 0, Json.createObject()));
+            builder.onRecord(rec(Type.VIRTUAL_THREAD_START, 1, 0, Json.createObject()));
+            builder.onRecord(rec(Type.VIRTUAL_THREAD_END, 2, 0, Json.createObject()));
+            builder.onRecord(rec(Type.VIRTUAL_THREAD_START, 3, 0, Json.createObject()));
+
+            VtLifecycleBuilder.Result result = builder.build();
+
+            assertEquals(3, result.started());
+            assertEquals(1, result.ended());
+            assertEquals(2, result.peakLive());
+            assertEquals(3, result.timeline().series().size());
+            assertEquals("Live", result.timeline().series().get(2).name());
+        }
+    }
+
+    @Nested
+    @DisplayName("VtSubmitFailedBuilder")
+    class SubmitFailed {
+
+        @Test
+        @DisplayName("Collects submit failures with exception messages")
+        void collects() {
+            VtSubmitFailedBuilder builder = new VtSubmitFailedBuilder(10);
+            ObjectNode fields = Json.createObject();
+            fields.put("eventThread", "vt-x");
+            fields.put("exceptionMessage", "rejected");
+            builder.onRecord(rec(Type.VIRTUAL_THREAD_SUBMIT_FAILED, 1, 0, fields));
+
+            List<SubmitFailure> result = builder.build();
+
+            assertEquals(1, result.size());
+            assertEquals("vt-x", result.getFirst().threadName());
+            assertEquals("rejected", result.getFirst().exceptionMessage());
+        }
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/virtualthread/VirtualThreadBuildersTest.java
+++ b/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/virtualthread/VirtualThreadBuildersTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import cafe.jeffrey.profile.manager.model.virtualthread.VirtualThreadData.DurationBucket;
 import cafe.jeffrey.profile.manager.model.virtualthread.VirtualThreadData.PinnedThreadStat;
+import cafe.jeffrey.profile.manager.model.virtualthread.VirtualThreadData.PinningReasonStat;
 import cafe.jeffrey.profile.manager.model.virtualthread.VirtualThreadData.SubmitFailure;
 import cafe.jeffrey.provider.profile.api.GenericRecord;
 import cafe.jeffrey.shared.common.Json;
@@ -55,6 +56,12 @@ class VirtualThreadBuildersTest {
         return node;
     }
 
+    private static ObjectNode pinned(String thread, String reason) {
+        ObjectNode node = pinned(thread);
+        node.put("pinnedReason", reason);
+        return node;
+    }
+
     @Nested
     @DisplayName("VtPinningBuilder")
     class Pinning {
@@ -83,6 +90,30 @@ class VirtualThreadBuildersTest {
             assertEquals("vt-1", top.get(1).threadName());
             assertEquals(2, top.get(1).count());
             assertEquals("Pinning Events", result.timeline().series().getFirst().name());
+        }
+
+        @Test
+        @DisplayName("Groups pinning incidents by reported reason")
+        void groupsByReason() {
+            VtPinningBuilder builder = new VtPinningBuilder(new RelativeTimeRange(0, 10_000), 10);
+            builder.onRecord(rec(Type.VIRTUAL_THREAD_PINNED, 1, 30 * MS, pinned("vt-1", "Monitor")));
+            builder.onRecord(rec(Type.VIRTUAL_THREAD_PINNED, 1, 60 * MS, pinned("vt-2", "Monitor")));
+            builder.onRecord(rec(Type.VIRTUAL_THREAD_PINNED, 2, 200 * MS, pinned("vt-3", "Native frame")));
+            builder.onRecord(rec(Type.VIRTUAL_THREAD_PINNED, 3, 10 * MS, pinned("vt-4")));
+
+            List<PinningReasonStat> reasons = builder.build().reasons();
+
+            assertEquals(3, reasons.size());
+            assertEquals("Native frame", reasons.getFirst().reason());
+            assertEquals(200 * MS, reasons.getFirst().totalNanos());
+            PinningReasonStat monitor = reasons.stream()
+                    .filter(r -> r.reason().equals("Monitor"))
+                    .findFirst()
+                    .orElseThrow();
+            assertEquals(2, monitor.count());
+            assertEquals(90 * MS, monitor.totalNanos());
+            assertEquals(60 * MS, monitor.maxNanos());
+            assertEquals(1, reasons.stream().filter(r -> r.reason().equals("unknown")).count());
         }
 
         private long bucket(List<DurationBucket> distribution, String label) {

--- a/jeffrey-pages/src/router/index.ts
+++ b/jeffrey-pages/src/router/index.ts
@@ -258,6 +258,11 @@ const routes: RouteRecordRaw[] = [
         component: () => import('@/views/docs/microscope/profiles/ProfileBlockingOperationsPage.vue')
       },
       {
+        path: 'microscope/profiles/virtual-threads',
+        name: 'DocsProfilesVirtualThreads',
+        component: () => import('@/views/docs/microscope/profiles/ProfileVirtualThreadsPage.vue')
+      },
+      {
         path: 'microscope/profiles/socket-io',
         name: 'DocsProfilesSocketIo',
         component: () => import('@/views/docs/microscope/profiles/ProfileSocketIoPage.vue')

--- a/jeffrey-pages/src/views/docs/microscope/profiles/ProfileVirtualThreadsPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/profiles/ProfileVirtualThreadsPage.vue
@@ -1,0 +1,80 @@
+<!--
+  - Jeffrey
+  - Copyright (C) 2026 Petr Bouda
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as published by
+  - the Free Software Foundation, either version 3 of the License, or
+  - (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import DocsCallout from '@/components/docs/DocsCallout.vue';
+import DocsNavFooter from '@/components/docs/DocsNavFooter.vue';
+import DocsPageHeader from '@/components/docs/DocsPageHeader.vue';
+import { useDocHeadings } from '@/composables/useDocHeadings';
+
+const { setHeadings } = useDocHeadings();
+
+const headings = [
+  { id: 'overview', text: 'Overview', level: 2 },
+  { id: 'pinning', text: 'Pinning', level: 2 },
+  { id: 'submit-failures', text: 'Submit Failures', level: 2 },
+  { id: 'lifecycle', text: 'Lifecycle', level: 2 }
+];
+
+onMounted(() => {
+  setHeadings(headings);
+});
+</script>
+
+<template>
+  <article class="docs-article">
+    <DocsPageHeader title="Virtual Threads" icon="bi bi-pin-angle" />
+
+    <div class="docs-content">
+      <p>The Virtual Threads page is a Project Loom dashboard built from the virtual-thread JFR events. It turns carrier pinning, submit failures, and (optionally) thread lifecycle into actionable performance and functionality signals. It shows an empty state when the recording contains no virtual-thread events.</p>
+
+      <h2 id="overview">Overview</h2>
+      <p>A header strip surfaces the headline numbers — pinning events with total and max pinned time, submit-failure count, and the peak live virtual-thread count (with started/ended totals when lifecycle events are present).</p>
+
+      <DocsCallout type="tip">
+        <strong>Where to start:</strong> open <em>Pinning</em> first. Pinning is the single biggest scalability footgun for virtual threads.
+      </DocsCallout>
+
+      <h2 id="pinning">Pinning</h2>
+      <p>When a virtual thread cannot unmount from its carrier (for example inside a native frame), it <strong>pins</strong> the carrier and serializes work — defeating Loom's scalability benefit. This tab plots pinning occurrences and total pinned time per second (<code>jdk.VirtualThreadPinned</code>), a duration distribution, and the virtual threads that pin the most. To see <em>where</em> in the code the pin happens, open the weighted <code>jdk.VirtualThreadPinned</code> flamegraph in the Visualization → Flamegraphs section.</p>
+
+      <DocsCallout type="info">
+        Since JDK 24 (JEP 491) <code>synchronized</code> no longer pins, so remaining pins typically come from native frames or older libraries — the flamegraph pinpoints the exact call site.
+      </DocsCallout>
+
+      <h2 id="submit-failures">Submit Failures</h2>
+      <p>A <code>jdk.VirtualThreadSubmitFailed</code> event fires when a virtual thread cannot be submitted to its carrier pool — usually carrier-pool rejection, executor shutdown, or a scheduling bug. The tab lists each failure with its timestamp, thread, and exception message; a non-empty list is a strong functionality signal worth investigating.</p>
+
+      <h2 id="lifecycle">Lifecycle</h2>
+      <p>When <code>jdk.VirtualThreadStart</code> and <code>jdk.VirtualThreadEnd</code> are enabled, this tab shows creation and completion rates plus a derived <strong>live count</strong> (cumulative starts minus ends). A live count that climbs without bound indicates a virtual-thread <strong>leak</strong>; sharp spikes indicate runaway spawning. These events are disabled by default and very high-volume, so the tab shows an empty state unless the recording explicitly enabled them.</p>
+
+      <DocsCallout type="info">
+        <strong>Read the JFR canonical event list:</strong> the
+        <a href="https://sap.github.io/jfrevents/" target="_blank" rel="noopener">SAP JFR Events catalog</a>
+        documents every virtual-thread event the JDK emits.
+      </DocsCallout>
+    </div>
+
+    <DocsNavFooter />
+  </article>
+</template>
+
+<style scoped>
+@import '@/views/docs/docs-page.css';
+</style>

--- a/jeffrey-pages/src/views/docs/microscope/profiles/ProfilesPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/profiles/ProfilesPage.vue
@@ -209,6 +209,8 @@ const folderStructure = `$JEFFREY_HOME/
         <router-link to="/docs/microscope/profiles/jit-compilation">Read the JIT compilation reference &rarr;</router-link>
         &nbsp;·&nbsp;
         <router-link to="/docs/microscope/profiles/exceptions">Read the exceptions reference &rarr;</router-link>
+        &nbsp;·&nbsp;
+        <router-link to="/docs/microscope/profiles/virtual-threads">Read the Virtual Threads reference &rarr;</router-link>
       </p>
 
       <h2 id="technologies">Technologies</h2>

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/EventTypeName.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/EventTypeName.java
@@ -113,6 +113,9 @@ public abstract class EventTypeName {
     public static final String EXECUTE_VM_OPERATION = "jdk.ExecuteVMOperation";
     public static final String JAVA_MONITOR_INFLATE = "jdk.JavaMonitorInflate";
     public static final String VIRTUAL_THREAD_PINNED = "jdk.VirtualThreadPinned";
+    public static final String VIRTUAL_THREAD_START = "jdk.VirtualThreadStart";
+    public static final String VIRTUAL_THREAD_END = "jdk.VirtualThreadEnd";
+    public static final String VIRTUAL_THREAD_SUBMIT_FAILED = "jdk.VirtualThreadSubmitFailed";
 
     // System & host events
     public static final String CPU_LOAD = "jdk.CPULoad";

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/Type.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/Type.java
@@ -121,6 +121,9 @@ public record Type(String code, boolean calculated) {
     public static final Type EXECUTE_VM_OPERATION = new Type(EventTypeName.EXECUTE_VM_OPERATION);
     public static final Type JAVA_MONITOR_INFLATE = new Type(EventTypeName.JAVA_MONITOR_INFLATE);
     public static final Type VIRTUAL_THREAD_PINNED = new Type(EventTypeName.VIRTUAL_THREAD_PINNED);
+    public static final Type VIRTUAL_THREAD_START = new Type(EventTypeName.VIRTUAL_THREAD_START);
+    public static final Type VIRTUAL_THREAD_END = new Type(EventTypeName.VIRTUAL_THREAD_END);
+    public static final Type VIRTUAL_THREAD_SUBMIT_FAILED = new Type(EventTypeName.VIRTUAL_THREAD_SUBMIT_FAILED);
 
     // System & host events
     public static final Type CPU_LOAD = new Type(EventTypeName.CPU_LOAD);
@@ -285,6 +288,9 @@ public record Type(String code, boolean calculated) {
                 SAFEPOINT_END,
                 JAVA_MONITOR_INFLATE,
                 VIRTUAL_THREAD_PINNED,
+                VIRTUAL_THREAD_START,
+                VIRTUAL_THREAD_END,
+                VIRTUAL_THREAD_SUBMIT_FAILED,
                 CPU_LOAD,
                 NETWORK_UTILIZATION,
                 THREAD_CONTEXT_SWITCH_RATE,


### PR DESCRIPTION
## Summary

Adds a dedicated **Virtual Threads** page under the THREADS sidebar section that turns the Project Loom JFR events into actionable performance and functionality signals. Today Jeffrey only surfaces `jdk.VirtualThreadPinned` as a small table on the Blocking page; this is a proper deep-dive.

JFR fields confirmed via the JDK's own `jfr metadata`:
- `jdk.VirtualThreadPinned` — `duration`, `eventThread`, `stackTrace` *(enabled by default, 20ms threshold)*
- `jdk.VirtualThreadSubmitFailed` — `eventThread`, `exceptionMessage`, `stackTrace`
- `jdk.VirtualThreadStart` / `jdk.VirtualThreadEnd` — `javaThreadId` *(disabled by default, high-volume)*

## Dashboard (tabs)
- **Pinning** — occurrences + total pinned time per second, a duration distribution, and the top pinned virtual threads. Pinning ties a virtual thread to its carrier and serializes work — the top Loom scalability footgun.
- **Submit Failures** — `jdk.VirtualThreadSubmitFailed` table (time, thread, exception) — carrier-pool rejection / executor shutdown / scheduling bugs.
- **Lifecycle** — per-second created/completed plus a derived **live count** for leak and spawn-rate detection. Shows an `EmptyState` unless `VirtualThreadStart/End` were enabled (off by default, high-volume).

## Pinning sites (where it pins)
`jdk.VirtualThreadPinned` is added to the flamegraph supported-events lists and categorized as a duration-weighted event, so pinning sites get a **weighted flamegraph** in the Visualization → Flamegraphs section (the dashboard links to it). Per-frame attribution isn't available from the generic event stream, so the flamegraph is the "where" and the dashboard table is the "who/how much."

## Implementation
- Register the 3 missing `Type`/`EventTypeName` constants (+ `KNOWN_TYPES`).
- `VirtualThreadManager`(+Impl) composite `virtualThreadData()` built from `VtPinningBuilder` / `VtSubmitFailedBuilder` / `VtLifecycleBuilder`; wired via `ProfileManager` / `JvmInsightFactories` / `ProfileFactoriesConfiguration`; `VirtualThreadController` at `/api/internal/profiles/{profileId}/virtual-threads`.
- Frontend: `ProfileVirtualThreads.vue` + client + models + route + sidebar entry; `EventTypes` pinned→blocking categorization.

## Tests
- `VirtualThreadBuildersTest` (pinning aggregation/distribution/top-threads, lifecycle live-count, submit failures), `VirtualThreadControllerTest`, and an `EventTypes.test.ts` case.

## Verification
- Frontend (`pages-microscope`): ESLint clean, Vitest passes, Vite build passes; docs (`jeffrey-pages`) build passes.
- Backend was **not** compiled here (only JDK 21 available; project targets `--release 25`). Field names come from authoritative JFR metadata and all wiring mirrors `BlockingManager`. Please run `mvn -pl jeffrey-microscope/profiles/profile-management,jeffrey-microscope/core-microscope -am test` in CI.

Docs: a Virtual Threads reference page under `jeffrey-pages`.

https://claude.ai/code/session_019PNnPZQ2oSTUGrEjFfsE4x

---
_Generated by [Claude Code](https://claude.ai/code/session_019PNnPZQ2oSTUGrEjFfsE4x)_