### PR TITLE
Add Security & TLS analysis page

### DIFF
--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/SecurityController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/SecurityController.java
@@ -1,0 +1,52 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.microscope.core.web.controllers.profile;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
+import cafe.jeffrey.profile.manager.SecurityManager;
+import cafe.jeffrey.profile.manager.model.security.SecurityData;
+
+@RestController
+@RequestMapping("/api/internal/profiles/{profileId}/security")
+public class SecurityController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SecurityController.class);
+
+    private final ProfileManagerResolver resolver;
+
+    public SecurityController(ProfileManagerResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    @GetMapping
+    public SecurityData securityData(@PathVariable("profileId") String profileId) {
+        LOG.debug("Fetching security & TLS analysis");
+        return mgr(profileId).securityData();
+    }
+
+    private SecurityManager mgr(String profileId) {
+        return resolver.resolve(profileId).securityManager();
+    }
+}

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/SecurityControllerTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/SecurityControllerTest.java
@@ -79,6 +79,6 @@ class SecurityControllerTest {
                 TimeseriesData.empty(),
                 List.of(), List.of(), List.of(), List.of(),
                 new DeserializationSummary(0, 0, 0, 0),
-                List.of(), List.of());
+                List.of(), List.of(), List.of());
     }
 }

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/SecurityControllerTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/SecurityControllerTest.java
@@ -1,0 +1,84 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.microscope.core.web.controllers.profile;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
+import cafe.jeffrey.profile.manager.ProfileManager;
+import cafe.jeffrey.profile.manager.SecurityManager;
+import cafe.jeffrey.profile.manager.model.security.SecurityData;
+import cafe.jeffrey.profile.manager.model.security.SecurityData.DeserializationSummary;
+import cafe.jeffrey.profile.manager.model.security.SecurityData.SecurityHeader;
+import cafe.jeffrey.shared.common.exception.Exceptions;
+import cafe.jeffrey.timeseries.TimeseriesData;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static cafe.jeffrey.microscope.core.web.MockMvcSupport.mockMvcTesterFor;
+
+@ExtendWith(MockitoExtension.class)
+class SecurityControllerTest {
+
+    @Mock
+    ProfileManagerResolver resolver;
+
+    @Mock
+    ProfileManager profileManager;
+
+    @Mock
+    SecurityManager securityManager;
+
+    @Test
+    void getsSecurityData() {
+        when(resolver.resolve("p-1")).thenReturn(profileManager);
+        when(profileManager.securityManager()).thenReturn(securityManager);
+        when(securityManager.securityData()).thenReturn(emptyData());
+
+        MockMvcTester mvc = mockMvcTesterFor(new SecurityController(resolver));
+
+        assertThat(mvc.get().uri("/api/internal/profiles/p-1/security")).hasStatusOk();
+    }
+
+    @Test
+    void profileNotFoundReturns404() {
+        when(resolver.resolve("ghost")).thenThrow(Exceptions.profileNotFound("ghost"));
+
+        MockMvcTester mvc = mockMvcTesterFor(new SecurityController(resolver));
+
+        assertThat(mvc.get().uri("/api/internal/profiles/ghost/security"))
+                .hasStatus(404)
+                .bodyJson()
+                .extractingPath("$.code").asString().isEqualTo("PROFILE_NOT_FOUND");
+    }
+
+    private static SecurityData emptyData() {
+        return new SecurityData(
+                new SecurityHeader(0, 0, 0, 0, 0, 0),
+                TimeseriesData.empty(),
+                List.of(), List.of(), List.of(), List.of(),
+                new DeserializationSummary(0, 0, 0, 0),
+                List.of(), List.of());
+    }
+}

--- a/jeffrey-microscope/pages-microscope/src/router/index.ts
+++ b/jeffrey-microscope/pages-microscope/src/router/index.ts
@@ -236,6 +236,12 @@ const profileChildRoutes = [
     meta: { layout: 'profile' }
   },
   {
+    path: 'security',
+    name: 'profile-security',
+    component: () => import('@/views/profiles/detail/ProfileSecurity.vue'),
+    meta: { layout: 'profile' }
+  },
+  {
     path: 'heap-dump/settings',
     name: 'profile-heap-dump-settings',
     component: () => import('@/views/profiles/detail/ProfileHeapDumpSettings.vue'),

--- a/jeffrey-microscope/pages-microscope/src/services/api/ProfileSecurityClient.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/ProfileSecurityClient.ts
@@ -1,0 +1,30 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import BaseProfileClient from '@/services/api/BaseProfileClient';
+import type SecurityData from '@/services/api/model/SecurityModels';
+
+export default class ProfileSecurityClient extends BaseProfileClient {
+  constructor(profileId: string) {
+    super(profileId, 'security');
+  }
+
+  public getData(): Promise<SecurityData> {
+    return this.get<SecurityData>('');
+  }
+}

--- a/jeffrey-microscope/pages-microscope/src/services/api/model/SecurityModels.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/model/SecurityModels.ts
@@ -1,0 +1,82 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type TimeseriesData from '@/services/timeseries/model/TimeseriesData';
+
+export interface SecurityHeader {
+  tlsHandshakes: number;
+  distinctPeers: number;
+  certificates: number;
+  flaggedCertificates: number;
+  deserializationEvents: number;
+  deserializationRejected: number;
+}
+
+export interface NamedCount {
+  name: string;
+  count: number;
+}
+
+export interface CertificateStat {
+  subject: string;
+  issuer: string;
+  keyType: string;
+  keyLength: number;
+  signatureAlgorithm: string;
+  validFrom: number;
+  validUntil: number;
+  validationCount: number;
+  weakKey: boolean;
+  weakSignature: boolean;
+  expired: boolean;
+  expiringSoon: boolean;
+}
+
+export interface DeserializationSummary {
+  totalEvents: number;
+  filterConfiguredEvents: number;
+  rejectedEvents: number;
+  exceptionEvents: number;
+}
+
+export interface DeserializationTypeStat {
+  type: string;
+  count: number;
+  totalBytes: number;
+  maxBytes: number;
+  maxDepth: number;
+}
+
+export interface ProviderServiceStat {
+  provider: string;
+  type: string;
+  algorithm: string;
+  count: number;
+}
+
+export default interface SecurityData {
+  header: SecurityHeader;
+  tlsTimeline: TimeseriesData;
+  protocols: NamedCount[];
+  ciphers: NamedCount[];
+  peers: NamedCount[];
+  certificates: CertificateStat[];
+  deserialization: DeserializationSummary;
+  deserializationTypes: DeserializationTypeStat[];
+  cryptoProviders: ProviderServiceStat[];
+}

--- a/jeffrey-microscope/pages-microscope/src/services/api/model/SecurityModels.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/model/SecurityModels.ts
@@ -69,6 +69,12 @@ export interface ProviderServiceStat {
   count: number;
 }
 
+export interface MisdeclarationStat {
+  misdeclaredClass: string;
+  message: string;
+  count: number;
+}
+
 export default interface SecurityData {
   header: SecurityHeader;
   tlsTimeline: TimeseriesData;
@@ -78,5 +84,6 @@ export default interface SecurityData {
   certificates: CertificateStat[];
   deserialization: DeserializationSummary;
   deserializationTypes: DeserializationTypeStat[];
+  serializationMisdeclarations: MisdeclarationStat[];
   cryptoProviders: ProviderServiceStat[];
 }

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/ProfileDetail.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/ProfileDetail.vue
@@ -232,6 +232,14 @@
                       <i class="bi bi-file-earmark"></i>
                       <span>File I/O</span>
                     </router-link>
+                    <router-link
+                      :to="`/profiles/${profileId}/security`"
+                      class="nav-item"
+                      active-class="active"
+                    >
+                      <i class="bi bi-shield-lock"></i>
+                      <span>Security &amp; TLS</span>
+                    </router-link>
                   </div>
                 </div>
 

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileSecurity.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileSecurity.vue
@@ -1,0 +1,422 @@
+<template>
+  <LoadingState v-if="loading" message="Loading security analysis..." />
+
+  <ErrorState v-else-if="error" message="Failed to load security analysis" />
+
+  <div v-else>
+    <PageHeader
+      title="Security & TLS"
+      description="TLS handshakes, X.509 certificates, deserialization and crypto-provider usage"
+      icon="bi-shield-lock"
+    />
+
+    <EmptyState
+      v-if="!hasData"
+      icon="bi-shield-lock"
+      title="No security events in this recording"
+      description="This profile contains no TLS, certificate, deserialization, or crypto-provider events."
+    />
+
+    <div v-else>
+      <div class="mb-4">
+        <StatsTable :metrics="metrics" />
+      </div>
+
+      <TabBar v-model="activeTab" :tabs="tabs" class="mb-3" />
+
+      <!-- TLS Handshakes -->
+      <div v-show="activeTab === 'tls'">
+        <ChartDescription
+          shows="TLS handshakes per second over the recording"
+          use-case="Sustained high handshake rates indicate connection churn / missing session resumption — a latency and CPU cost"
+        />
+        <TimeSeriesChart
+          :primary-data="tlsTimeline"
+          primary-title="TLS Handshakes"
+          :primary-axis-type="AxisFormatType.NUMBER"
+          :visible-minutes="60"
+          primary-color="#4285F4"
+        />
+        <div class="row mt-4">
+          <div class="col-lg-4">
+            <h6 class="section-title">Protocol Versions</h6>
+            <div class="table-responsive">
+              <table class="table table-sm table-hover mb-0">
+                <thead>
+                  <tr>
+                    <th>Protocol</th>
+                    <th class="text-end">Handshakes</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="p in data!.protocols" :key="p.name">
+                    <td>
+                      {{ p.name }}
+                      <Badge
+                        v-if="isLegacyProtocol(p.name)"
+                        value="legacy"
+                        variant="danger"
+                        size="xs"
+                      />
+                    </td>
+                    <td class="text-end">{{ FormattingService.formatNumber(p.count) }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+          <div class="col-lg-4">
+            <h6 class="section-title">Cipher Suites</h6>
+            <div class="table-responsive">
+              <table class="table table-sm table-hover mb-0">
+                <thead>
+                  <tr>
+                    <th>Cipher</th>
+                    <th class="text-end">Handshakes</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="c in data!.ciphers" :key="c.name">
+                    <td>{{ c.name }}</td>
+                    <td class="text-end">{{ FormattingService.formatNumber(c.count) }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+          <div class="col-lg-4">
+            <h6 class="section-title">Top Peers</h6>
+            <div class="table-responsive">
+              <table class="table table-sm table-hover mb-0">
+                <thead>
+                  <tr>
+                    <th>Peer</th>
+                    <th class="text-end">Handshakes</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="peer in data!.peers" :key="peer.name">
+                    <td>{{ peer.name }}</td>
+                    <td class="text-end">{{ FormattingService.formatNumber(peer.count) }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+        <EmptyState
+          v-if="data!.protocols.length === 0"
+          icon="bi-shield"
+          title="No TLS handshakes recorded"
+        />
+      </div>
+
+      <!-- Certificates -->
+      <div v-show="activeTab === 'certificates'">
+        <ChartDescription
+          shows="X.509 certificates observed, with key/signature strength and expiry flags"
+          use-case="Spot weak keys, deprecated signature algorithms, and certificates that are expired or expiring soon"
+        />
+        <div class="table-responsive">
+          <table class="table table-sm table-hover mb-0">
+            <thead>
+              <tr>
+                <th>Subject</th>
+                <th>Issuer</th>
+                <th>Key</th>
+                <th>Signature</th>
+                <th>Valid Until</th>
+                <th class="text-end">Validations</th>
+                <th>Flags</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(c, i) in data!.certificates" :key="i">
+                <td>{{ c.subject }}</td>
+                <td>{{ c.issuer }}</td>
+                <td>{{ c.keyType }} {{ c.keyLength }}</td>
+                <td>{{ c.signatureAlgorithm }}</td>
+                <td>{{ FormattingService.formatTimestamp(c.validUntil) }}</td>
+                <td class="text-end">{{ FormattingService.formatNumber(c.validationCount) }}</td>
+                <td>
+                  <Badge
+                    v-if="c.weakKey"
+                    value="weak key"
+                    variant="danger"
+                    size="xs"
+                    class="me-1"
+                  />
+                  <Badge
+                    v-if="c.weakSignature"
+                    value="weak sig"
+                    variant="danger"
+                    size="xs"
+                    class="me-1"
+                  />
+                  <Badge v-if="c.expired" value="expired" variant="danger" size="xs" class="me-1" />
+                  <Badge
+                    v-if="c.expiringSoon"
+                    value="expiring"
+                    variant="warning"
+                    size="xs"
+                    class="me-1"
+                  />
+                  <span v-if="!c.weakKey && !c.weakSignature && !c.expired && !c.expiringSoon"
+                    >—</span
+                  >
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <EmptyState
+          v-if="data!.certificates.length === 0"
+          icon="bi-patch-check"
+          title="No certificates recorded"
+          description="No jdk.X509Certificate events were present."
+        />
+      </div>
+
+      <!-- Deserialization -->
+      <div v-show="activeTab === 'deserialization'">
+        <ChartDescription
+          shows="Object deserialization by type, with filter status and payload size"
+          use-case="Unfiltered or oversized deserialization is a security and performance risk — review rejected events and the largest graphs"
+        />
+        <div class="mb-3">
+          <StatsTable :metrics="deserMetrics" />
+        </div>
+        <div class="table-responsive">
+          <table class="table table-sm table-hover mb-0">
+            <thead>
+              <tr>
+                <th>Type</th>
+                <th class="text-end">Count</th>
+                <th class="text-end">Total Bytes</th>
+                <th class="text-end">Max Bytes</th>
+                <th class="text-end">Max Depth</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(t, i) in data!.deserializationTypes" :key="i">
+                <td>{{ t.type }}</td>
+                <td class="text-end">{{ FormattingService.formatNumber(t.count) }}</td>
+                <td class="text-end">{{ FormattingService.formatBytes(t.totalBytes) }}</td>
+                <td class="text-end">{{ FormattingService.formatBytes(t.maxBytes) }}</td>
+                <td class="text-end">{{ FormattingService.formatNumber(t.maxDepth) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <EmptyState
+          v-if="data!.deserializationTypes.length === 0"
+          icon="bi-box-arrow-in-down"
+          title="No deserialization recorded"
+          description="No jdk.Deserialization events were present."
+        />
+      </div>
+
+      <!-- Crypto Providers -->
+      <div v-show="activeTab === 'providers'">
+        <ChartDescription
+          shows="JCA crypto providers, service types, and algorithms actually exercised"
+          use-case="Confirm which providers/algorithms are in use and detect unexpected or weak algorithm usage"
+        />
+        <div class="table-responsive">
+          <table class="table table-sm table-hover mb-0">
+            <thead>
+              <tr>
+                <th>Provider</th>
+                <th>Type</th>
+                <th>Algorithm</th>
+                <th class="text-end">Uses</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(p, i) in data!.cryptoProviders" :key="i">
+                <td>{{ p.provider }}</td>
+                <td>{{ p.type }}</td>
+                <td>{{ p.algorithm }}</td>
+                <td class="text-end">{{ FormattingService.formatNumber(p.count) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <EmptyState
+          v-if="data!.cryptoProviders.length === 0"
+          icon="bi-key"
+          title="No crypto-provider events"
+          description="No jdk.SecurityProviderService events were present."
+        />
+      </div>
+
+      <!-- About -->
+      <div v-show="activeTab === 'about'">
+        <ConfigurationSection title="How Security & TLS Analysis Works" icon="bi-info-circle">
+          <p class="about-text">
+            This page aggregates the JDK security JFR events. <strong>TLS handshakes</strong>
+            (<code>jdk.TLSHandshake</code>) reveal negotiated protocols/ciphers and connection
+            churn;
+            <strong>certificates</strong> (<code>jdk.X509Certificate</code> /
+            <code>jdk.X509Validation</code>) are flagged for weak keys, deprecated signature
+            algorithms, and expiry;
+            <strong>deserialization</strong> (<code>jdk.Deserialization</code>) surfaces unfiltered
+            or oversized object graphs; and <strong>crypto providers</strong>
+            (<code>jdk.SecurityProviderService</code>) show which JCA algorithms were exercised.
+            These are instant events, so no per-operation latency is available.
+          </p>
+        </ConfigurationSection>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { useRoute } from 'vue-router';
+
+import PageHeader from '@/components/layout/PageHeader.vue';
+import StatsTable from '@/components/StatsTable.vue';
+import TabBar from '@/components/TabBar.vue';
+import TimeSeriesChart from '@/components/TimeSeriesChart.vue';
+import ChartDescription from '@/components/ChartDescription.vue';
+import ConfigurationSection from '@/components/ConfigurationSection.vue';
+import LoadingState from '@/components/LoadingState.vue';
+import ErrorState from '@/components/ErrorState.vue';
+import EmptyState from '@/components/EmptyState.vue';
+import Badge from '@/components/Badge.vue';
+import ProfileSecurityClient from '@/services/api/ProfileSecurityClient';
+import FormattingService from '@/services/FormattingService';
+import AxisFormatType from '@/services/timeseries/AxisFormatType';
+import type SecurityData from '@/services/api/model/SecurityModels';
+
+const route = useRoute();
+
+const loading = ref(true);
+const error = ref<string | null>(null);
+const data = ref<SecurityData>();
+
+const tabs = [
+  { id: 'tls', label: 'TLS Handshakes', icon: 'shield' },
+  { id: 'certificates', label: 'Certificates', icon: 'patch-check' },
+  { id: 'deserialization', label: 'Deserialization', icon: 'box-arrow-in-down' },
+  { id: 'providers', label: 'Crypto Providers', icon: 'key' },
+  { id: 'about', label: 'About', icon: 'info-circle' }
+];
+const activeTab = ref(tabs[0].id);
+
+const hasData = computed(() => {
+  const d = data.value;
+  if (!d) {
+    return false;
+  }
+  return (
+    d.header.tlsHandshakes > 0 ||
+    d.header.certificates > 0 ||
+    d.header.deserializationEvents > 0 ||
+    d.cryptoProviders.length > 0
+  );
+});
+
+const tlsTimeline = computed(() => data.value?.tlsTimeline.series?.[0]?.data ?? []);
+
+const isLegacyProtocol = (name: string): boolean => name.includes('1.0') || name.includes('1.1');
+
+const metrics = computed(() => {
+  const h = data.value?.header;
+  if (!h) {
+    return [];
+  }
+  return [
+    {
+      icon: 'shield',
+      title: 'TLS Handshakes',
+      value: FormattingService.formatNumber(h.tlsHandshakes),
+      variant: 'highlight' as const,
+      breakdown: [
+        { label: 'Distinct Peers', value: FormattingService.formatNumber(h.distinctPeers) }
+      ]
+    },
+    {
+      icon: 'patch-check',
+      title: 'Certificates',
+      value: FormattingService.formatNumber(h.certificates),
+      variant: h.flaggedCertificates > 0 ? ('danger' as const) : ('success' as const),
+      breakdown: [
+        { label: 'Flagged', value: FormattingService.formatNumber(h.flaggedCertificates) }
+      ]
+    },
+    {
+      icon: 'box-arrow-in-down',
+      title: 'Deserialization',
+      value: FormattingService.formatNumber(h.deserializationEvents),
+      variant: h.deserializationRejected > 0 ? ('warning' as const) : ('info' as const),
+      breakdown: [
+        { label: 'Rejected', value: FormattingService.formatNumber(h.deserializationRejected) }
+      ]
+    }
+  ];
+});
+
+const deserMetrics = computed(() => {
+  const s = data.value?.deserialization;
+  if (!s) {
+    return [];
+  }
+  return [
+    {
+      icon: 'box-arrow-in-down',
+      title: 'Deserialization Events',
+      value: FormattingService.formatNumber(s.totalEvents),
+      variant: 'highlight' as const,
+      breakdown: [
+        {
+          label: 'Filter Configured',
+          value: FormattingService.formatNumber(s.filterConfiguredEvents)
+        }
+      ]
+    },
+    {
+      icon: 'shield-exclamation',
+      title: 'Rejected',
+      value: FormattingService.formatNumber(s.rejectedEvents),
+      variant: s.rejectedEvents > 0 ? ('warning' as const) : ('success' as const),
+      breakdown: [{ label: 'Exceptions', value: FormattingService.formatNumber(s.exceptionEvents) }]
+    }
+  ];
+});
+
+const loadData = async () => {
+  try {
+    loading.value = true;
+    error.value = null;
+    const client = new ProfileSecurityClient(route.params.profileId as string);
+    data.value = await client.getData();
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Unknown error occurred';
+    console.error('Error loading security analysis:', err);
+  } finally {
+    loading.value = false;
+  }
+};
+
+onMounted(loadData);
+</script>
+
+<style scoped>
+.section-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: var(--color-text-muted);
+  margin-bottom: 0.5rem;
+}
+
+.about-text {
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: var(--color-dark);
+  margin: 0;
+}
+</style>

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileSecurity.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileSecurity.vue
@@ -214,6 +214,36 @@
           title="No deserialization recorded"
           description="No jdk.Deserialization events were present."
         />
+
+        <h6 class="section-title mt-4">Serialization Misdeclarations</h6>
+        <ChartDescription
+          shows="Serializable classes the JVM flagged for misdeclared serialization members"
+          use-case="Misdeclared serialVersionUID, writeObject, or serialPersistentFields silently break serialization contracts — fix or document each"
+        />
+        <div class="table-responsive">
+          <table class="table table-sm table-hover mb-0">
+            <thead>
+              <tr>
+                <th>Class</th>
+                <th>Message</th>
+                <th class="text-end">Count</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(m, i) in data!.serializationMisdeclarations" :key="i">
+                <td>{{ m.misdeclaredClass }}</td>
+                <td>{{ m.message }}</td>
+                <td class="text-end">{{ FormattingService.formatNumber(m.count) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <EmptyState
+          v-if="data!.serializationMisdeclarations.length === 0"
+          icon="bi-check-circle"
+          title="No serialization misdeclarations"
+          description="No jdk.SerializationMisdeclaration events were recorded (JDK 26+)."
+        />
       </div>
 
       <!-- Crypto Providers -->

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/configuration/ProfileFactoriesConfiguration.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/configuration/ProfileFactoriesConfiguration.java
@@ -144,6 +144,7 @@ public class ProfileFactoriesConfiguration {
             IoManager.Factory ioFactory,
             AllocationManager.Factory allocationFactory,
             LeakCandidatesManager.Factory leakCandidatesFactory,
+            SecurityManager.Factory securityFactory,
             SpanManager.Factory spanFactory) {
 
         return new JvmInsightFactories(
@@ -165,6 +166,7 @@ public class ProfileFactoriesConfiguration {
                 ioFactory,
                 allocationFactory,
                 leakCandidatesFactory,
+                securityFactory,
                 spanFactory);
     }
 
@@ -639,6 +641,17 @@ public class ProfileFactoriesConfiguration {
         return profileInfo -> {
             DataSource profileDb = databaseManagerResolver.open(profileInfo);
             return new LeakCandidatesManagerImpl(profileRepositories.newEventRepository(profileDb));
+        };
+    }
+
+    @Bean
+    public SecurityManager.Factory securityManagerFactory() {
+
+        return profileInfo -> {
+            DataSource profileDb = databaseManagerResolver.open(profileInfo);
+            return new SecurityManagerImpl(
+                    profileInfo,
+                    profileRepositories.newEventStreamRepository(profileDb));
         };
     }
 

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/configuration/ProfileFactoriesConfiguration.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/configuration/ProfileFactoriesConfiguration.java
@@ -35,6 +35,8 @@ import cafe.jeffrey.profile.guardian.GuardianProperties;
 import cafe.jeffrey.profile.guardian.GuardianProvider;
 import cafe.jeffrey.profile.guardian.ParsingGuardianProvider;
 import cafe.jeffrey.profile.manager.*;
+// Explicit import: disambiguates from java.lang.SecurityManager (both match the wildcard above)
+import cafe.jeffrey.profile.manager.SecurityManager;
 import cafe.jeffrey.profile.tools.collapse.CollapseFramesManager;
 
 

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/ProfileManager.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/ProfileManager.java
@@ -85,6 +85,8 @@ public interface ProfileManager {
 
     LeakCandidatesManager leakCandidatesManager();
 
+    SecurityManager securityManager();
+
     ContainerManager containerManager();
 
     HeapMemoryManager heapMemoryManager();

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/ProfileManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/ProfileManagerImpl.java
@@ -187,6 +187,11 @@ public class ProfileManagerImpl implements ProfileManager {
     }
 
     @Override
+    public SecurityManager securityManager() {
+        return registry.jvmInsight().security().apply(profileInfo);
+    }
+
+    @Override
     public ContainerManager containerManager() {
         return registry.jvmInsight().container().apply(profileInfo);
     }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/SecurityManager.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/SecurityManager.java
@@ -1,0 +1,43 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager;
+
+import cafe.jeffrey.profile.manager.model.security.SecurityData;
+import cafe.jeffrey.shared.common.model.ProfileInfo;
+
+import java.util.function.Function;
+
+/**
+ * Security &amp; TLS insight for a single profile: TLS handshakes ({@code jdk.TLSHandshake}), X.509
+ * certificates and validation ({@code jdk.X509Certificate}/{@code jdk.X509Validation}),
+ * deserialization ({@code jdk.Deserialization}) and crypto-provider usage
+ * ({@code jdk.SecurityProviderService}). All are optional, so consumers must handle empty results.
+ */
+public interface SecurityManager {
+
+    @FunctionalInterface
+    interface Factory extends Function<ProfileInfo, SecurityManager> {
+    }
+
+    /**
+     * Composite security dashboard data: TLS handshake breakdowns, certificates with security flags,
+     * deserialization summary/top-types, and crypto-provider usage.
+     */
+    SecurityData securityData();
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/SecurityManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/SecurityManagerImpl.java
@@ -1,0 +1,164 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager;
+
+import cafe.jeffrey.profile.manager.model.security.CertificateBuilder;
+import cafe.jeffrey.profile.manager.model.security.CertificateBuilder.CertInfo;
+import cafe.jeffrey.profile.manager.model.security.CertificateValidationBuilder;
+import cafe.jeffrey.profile.manager.model.security.DeserializationBuilder;
+import cafe.jeffrey.profile.manager.model.security.ProviderServiceBuilder;
+import cafe.jeffrey.profile.manager.model.security.SecurityData;
+import cafe.jeffrey.profile.manager.model.security.SecurityData.CertificateStat;
+import cafe.jeffrey.profile.manager.model.security.SecurityData.ProviderServiceStat;
+import cafe.jeffrey.profile.manager.model.security.SecurityData.SecurityHeader;
+import cafe.jeffrey.profile.manager.model.security.TlsHandshakeBuilder;
+import cafe.jeffrey.provider.profile.api.EventQueryConfigurer;
+import cafe.jeffrey.provider.profile.api.ProfileEventStreamRepository;
+import cafe.jeffrey.shared.common.model.ProfileInfo;
+import cafe.jeffrey.shared.common.model.Type;
+import cafe.jeffrey.shared.common.model.time.RelativeTimeRange;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class SecurityManagerImpl implements SecurityManager {
+
+    private static final long EXPIRING_SOON_WINDOW_MILLIS = 30L * 24 * 60 * 60 * 1000;
+    private static final int RSA_MIN_BITS = 2048;
+    private static final int EC_MIN_BITS = 256;
+    private static final int MAX_CERTIFICATES = 200;
+    private static final Set<String> RSA_LIKE_KEY_TYPES = Set.of("RSA", "DSA", "DH", "DIFFIEHELLMAN");
+    private static final Set<String> WEAK_SIGNATURE_MARKERS = Set.of("MD2", "MD5", "SHA1");
+
+    private final ProfileInfo profileInfo;
+    private final ProfileEventStreamRepository eventStreamRepository;
+
+    public SecurityManagerImpl(ProfileInfo profileInfo, ProfileEventStreamRepository eventStreamRepository) {
+        this.profileInfo = profileInfo;
+        this.eventStreamRepository = eventStreamRepository;
+    }
+
+    @Override
+    public SecurityData securityData() {
+        RelativeTimeRange timeRange = new RelativeTimeRange(profileInfo.profilingStartEnd());
+        long recordingEndMillis = profileInfo.profilingStartEnd().end().toEpochMilli();
+
+        TlsHandshakeBuilder.Result tls = eventStreamRepository.genericStreaming(
+                configurer(Type.TLS_HANDSHAKE), new TlsHandshakeBuilder(timeRange));
+
+        Map<Long, CertInfo> certInfos = eventStreamRepository.genericStreaming(
+                configurer(Type.X509_CERTIFICATE), new CertificateBuilder());
+        Map<Long, Long> validations = eventStreamRepository.genericStreaming(
+                configurer(Type.X509_VALIDATION), new CertificateValidationBuilder());
+
+        DeserializationBuilder.Result deserialization = eventStreamRepository.genericStreaming(
+                configurer(Type.DESERIALIZATION), new DeserializationBuilder());
+
+        List<ProviderServiceStat> providers = eventStreamRepository.genericStreaming(
+                configurer(Type.SECURITY_PROVIDER_SERVICE), new ProviderServiceBuilder());
+
+        List<CertificateStat> certificates = buildCertificates(certInfos, validations, recordingEndMillis);
+        long flagged = certificates.stream()
+                .filter(c -> c.weakKey() || c.weakSignature() || c.expired() || c.expiringSoon())
+                .count();
+
+        SecurityHeader header = new SecurityHeader(
+                tls.total(),
+                tls.distinctPeers(),
+                certificates.size(),
+                flagged,
+                deserialization.summary().totalEvents(),
+                deserialization.summary().rejectedEvents());
+
+        return new SecurityData(
+                header,
+                tls.timeline(),
+                tls.protocols(),
+                tls.ciphers(),
+                tls.peers(),
+                certificates,
+                deserialization.summary(),
+                deserialization.types(),
+                providers);
+    }
+
+    private static EventQueryConfigurer configurer(Type type) {
+        return new EventQueryConfigurer().withEventType(type).withJsonFields();
+    }
+
+    static List<CertificateStat> buildCertificates(
+            Map<Long, CertInfo> certInfos, Map<Long, Long> validations, long recordingEndMillis) {
+        return certInfos.values().stream()
+                .map(cert -> new CertificateStat(
+                        cert.subject(),
+                        cert.issuer(),
+                        cert.keyType(),
+                        cert.keyLength(),
+                        cert.algorithm(),
+                        cert.validFrom(),
+                        cert.validUntil(),
+                        validations.getOrDefault(cert.certificateId(), 0L),
+                        isWeakKey(cert.keyType(), cert.keyLength()),
+                        isWeakSignature(cert.algorithm()),
+                        isExpired(cert.validUntil(), recordingEndMillis),
+                        isExpiringSoon(cert.validUntil(), recordingEndMillis)))
+                .sorted(Comparator.comparingLong(SecurityManagerImpl::flagRank).reversed()
+                        .thenComparing(Comparator.comparingLong(CertificateStat::validationCount).reversed()))
+                .limit(MAX_CERTIFICATES)
+                .toList();
+    }
+
+    private static long flagRank(CertificateStat cert) {
+        return (cert.weakKey() || cert.weakSignature() || cert.expired() || cert.expiringSoon()) ? 1 : 0;
+    }
+
+    private static boolean isWeakKey(String keyType, int keyLength) {
+        if (keyType == null || keyLength <= 0) {
+            return false;
+        }
+        String normalized = keyType.toUpperCase().replace("-", "");
+        if (RSA_LIKE_KEY_TYPES.contains(normalized)) {
+            return keyLength < RSA_MIN_BITS;
+        }
+        if (normalized.startsWith("EC")) {
+            return keyLength < EC_MIN_BITS;
+        }
+        return false;
+    }
+
+    private static boolean isWeakSignature(String algorithm) {
+        if (algorithm == null) {
+            return false;
+        }
+        String upper = algorithm.toUpperCase().replace("-", "");
+        return WEAK_SIGNATURE_MARKERS.stream().anyMatch(upper::contains);
+    }
+
+    private static boolean isExpired(long validUntil, long recordingEndMillis) {
+        return validUntil > 0 && validUntil < recordingEndMillis;
+    }
+
+    private static boolean isExpiringSoon(long validUntil, long recordingEndMillis) {
+        return validUntil > 0
+                && validUntil >= recordingEndMillis
+                && (validUntil - recordingEndMillis) < EXPIRING_SOON_WINDOW_MILLIS;
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/SecurityManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/SecurityManagerImpl.java
@@ -25,8 +25,10 @@ import cafe.jeffrey.profile.manager.model.security.DeserializationBuilder;
 import cafe.jeffrey.profile.manager.model.security.ProviderServiceBuilder;
 import cafe.jeffrey.profile.manager.model.security.SecurityData;
 import cafe.jeffrey.profile.manager.model.security.SecurityData.CertificateStat;
+import cafe.jeffrey.profile.manager.model.security.SecurityData.MisdeclarationStat;
 import cafe.jeffrey.profile.manager.model.security.SecurityData.ProviderServiceStat;
 import cafe.jeffrey.profile.manager.model.security.SecurityData.SecurityHeader;
+import cafe.jeffrey.profile.manager.model.security.SerializationMisdeclarationBuilder;
 import cafe.jeffrey.profile.manager.model.security.TlsHandshakeBuilder;
 import cafe.jeffrey.provider.profile.api.EventQueryConfigurer;
 import cafe.jeffrey.provider.profile.api.ProfileEventStreamRepository;
@@ -72,6 +74,9 @@ public class SecurityManagerImpl implements SecurityManager {
         DeserializationBuilder.Result deserialization = eventStreamRepository.genericStreaming(
                 configurer(Type.DESERIALIZATION), new DeserializationBuilder());
 
+        List<MisdeclarationStat> misdeclarations = eventStreamRepository.genericStreaming(
+                configurer(Type.SERIALIZATION_MISDECLARATION), new SerializationMisdeclarationBuilder());
+
         List<ProviderServiceStat> providers = eventStreamRepository.genericStreaming(
                 configurer(Type.SECURITY_PROVIDER_SERVICE), new ProviderServiceBuilder());
 
@@ -97,6 +102,7 @@ public class SecurityManagerImpl implements SecurityManager {
                 certificates,
                 deserialization.summary(),
                 deserialization.types(),
+                misdeclarations,
                 providers);
     }
 

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/security/CertificateBuilder.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/security/CertificateBuilder.java
@@ -1,0 +1,80 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.security;
+
+import tools.jackson.databind.node.ObjectNode;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.provider.profile.api.RecordBuilder;
+import cafe.jeffrey.shared.common.Json;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Collects {@code jdk.X509Certificate} events, deduplicated by {@code certificateId} (a certificate
+ * is reported once per validation path). The manager turns these into
+ * {@link SecurityData.CertificateStat} rows with security flags and validation counts.
+ */
+public class CertificateBuilder implements RecordBuilder<GenericRecord, Map<Long, CertificateBuilder.CertInfo>> {
+
+    public record CertInfo(
+            long certificateId,
+            String subject,
+            String issuer,
+            String keyType,
+            int keyLength,
+            String algorithm,
+            long validFrom,
+            long validUntil) {
+    }
+
+    private static final String CERTIFICATE_ID_FIELD = "certificateId";
+    private static final String SUBJECT_FIELD = "subject";
+    private static final String ISSUER_FIELD = "issuer";
+    private static final String KEY_TYPE_FIELD = "keyType";
+    private static final String KEY_LENGTH_FIELD = "keyLength";
+    private static final String ALGORITHM_FIELD = "algorithm";
+    private static final String VALID_FROM_FIELD = "validFrom";
+    private static final String VALID_UNTIL_FIELD = "validUntil";
+
+    private final Map<Long, CertInfo> byId = new LinkedHashMap<>();
+
+    @Override
+    public void onRecord(GenericRecord record) {
+        ObjectNode fields = record.jsonFields();
+        long certificateId = Json.readLong(fields, CERTIFICATE_ID_FIELD);
+        if (certificateId < 0) {
+            return;
+        }
+        byId.putIfAbsent(certificateId, new CertInfo(
+                certificateId,
+                Json.readString(fields, SUBJECT_FIELD),
+                Json.readString(fields, ISSUER_FIELD),
+                Json.readString(fields, KEY_TYPE_FIELD),
+                Json.readInt(fields, KEY_LENGTH_FIELD),
+                Json.readString(fields, ALGORITHM_FIELD),
+                Json.readLong(fields, VALID_FROM_FIELD),
+                Json.readLong(fields, VALID_UNTIL_FIELD)));
+    }
+
+    @Override
+    public Map<Long, CertInfo> build() {
+        return byId;
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/security/CertificateValidationBuilder.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/security/CertificateValidationBuilder.java
@@ -1,0 +1,55 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.security;
+
+import tools.jackson.databind.node.ObjectNode;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.provider.profile.api.RecordBuilder;
+import cafe.jeffrey.shared.common.Json;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Sums {@code jdk.X509Validation.validationCounter} per {@code certificateId} so each certificate row
+ * can show how often it was validated.
+ */
+public class CertificateValidationBuilder implements RecordBuilder<GenericRecord, Map<Long, Long>> {
+
+    private static final String CERTIFICATE_ID_FIELD = "certificateId";
+    private static final String VALIDATION_COUNTER_FIELD = "validationCounter";
+
+    private final Map<Long, Long> validationsById = new HashMap<>();
+
+    @Override
+    public void onRecord(GenericRecord record) {
+        ObjectNode fields = record.jsonFields();
+        long certificateId = Json.readLong(fields, CERTIFICATE_ID_FIELD);
+        if (certificateId < 0) {
+            return;
+        }
+        long counter = Math.max(1, Json.readLong(fields, VALIDATION_COUNTER_FIELD));
+        validationsById.merge(certificateId, counter, Long::sum);
+    }
+
+    @Override
+    public Map<Long, Long> build() {
+        return validationsById;
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/security/DeserializationBuilder.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/security/DeserializationBuilder.java
@@ -1,0 +1,106 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.security;
+
+import tools.jackson.databind.node.ObjectNode;
+import cafe.jeffrey.profile.manager.model.security.SecurityData.DeserializationSummary;
+import cafe.jeffrey.profile.manager.model.security.SecurityData.DeserializationTypeStat;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.provider.profile.api.RecordBuilder;
+import cafe.jeffrey.shared.common.Json;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Aggregates {@code jdk.Deserialization} events: top types by total bytes read, plus a summary of
+ * filter configuration / rejections / exceptions. Surfaces oversized object graphs and unfiltered
+ * deserialization (a security risk).
+ */
+public class DeserializationBuilder implements RecordBuilder<GenericRecord, DeserializationBuilder.Result> {
+
+    public record Result(DeserializationSummary summary, List<DeserializationTypeStat> types) {
+    }
+
+    private static final String TYPE_FIELD = "type";
+    private static final String FILTER_CONFIGURED_FIELD = "filterConfigured";
+    private static final String FILTER_STATUS_FIELD = "filterStatus";
+    private static final String BYTES_READ_FIELD = "bytesRead";
+    private static final String DEPTH_FIELD = "depth";
+    private static final String EXCEPTION_TYPE_FIELD = "exceptionType";
+    private static final String REJECTED_STATUS = "REJECTED";
+    private static final String UNKNOWN_TYPE = "unknown";
+    private static final int MAX_TYPES = 100;
+
+    private static final class TypeAcc {
+        private long count;
+        private long totalBytes;
+        private long maxBytes;
+        private long maxDepth;
+    }
+
+    private final Map<String, TypeAcc> byType = new HashMap<>();
+    private long totalEvents;
+    private long filterConfiguredEvents;
+    private long rejectedEvents;
+    private long exceptionEvents;
+
+    @Override
+    public void onRecord(GenericRecord record) {
+        ObjectNode fields = record.jsonFields();
+        totalEvents++;
+
+        if (Json.readBoolean(fields, FILTER_CONFIGURED_FIELD)) {
+            filterConfiguredEvents++;
+        }
+        if (REJECTED_STATUS.equalsIgnoreCase(Json.readString(fields, FILTER_STATUS_FIELD))) {
+            rejectedEvents++;
+        }
+        String exceptionType = Json.readString(fields, EXCEPTION_TYPE_FIELD);
+        if (exceptionType != null && !exceptionType.isBlank()) {
+            exceptionEvents++;
+        }
+
+        String type = Json.readString(fields, TYPE_FIELD);
+        long bytes = Math.max(0, Json.readLong(fields, BYTES_READ_FIELD));
+        long depth = Math.max(0, Json.readLong(fields, DEPTH_FIELD));
+        TypeAcc acc = byType.computeIfAbsent(type == null ? UNKNOWN_TYPE : type, key -> new TypeAcc());
+        acc.count++;
+        acc.totalBytes += bytes;
+        acc.maxBytes = Math.max(acc.maxBytes, bytes);
+        acc.maxDepth = Math.max(acc.maxDepth, depth);
+    }
+
+    @Override
+    public Result build() {
+        List<DeserializationTypeStat> types = byType.entrySet().stream()
+                .map(entry -> new DeserializationTypeStat(
+                        entry.getKey(), entry.getValue().count, entry.getValue().totalBytes,
+                        entry.getValue().maxBytes, entry.getValue().maxDepth))
+                .sorted(Comparator.comparingLong(DeserializationTypeStat::totalBytes).reversed())
+                .limit(MAX_TYPES)
+                .toList();
+
+        return new Result(
+                new DeserializationSummary(totalEvents, filterConfiguredEvents, rejectedEvents, exceptionEvents),
+                types);
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/security/ProviderServiceBuilder.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/security/ProviderServiceBuilder.java
@@ -1,0 +1,73 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.security;
+
+import tools.jackson.databind.node.ObjectNode;
+import cafe.jeffrey.profile.manager.model.security.SecurityData.ProviderServiceStat;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.provider.profile.api.RecordBuilder;
+import cafe.jeffrey.shared.common.Json;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Aggregates {@code jdk.SecurityProviderService} events into provider/type/algorithm usage counts —
+ * which JCA providers and algorithms the application actually exercised.
+ */
+public class ProviderServiceBuilder implements RecordBuilder<GenericRecord, List<ProviderServiceStat>> {
+
+    private static final String PROVIDER_FIELD = "provider";
+    private static final String TYPE_FIELD = "type";
+    private static final String ALGORITHM_FIELD = "algorithm";
+    private static final String UNKNOWN = "unknown";
+    private static final int MAX_ROWS = 200;
+
+    private record Key(String provider, String type, String algorithm) {
+    }
+
+    private final Map<Key, Long> counts = new HashMap<>();
+
+    @Override
+    public void onRecord(GenericRecord record) {
+        ObjectNode fields = record.jsonFields();
+        Key key = new Key(
+                orUnknown(Json.readString(fields, PROVIDER_FIELD)),
+                orUnknown(Json.readString(fields, TYPE_FIELD)),
+                orUnknown(Json.readString(fields, ALGORITHM_FIELD)));
+        counts.merge(key, 1L, Long::sum);
+    }
+
+    private static String orUnknown(String value) {
+        return value == null || value.isBlank() ? UNKNOWN : value;
+    }
+
+    @Override
+    public List<ProviderServiceStat> build() {
+        return counts.entrySet().stream()
+                .map(entry -> new ProviderServiceStat(
+                        entry.getKey().provider(), entry.getKey().type(), entry.getKey().algorithm(),
+                        entry.getValue()))
+                .sorted(Comparator.comparingLong(ProviderServiceStat::count).reversed())
+                .limit(MAX_ROWS)
+                .toList();
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/security/SecurityData.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/security/SecurityData.java
@@ -34,9 +34,11 @@ import java.util.List;
  * @param ciphers              handshake counts by cipher suite
  * @param peers                handshake counts by peer ({@code host:port})
  * @param certificates         observed certificates with security flags and validation counts
- * @param deserialization      deserialization summary (events / filter / exceptions)
- * @param deserializationTypes top deserialized types by total bytes read
- * @param cryptoProviders      crypto provider/algorithm usage counts
+ * @param deserialization            deserialization summary (events / filter / exceptions)
+ * @param deserializationTypes       top deserialized types by total bytes read
+ * @param serializationMisdeclarations classes with serialization misdeclarations
+ *                                   ({@code jdk.SerializationMisdeclaration}, JDK 26+)
+ * @param cryptoProviders            crypto provider/algorithm usage counts
  */
 public record SecurityData(
         SecurityHeader header,
@@ -47,6 +49,7 @@ public record SecurityData(
         List<CertificateStat> certificates,
         DeserializationSummary deserialization,
         List<DeserializationTypeStat> deserializationTypes,
+        List<MisdeclarationStat> serializationMisdeclarations,
         List<ProviderServiceStat> cryptoProviders) {
 
     public record SecurityHeader(
@@ -84,6 +87,9 @@ public record SecurityData(
     }
 
     public record DeserializationTypeStat(String type, long count, long totalBytes, long maxBytes, long maxDepth) {
+    }
+
+    public record MisdeclarationStat(String misdeclaredClass, String message, long count) {
     }
 
     public record ProviderServiceStat(String provider, String type, String algorithm, long count) {

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/security/SecurityData.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/security/SecurityData.java
@@ -1,0 +1,91 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.security;
+
+import cafe.jeffrey.timeseries.TimeseriesData;
+
+import java.util.List;
+
+/**
+ * Security &amp; TLS insight from the JDK security JFR events: TLS handshakes
+ * ({@code jdk.TLSHandshake}), X.509 certificates and validation
+ * ({@code jdk.X509Certificate}/{@code jdk.X509Validation}), deserialization
+ * ({@code jdk.Deserialization}) and crypto-provider usage ({@code jdk.SecurityProviderService}).
+ *
+ * @param header               headline counters
+ * @param tlsTimeline          TLS handshakes per second (single series)
+ * @param protocols            handshake counts by TLS protocol version
+ * @param ciphers              handshake counts by cipher suite
+ * @param peers                handshake counts by peer ({@code host:port})
+ * @param certificates         observed certificates with security flags and validation counts
+ * @param deserialization      deserialization summary (events / filter / exceptions)
+ * @param deserializationTypes top deserialized types by total bytes read
+ * @param cryptoProviders      crypto provider/algorithm usage counts
+ */
+public record SecurityData(
+        SecurityHeader header,
+        TimeseriesData tlsTimeline,
+        List<NamedCount> protocols,
+        List<NamedCount> ciphers,
+        List<NamedCount> peers,
+        List<CertificateStat> certificates,
+        DeserializationSummary deserialization,
+        List<DeserializationTypeStat> deserializationTypes,
+        List<ProviderServiceStat> cryptoProviders) {
+
+    public record SecurityHeader(
+            long tlsHandshakes,
+            long distinctPeers,
+            long certificates,
+            long flaggedCertificates,
+            long deserializationEvents,
+            long deserializationRejected) {
+    }
+
+    public record NamedCount(String name, long count) {
+    }
+
+    public record CertificateStat(
+            String subject,
+            String issuer,
+            String keyType,
+            int keyLength,
+            String signatureAlgorithm,
+            long validFrom,
+            long validUntil,
+            long validationCount,
+            boolean weakKey,
+            boolean weakSignature,
+            boolean expired,
+            boolean expiringSoon) {
+    }
+
+    public record DeserializationSummary(
+            long totalEvents,
+            long filterConfiguredEvents,
+            long rejectedEvents,
+            long exceptionEvents) {
+    }
+
+    public record DeserializationTypeStat(String type, long count, long totalBytes, long maxBytes, long maxDepth) {
+    }
+
+    public record ProviderServiceStat(String provider, String type, String algorithm, long count) {
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/security/SerializationMisdeclarationBuilder.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/security/SerializationMisdeclarationBuilder.java
@@ -1,0 +1,72 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.security;
+
+import tools.jackson.databind.node.ObjectNode;
+import cafe.jeffrey.profile.manager.model.security.SecurityData.MisdeclarationStat;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.provider.profile.api.RecordBuilder;
+import cafe.jeffrey.shared.common.Json;
+
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Aggregates {@code jdk.SerializationMisdeclaration} events (JDK 26+). The JVM emits one event the
+ * first time a serializable class with a misdeclared {@code serialVersionUID}, {@code writeObject},
+ * {@code serialPersistentFields}, etc. is used by serialization. Grouped by class + message and
+ * counted, these point to brittle/incorrect serialization contracts.
+ */
+public class SerializationMisdeclarationBuilder
+        implements RecordBuilder<GenericRecord, List<MisdeclarationStat>> {
+
+    private static final String MISDECLARED_CLASS_FIELD = "misdeclaredClass";
+    private static final String MESSAGE_FIELD = "message";
+    private static final String UNKNOWN_CLASS = "unknown";
+    private static final String NO_MESSAGE = "";
+    private static final int MAX_MISDECLARATIONS = 200;
+
+    private record Key(String misdeclaredClass, String message) {
+    }
+
+    private final Map<Key, long[]> byClassAndMessage = new LinkedHashMap<>();
+
+    @Override
+    public void onRecord(GenericRecord record) {
+        ObjectNode fields = record.jsonFields();
+        String misdeclaredClass = Json.readString(fields, MISDECLARED_CLASS_FIELD);
+        String message = Json.readString(fields, MESSAGE_FIELD);
+        Key key = new Key(
+                misdeclaredClass == null ? UNKNOWN_CLASS : misdeclaredClass,
+                message == null ? NO_MESSAGE : message);
+        byClassAndMessage.computeIfAbsent(key, ignored -> new long[1])[0]++;
+    }
+
+    @Override
+    public List<MisdeclarationStat> build() {
+        return byClassAndMessage.entrySet().stream()
+                .map(entry -> new MisdeclarationStat(
+                        entry.getKey().misdeclaredClass(), entry.getKey().message(), entry.getValue()[0]))
+                .sorted(Comparator.comparingLong(MisdeclarationStat::count).reversed())
+                .limit(MAX_MISDECLARATIONS)
+                .toList();
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/security/TlsHandshakeBuilder.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/security/TlsHandshakeBuilder.java
@@ -1,0 +1,111 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.security;
+
+import org.eclipse.collections.impl.map.mutable.primitive.LongLongHashMap;
+import tools.jackson.databind.node.ObjectNode;
+import cafe.jeffrey.profile.manager.model.security.SecurityData.NamedCount;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.provider.profile.api.RecordBuilder;
+import cafe.jeffrey.shared.common.Json;
+import cafe.jeffrey.shared.common.model.time.RelativeTimeRange;
+import cafe.jeffrey.timeseries.SingleSerie;
+import cafe.jeffrey.timeseries.TimeseriesData;
+import cafe.jeffrey.timeseries.TimeseriesUtils;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Aggregates {@code jdk.TLSHandshake} (an instant event) into a per-second handshake-count timeline
+ * and counts by protocol version, cipher suite, and peer ({@code host:port}).
+ */
+public class TlsHandshakeBuilder implements RecordBuilder<GenericRecord, TlsHandshakeBuilder.Result> {
+
+    public record Result(
+            TimeseriesData timeline,
+            List<NamedCount> protocols,
+            List<NamedCount> ciphers,
+            List<NamedCount> peers,
+            long total,
+            long distinctPeers) {
+    }
+
+    private static final String PEER_HOST_FIELD = "peerHost";
+    private static final String PEER_PORT_FIELD = "peerPort";
+    private static final String PROTOCOL_VERSION_FIELD = "protocolVersion";
+    private static final String CIPHER_SUITE_FIELD = "cipherSuite";
+    private static final String COUNT_SERIES = "TLS Handshakes";
+    private static final String UNKNOWN = "unknown";
+    private static final int MAX_ROWS = 50;
+
+    private final LongLongHashMap countSeries;
+    private final Map<String, Long> protocolCounts = new HashMap<>();
+    private final Map<String, Long> cipherCounts = new HashMap<>();
+    private final Map<String, Long> peerCounts = new HashMap<>();
+    private long total;
+
+    public TlsHandshakeBuilder(RelativeTimeRange timeRange) {
+        this.countSeries = TimeseriesUtils.initWithZeros(timeRange);
+    }
+
+    @Override
+    public void onRecord(GenericRecord record) {
+        ObjectNode fields = record.jsonFields();
+        countSeries.addToValue(record.timestampFromStart().toSeconds(), 1);
+        total++;
+
+        increment(protocolCounts, orUnknown(Json.readString(fields, PROTOCOL_VERSION_FIELD)));
+        increment(cipherCounts, orUnknown(Json.readString(fields, CIPHER_SUITE_FIELD)));
+
+        String host = orUnknown(Json.readString(fields, PEER_HOST_FIELD));
+        long port = Json.readLong(fields, PEER_PORT_FIELD);
+        increment(peerCounts, port >= 0 ? host + ":" + port : host);
+    }
+
+    private static String orUnknown(String value) {
+        return value == null || value.isBlank() ? UNKNOWN : value;
+    }
+
+    private static void increment(Map<String, Long> counts, String key) {
+        counts.merge(key, 1L, Long::sum);
+    }
+
+    @Override
+    public Result build() {
+        SingleSerie serie = TimeseriesUtils.buildSerie(COUNT_SERIES, countSeries);
+        return new Result(
+                new TimeseriesData(serie),
+                topCounts(protocolCounts),
+                topCounts(cipherCounts),
+                topCounts(peerCounts),
+                total,
+                peerCounts.size());
+    }
+
+    private static List<NamedCount> topCounts(Map<String, Long> counts) {
+        return counts.entrySet().stream()
+                .map(entry -> new NamedCount(entry.getKey(), entry.getValue()))
+                .sorted(Comparator.comparingLong(NamedCount::count).reversed())
+                .limit(MAX_ROWS)
+                .toList();
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/registry/JvmInsightFactories.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/registry/JvmInsightFactories.java
@@ -27,6 +27,7 @@ import cafe.jeffrey.profile.manager.IoManager;
 import cafe.jeffrey.profile.manager.LeakCandidatesManager;
 import cafe.jeffrey.profile.manager.NativeMemoryManager;
 import cafe.jeffrey.profile.manager.NativeMemoryTrackingManager;
+import cafe.jeffrey.profile.manager.SecurityManager;
 import cafe.jeffrey.profile.manager.SystemResourcesManager;
 import cafe.jeffrey.profile.manager.GarbageCollectionManager;
 import cafe.jeffrey.profile.manager.HeapDumpManager;
@@ -57,5 +58,6 @@ public record JvmInsightFactories(
         IoManager.Factory io,
         AllocationManager.Factory allocation,
         LeakCandidatesManager.Factory leakCandidates,
+        SecurityManager.Factory security,
         SpanManager.Factory span) {
 }

--- a/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/SecurityManagerImplTest.java
+++ b/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/SecurityManagerImplTest.java
@@ -1,0 +1,74 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import cafe.jeffrey.profile.manager.model.security.CertificateBuilder.CertInfo;
+import cafe.jeffrey.profile.manager.model.security.SecurityData.CertificateStat;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("SecurityManagerImpl.buildCertificates")
+class SecurityManagerImplTest {
+
+    private static final long RECORDING_END = 1_000_000_000L;
+    private static final long DAY = 24L * 60 * 60 * 1000;
+
+    private static CertInfo cert(long id, String keyType, int keyLength, String algorithm, long validUntil) {
+        return new CertInfo(id, "CN=test-" + id, "CN=ca", keyType, keyLength, algorithm, 0L, validUntil);
+    }
+
+    @Test
+    @DisplayName("Flags weak key, weak signature, expired and expiring-soon; attaches validation counts")
+    void flagsCertificates() {
+        Map<Long, CertInfo> certs = Map.of(
+                1L, cert(1, "RSA", 1024, "SHA256withRSA", RECORDING_END + 365 * DAY),   // weak key
+                2L, cert(2, "RSA", 4096, "SHA1withRSA", RECORDING_END + 365 * DAY),      // weak signature
+                3L, cert(3, "RSA", 4096, "SHA256withRSA", RECORDING_END - DAY),          // expired
+                4L, cert(4, "EC", 256, "SHA256withECDSA", RECORDING_END + 10 * DAY),     // expiring soon
+                5L, cert(5, "RSA", 4096, "SHA256withRSA", RECORDING_END + 365 * DAY));   // healthy
+
+        List<CertificateStat> result = SecurityManagerImpl.buildCertificates(
+                certs, Map.of(1L, 7L), RECORDING_END);
+
+        assertEquals(5, result.size());
+        assertTrue(byId(result, "CN=test-1").weakKey());
+        assertTrue(byId(result, "CN=test-2").weakSignature());
+        assertTrue(byId(result, "CN=test-3").expired());
+        assertTrue(byId(result, "CN=test-4").expiringSoon());
+
+        CertificateStat healthy = byId(result, "CN=test-5");
+        assertFalse(healthy.weakKey() || healthy.weakSignature() || healthy.expired() || healthy.expiringSoon());
+
+        assertEquals(7, byId(result, "CN=test-1").validationCount());
+    }
+
+    private static CertificateStat byId(List<CertificateStat> result, String subject) {
+        return result.stream()
+                .filter(c -> subject.equals(c.subject()))
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/security/SecurityBuildersTest.java
+++ b/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/security/SecurityBuildersTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import cafe.jeffrey.profile.manager.model.security.DeserializationBuilder.Result;
+import cafe.jeffrey.profile.manager.model.security.SecurityData.MisdeclarationStat;
 import cafe.jeffrey.profile.manager.model.security.SecurityData.NamedCount;
 import cafe.jeffrey.profile.manager.model.security.SecurityData.ProviderServiceStat;
 import cafe.jeffrey.provider.profile.api.GenericRecord;
@@ -190,6 +191,36 @@ class SecurityBuildersTest {
             ObjectNode node = Json.createObject();
             node.put("certificateId", id);
             node.put("validationCounter", counter);
+            return node;
+        }
+    }
+
+    @Nested
+    @DisplayName("SerializationMisdeclarationBuilder")
+    class SerializationMisdeclarations {
+
+        @Test
+        @DisplayName("Groups misdeclarations by class and message, ranked by count")
+        void groupsByClassAndMessage() {
+            SerializationMisdeclarationBuilder builder = new SerializationMisdeclarationBuilder();
+            builder.onRecord(rec(Type.SERIALIZATION_MISDECLARATION, 1, misdeclaration("com.A", "bad serialVersionUID")));
+            builder.onRecord(rec(Type.SERIALIZATION_MISDECLARATION, 2, misdeclaration("com.A", "bad serialVersionUID")));
+            builder.onRecord(rec(Type.SERIALIZATION_MISDECLARATION, 3, misdeclaration("com.B", "non-private writeObject")));
+
+            List<MisdeclarationStat> result = builder.build();
+
+            assertEquals(2, result.size());
+            assertEquals("com.A", result.getFirst().misdeclaredClass());
+            assertEquals("bad serialVersionUID", result.getFirst().message());
+            assertEquals(2, result.getFirst().count());
+            assertEquals("com.B", result.get(1).misdeclaredClass());
+            assertEquals(1, result.get(1).count());
+        }
+
+        private ObjectNode misdeclaration(String misdeclaredClass, String message) {
+            ObjectNode node = Json.createObject();
+            node.put("misdeclaredClass", misdeclaredClass);
+            node.put("message", message);
             return node;
         }
     }

--- a/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/security/SecurityBuildersTest.java
+++ b/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/security/SecurityBuildersTest.java
@@ -1,0 +1,196 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.security;
+
+import tools.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import cafe.jeffrey.profile.manager.model.security.DeserializationBuilder.Result;
+import cafe.jeffrey.profile.manager.model.security.SecurityData.NamedCount;
+import cafe.jeffrey.profile.manager.model.security.SecurityData.ProviderServiceStat;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.shared.common.Json;
+import cafe.jeffrey.shared.common.model.Type;
+import cafe.jeffrey.shared.common.model.time.RelativeTimeRange;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DisplayName("Security builders")
+class SecurityBuildersTest {
+
+    private static final Instant START = Instant.parse("2024-01-01T00:00:00Z");
+
+    private static GenericRecord rec(Type type, long secondsFromStart, ObjectNode fields) {
+        return new GenericRecord(
+                type, "label", START,
+                Duration.ofSeconds(secondsFromStart), Duration.ZERO,
+                null, null, 0L, 0L, fields);
+    }
+
+    private static long countOf(List<NamedCount> list, String name) {
+        return list.stream().filter(n -> n.name().equals(name)).mapToLong(NamedCount::count).findFirst().orElse(0);
+    }
+
+    @Nested
+    @DisplayName("TlsHandshakeBuilder")
+    class Tls {
+
+        @Test
+        @DisplayName("Counts handshakes by protocol, cipher and peer")
+        void aggregates() {
+            TlsHandshakeBuilder builder = new TlsHandshakeBuilder(new RelativeTimeRange(0, 10_000));
+            builder.onRecord(rec(Type.TLS_HANDSHAKE, 1, tls("h1", 443, "TLSv1.3", "TLS_AES_128_GCM_SHA256")));
+            builder.onRecord(rec(Type.TLS_HANDSHAKE, 1, tls("h1", 443, "TLSv1.3", "TLS_AES_128_GCM_SHA256")));
+            builder.onRecord(rec(Type.TLS_HANDSHAKE, 2, tls("h2", 8443, "TLSv1.2", "TLS_RSA_WITH_AES_128_CBC_SHA")));
+
+            TlsHandshakeBuilder.Result result = builder.build();
+
+            assertEquals(3, result.total());
+            assertEquals(2, result.distinctPeers());
+            assertEquals(2, countOf(result.protocols(), "TLSv1.3"));
+            assertEquals(1, countOf(result.protocols(), "TLSv1.2"));
+            assertEquals(2, countOf(result.peers(), "h1:443"));
+            assertEquals("TLS Handshakes", result.timeline().series().getFirst().name());
+        }
+
+        private ObjectNode tls(String host, long port, String protocol, String cipher) {
+            ObjectNode node = Json.createObject();
+            node.put("peerHost", host);
+            node.put("peerPort", port);
+            node.put("protocolVersion", protocol);
+            node.put("cipherSuite", cipher);
+            return node;
+        }
+    }
+
+    @Nested
+    @DisplayName("DeserializationBuilder")
+    class Deser {
+
+        @Test
+        @DisplayName("Summarises filter status and ranks types by bytes")
+        void summarises() {
+            DeserializationBuilder builder = new DeserializationBuilder();
+            builder.onRecord(rec(Type.DESERIALIZATION, 1, deser("com.A", 1000, 5, true, "ALLOWED", null)));
+            builder.onRecord(rec(Type.DESERIALIZATION, 1, deser("com.A", 4000, 9, true, "ALLOWED", null)));
+            builder.onRecord(rec(Type.DESERIALIZATION, 2, deser("com.B", 200, 2, true, "REJECTED", "java.io.IOException")));
+
+            Result result = builder.build();
+
+            assertEquals(3, result.summary().totalEvents());
+            assertEquals(3, result.summary().filterConfiguredEvents());
+            assertEquals(1, result.summary().rejectedEvents());
+            assertEquals(1, result.summary().exceptionEvents());
+            assertEquals("com.A", result.types().getFirst().type());
+            assertEquals(5000, result.types().getFirst().totalBytes());
+            assertEquals(9, result.types().getFirst().maxDepth());
+        }
+
+        private ObjectNode deser(String type, long bytes, long depth, boolean configured, String status, String ex) {
+            ObjectNode node = Json.createObject();
+            node.put("type", type);
+            node.put("bytesRead", bytes);
+            node.put("depth", depth);
+            node.put("filterConfigured", configured);
+            node.put("filterStatus", status);
+            if (ex != null) {
+                node.put("exceptionType", ex);
+            }
+            return node;
+        }
+    }
+
+    @Nested
+    @DisplayName("ProviderServiceBuilder")
+    class Providers {
+
+        @Test
+        @DisplayName("Counts provider/type/algorithm combinations")
+        void counts() {
+            ProviderServiceBuilder builder = new ProviderServiceBuilder();
+            builder.onRecord(rec(Type.SECURITY_PROVIDER_SERVICE, 1, provider("SunJCE", "Cipher", "AES")));
+            builder.onRecord(rec(Type.SECURITY_PROVIDER_SERVICE, 1, provider("SunJCE", "Cipher", "AES")));
+            builder.onRecord(rec(Type.SECURITY_PROVIDER_SERVICE, 2, provider("SUN", "MessageDigest", "SHA-256")));
+
+            List<ProviderServiceStat> result = builder.build();
+
+            assertEquals(2, result.size());
+            assertEquals("SunJCE", result.getFirst().provider());
+            assertEquals(2, result.getFirst().count());
+        }
+
+        private ObjectNode provider(String provider, String type, String algorithm) {
+            ObjectNode node = Json.createObject();
+            node.put("provider", provider);
+            node.put("type", type);
+            node.put("algorithm", algorithm);
+            return node;
+        }
+    }
+
+    @Nested
+    @DisplayName("CertificateBuilder + CertificateValidationBuilder")
+    class Certificates {
+
+        @Test
+        @DisplayName("Dedups certificates by id and sums validations")
+        void dedupAndSum() {
+            CertificateBuilder certBuilder = new CertificateBuilder();
+            certBuilder.onRecord(rec(Type.X509_CERTIFICATE, 1, cert(1, "CN=a", 2048)));
+            certBuilder.onRecord(rec(Type.X509_CERTIFICATE, 2, cert(1, "CN=a", 2048)));
+            certBuilder.onRecord(rec(Type.X509_CERTIFICATE, 3, cert(2, "CN=b", 1024)));
+            Map<Long, CertificateBuilder.CertInfo> certs = certBuilder.build();
+
+            CertificateValidationBuilder valBuilder = new CertificateValidationBuilder();
+            valBuilder.onRecord(rec(Type.X509_VALIDATION, 1, validation(1, 3)));
+            valBuilder.onRecord(rec(Type.X509_VALIDATION, 2, validation(1, 2)));
+            Map<Long, Long> validations = valBuilder.build();
+
+            assertEquals(2, certs.size());
+            assertEquals("CN=a", certs.get(1L).subject());
+            assertEquals(5, validations.get(1L));
+        }
+
+        private ObjectNode cert(long id, String subject, int keyLength) {
+            ObjectNode node = Json.createObject();
+            node.put("certificateId", id);
+            node.put("subject", subject);
+            node.put("issuer", "CN=ca");
+            node.put("keyType", "RSA");
+            node.put("keyLength", keyLength);
+            node.put("algorithm", "SHA256withRSA");
+            node.put("validFrom", 1000L);
+            node.put("validUntil", 2000L);
+            return node;
+        }
+
+        private ObjectNode validation(long id, long counter) {
+            ObjectNode node = Json.createObject();
+            node.put("certificateId", id);
+            node.put("validationCounter", counter);
+            return node;
+        }
+    }
+}

--- a/jeffrey-pages/src/router/index.ts
+++ b/jeffrey-pages/src/router/index.ts
@@ -273,6 +273,11 @@ const routes: RouteRecordRaw[] = [
         component: () => import('@/views/docs/microscope/profiles/ProfileVirtualThreadsPage.vue')
       },
       {
+        path: 'microscope/profiles/security',
+        name: 'DocsProfilesSecurity',
+        component: () => import('@/views/docs/microscope/profiles/ProfileSecurityPage.vue')
+      },
+      {
         path: 'microscope/profiles/socket-io',
         name: 'DocsProfilesSocketIo',
         component: () => import('@/views/docs/microscope/profiles/ProfileSocketIoPage.vue')

--- a/jeffrey-pages/src/views/docs/microscope/profiles/ProfileSecurityPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/profiles/ProfileSecurityPage.vue
@@ -1,0 +1,80 @@
+<!--
+  - Jeffrey
+  - Copyright (C) 2026 Petr Bouda
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as published by
+  - the Free Software Foundation, either version 3 of the License, or
+  - (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import DocsCallout from '@/components/docs/DocsCallout.vue';
+import DocsNavFooter from '@/components/docs/DocsNavFooter.vue';
+import DocsPageHeader from '@/components/docs/DocsPageHeader.vue';
+import { useDocHeadings } from '@/composables/useDocHeadings';
+
+const { setHeadings } = useDocHeadings();
+
+const headings = [
+  { id: 'overview', text: 'Overview', level: 2 },
+  { id: 'tls', text: 'TLS Handshakes', level: 2 },
+  { id: 'certificates', text: 'Certificates', level: 2 },
+  { id: 'deserialization', text: 'Deserialization', level: 2 },
+  { id: 'providers', text: 'Crypto Providers', level: 2 }
+];
+
+onMounted(() => {
+  setHeadings(headings);
+});
+</script>
+
+<template>
+  <article class="docs-article">
+    <DocsPageHeader title="Security & TLS" icon="bi bi-shield-lock" />
+
+    <div class="docs-content">
+      <p>The Security &amp; TLS page (the last item in the Analysis section) aggregates the JDK security JFR events for both security-posture review and performance investigation. All of these are instant events, so there is no per-operation latency — the value is in the breakdowns, flags, and counts. The page shows an empty state when no security events are present.</p>
+
+      <h2 id="overview">Overview</h2>
+      <p>A header strip shows total TLS handshakes (and distinct peers), certificates observed (and how many were flagged), and deserialization events (and how many were rejected).</p>
+
+      <DocsCallout type="tip">
+        <strong>Where to start:</strong> open <em>Certificates</em> for posture (weak keys, deprecated signatures, expiry) and <em>TLS Handshakes</em> for protocol/cipher hygiene and connection churn.
+      </DocsCallout>
+
+      <h2 id="tls">TLS Handshakes</h2>
+      <p>Handshakes per second over time (<code>jdk.TLSHandshake</code>), plus breakdowns by protocol version (legacy TLS 1.0/1.1 are flagged), cipher suite, and peer (<code>host:port</code>). Sustained high handshake rates point to connection churn or missing session resumption — a latency and CPU cost.</p>
+
+      <h2 id="certificates">Certificates</h2>
+      <p>Every X.509 certificate observed (<code>jdk.X509Certificate</code>), deduplicated by id and annotated with validation counts (<code>jdk.X509Validation</code>). Each row is flagged server-side for a <strong>weak key</strong> (&lt; 2048-bit RSA / &lt; 256-bit EC), a <strong>weak signature</strong> (MD5/SHA-1), and <strong>expired</strong> or <strong>expiring-soon</strong> status (validity compared to the recording's end time).</p>
+
+      <h2 id="deserialization">Deserialization</h2>
+      <p>Java deserialization activity (<code>jdk.Deserialization</code>): a summary of total events, how many had a filter configured, how many were rejected, and how many threw; plus the top deserialized types by total bytes read (with max bytes and max graph depth). Unfiltered or oversized deserialization is both a security risk and a performance concern.</p>
+
+      <h2 id="providers">Crypto Providers</h2>
+      <p>JCA provider/service-type/algorithm usage counts (<code>jdk.SecurityProviderService</code>) — confirm which providers and algorithms were actually exercised and spot unexpected or weak algorithm usage.</p>
+
+      <DocsCallout type="info">
+        <strong>Read the JFR canonical event list:</strong> the
+        <a href="https://sap.github.io/jfrevents/" target="_blank" rel="noopener">SAP JFR Events catalog</a>
+        documents every security event the JDK emits.
+      </DocsCallout>
+    </div>
+
+    <DocsNavFooter />
+  </article>
+</template>
+
+<style scoped>
+@import '@/views/docs/docs-page.css';
+</style>

--- a/jeffrey-pages/src/views/docs/microscope/profiles/ProfilesPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/profiles/ProfilesPage.vue
@@ -215,6 +215,8 @@ const folderStructure = `$JEFFREY_HOME/
         <router-link to="/docs/microscope/profiles/exceptions">Read the exceptions reference &rarr;</router-link>
         &nbsp;·&nbsp;
         <router-link to="/docs/microscope/profiles/virtual-threads">Read the Virtual Threads reference &rarr;</router-link>
+        &nbsp;·&nbsp;
+        <router-link to="/docs/microscope/profiles/security">Read the Security &amp; TLS reference &rarr;</router-link>
       </p>
 
       <h2 id="technologies">Technologies</h2>

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/EventTypeName.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/EventTypeName.java
@@ -154,6 +154,7 @@ public abstract class EventTypeName {
     public static final String X509_VALIDATION = "jdk.X509Validation";
     public static final String DESERIALIZATION = "jdk.Deserialization";
     public static final String SECURITY_PROVIDER_SERVICE = "jdk.SecurityProviderService";
+    public static final String SERIALIZATION_MISDECLARATION = "jdk.SerializationMisdeclaration";
 
     // ----------------------------
     // Application events - JEFFREY

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/EventTypeName.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/EventTypeName.java
@@ -148,6 +148,13 @@ public abstract class EventTypeName {
     public static final String CLASS_REDEFINITION = "jdk.ClassRedefinition";
     public static final String RETRANSFORM_CLASSES = "jdk.RetransformClasses";
 
+    // Security events
+    public static final String TLS_HANDSHAKE = "jdk.TLSHandshake";
+    public static final String X509_CERTIFICATE = "jdk.X509Certificate";
+    public static final String X509_VALIDATION = "jdk.X509Validation";
+    public static final String DESERIALIZATION = "jdk.Deserialization";
+    public static final String SECURITY_PROVIDER_SERVICE = "jdk.SecurityProviderService";
+
     // ----------------------------
     // Application events - JEFFREY
     // ----------------------------

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/Type.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/Type.java
@@ -158,6 +158,13 @@ public record Type(String code, boolean calculated) {
     public static final Type CLASS_REDEFINITION = new Type(EventTypeName.CLASS_REDEFINITION);
     public static final Type RETRANSFORM_CLASSES = new Type(EventTypeName.RETRANSFORM_CLASSES);
 
+    // Security events
+    public static final Type TLS_HANDSHAKE = new Type(EventTypeName.TLS_HANDSHAKE);
+    public static final Type X509_CERTIFICATE = new Type(EventTypeName.X509_CERTIFICATE);
+    public static final Type X509_VALIDATION = new Type(EventTypeName.X509_VALIDATION);
+    public static final Type DESERIALIZATION = new Type(EventTypeName.DESERIALIZATION);
+    public static final Type SECURITY_PROVIDER_SERVICE = new Type(EventTypeName.SECURITY_PROVIDER_SERVICE);
+
     // ----------------------------
     // Application events - JEFFREY
     // ----------------------------
@@ -320,6 +327,11 @@ public record Type(String code, boolean calculated) {
                 CLASS_UNLOAD,
                 CLASS_REDEFINITION,
                 RETRANSFORM_CLASSES,
+                TLS_HANDSHAKE,
+                X509_CERTIFICATE,
+                X509_VALIDATION,
+                DESERIALIZATION,
+                SECURITY_PROVIDER_SERVICE,
                 JDBC_POOL_STATISTICS,
                 ACQUIRING_POOLED_JDBC_CONNECTION_TIMEOUT,
                 POOLED_JDBC_CONNECTION_ACQUIRED,

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/Type.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/Type.java
@@ -164,6 +164,7 @@ public record Type(String code, boolean calculated) {
     public static final Type X509_VALIDATION = new Type(EventTypeName.X509_VALIDATION);
     public static final Type DESERIALIZATION = new Type(EventTypeName.DESERIALIZATION);
     public static final Type SECURITY_PROVIDER_SERVICE = new Type(EventTypeName.SECURITY_PROVIDER_SERVICE);
+    public static final Type SERIALIZATION_MISDECLARATION = new Type(EventTypeName.SERIALIZATION_MISDECLARATION);
 
     // ----------------------------
     // Application events - JEFFREY
@@ -332,6 +333,7 @@ public record Type(String code, boolean calculated) {
                 X509_VALIDATION,
                 DESERIALIZATION,
                 SECURITY_PROVIDER_SERVICE,
+                SERIALIZATION_MISDECLARATION,
                 JDBC_POOL_STATISTICS,
                 ACQUIRING_POOLED_JDBC_CONNECTION_TIMEOUT,
                 POOLED_JDBC_CONNECTION_ACQUIRED,


### PR DESCRIPTION
## Summary

A new **Security & TLS** page, added as the **last item in the Analysis sidebar section**, surfacing the JDK security JFR events for both security-posture review and performance investigation.

Field names were verified against **Temurin JDK 26.0.1** (`jfr metadata`) — and that caught a real difference vs JDK 21: these are **instant events with no `duration`**, so there's no per-operation latency (the value is in breakdowns/flags/counts).

## Tabs
- **TLS Handshakes** (`jdk.TLSHandshake`): handshakes/sec timeline + breakdowns by protocol version (legacy TLS 1.0/1.1 flagged), cipher suite, and peer (`host:port`). Connection-churn / weak-cipher signal.
- **Certificates** (`jdk.X509Certificate` + `jdk.X509Validation`): per-cert table with validation counts and **server-side flags** — weak key (<2048 RSA / <256 EC), weak signature (MD5/SHA-1), expired / expiring-soon (vs the recording's end time).
- **Deserialization** (`jdk.Deserialization`): summary (events, filter-configured, rejected, exceptions) + top types by total bytes (count/max bytes/max depth). Unfiltered/oversized-graph detection.
- **Crypto Providers** (`jdk.SecurityProviderService`): provider/type/algorithm usage counts.

## Implementation
- Register the 5 event constants in `Type`/`EventTypeName` (+ `KNOWN_TYPES`).
- `SecurityManager`(+Impl) composite `securityData()` from `TlsHandshakeBuilder`, `CertificateBuilder` + `CertificateValidationBuilder`, `DeserializationBuilder`, `ProviderServiceBuilder`; certificate flags computed in the manager. Wired via `ProfileManager` / `JvmInsightFactories` / `ProfileFactoriesConfiguration`; `SecurityController` at `/api/internal/profiles/{profileId}/security`.
- Frontend: `ProfileSecurity.vue`, client, models, route, Analysis-section sidebar entry; `Badge` flags.

## Tests
- `SecurityBuildersTest` (TLS/deserialization/provider aggregation + cert dedup/validation sum), `SecurityManagerImplTest` (certificate flag logic), `SecurityControllerTest`.

## Verification
- Frontend (`pages-microscope`): ESLint clean, Vite build passes; docs (`jeffrey-pages`) build passes (reference page added).
- Backend not compiled here (only JDK 21; project targets `--release 25`) — field names are authoritative (JDK 26 metadata) and wiring mirrors `BlockingManager`. Run `mvn -pl jeffrey-microscope/profiles/profile-management,jeffrey-microscope/core-microscope -am test` in CI.

## Scoped out
`jdk.SecurityProperty` (absent from JDK 26 metadata).

https://claude.ai/code/session_019PNnPZQ2oSTUGrEjFfsE4x

---
_Generated by [Claude Code](https://claude.ai/code/session_019PNnPZQ2oSTUGrEjFfsE4x)_