### PR TITLE
Add Native Library Loads page

### DIFF
--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/NativeMemoryController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/NativeMemoryController.java
@@ -26,6 +26,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
 import cafe.jeffrey.profile.manager.NativeMemoryManager;
+import cafe.jeffrey.profile.manager.model.nativememory.NativeLibraryActivityData;
 import cafe.jeffrey.profile.manager.model.nativememory.NativeLibraryInfo;
 import cafe.jeffrey.profile.manager.model.nativememory.NativeMemoryOverview;
 import cafe.jeffrey.timeseries.TimeseriesData;
@@ -66,6 +67,12 @@ public class NativeMemoryController {
     public List<NativeLibraryInfo> nativeLibraries(@PathVariable("profileId") String profileId) {
         LOG.debug("Fetching native libraries");
         return mgr(profileId).nativeLibraries();
+    }
+
+    @GetMapping("/library-activity")
+    public NativeLibraryActivityData nativeLibraryActivity(@PathVariable("profileId") String profileId) {
+        LOG.debug("Fetching native-library load/unload activity");
+        return mgr(profileId).nativeLibraryActivity();
     }
 
     private NativeMemoryManager mgr(String profileId) {

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/NativeMemoryControllerTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/NativeMemoryControllerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.microscope.core.web.controllers.profile;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
+import cafe.jeffrey.profile.manager.NativeMemoryManager;
+import cafe.jeffrey.profile.manager.ProfileManager;
+import cafe.jeffrey.profile.manager.model.nativememory.NativeLibraryActivityData;
+import cafe.jeffrey.shared.common.exception.Exceptions;
+import cafe.jeffrey.timeseries.TimeseriesData;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static cafe.jeffrey.microscope.core.web.MockMvcSupport.mockMvcTesterFor;
+
+@ExtendWith(MockitoExtension.class)
+class NativeMemoryControllerTest {
+
+    @Mock
+    ProfileManagerResolver resolver;
+
+    @Mock
+    ProfileManager profileManager;
+
+    @Mock
+    NativeMemoryManager nativeMemoryManager;
+
+    @Test
+    void getsLibraryActivity() {
+        when(resolver.resolve("p-1")).thenReturn(profileManager);
+        when(profileManager.nativeMemoryManager()).thenReturn(nativeMemoryManager);
+        when(nativeMemoryManager.nativeLibraryActivity()).thenReturn(new NativeLibraryActivityData(
+                new NativeLibraryActivityData.Header(0, 0, 0, 0, 0, null),
+                List.of(), new TimeseriesData(List.of())));
+
+        MockMvcTester mvc = mockMvcTesterFor(new NativeMemoryController(resolver));
+
+        assertThat(mvc.get().uri("/api/internal/profiles/p-1/native-memory/library-activity")).hasStatusOk();
+    }
+
+    @Test
+    void profileNotFoundReturns404() {
+        when(resolver.resolve("ghost")).thenThrow(Exceptions.profileNotFound("ghost"));
+
+        MockMvcTester mvc = mockMvcTesterFor(new NativeMemoryController(resolver));
+
+        assertThat(mvc.get().uri("/api/internal/profiles/ghost/native-memory/library-activity"))
+                .hasStatus(404)
+                .bodyJson()
+                .extractingPath("$.code").asString().isEqualTo("PROFILE_NOT_FOUND");
+    }
+}

--- a/jeffrey-microscope/pages-microscope/src/router/index.ts
+++ b/jeffrey-microscope/pages-microscope/src/router/index.ts
@@ -194,6 +194,12 @@ const profileChildRoutes = [
     meta: { layout: 'profile' }
   },
   {
+    path: 'native-library-loads',
+    name: 'profile-native-library-loads',
+    component: () => import('@/views/profiles/detail/ProfileNativeLibraryLoads.vue'),
+    meta: { layout: 'profile' }
+  },
+  {
     path: 'nmt',
     name: 'profile-nmt',
     component: () => import('@/views/profiles/detail/ProfileNmt.vue'),

--- a/jeffrey-microscope/pages-microscope/src/services/api/ProfileNativeMemoryClient.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/ProfileNativeMemoryClient.ts
@@ -19,6 +19,7 @@
 import BaseProfileClient from '@/services/api/BaseProfileClient';
 import TimeseriesData from '@/services/timeseries/model/TimeseriesData';
 import type { NativeLibraryInfo, NativeMemoryOverview } from '@/services/api/model/NativeMemoryModels';
+import type { NativeLibraryActivityData } from '@/services/api/model/NativeLibraryActivityModels';
 
 export default class ProfileNativeMemoryClient extends BaseProfileClient {
   constructor(profileId: string) {
@@ -39,5 +40,9 @@ export default class ProfileNativeMemoryClient extends BaseProfileClient {
 
   public getNativeLibraries(): Promise<NativeLibraryInfo[]> {
     return this.get<NativeLibraryInfo[]>('/native-libraries');
+  }
+
+  public getNativeLibraryActivity(): Promise<NativeLibraryActivityData> {
+    return this.get<NativeLibraryActivityData>('/library-activity');
   }
 }

--- a/jeffrey-microscope/pages-microscope/src/services/api/model/NativeLibraryActivityModels.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/model/NativeLibraryActivityModels.ts
@@ -1,0 +1,45 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type TimeseriesData from '@/services/timeseries/model/TimeseriesData';
+
+export type LibraryOperationKind = 'LOAD' | 'UNLOAD';
+
+export interface NativeLibraryActivityHeader {
+  totalLoads: number;
+  failedLoads: number;
+  totalUnloads: number;
+  slowestLoadNanos: number;
+  totalLoadNanos: number;
+  slowestLibrary: string | null;
+}
+
+export interface LibraryOperation {
+  operation: LibraryOperationKind;
+  name: string;
+  timeOffsetMillis: number;
+  durationNanos: number;
+  success: boolean;
+  errorMessage: string | null;
+}
+
+export interface NativeLibraryActivityData {
+  header: NativeLibraryActivityHeader;
+  operations: LibraryOperation[];
+  timeline: TimeseriesData;
+}

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/ProfileDetail.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/ProfileDetail.vue
@@ -427,6 +427,14 @@
                       <span>Native Memory</span>
                     </router-link>
                     <router-link
+                      :to="`/profiles/${profileId}/native-library-loads`"
+                      class="nav-item"
+                      active-class="active"
+                    >
+                      <i class="bi bi-box-arrow-in-down"></i>
+                      <span>Native Library Loads</span>
+                    </router-link>
+                    <router-link
                       :to="`/profiles/${profileId}/nmt`"
                       class="nav-item"
                       active-class="active"

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileNativeLibraryLoads.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileNativeLibraryLoads.vue
@@ -1,0 +1,331 @@
+<!--
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ -->
+
+<template>
+  <LoadingState v-if="loading" message="Loading native-library load activity..." />
+
+  <ErrorState v-else-if="error" message="Failed to load native-library load activity" />
+
+  <div v-else>
+    <PageHeader
+      title="Native Library Loads"
+      description="Native dynamic-library load/unload timing and failures from jdk.NativeLibraryLoad / jdk.NativeLibraryUnload"
+      icon="bi-box-arrow-in-down"
+    />
+
+    <EmptyState
+      v-if="!hasData"
+      icon="bi-box-arrow-in-down"
+      title="No native-library load events"
+      description="This recording contains no jdk.NativeLibraryLoad or jdk.NativeLibraryUnload events (requires JDK 24+)."
+    />
+
+    <div v-else>
+      <div class="mb-4">
+        <StatsTable :metrics="metrics" />
+      </div>
+
+      <TabBar v-model="activeTab" :tabs="tabs" class="mb-3" />
+
+      <!-- Operations -->
+      <div v-show="activeTab === 'operations'">
+        <ChartDescription
+          shows="Each native-library load/unload, slowest first, with duration and success status"
+          use-case="Slow loads inflate startup; a failed load (missing or incompatible native dependency) is a real bug"
+        />
+        <DataTable>
+          <template #toolbar>
+            <TableToolbar v-model="operationsView.query" search-placeholder="Filter libraries...">
+              <span class="toolbar-info">Library operations</span>
+              <template #filters>
+                <label class="failures-toggle">
+                  <input v-model="failuresOnly" type="checkbox" />
+                  Failures only
+                </label>
+                <Badge key-label="Shown" :value="operationsView.matchCount" variant="secondary" size="s" borderless />
+              </template>
+            </TableToolbar>
+          </template>
+          <thead>
+            <tr>
+              <th>Operation</th>
+              <th>Library</th>
+              <th class="text-end">Time</th>
+              <th class="text-end">Load Time</th>
+              <th>Status</th>
+              <th>Error</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(op, i) in operationsView.visible" :key="i">
+              <td>
+                <Badge
+                  :value="op.operation === 'LOAD' ? 'Load' : 'Unload'"
+                  :variant="op.operation === 'LOAD' ? 'info' : 'secondary'"
+                  size="s"
+                />
+              </td>
+              <td :title="op.name">
+                <div class="path-display">
+                  <code class="path-name">{{ fileName(op.name) }}</code>
+                  <span v-if="dirName(op.name)" class="path-dir">{{ dirName(op.name) }}</span>
+                </div>
+              </td>
+              <td class="text-end">
+                {{ FormattingService.formatDuration2Units(op.timeOffsetMillis * 1_000_000) }}
+              </td>
+              <td class="text-end">{{ FormattingService.formatDuration2Units(op.durationNanos) }}</td>
+              <td>
+                <Badge
+                  :value="op.success ? 'OK' : 'Failed'"
+                  :variant="op.success ? 'success' : 'danger'"
+                  size="s"
+                />
+              </td>
+              <td class="error-cell" :title="op.errorMessage ?? ''">{{ op.errorMessage ?? '—' }}</td>
+            </tr>
+          </tbody>
+          <template #footer>
+            <TableShowMore
+              :shown="operationsView.visible.length"
+              :match-count="operationsView.matchCount"
+              :total="operationsView.total"
+              :expanded="operationsView.expanded"
+              :page-size="operationsView.pageSize"
+              @toggle="operationsView.toggle"
+            />
+          </template>
+        </DataTable>
+      </div>
+
+      <!-- Timeline -->
+      <div v-show="activeTab === 'timeline'">
+        <ChartDescription
+          shows="Library loads and unloads per second"
+          use-case="Loads cluster at startup; later spikes reveal lazy/dynamic JNI loading or class-loader churn"
+        />
+        <TimeSeriesChart
+          :primary-data="loadsSeries"
+          :secondary-data="unloadsSeries"
+          primary-title="Loads"
+          secondary-title="Unloads"
+          :primary-axis-type="AxisFormatType.NUMBER"
+          :secondary-axis-type="AxisFormatType.NUMBER"
+          :visible-minutes="60"
+          primary-color="#34A853"
+          secondary-color="#9AA0A6"
+        />
+      </div>
+
+      <!-- About -->
+      <div v-show="activeTab === 'about'">
+        <AboutPanel>
+          <AboutSection icon="bi-box-arrow-in-down" title="What Native Library Loads Tell You">
+            <p>
+              The JVM loads native dynamic libraries (<code>.so</code> / <code>.dll</code> /
+              <code>.dylib</code>) for JNI code, the JDK's own native pieces, and agents.
+              <code>jdk.NativeLibraryLoad</code> and <code>jdk.NativeLibraryUnload</code> (JDK 24+)
+              record each operation with its <strong>duration</strong> and a <strong>success</strong>
+              flag, unlike the static <code>jdk.NativeLibrary</code> inventory on the Native Memory page.
+            </p>
+            <AboutCallout variant="warning" title="Failed loads are real bugs" icon="bi-exclamation-triangle-fill">
+              A failed load (a missing or ABI-incompatible native dependency) often surfaces only as a
+              later <code>UnsatisfiedLinkError</code>. The error message here is the earliest signal.
+            </AboutCallout>
+          </AboutSection>
+
+          <AboutSection icon="bi-graph-up" title="Reading the Views">
+            <FeatureGrid>
+              <FeatureCard icon="bi-list-ol" variant="primary" title="Operations">
+                Every load/unload, slowest first, with duration, status and error — find slow loads and
+                failures at a glance.
+              </FeatureCard>
+              <FeatureCard icon="bi-activity" variant="success" title="Timeline">
+                Loads/unloads per second. A burst long after startup points at lazy JNI loading or
+                class-loader churn.
+              </FeatureCard>
+            </FeatureGrid>
+          </AboutSection>
+        </AboutPanel>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { useRoute } from 'vue-router';
+
+import PageHeader from '@/components/layout/PageHeader.vue';
+import StatsTable from '@/components/StatsTable.vue';
+import TabBar from '@/components/TabBar.vue';
+import type { TabBarItem } from '@/components/TabBar.vue';
+import TimeSeriesChart from '@/components/TimeSeriesChart.vue';
+import DataTable from '@/components/table/DataTable.vue';
+import TableToolbar from '@/components/table/TableToolbar.vue';
+import TableShowMore from '@/components/table/TableShowMore.vue';
+import ChartDescription from '@/components/ChartDescription.vue';
+import AboutPanel from '@/components/about/AboutPanel.vue';
+import AboutCallout from '@/components/about/AboutCallout.vue';
+import AboutSection from '@/components/about/AboutSection.vue';
+import FeatureGrid from '@/components/about/FeatureGrid.vue';
+import FeatureCard from '@/components/about/FeatureCard.vue';
+import Badge from '@/components/Badge.vue';
+import EmptyState from '@/components/EmptyState.vue';
+import LoadingState from '@/components/LoadingState.vue';
+import ErrorState from '@/components/ErrorState.vue';
+import FormattingService from '@/services/FormattingService';
+import AxisFormatType from '@/services/timeseries/AxisFormatType';
+import ProfileNativeMemoryClient from '@/services/api/ProfileNativeMemoryClient';
+import type {
+  LibraryOperation,
+  NativeLibraryActivityData
+} from '@/services/api/model/NativeLibraryActivityModels';
+import { useTableView } from '@/composables/useTableView';
+
+const route = useRoute();
+
+const loading = ref(true);
+const error = ref(false);
+const data = ref<NativeLibraryActivityData>();
+const failuresOnly = ref(false);
+const activeTab = ref('operations');
+
+const allOperations = computed<LibraryOperation[]>(() => data.value?.operations ?? []);
+const filteredOperations = computed<LibraryOperation[]>(() =>
+  failuresOnly.value ? allOperations.value.filter((op) => !op.success) : allOperations.value
+);
+const operationsView = useTableView<LibraryOperation>(filteredOperations, {
+  searchableText: (op) => op.name
+});
+
+// Split a library path into its file name and parent directory for a two-line cell.
+const fileName = (path: string): string => {
+  const trimmed = path.replace(/\/+$/, '');
+  const slash = trimmed.lastIndexOf('/');
+  return slash >= 0 ? trimmed.substring(slash + 1) : trimmed;
+};
+
+const dirName = (path: string): string => {
+  const trimmed = path.replace(/\/+$/, '');
+  const slash = trimmed.lastIndexOf('/');
+  return slash > 0 ? trimmed.substring(0, slash) : '';
+};
+
+const hasData = computed(() => {
+  const h = data.value?.header;
+  if (!h) {
+    return false;
+  }
+  return h.totalLoads > 0 || h.totalUnloads > 0;
+});
+
+const loadsSeries = computed<number[][]>(() => data.value?.timeline.series?.[0]?.data ?? []);
+const unloadsSeries = computed<number[][]>(() => data.value?.timeline.series?.[1]?.data ?? []);
+
+const tabs = computed<TabBarItem[]>(() => [
+  { id: 'operations', label: 'Operations', icon: 'list-ol' },
+  { id: 'timeline', label: 'Timeline', icon: 'activity' },
+  { id: 'about', label: 'How It Works', icon: 'book' }
+]);
+
+const metrics = computed(() => {
+  const h = data.value?.header;
+  if (!h) {
+    return [];
+  }
+  return [
+    {
+      icon: 'box-arrow-in-down',
+      title: 'Library Loads',
+      value: FormattingService.formatNumber(h.totalLoads),
+      variant: 'highlight' as const,
+      breakdown: [{ label: 'Failed', value: FormattingService.formatNumber(h.failedLoads) }]
+    },
+    {
+      icon: 'hourglass-split',
+      title: 'Slowest Load',
+      value: FormattingService.formatDuration2Units(h.slowestLoadNanos),
+      variant: 'warning' as const,
+      breakdown: [{ label: 'Library', value: h.slowestLibrary ?? '—' }]
+    },
+    {
+      icon: 'stopwatch',
+      title: 'Total Load Time',
+      value: FormattingService.formatDuration2Units(h.totalLoadNanos),
+      variant: 'info' as const
+    },
+    {
+      icon: 'box-arrow-up',
+      title: 'Unloads',
+      value: FormattingService.formatNumber(h.totalUnloads),
+      variant: 'success' as const
+    }
+  ];
+});
+
+const loadData = async () => {
+  try {
+    loading.value = true;
+    error.value = false;
+    const client = new ProfileNativeMemoryClient(route.params.profileId as string);
+    data.value = await client.getNativeLibraryActivity();
+  } catch (err) {
+    error.value = true;
+    console.error('Error loading native-library activity:', err);
+  } finally {
+    loading.value = false;
+  }
+};
+
+onMounted(loadData);
+</script>
+
+<style scoped>
+.path-display {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
+}
+
+.path-name {
+  font-weight: 600;
+}
+
+.path-dir {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.error-cell {
+  max-width: 28rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--color-danger);
+}
+
+.failures-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+</style>

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/NativeMemoryManager.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/NativeMemoryManager.java
@@ -18,6 +18,7 @@
 
 package cafe.jeffrey.profile.manager;
 
+import cafe.jeffrey.profile.manager.model.nativememory.NativeLibraryActivityData;
 import cafe.jeffrey.profile.manager.model.nativememory.NativeLibraryInfo;
 import cafe.jeffrey.profile.manager.model.nativememory.NativeMemoryOverview;
 import cafe.jeffrey.shared.common.model.ProfileInfo;
@@ -57,4 +58,10 @@ public interface NativeMemoryManager {
      * Loaded native libraries, ordered by descending mapped size.
      */
     List<NativeLibraryInfo> nativeLibraries();
+
+    /**
+     * Native dynamic-library load/unload activity ({@code jdk.NativeLibraryLoad} /
+     * {@code jdk.NativeLibraryUnload}): load durations, failed loads, and load/unload timelines.
+     */
+    NativeLibraryActivityData nativeLibraryActivity();
 }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/NativeMemoryManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/NativeMemoryManagerImpl.java
@@ -21,6 +21,8 @@ package cafe.jeffrey.profile.manager;
 import tools.jackson.databind.node.ObjectNode;
 import cafe.jeffrey.profile.manager.model.nativememory.DirectBufferTimeseriesBuilder;
 import cafe.jeffrey.profile.manager.model.nativememory.NativeLibrariesBuilder;
+import cafe.jeffrey.profile.manager.model.nativememory.NativeLibraryActivityBuilder;
+import cafe.jeffrey.profile.manager.model.nativememory.NativeLibraryActivityData;
 import cafe.jeffrey.profile.manager.model.nativememory.NativeLibraryInfo;
 import cafe.jeffrey.profile.manager.model.nativememory.NativeMemoryOverview;
 import cafe.jeffrey.profile.manager.model.nativememory.RssStatsBuilder;
@@ -42,6 +44,7 @@ public class NativeMemoryManagerImpl implements NativeMemoryManager {
     private static final String DIRECT_BUFFER_COUNT_FIELD = "count";
     private static final String DIRECT_BUFFER_MEMORY_USED_FIELD = "memoryUsed";
     private static final String DIRECT_BUFFER_TOTAL_CAPACITY_FIELD = "totalCapacity";
+    private static final int MAX_LIBRARY_OPERATIONS = 500;
 
     private final ProfileInfo profileInfo;
     private final ProfileEventRepository eventRepository;
@@ -109,5 +112,17 @@ public class NativeMemoryManagerImpl implements NativeMemoryManager {
                 .orderedByTime();
 
         return eventStreamRepository.genericStreaming(configurer, new NativeLibrariesBuilder());
+    }
+
+    @Override
+    public NativeLibraryActivityData nativeLibraryActivity() {
+        RelativeTimeRange timeRange = new RelativeTimeRange(profileInfo.profilingStartEnd());
+
+        EventQueryConfigurer configurer = new EventQueryConfigurer()
+                .withEventTypes(List.of(Type.NATIVE_LIBRARY_LOAD, Type.NATIVE_LIBRARY_UNLOAD))
+                .withJsonFields();
+
+        return eventStreamRepository.genericStreaming(
+                configurer, new NativeLibraryActivityBuilder(timeRange, MAX_LIBRARY_OPERATIONS));
     }
 }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/nativememory/NativeLibraryActivityBuilder.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/nativememory/NativeLibraryActivityBuilder.java
@@ -1,0 +1,126 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.nativememory;
+
+import org.eclipse.collections.impl.map.mutable.primitive.LongLongHashMap;
+import tools.jackson.databind.node.ObjectNode;
+import cafe.jeffrey.profile.manager.model.nativememory.NativeLibraryActivityData.Header;
+import cafe.jeffrey.profile.manager.model.nativememory.NativeLibraryActivityData.LibraryOperation;
+import cafe.jeffrey.profile.manager.model.nativememory.NativeLibraryActivityData.Operation;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.provider.profile.api.RecordBuilder;
+import cafe.jeffrey.shared.common.Json;
+import cafe.jeffrey.shared.common.model.Type;
+import cafe.jeffrey.shared.common.model.time.RelativeTimeRange;
+import cafe.jeffrey.timeseries.SingleSerie;
+import cafe.jeffrey.timeseries.TimeseriesData;
+import cafe.jeffrey.timeseries.TimeseriesUtils;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Aggregates {@code jdk.NativeLibraryLoad} / {@code jdk.NativeLibraryUnload} into headline counters, a
+ * per-operation list (slowest first) and per-second load/unload count timelines.
+ */
+public class NativeLibraryActivityBuilder
+        implements RecordBuilder<GenericRecord, NativeLibraryActivityData> {
+
+    private static final String NAME_FIELD = "name";
+    private static final String SUCCESS_FIELD = "success";
+    private static final String ERROR_MESSAGE_FIELD = "errorMessage";
+    private static final String UNKNOWN_LIBRARY = "unknown";
+    private static final String LOADS_SERIES = "Loads";
+    private static final String UNLOADS_SERIES = "Unloads";
+
+    private final int maxOps;
+    private final LongLongHashMap loadsSeries;
+    private final LongLongHashMap unloadsSeries;
+    private final List<LibraryOperation> operations = new ArrayList<>();
+    private long totalLoads;
+    private long failedLoads;
+    private long totalUnloads;
+    private long slowestLoadNanos;
+    private long totalLoadNanos;
+    private String slowestLibrary;
+
+    public NativeLibraryActivityBuilder(RelativeTimeRange timeRange, int maxOps) {
+        if (maxOps <= 0) {
+            throw new IllegalArgumentException("maxOps must be positive: " + maxOps);
+        }
+        this.maxOps = maxOps;
+        this.loadsSeries = TimeseriesUtils.initWithZeros(timeRange);
+        this.unloadsSeries = TimeseriesUtils.initWithZeros(timeRange);
+    }
+
+    @Override
+    public void onRecord(GenericRecord record) {
+        ObjectNode fields = record.jsonFields();
+        Operation operation = Type.NATIVE_LIBRARY_UNLOAD.sameAs(record.type()) ? Operation.UNLOAD : Operation.LOAD;
+
+        String name = Json.readString(fields, NAME_FIELD);
+        boolean success = Json.readBoolean(fields, SUCCESS_FIELD);
+        String errorMessage = Json.readString(fields, ERROR_MESSAGE_FIELD);
+        Duration duration = record.duration();
+        long durationNanos = duration == null ? 0 : Math.max(0, duration.toNanos());
+        long seconds = record.timestampFromStart().toSeconds();
+
+        operations.add(new LibraryOperation(
+                operation,
+                name == null ? UNKNOWN_LIBRARY : name,
+                record.timestampFromStart().toMillis(),
+                durationNanos,
+                success,
+                errorMessage == null || errorMessage.isBlank() ? null : errorMessage));
+
+        if (operation == Operation.LOAD) {
+            totalLoads++;
+            totalLoadNanos += durationNanos;
+            if (!success) {
+                failedLoads++;
+            }
+            if (durationNanos > slowestLoadNanos) {
+                slowestLoadNanos = durationNanos;
+                slowestLibrary = name;
+            }
+            loadsSeries.addToValue(seconds, 1);
+        } else {
+            totalUnloads++;
+            unloadsSeries.addToValue(seconds, 1);
+        }
+    }
+
+    @Override
+    public NativeLibraryActivityData build() {
+        List<LibraryOperation> sorted = operations.stream()
+                .sorted(Comparator.comparingLong(LibraryOperation::durationNanos).reversed())
+                .limit(maxOps)
+                .toList();
+
+        SingleSerie loadsSerie = TimeseriesUtils.buildSerie(LOADS_SERIES, loadsSeries);
+        SingleSerie unloadsSerie = TimeseriesUtils.buildSerie(UNLOADS_SERIES, unloadsSeries);
+
+        Header header = new Header(
+                totalLoads, failedLoads, totalUnloads, slowestLoadNanos, totalLoadNanos, slowestLibrary);
+
+        return new NativeLibraryActivityData(header, sorted, new TimeseriesData(loadsSerie, unloadsSerie));
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/nativememory/NativeLibraryActivityData.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/nativememory/NativeLibraryActivityData.java
@@ -1,0 +1,80 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.nativememory;
+
+import cafe.jeffrey.timeseries.TimeseriesData;
+
+import java.util.List;
+
+/**
+ * Native dynamic-library load/unload activity from {@code jdk.NativeLibraryLoad} and
+ * {@code jdk.NativeLibraryUnload} (JDK 24+). Unlike the static {@code jdk.NativeLibrary} list, these
+ * carry the load/unload {@code duration} (slow-startup contributors) and a {@code success} flag with
+ * an {@code errorMessage} (failed {@code dlopen}/JNI loads — a real startup bug).
+ *
+ * @param header     headline counters
+ * @param operations individual load/unload operations, slowest first, capped
+ * @param timeline   per-second load and unload counts ({@code Loads} / {@code Unloads} series)
+ */
+public record NativeLibraryActivityData(
+        Header header,
+        List<LibraryOperation> operations,
+        TimeseriesData timeline) {
+
+    public enum Operation {
+        LOAD,
+        UNLOAD
+    }
+
+    /**
+     * @param totalLoads      number of load operations
+     * @param failedLoads     loads whose {@code success} flag was false
+     * @param totalUnloads    number of unload operations
+     * @param slowestLoadNanos duration of the slowest load
+     * @param totalLoadNanos  summed load duration (approximate startup cost of native linking)
+     * @param slowestLibrary  name of the slowest-loading library ({@code null} when none)
+     */
+    public record Header(
+            long totalLoads,
+            long failedLoads,
+            long totalUnloads,
+            long slowestLoadNanos,
+            long totalLoadNanos,
+            String slowestLibrary) {
+    }
+
+    /**
+     * A single native-library load or unload.
+     *
+     * @param operation       LOAD or UNLOAD
+     * @param name            library name/path
+     * @param timeOffsetMillis offset from the recording start
+     * @param durationNanos   load/unload duration
+     * @param success         whether the operation succeeded
+     * @param errorMessage    failure description when {@code success} is false ({@code null} otherwise)
+     */
+    public record LibraryOperation(
+            Operation operation,
+            String name,
+            long timeOffsetMillis,
+            long durationNanos,
+            boolean success,
+            String errorMessage) {
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/nativememory/NativeLibraryActivityBuilderTest.java
+++ b/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/nativememory/NativeLibraryActivityBuilderTest.java
@@ -1,0 +1,112 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.nativememory;
+
+import tools.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import cafe.jeffrey.profile.manager.model.nativememory.NativeLibraryActivityData.LibraryOperation;
+import cafe.jeffrey.profile.manager.model.nativememory.NativeLibraryActivityData.Operation;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.shared.common.Json;
+import cafe.jeffrey.shared.common.model.Type;
+import cafe.jeffrey.shared.common.model.time.RelativeTimeRange;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@DisplayName("NativeLibraryActivityBuilder")
+class NativeLibraryActivityBuilderTest {
+
+    private static final Instant START = Instant.parse("2024-01-01T00:00:00Z");
+    private static final long MS = 1_000_000L;
+
+    private static GenericRecord rec(Type type, long secondsFromStart, long durationNanos, ObjectNode fields) {
+        return new GenericRecord(
+                type, "label", START,
+                Duration.ofSeconds(secondsFromStart), Duration.ofNanos(durationNanos),
+                null, null, 0L, 0L, fields);
+    }
+
+    private static ObjectNode fields(String name, boolean success, String errorMessage) {
+        ObjectNode node = Json.createObject();
+        node.put("name", name);
+        node.put("success", success);
+        if (errorMessage != null) {
+            node.put("errorMessage", errorMessage);
+        }
+        return node;
+    }
+
+    @Test
+    @DisplayName("Counts loads/unloads, tracks failures and slowest load, builds timelines")
+    void aggregates() {
+        NativeLibraryActivityBuilder builder = new NativeLibraryActivityBuilder(new RelativeTimeRange(0, 10_000), 10);
+        builder.onRecord(rec(Type.NATIVE_LIBRARY_LOAD, 1, 5 * MS, fields("libfast.so", true, null)));
+        builder.onRecord(rec(Type.NATIVE_LIBRARY_LOAD, 1, 40 * MS, fields("libslow.so", true, null)));
+        builder.onRecord(rec(Type.NATIVE_LIBRARY_LOAD, 2, 0, fields("libmissing.so", false, "cannot open shared object file")));
+        builder.onRecord(rec(Type.NATIVE_LIBRARY_UNLOAD, 3, 1 * MS, fields("libfast.so", true, null)));
+
+        NativeLibraryActivityData data = builder.build();
+
+        assertEquals(3, data.header().totalLoads());
+        assertEquals(1, data.header().failedLoads());
+        assertEquals(1, data.header().totalUnloads());
+        assertEquals(40 * MS, data.header().slowestLoadNanos());
+        assertEquals(45 * MS, data.header().totalLoadNanos());
+        assertEquals("libslow.so", data.header().slowestLibrary());
+
+        // Operations are sorted by duration desc; slowest load first.
+        assertEquals("libslow.so", data.operations().getFirst().name());
+        assertEquals(Operation.LOAD, data.operations().getFirst().operation());
+
+        // Failed load carries its error message and false success.
+        LibraryOperation failed = data.operations().stream()
+                .filter(op -> op.name().equals("libmissing.so"))
+                .findFirst()
+                .orElseThrow();
+        assertFalse(failed.success());
+        assertEquals("cannot open shared object file", failed.errorMessage());
+
+        // Successful op has no error message.
+        assertNull(data.operations().getFirst().errorMessage());
+
+        assertEquals("Loads", data.timeline().series().getFirst().name());
+        assertEquals("Unloads", data.timeline().series().get(1).name());
+    }
+
+    @Test
+    @DisplayName("Caps the number of returned operations")
+    void capsOperations() {
+        NativeLibraryActivityBuilder builder = new NativeLibraryActivityBuilder(new RelativeTimeRange(0, 10_000), 2);
+        for (int i = 0; i < 5; i++) {
+            builder.onRecord(rec(Type.NATIVE_LIBRARY_LOAD, 1, i * MS, fields("lib" + i + ".so", true, null)));
+        }
+
+        NativeLibraryActivityData data = builder.build();
+
+        assertEquals(5, data.header().totalLoads());
+        assertEquals(2, data.operations().size());
+        assertEquals("lib4.so", data.operations().getFirst().name());
+    }
+}

--- a/jeffrey-pages/src/views/docs/microscope/profiles/ProfileNativeMemoryPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/profiles/ProfileNativeMemoryPage.vue
@@ -30,6 +30,7 @@ const headings = [
   { id: 'rss-vs-heap', text: 'RSS vs Heap', level: 2 },
   { id: 'direct-buffers', text: 'Direct Buffers', level: 2 },
   { id: 'native-libraries', text: 'Native Libraries', level: 2 },
+  { id: 'native-library-loads', text: 'Native Library Loads', level: 2 },
   { id: 'events', text: 'Source Events', level: 2 }
 ];
 
@@ -64,12 +65,16 @@ onMounted(() => {
       <h2 id="native-libraries">Native Libraries</h2>
       <p>All native libraries mapped into the process with their mapped address-range sizes, from <code>jdk.NativeLibrary</code>. Useful to confirm which JNI-backed dependencies are present when chasing a native leak suspect.</p>
 
+      <h2 id="native-library-loads">Native Library Loads</h2>
+      <p>A dedicated page (<strong>Native Library Loads</strong> in the sidebar) for the load/unload <em>operations</em> from <code>jdk.NativeLibraryLoad</code> / <code>jdk.NativeLibraryUnload</code> (JDK 24+) — unlike the static inventory above, these carry each operation's <strong>duration</strong> and a <strong>success</strong> flag. The Operations tab lists every load/unload slowest-first (with a failures-only filter); a failed load (a missing or ABI-incompatible native dependency) is the earliest signal of an eventual <code>UnsatisfiedLinkError</code>. The Timeline tab shows loads/unloads per second — loads cluster at startup, so later bursts reveal lazy JNI loading or class-loader churn.</p>
+
       <h2 id="events">Source Events</h2>
       <ul>
         <li><code>jdk.ResidentSetSize</code> — periodic RSS samples with current and peak values.</li>
         <li><code>jdk.GCHeapSummary</code> — heap usage at GC boundaries (the heap overlay).</li>
         <li><code>jdk.DirectBufferStatistics</code> — periodic direct-buffer count, capacity, and memory used.</li>
         <li><code>jdk.NativeLibrary</code> — loaded native libraries with mapped address ranges.</li>
+        <li><code>jdk.NativeLibraryLoad</code> / <code>jdk.NativeLibraryUnload</code> — per-operation load/unload timing and success (JDK 24+).</li>
       </ul>
 
       <DocsCallout type="info">

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/EventTypeName.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/EventTypeName.java
@@ -131,6 +131,8 @@ public abstract class EventTypeName {
     public static final String RESIDENT_SET_SIZE = "jdk.ResidentSetSize";
     public static final String DIRECT_BUFFER_STATISTICS = "jdk.DirectBufferStatistics";
     public static final String NATIVE_LIBRARY = "jdk.NativeLibrary";
+    public static final String NATIVE_LIBRARY_LOAD = "jdk.NativeLibraryLoad";
+    public static final String NATIVE_LIBRARY_UNLOAD = "jdk.NativeLibraryUnload";
     public static final String NATIVE_MEMORY_USAGE = "jdk.NativeMemoryUsage";
     public static final String NATIVE_MEMORY_USAGE_TOTAL = "jdk.NativeMemoryUsageTotal";
 

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/Type.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/Type.java
@@ -141,6 +141,8 @@ public record Type(String code, boolean calculated) {
     public static final Type RESIDENT_SET_SIZE = new Type(EventTypeName.RESIDENT_SET_SIZE);
     public static final Type DIRECT_BUFFER_STATISTICS = new Type(EventTypeName.DIRECT_BUFFER_STATISTICS);
     public static final Type NATIVE_LIBRARY = new Type(EventTypeName.NATIVE_LIBRARY);
+    public static final Type NATIVE_LIBRARY_LOAD = new Type(EventTypeName.NATIVE_LIBRARY_LOAD);
+    public static final Type NATIVE_LIBRARY_UNLOAD = new Type(EventTypeName.NATIVE_LIBRARY_UNLOAD);
     public static final Type NATIVE_MEMORY_USAGE = new Type(EventTypeName.NATIVE_MEMORY_USAGE);
     public static final Type NATIVE_MEMORY_USAGE_TOTAL = new Type(EventTypeName.NATIVE_MEMORY_USAGE_TOTAL);
 
@@ -316,6 +318,8 @@ public record Type(String code, boolean calculated) {
                 RESIDENT_SET_SIZE,
                 DIRECT_BUFFER_STATISTICS,
                 NATIVE_LIBRARY,
+                NATIVE_LIBRARY_LOAD,
+                NATIVE_LIBRARY_UNLOAD,
                 NATIVE_MEMORY_USAGE,
                 NATIVE_MEMORY_USAGE_TOTAL,
                 EXCEPTION_STATISTICS,


### PR DESCRIPTION
## Summary

A new dedicated **Native Library Loads** page (sidebar item directly under **Native Memory**) surfacing `jdk.NativeLibraryLoad` / `jdk.NativeLibraryUnload` (JDK 24+) — the load/unload *operations*, which the existing static `jdk.NativeLibrary` inventory does not cover.

**JDK-26 verification (`jfr metadata`, Temurin 26.0.1):** both events carry a `duration` (@Timespan load/unload time), a `success` flag, and an `errorMessage` — richer than a bare timeline. A failed load (a missing or ABI-incompatible native dependency) is the earliest signal of an eventual `UnsatisfiedLinkError`.

## Views (tabs)
- **Operations** — every load/unload, slowest first: operation (`Badge`), library (file/dir), time offset, load time, status (success/failed `Badge`), error message. Includes a **failures-only** filter.
- **Timeline** — Loads vs Unloads per second (shared `TimeSeriesChart`). Loads cluster at startup, so later bursts reveal lazy JNI loading / class-loader churn.
- **Header** (`StatsTable`) — library loads (+ failed breakdown), slowest load (+ which library), total load time, unloads.
- **About** — explainer.

## Implementation
- Register `NATIVE_LIBRARY_LOAD` / `NATIVE_LIBRARY_UNLOAD` in `Type`/`EventTypeName` (+ `KNOWN_TYPES`).
- `NativeLibraryActivityBuilder` + `NativeLibraryActivityData` (`model/nativememory/`): headline counters, per-operation list (slowest first, capped at 500), per-second `Loads`/`Unloads` timelines.
- `NativeMemoryManager.nativeLibraryActivity()` + `NativeMemoryManagerImpl` (single `genericStreaming` pass over the two event types); `GET /api/internal/profiles/{profileId}/native-memory/library-activity`. No new factory wiring — a method on the existing manager.
- Frontend: `ProfileNativeLibraryLoads.vue`, `ProfileNativeMemoryClient.getNativeLibraryActivity()`, `NativeLibraryActivityModels.ts`, route, sidebar entry.

## Tests
- `NativeLibraryActivityBuilderTest`: load/unload counting, failed-load count, slowest/total load nanos, ops sorted + capped, timeline series names.
- New `NativeMemoryControllerTest`: `/native-memory/library-activity` + profile-not-found.

## Verification
- Backend compiled + tested on **JDK 26** (`mvn -pl jeffrey-microscope/profiles/profile-management,jeffrey-microscope/core-microscope -am test`) — green.
- Frontend (`pages-microscope`): ESLint clean, Vite build passes. Docs (`jeffrey-pages`) build passes (Native Library Loads section added to the Native Memory docs page).

https://claude.ai/code/session_019PNnPZQ2oSTUGrEjFfsE4x

---
_Generated by [Claude Code](https://claude.ai/code/session_019PNnPZQ2oSTUGrEjFfsE4x)_