### PR TITLE
Add Thread Dumps page

### DIFF
--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/ThreadController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/ThreadController.java
@@ -29,6 +29,8 @@ import cafe.jeffrey.profile.manager.ThreadManager;
 import cafe.jeffrey.profile.manager.model.thread.ThreadCpuLoads;
 import cafe.jeffrey.profile.manager.model.thread.ThreadStats;
 import cafe.jeffrey.profile.manager.model.thread.ThreadWithCpuLoad;
+import cafe.jeffrey.profile.manager.model.thread.dump.ParsedDump;
+import cafe.jeffrey.profile.manager.model.thread.dump.ThreadDumpAnalysis;
 import cafe.jeffrey.profile.thread.ThreadRoot;
 import cafe.jeffrey.provider.profile.api.AllocatingThread;
 import cafe.jeffrey.shared.common.model.Type;
@@ -80,6 +82,20 @@ public class ThreadController {
     public SingleSerie activeThreadsSerie(@PathVariable("profileId") String profileId) {
         LOG.debug("Fetching active threads timeseries");
         return mgr(profileId).activeThreadsSerie();
+    }
+
+    @GetMapping("/dumps")
+    public ThreadDumpAnalysis threadDumpAnalysis(@PathVariable("profileId") String profileId) {
+        LOG.debug("Fetching thread-dump analysis");
+        return mgr(profileId).threadDumpAnalysis();
+    }
+
+    @GetMapping("/dumps/{index}")
+    public ParsedDump threadDump(
+            @PathVariable("profileId") String profileId,
+            @PathVariable("index") int index) {
+        LOG.debug("Fetching thread dump: index={}", index);
+        return mgr(profileId).threadDump(index);
     }
 
     private ThreadManager mgr(String profileId) {

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/ThreadControllerTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/ThreadControllerTest.java
@@ -26,8 +26,11 @@ import org.springframework.test.web.servlet.assertj.MockMvcTester;
 import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
 import cafe.jeffrey.profile.manager.ProfileManager;
 import cafe.jeffrey.profile.manager.ThreadManager;
+import cafe.jeffrey.profile.manager.model.thread.dump.ParsedDump;
+import cafe.jeffrey.profile.manager.model.thread.dump.ThreadDumpAnalysis;
 import cafe.jeffrey.shared.common.exception.Exceptions;
 import cafe.jeffrey.timeseries.SingleSerie;
+import cafe.jeffrey.timeseries.TimeseriesData;
 
 import java.util.List;
 
@@ -59,6 +62,31 @@ class ThreadControllerTest {
                 .hasStatusOk()
                 .bodyJson()
                 .extractingPath("$.name").asString().isEqualTo("threads");
+    }
+
+    @Test
+    void getsThreadDumpAnalysis() {
+        when(resolver.resolve("p-1")).thenReturn(profileManager);
+        when(profileManager.threadManager()).thenReturn(threadManager);
+        when(threadManager.threadDumpAnalysis()).thenReturn(new ThreadDumpAnalysis(
+                new ThreadDumpAnalysis.Header(0, 0, 0, 0, 0, 0),
+                List.of(), new TimeseriesData(List.of()), List.of(), List.of(), List.of(), List.of(),
+                new ThreadDumpAnalysis.Heatmap(List.of(), List.of())));
+
+        MockMvcTester mvc = mockMvcTesterFor(new ThreadController(resolver));
+
+        assertThat(mvc.get().uri("/api/internal/profiles/p-1/thread/dumps")).hasStatusOk();
+    }
+
+    @Test
+    void getsSingleThreadDump() {
+        when(resolver.resolve("p-1")).thenReturn(profileManager);
+        when(profileManager.threadManager()).thenReturn(threadManager);
+        when(threadManager.threadDump(0)).thenReturn(new ParsedDump(0, List.of(), List.of(), ""));
+
+        MockMvcTester mvc = mockMvcTesterFor(new ThreadController(resolver));
+
+        assertThat(mvc.get().uri("/api/internal/profiles/p-1/thread/dumps/0")).hasStatusOk();
     }
 
     @Test

--- a/jeffrey-microscope/pages-microscope/src/router/index.ts
+++ b/jeffrey-microscope/pages-microscope/src/router/index.ts
@@ -104,6 +104,12 @@ const profileChildRoutes = [
     meta: { layout: 'profile' }
   },
   {
+    path: 'thread-dumps',
+    name: 'profile-thread-dumps',
+    component: () => import('@/views/profiles/detail/ProfileThreadDumps.vue'),
+    meta: { layout: 'profile' }
+  },
+  {
     path: 'jit-compilation',
     name: 'profile-jit-compilation',
     component: () => import('@/views/profiles/detail/ProfileJitCompilation.vue'),

--- a/jeffrey-microscope/pages-microscope/src/services/api/ProfileThreadClient.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/ProfileThreadClient.ts
@@ -20,6 +20,7 @@ import BaseProfileClient from '@/services/api/BaseProfileClient';
 import ThreadResponse from '@/services/api/model/ThreadResponse';
 import ThreadStatisticsResponse from '@/services/api/model/ThreadStatisticsResponse';
 import Serie from '@/services/timeseries/model/Serie';
+import type { ParsedDump, ThreadDumpAnalysis } from '@/services/api/model/ThreadDumpModels';
 
 export default class ProfileThreadClient extends BaseProfileClient {
   constructor(profileId: string) {
@@ -36,5 +37,13 @@ export default class ProfileThreadClient extends BaseProfileClient {
 
   public timeseries(): Promise<Serie> {
     return this.get<Serie>('/timeseries');
+  }
+
+  public dumps(): Promise<ThreadDumpAnalysis> {
+    return this.get<ThreadDumpAnalysis>('/dumps');
+  }
+
+  public dump(index: number): Promise<ParsedDump> {
+    return this.get<ParsedDump>(`/dumps/${index}`);
   }
 }

--- a/jeffrey-microscope/pages-microscope/src/services/api/model/ThreadDumpModels.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/model/ThreadDumpModels.ts
@@ -1,0 +1,121 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type TimeseriesData from '@/services/timeseries/model/TimeseriesData';
+
+export type ThreadState =
+  | 'RUNNABLE'
+  | 'BLOCKED'
+  | 'WAITING'
+  | 'TIMED_WAITING'
+  | 'NEW'
+  | 'TERMINATED'
+  | 'UNKNOWN';
+
+export type ThreadLockKind = 'LOCKED' | 'WAITING_TO_LOCK' | 'WAITING_ON' | 'PARKING_TO_WAIT';
+
+export interface ThreadDumpHeader {
+  dumpCount: number;
+  peakThreadCount: number;
+  deadlockCount: number;
+  stuckThreadCount: number;
+  firstOffsetMillis: number;
+  lastOffsetMillis: number;
+}
+
+export interface DumpDescriptor {
+  index: number;
+  timeOffsetMillis: number;
+  threadCount: number;
+  deadlockCount: number;
+}
+
+export interface FrameStat {
+  frame: string;
+  occurrences: number;
+  distinctThreads: number;
+}
+
+export interface DeadlockEntry {
+  dumpIndex: number;
+  timeOffsetMillis: number;
+  description: string;
+  involvedThreads: string[];
+}
+
+export interface LockContention {
+  monitorId: string;
+  monitorClass: string | null;
+  waiterCount: number;
+  owner: string | null;
+}
+
+export interface StuckThread {
+  name: string;
+  state: ThreadState;
+  topFrame: string;
+  consecutiveDumps: number;
+  stuckForMillis: number;
+}
+
+export interface HeatmapRow {
+  threadName: string;
+  states: (ThreadState | null)[];
+}
+
+export interface Heatmap {
+  dumpOffsets: number[];
+  rows: HeatmapRow[];
+}
+
+export interface ThreadDumpAnalysis {
+  header: ThreadDumpHeader;
+  dumps: DumpDescriptor[];
+  stateTimeline: TimeseriesData;
+  topFrames: FrameStat[];
+  deadlocks: DeadlockEntry[];
+  lockContention: LockContention[];
+  stuckThreads: StuckThread[];
+  heatmap: Heatmap;
+}
+
+export interface ThreadLock {
+  kind: ThreadLockKind;
+  monitorId: string | null;
+  monitorClass: string | null;
+}
+
+export interface ParsedThread {
+  name: string;
+  group: string;
+  state: ThreadState;
+  frames: string[];
+  locks: ThreadLock[];
+}
+
+export interface Deadlock {
+  description: string;
+  involvedThreads: string[];
+}
+
+export interface ParsedDump {
+  timeOffsetMillis: number;
+  threads: ParsedThread[];
+  deadlocks: Deadlock[];
+  rawText: string;
+}

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/ProfileDetail.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/ProfileDetail.vue
@@ -300,6 +300,14 @@
                       <i class="bi bi-pin-angle"></i>
                       <span>Virtual Threads</span>
                     </router-link>
+                    <router-link
+                      :to="`/profiles/${profileId}/thread-dumps`"
+                      class="nav-item"
+                      active-class="active"
+                    >
+                      <i class="bi bi-file-earmark-text"></i>
+                      <span>Thread Dumps</span>
+                    </router-link>
                   </div>
                 </div>
 

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileThreadDumps.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileThreadDumps.vue
@@ -1,0 +1,698 @@
+<!--
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ -->
+
+<template>
+  <LoadingState v-if="loading" message="Loading thread dumps..." />
+
+  <ErrorState v-else-if="error" message="Failed to load thread dumps" />
+
+  <div v-else>
+    <PageHeader
+      title="Thread Dumps"
+      description="Periodic jstack-style snapshots from jdk.ThreadDump: states, hot frames, locks, deadlocks and stuck threads"
+      icon="bi-file-earmark-text"
+    />
+
+    <EmptyState
+      v-if="!hasData"
+      icon="bi-file-earmark-text"
+      title="No thread dumps in this recording"
+      description="This profile contains no jdk.ThreadDump events (periodic dumps are emitted ~every 60s by the default profiling config)."
+    />
+
+    <div v-else>
+      <div class="mb-4">
+        <StatsTable :metrics="metrics" />
+      </div>
+
+      <TabBar v-model="activeTab" :tabs="tabs" class="mb-3" />
+
+      <!-- Timeline -->
+      <div v-show="activeTab === 'timeline'">
+        <ChartDescription
+          shows="Thread counts by state across the periodic dumps (carried forward between samples)"
+          use-case="A BLOCKED spike is a lock storm; a steadily climbing total is a thread leak; a pool full of WAITING is an idle pool"
+        />
+        <div class="chart-container">
+          <div id="thread-dump-state-chart"></div>
+        </div>
+      </div>
+
+      <!-- Activity -->
+      <div v-show="activeTab === 'activity'">
+        <ChartDescription
+          shows="The stack frames threads sit at most often, across all dumps"
+          use-case="Many threads at the same frame reveal idle pools (parked), I/O waits, or a genuine hotspot"
+        />
+        <DataTable>
+          <template #toolbar>
+            <TableToolbar v-model="framesView.query" search-placeholder="Filter frames...">
+              <span class="toolbar-info">Top frames</span>
+              <template #filters>
+                <Badge key-label="Frames" :value="framesView.matchCount" variant="secondary" size="s" borderless />
+              </template>
+            </TableToolbar>
+          </template>
+          <thead>
+            <tr>
+              <th>Frame</th>
+              <th class="text-end">Occurrences</th>
+              <th class="text-end">Distinct Threads</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(f, i) in framesView.visible" :key="i">
+              <td><code>{{ f.frame }}</code></td>
+              <td class="text-end">{{ FormattingService.formatNumber(f.occurrences) }}</td>
+              <td class="text-end">{{ FormattingService.formatNumber(f.distinctThreads) }}</td>
+            </tr>
+          </tbody>
+          <template #footer>
+            <TableShowMore
+              :shown="framesView.visible.length"
+              :match-count="framesView.matchCount"
+              :total="framesView.total"
+              :expanded="framesView.expanded"
+              :page-size="framesView.pageSize"
+              @toggle="framesView.toggle"
+            />
+          </template>
+        </DataTable>
+      </div>
+
+      <!-- Locks & Deadlocks -->
+      <div v-show="activeTab === 'locks'">
+        <h6 class="section-title">Deadlocks</h6>
+        <EmptyState
+          v-if="data!.deadlocks.length === 0"
+          icon="bi-check-circle"
+          title="No deadlocks detected"
+          description="No 'Found one Java-level deadlock' section appeared in any dump."
+        />
+        <div v-for="(d, i) in data!.deadlocks" :key="i" class="deadlock-card mb-3">
+          <div class="deadlock-head">
+            <i class="bi bi-exclamation-octagon-fill"></i>
+            <span>Deadlock at {{ formatOffset(d.timeOffsetMillis) }}</span>
+            <span class="deadlock-threads">{{ d.involvedThreads.join(' ↔ ') }}</span>
+          </div>
+          <pre class="deadlock-body">{{ d.description }}</pre>
+        </div>
+
+        <h6 class="section-title mt-4">Lock Contention <span class="muted">(worst dump)</span></h6>
+        <div class="table-responsive">
+          <table class="table table-sm table-hover mb-0">
+            <thead>
+              <tr>
+                <th>Monitor</th>
+                <th>Class</th>
+                <th class="text-end">Waiters</th>
+                <th>Owner</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(c, i) in data!.lockContention" :key="i">
+                <td><code>{{ c.monitorId }}</code></td>
+                <td>{{ c.monitorClass ?? '—' }}</td>
+                <td class="text-end">{{ FormattingService.formatNumber(c.waiterCount) }}</td>
+                <td>{{ c.owner ?? '—' }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <EmptyState
+          v-if="data!.lockContention.length === 0"
+          icon="bi-unlock"
+          title="No monitor contention recorded"
+        />
+      </div>
+
+      <!-- Stuck -->
+      <div v-show="activeTab === 'stuck'">
+        <ChartDescription
+          shows="Threads whose stack stayed identical across consecutive dumps"
+          use-case="A stack that does not move across dumps is a hung, slow, or deadlocked thread — the longer the run, the more suspicious"
+        />
+        <div class="table-responsive">
+          <table class="table table-sm table-hover mb-0">
+            <thead>
+              <tr>
+                <th>Thread</th>
+                <th>State</th>
+                <th>Top Frame</th>
+                <th class="text-end">Dumps</th>
+                <th class="text-end">Stuck For</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(s, i) in data!.stuckThreads" :key="i">
+                <td>{{ s.name }}</td>
+                <td><Badge :value="s.state" :variant="stateVariant(s.state)" size="s" /></td>
+                <td><code>{{ s.topFrame }}</code></td>
+                <td class="text-end">{{ s.consecutiveDumps }}</td>
+                <td class="text-end">{{ formatOffset(s.stuckForMillis) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <EmptyState
+          v-if="data!.stuckThreads.length === 0"
+          icon="bi-check-circle"
+          title="No stuck threads"
+          description="No thread kept the same stack across 3+ consecutive dumps."
+        />
+      </div>
+
+      <!-- Heatmap -->
+      <div v-show="activeTab === 'heatmap'">
+        <ChartDescription
+          shows="Each tracked thread's state across the dump sequence (BLOCKED and stuck threads first)"
+          use-case="Spot a thread that turns and stays BLOCKED, or a pool that fills with BLOCKED over time"
+        />
+        <div class="heatmap-legend">
+          <span v-for="state in legendStates" :key="state" class="legend-item">
+            <span class="legend-swatch" :style="{ background: stateColor(state) }"></span>{{ state }}
+          </span>
+        </div>
+        <div class="heatmap-scroll">
+          <div
+            class="heatmap-grid"
+            :style="{ gridTemplateColumns: `var(--heatmap-label-w) repeat(${data!.heatmap.dumpOffsets.length}, 16px)` }"
+          >
+            <template v-for="row in data!.heatmap.rows" :key="row.threadName">
+              <div class="heatmap-label" :title="row.threadName">{{ row.threadName }}</div>
+              <div
+                v-for="(state, i) in row.states"
+                :key="i"
+                class="heatmap-cell"
+                :style="{ background: state ? stateColor(state) : 'transparent' }"
+                :title="`${row.threadName} · ${state ?? 'absent'} @ ${formatOffset(data!.heatmap.dumpOffsets[i])}`"
+              ></div>
+            </template>
+          </div>
+        </div>
+      </div>
+
+      <!-- Browse -->
+      <div v-show="activeTab === 'browse'">
+        <div class="browse-controls">
+          <label>
+            Dump
+            <select v-model.number="selectedIndex" class="form-select form-select-sm" @change="loadDump">
+              <option v-for="d in data!.dumps" :key="d.index" :value="d.index">
+                {{ formatOffset(d.timeOffsetMillis) }} · {{ d.threadCount }} threads
+                <template v-if="d.deadlockCount > 0"> · ⚠ deadlock</template>
+              </option>
+            </select>
+          </label>
+          <label>
+            State
+            <select v-model="browseStateFilter" class="form-select form-select-sm">
+              <option value="">All</option>
+              <option v-for="state in legendStates" :key="state" :value="state">{{ state }}</option>
+            </select>
+          </label>
+          <input v-model="browseQuery" class="form-control form-control-sm browse-search" placeholder="Filter by thread name..." />
+          <label class="raw-toggle"><input v-model="showRaw" type="checkbox" /> Raw text</label>
+        </div>
+
+        <LoadingState v-if="dumpLoading" message="Loading dump..." />
+        <pre v-else-if="showRaw" class="raw-dump">{{ selectedDump?.rawText }}</pre>
+        <div v-else>
+          <details v-for="(t, i) in browseThreads" :key="i" class="thread-block">
+            <summary>
+              <Badge :value="t.state" :variant="stateVariant(t.state)" size="s" />
+              <span class="thread-name">{{ t.name }}</span>
+              <code v-if="t.frames.length" class="thread-top">{{ t.frames[0] }}</code>
+            </summary>
+            <pre class="thread-stack">{{ t.frames.map((f) => '  at ' + f).join('\n') || '(no Java frames)' }}</pre>
+            <ul v-if="t.locks.length" class="thread-locks">
+              <li v-for="(l, li) in t.locks" :key="li">
+                {{ lockLabel(l.kind) }} <code>{{ l.monitorId }}</code>
+                <span v-if="l.monitorClass">(a {{ l.monitorClass }})</span>
+              </li>
+            </ul>
+          </details>
+          <EmptyState
+            v-if="browseThreads.length === 0"
+            icon="bi-search"
+            title="No threads match"
+          />
+        </div>
+      </div>
+
+      <!-- About -->
+      <div v-show="activeTab === 'about'">
+        <AboutPanel>
+          <AboutSection icon="bi-file-earmark-text" title="What Thread Dumps Tell You">
+            <p>
+              The JVM periodically emits a full textual thread dump (<code>jdk.ThreadDump</code>, like
+              <code>jstack</code>): every thread's state, stack and held/awaited locks. Jeffrey parses
+              each dump and correlates them across the recording, so you get trends instead of a single
+              snapshot.
+            </p>
+            <AboutCallout variant="tip" title="Sampled, not continuous" icon="bi-lightbulb-fill">
+              Dumps are periodic (~every 60s by default), so the timeline is a coarse sample — great for
+              hangs and saturation, not for sub-second spikes.
+            </AboutCallout>
+          </AboutSection>
+          <AboutSection icon="bi-graph-up" title="Reading the Views">
+            <FeatureGrid>
+              <FeatureCard icon="bi-activity" variant="primary" title="Timeline & Activity">
+                State counts over time and the frames threads sit at most — saturation and idle vs busy.
+              </FeatureCard>
+              <FeatureCard icon="bi-lock" variant="danger" title="Locks & Deadlocks">
+                JVM-reported deadlocks and the most-contended monitors with their waiters and owner.
+              </FeatureCard>
+              <FeatureCard icon="bi-hourglass-split" variant="warning" title="Stuck & Heatmap">
+                Threads whose stack never moves across dumps, and a per-thread state heatmap.
+              </FeatureCard>
+            </FeatureGrid>
+          </AboutSection>
+        </AboutPanel>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
+import { useRoute } from 'vue-router';
+import ApexCharts from 'apexcharts';
+
+import PageHeader from '@/components/layout/PageHeader.vue';
+import StatsTable from '@/components/StatsTable.vue';
+import TabBar from '@/components/TabBar.vue';
+import ChartDescription from '@/components/ChartDescription.vue';
+import DataTable from '@/components/table/DataTable.vue';
+import TableToolbar from '@/components/table/TableToolbar.vue';
+import TableShowMore from '@/components/table/TableShowMore.vue';
+import AboutPanel from '@/components/about/AboutPanel.vue';
+import AboutSection from '@/components/about/AboutSection.vue';
+import AboutCallout from '@/components/about/AboutCallout.vue';
+import FeatureGrid from '@/components/about/FeatureGrid.vue';
+import FeatureCard from '@/components/about/FeatureCard.vue';
+import Badge from '@/components/Badge.vue';
+import LoadingState from '@/components/LoadingState.vue';
+import ErrorState from '@/components/ErrorState.vue';
+import EmptyState from '@/components/EmptyState.vue';
+import ProfileThreadClient from '@/services/api/ProfileThreadClient';
+import FormattingService from '@/services/FormattingService';
+import { useTableView } from '@/composables/useTableView';
+import type {
+  FrameStat,
+  ParsedDump,
+  ThreadDumpAnalysis,
+  ThreadLockKind,
+  ThreadState
+} from '@/services/api/model/ThreadDumpModels';
+import type { Variant } from '@/types/ui';
+
+const route = useRoute();
+
+const loading = ref(true);
+const error = ref(false);
+const data = ref<ThreadDumpAnalysis>();
+const activeTab = ref('timeline');
+
+let client: ProfileThreadClient | null = null;
+let chart: ApexCharts | null = null;
+
+const legendStates: ThreadState[] = ['RUNNABLE', 'BLOCKED', 'WAITING', 'TIMED_WAITING', 'NEW', 'TERMINATED', 'UNKNOWN'];
+
+const STATE_COLORS: Record<ThreadState, string> = {
+  RUNNABLE: '#34A853',
+  BLOCKED: '#EA4335',
+  WAITING: '#4285F4',
+  TIMED_WAITING: '#FBBC04',
+  NEW: '#9AA0A6',
+  TERMINATED: '#5F6368',
+  UNKNOWN: '#DADCE0'
+};
+const stateColor = (state: ThreadState): string => STATE_COLORS[state] ?? STATE_COLORS.UNKNOWN;
+
+const stateVariant = (state: ThreadState): Variant => {
+  switch (state) {
+    case 'RUNNABLE':
+      return 'success';
+    case 'BLOCKED':
+      return 'danger';
+    case 'WAITING':
+      return 'info';
+    case 'TIMED_WAITING':
+      return 'warning';
+    default:
+      return 'secondary';
+  }
+};
+
+const lockLabel = (kind: ThreadLockKind): string => {
+  switch (kind) {
+    case 'LOCKED':
+      return 'locked';
+    case 'WAITING_TO_LOCK':
+      return 'waiting to lock';
+    case 'PARKING_TO_WAIT':
+      return 'parking to wait for';
+    default:
+      return 'waiting on';
+  }
+};
+
+const formatOffset = (millis: number): string => FormattingService.formatDuration2Units(millis * 1_000_000);
+
+const tabs = [
+  { id: 'timeline', label: 'Timeline', icon: 'activity' },
+  { id: 'activity', label: 'Activity', icon: 'list-ol' },
+  { id: 'locks', label: 'Locks & Deadlocks', icon: 'lock' },
+  { id: 'stuck', label: 'Stuck Threads', icon: 'hourglass-split' },
+  { id: 'heatmap', label: 'Heatmap', icon: 'grid-3x3' },
+  { id: 'browse', label: 'Browse', icon: 'search' },
+  { id: 'about', label: 'About', icon: 'info-circle' }
+];
+
+const hasData = computed(() => (data.value?.header.dumpCount ?? 0) > 0);
+
+const framesSource = computed<FrameStat[]>(() => data.value?.topFrames ?? []);
+const framesView = useTableView<FrameStat>(framesSource, { searchableText: (f) => f.frame });
+
+const metrics = computed(() => {
+  const h = data.value?.header;
+  if (!h) {
+    return [];
+  }
+  return [
+    {
+      icon: 'file-earmark-text',
+      title: 'Thread Dumps',
+      value: FormattingService.formatNumber(h.dumpCount),
+      variant: 'highlight' as const,
+      breakdown: [{ label: 'Peak Threads', value: FormattingService.formatNumber(h.peakThreadCount) }]
+    },
+    {
+      icon: 'exclamation-octagon',
+      title: 'Deadlocks',
+      value: FormattingService.formatNumber(h.deadlockCount),
+      variant: h.deadlockCount > 0 ? ('danger' as const) : ('success' as const)
+    },
+    {
+      icon: 'hourglass-split',
+      title: 'Stuck Threads',
+      value: FormattingService.formatNumber(h.stuckThreadCount),
+      variant: h.stuckThreadCount > 0 ? ('warning' as const) : ('success' as const)
+    }
+  ];
+});
+
+// ----- State timeline chart (custom stacked area: one series per state) -----
+const renderChart = async () => {
+  if (!hasData.value) {
+    return;
+  }
+  await nextTick();
+  const element = document.getElementById('thread-dump-state-chart');
+  if (!element) {
+    return;
+  }
+  const series = (data.value?.stateTimeline.series ?? []).map((s) => ({ name: s.name, data: s.data }));
+  const colors = (data.value?.stateTimeline.series ?? []).map((s) => stateColor(s.name as ThreadState));
+
+  const options = {
+    chart: { type: 'area' as const, height: 380, stacked: true, fontFamily: 'inherit', toolbar: { show: false } },
+    series,
+    colors,
+    dataLabels: { enabled: false },
+    stroke: { curve: 'stepline' as const, width: 1 },
+    fill: { type: 'solid', opacity: 0.55 },
+    xaxis: {
+      type: 'numeric' as const,
+      title: { text: 'Time', style: { fontSize: '12px' } },
+      labels: {
+        style: { fontSize: '10px' },
+        formatter: (value: string | number) => FormattingService.formatDuration2Units(Number(value) * 1e9)
+      }
+    },
+    yaxis: { title: { text: 'Threads', style: { fontSize: '12px' } }, labels: { style: { fontSize: '10px' } } },
+    legend: { position: 'bottom' as const },
+    grid: { borderColor: '#e7e7e7', strokeDashArray: 3 }
+  } as ApexCharts.ApexOptions;
+
+  if (chart) {
+    chart.destroy();
+  }
+  chart = new ApexCharts(element, options);
+  chart.render();
+};
+
+// ----- Browse: lazily load a single parsed dump -----
+const selectedIndex = ref(0);
+const selectedDump = ref<ParsedDump>();
+const dumpLoading = ref(false);
+const showRaw = ref(false);
+const browseQuery = ref('');
+const browseStateFilter = ref<'' | ThreadState>('');
+
+const browseThreads = computed(() => {
+  const threads = selectedDump.value?.threads ?? [];
+  const query = browseQuery.value.trim().toLowerCase();
+  return threads.filter((t) => {
+    if (browseStateFilter.value && t.state !== browseStateFilter.value) {
+      return false;
+    }
+    return query === '' || t.name.toLowerCase().includes(query);
+  });
+});
+
+const loadDump = async () => {
+  if (!client) {
+    return;
+  }
+  try {
+    dumpLoading.value = true;
+    selectedDump.value = await client.dump(selectedIndex.value);
+  } catch (err) {
+    console.error('Error loading thread dump:', err);
+  } finally {
+    dumpLoading.value = false;
+  }
+};
+
+const loadData = async () => {
+  try {
+    loading.value = true;
+    error.value = false;
+    client = new ProfileThreadClient(route.params.profileId as string);
+    data.value = await client.dumps();
+    if (activeTab.value === 'timeline') {
+      renderChart();
+    }
+  } catch (err) {
+    error.value = true;
+    console.error('Error loading thread dumps:', err);
+  } finally {
+    loading.value = false;
+  }
+};
+
+watch(activeTab, (tab) => {
+  if (tab === 'timeline') {
+    renderChart();
+  } else if (tab === 'browse' && !selectedDump.value && (data.value?.dumps.length ?? 0) > 0) {
+    loadDump();
+  }
+});
+
+onMounted(loadData);
+onUnmounted(() => {
+  if (chart) {
+    chart.destroy();
+    chart = null;
+  }
+});
+</script>
+
+<style scoped>
+.chart-container {
+  background: var(--color-white);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 1rem;
+}
+
+.section-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: var(--color-text-muted);
+  margin-bottom: 0.5rem;
+}
+
+.muted {
+  color: var(--color-text-muted);
+  font-weight: 400;
+  text-transform: none;
+}
+
+.deadlock-card {
+  border: 1px solid var(--color-danger-border-light);
+  border-radius: var(--radius-md);
+  background: var(--color-danger-bg-light);
+  overflow: hidden;
+}
+
+.deadlock-head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  font-weight: 600;
+  color: var(--color-danger);
+}
+
+.deadlock-threads {
+  margin-left: auto;
+  font-weight: 500;
+  font-size: 0.85rem;
+}
+
+.deadlock-body {
+  margin: 0;
+  padding: 0.75rem;
+  font-size: 0.8rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* Heatmap */
+.heatmap-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 0.5rem 0 0.75rem;
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+}
+
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.legend-swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: var(--radius-sm);
+}
+
+.heatmap-scroll {
+  overflow-x: auto;
+}
+
+.heatmap-grid {
+  --heatmap-label-w: 220px;
+  display: grid;
+  gap: 2px;
+  align-items: center;
+}
+
+.heatmap-label {
+  font-size: 0.75rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-right: 0.5rem;
+}
+
+.heatmap-cell {
+  width: 16px;
+  height: 16px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border-light);
+}
+
+/* Browse */
+.browse-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+  font-size: 0.85rem;
+}
+
+.browse-search {
+  max-width: 18rem;
+}
+
+.raw-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+
+.raw-dump {
+  font-size: 0.78rem;
+  max-height: 70vh;
+  overflow: auto;
+  background: var(--color-light);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 0.75rem;
+}
+
+.thread-block {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 0.4rem 0.6rem;
+  margin-bottom: 0.4rem;
+}
+
+.thread-block summary {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.thread-name {
+  font-weight: 600;
+}
+
+.thread-top {
+  color: var(--color-text-muted);
+  font-size: 0.78rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.thread-stack {
+  margin: 0.5rem 0 0;
+  font-size: 0.78rem;
+  white-space: pre-wrap;
+}
+
+.thread-locks {
+  margin: 0.4rem 0 0;
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+}
+</style>

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/ThreadManager.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/ThreadManager.java
@@ -22,6 +22,8 @@ import cafe.jeffrey.shared.common.model.ProfileInfo;
 import cafe.jeffrey.shared.common.model.Type;
 import cafe.jeffrey.profile.manager.model.thread.ThreadCpuLoads;
 import cafe.jeffrey.profile.manager.model.thread.ThreadStats;
+import cafe.jeffrey.profile.manager.model.thread.dump.ParsedDump;
+import cafe.jeffrey.profile.manager.model.thread.dump.ThreadDumpAnalysis;
 import cafe.jeffrey.profile.thread.ThreadRoot;
 import cafe.jeffrey.provider.profile.api.AllocatingThread;
 import cafe.jeffrey.timeseries.SingleSerie;
@@ -46,4 +48,17 @@ public interface ThreadManager {
     ThreadCpuLoads threadCpuLoads(int limit);
 
     ThreadRoot threadRows();
+
+    /**
+     * Cross-dump analysis of all {@code jdk.ThreadDump} occurrences (state timeline, top frames,
+     * deadlocks, lock contention, stuck threads, heatmap). Excludes per-thread stacks — fetch those
+     * per dump via {@link #threadDump(int)}.
+     */
+    ThreadDumpAnalysis threadDumpAnalysis();
+
+    /**
+     * The fully parsed thread dump at {@code index} (its threads + stacks + raw text), for the dump
+     * viewer. Returns an empty dump when the index is out of range.
+     */
+    ParsedDump threadDump(int index);
 }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/ThreadManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/ThreadManagerImpl.java
@@ -27,6 +27,12 @@ import cafe.jeffrey.profile.manager.builder.CPULoadBuilder;
 import cafe.jeffrey.profile.manager.builder.ThreadTimeseriesBuilder;
 import cafe.jeffrey.profile.manager.model.thread.ThreadCpuLoads;
 import cafe.jeffrey.profile.manager.model.thread.ThreadStats;
+import cafe.jeffrey.profile.manager.model.thread.dump.ParsedDump;
+import cafe.jeffrey.profile.manager.model.thread.dump.RawDump;
+import cafe.jeffrey.profile.manager.model.thread.dump.ThreadDumpAnalysis;
+import cafe.jeffrey.profile.manager.model.thread.dump.ThreadDumpAnalyzer;
+import cafe.jeffrey.profile.manager.model.thread.dump.ThreadDumpBuilder;
+import cafe.jeffrey.profile.manager.model.thread.dump.ThreadDumpParser;
 import cafe.jeffrey.profile.thread.ThreadInfoProvider;
 import cafe.jeffrey.profile.thread.ThreadRoot;
 import cafe.jeffrey.provider.profile.api.EventQueryConfigurer;
@@ -41,6 +47,8 @@ import java.util.List;
 import java.util.Optional;
 
 public class ThreadManagerImpl implements ThreadManager {
+
+    private static final int MAX_THREAD_DUMPS = 200;
 
     private final ProfileInfo profileInfo;
     private final ProfileEventRepository eventRepository;
@@ -133,5 +141,29 @@ public class ThreadManagerImpl implements ThreadManager {
     @Override
     public ThreadRoot threadRows() {
         return threadInfoProvider.get();
+    }
+
+    @Override
+    public ThreadDumpAnalysis threadDumpAnalysis() {
+        RelativeTimeRange timeRange = new RelativeTimeRange(profileInfo.profilingStartEnd());
+        return ThreadDumpAnalyzer.analyze(rawDumps(), timeRange);
+    }
+
+    @Override
+    public ParsedDump threadDump(int index) {
+        List<RawDump> dumps = rawDumps();
+        if (index < 0 || index >= dumps.size()) {
+            return new ParsedDump(0, List.of(), List.of(), "");
+        }
+        RawDump raw = dumps.get(index);
+        return ThreadDumpParser.parse(raw.timeOffsetMillis(), raw.text());
+    }
+
+    private List<RawDump> rawDumps() {
+        EventQueryConfigurer configurer = new EventQueryConfigurer()
+                .withEventType(Type.THREAD_DUMP)
+                .withJsonFields()
+                .orderedByTime();
+        return eventStreamRepository.genericStreaming(configurer, new ThreadDumpBuilder(MAX_THREAD_DUMPS));
     }
 }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/thread/dump/ParsedDump.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/thread/dump/ParsedDump.java
@@ -1,0 +1,79 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.thread.dump;
+
+import java.util.List;
+
+/**
+ * One parsed thread dump ({@code jdk.ThreadDump.result}): its threads, any JVM-reported deadlocks, and
+ * the original raw text (kept so the UI can always fall back to the verbatim dump).
+ *
+ * @param timeOffsetMillis offset of the dump from the recording start
+ * @param threads          parsed per-thread entries
+ * @param deadlocks        JVM-reported Java-level deadlocks found in the dump
+ * @param rawText          the original dump text
+ */
+public record ParsedDump(
+        long timeOffsetMillis,
+        List<ParsedThread> threads,
+        List<Deadlock> deadlocks,
+        String rawText) {
+
+    /**
+     * A single thread within a dump.
+     *
+     * @param name   thread name
+     * @param group  pool/group name (numeric/worker suffix stripped from {@code name})
+     * @param state  parsed thread state
+     * @param frames stack frames, top first (the text after {@code "at "})
+     * @param locks  monitor lock operations recorded for the thread
+     */
+    public record ParsedThread(
+            String name,
+            String group,
+            ThreadState state,
+            List<String> frames,
+            List<ThreadLock> locks) {
+
+        public String topFrame() {
+            return frames.isEmpty() ? null : frames.getFirst();
+        }
+    }
+
+    /**
+     * A monitor lock operation on a thread's stack.
+     */
+    public record ThreadLock(Kind kind, String monitorId, String monitorClass) {
+        public enum Kind {
+            LOCKED,
+            WAITING_TO_LOCK,
+            WAITING_ON,
+            PARKING_TO_WAIT
+        }
+    }
+
+    /**
+     * A JVM-reported Java-level deadlock.
+     *
+     * @param description     the deadlock section text
+     * @param involvedThreads names of the threads in the deadlock cycle
+     */
+    public record Deadlock(String description, List<String> involvedThreads) {
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/thread/dump/RawDump.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/thread/dump/RawDump.java
@@ -1,0 +1,25 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.thread.dump;
+
+/**
+ * A raw {@code jdk.ThreadDump} occurrence: the dump text and its offset from the recording start.
+ */
+public record RawDump(long timeOffsetMillis, String text) {
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/thread/dump/ThreadDumpAnalysis.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/thread/dump/ThreadDumpAnalysis.java
@@ -1,0 +1,86 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.thread.dump;
+
+import cafe.jeffrey.timeseries.TimeseriesData;
+
+import java.util.List;
+
+/**
+ * Cross-dump analysis of all {@code jdk.ThreadDump} occurrences in a recording. Heavy per-thread stacks
+ * are excluded here (fetched lazily per dump via {@link ParsedDump}); this is the compact overview.
+ *
+ * @param header        headline counters
+ * @param dumps         per-dump descriptors (for the dump selector), no stacks
+ * @param stateTimeline thread counts per state across dumps, one carried-forward series per state
+ * @param topFrames     the stack frames threads sit at most often, across all dumps
+ * @param deadlocks     JVM-reported deadlocks, with the dump they appeared in
+ * @param lockContention most-contended monitors in the worst dump
+ * @param stuckThreads  threads whose stack stayed identical across consecutive dumps
+ * @param heatmap       per-thread state across the dump sequence (capped rows)
+ */
+public record ThreadDumpAnalysis(
+        Header header,
+        List<DumpDescriptor> dumps,
+        TimeseriesData stateTimeline,
+        List<FrameStat> topFrames,
+        List<DeadlockEntry> deadlocks,
+        List<LockContention> lockContention,
+        List<StuckThread> stuckThreads,
+        Heatmap heatmap) {
+
+    public record Header(
+            int dumpCount,
+            int peakThreadCount,
+            int deadlockCount,
+            int stuckThreadCount,
+            long firstOffsetMillis,
+            long lastOffsetMillis) {
+    }
+
+    public record DumpDescriptor(int index, long timeOffsetMillis, int threadCount, int deadlockCount) {
+    }
+
+    public record FrameStat(String frame, long occurrences, int distinctThreads) {
+    }
+
+    public record DeadlockEntry(int dumpIndex, long timeOffsetMillis, String description, List<String> involvedThreads) {
+    }
+
+    public record LockContention(String monitorId, String monitorClass, int waiterCount, String owner) {
+    }
+
+    public record StuckThread(
+            String name,
+            ThreadState state,
+            String topFrame,
+            int consecutiveDumps,
+            long stuckForMillis) {
+    }
+
+    /**
+     * @param dumpOffsets the dump time offsets (columns)
+     * @param rows        per-thread state across the dump sequence; a {@code null} cell means the thread
+     *                    was absent from that dump
+     */
+    public record Heatmap(List<Long> dumpOffsets, List<Row> rows) {
+        public record Row(String threadName, List<ThreadState> states) {
+        }
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/thread/dump/ThreadDumpAnalyzer.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/thread/dump/ThreadDumpAnalyzer.java
@@ -1,0 +1,318 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.thread.dump;
+
+import org.eclipse.collections.impl.map.mutable.primitive.LongLongHashMap;
+import cafe.jeffrey.profile.manager.model.thread.dump.ParsedDump.ParsedThread;
+import cafe.jeffrey.profile.manager.model.thread.dump.ParsedDump.ThreadLock;
+import cafe.jeffrey.profile.manager.model.thread.dump.ThreadDumpAnalysis.DeadlockEntry;
+import cafe.jeffrey.profile.manager.model.thread.dump.ThreadDumpAnalysis.DumpDescriptor;
+import cafe.jeffrey.profile.manager.model.thread.dump.ThreadDumpAnalysis.FrameStat;
+import cafe.jeffrey.profile.manager.model.thread.dump.ThreadDumpAnalysis.Header;
+import cafe.jeffrey.profile.manager.model.thread.dump.ThreadDumpAnalysis.Heatmap;
+import cafe.jeffrey.profile.manager.model.thread.dump.ThreadDumpAnalysis.LockContention;
+import cafe.jeffrey.profile.manager.model.thread.dump.ThreadDumpAnalysis.StuckThread;
+import cafe.jeffrey.shared.common.model.time.RelativeTimeRange;
+import cafe.jeffrey.timeseries.SingleSerie;
+import cafe.jeffrey.timeseries.TimeseriesData;
+import cafe.jeffrey.timeseries.TimeseriesUtils;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Aggregates a recording's {@code jdk.ThreadDump} occurrences into a {@link ThreadDumpAnalysis}: state
+ * timeline, top frames, deadlocks, lock contention, stuck threads and a per-thread state heatmap.
+ */
+public final class ThreadDumpAnalyzer {
+
+    private static final int MAX_TOP_FRAMES = 100;
+    private static final int MAX_LOCK_CONTENTION = 50;
+    private static final int MAX_HEATMAP_ROWS = 200;
+    private static final int MIN_STUCK_DUMPS = 3;
+    private static final int STUCK_SIGNATURE_FRAMES = 5;
+    private static final long CARRY_FORWARD_MARK = 0L;
+
+    private ThreadDumpAnalyzer() {
+    }
+
+    public static ThreadDumpAnalysis analyze(List<RawDump> rawDumps, RelativeTimeRange timeRange) {
+        List<ParsedDump> dumps = new ArrayList<>(rawDumps.size());
+        for (RawDump raw : rawDumps) {
+            dumps.add(ThreadDumpParser.parse(raw.timeOffsetMillis(), raw.text()));
+        }
+
+        List<DumpDescriptor> descriptors = descriptors(dumps);
+        TimeseriesData stateTimeline = stateTimeline(dumps, timeRange);
+        List<FrameStat> topFrames = topFrames(dumps);
+        List<DeadlockEntry> deadlocks = deadlocks(dumps);
+        List<LockContention> lockContention = lockContention(dumps);
+        List<StuckThread> stuckThreads = stuckThreads(dumps);
+        Heatmap heatmap = heatmap(dumps, stuckThreads);
+        Header header = header(dumps, deadlocks.size(), stuckThreads.size());
+
+        return new ThreadDumpAnalysis(
+                header, descriptors, stateTimeline, topFrames, deadlocks, lockContention, stuckThreads, heatmap);
+    }
+
+    private static List<DumpDescriptor> descriptors(List<ParsedDump> dumps) {
+        List<DumpDescriptor> result = new ArrayList<>(dumps.size());
+        for (int i = 0; i < dumps.size(); i++) {
+            ParsedDump dump = dumps.get(i);
+            result.add(new DumpDescriptor(i, dump.timeOffsetMillis(), dump.threads().size(), dump.deadlocks().size()));
+        }
+        return result;
+    }
+
+    private static TimeseriesData stateTimeline(List<ParsedDump> dumps, RelativeTimeRange timeRange) {
+        Map<ThreadState, LongLongHashMap> seriesByState = new LinkedHashMap<>();
+        for (ThreadState state : ThreadState.values()) {
+            seriesByState.put(state, TimeseriesUtils.initWithZeros(timeRange));
+        }
+
+        for (ParsedDump dump : dumps) {
+            long second = dump.timeOffsetMillis() / 1000;
+            Map<ThreadState, Long> counts = new HashMap<>();
+            for (ParsedThread thread : dump.threads()) {
+                counts.merge(thread.state(), 1L, Long::sum);
+            }
+            counts.forEach((state, count) -> seriesByState.get(state).put(second, count));
+        }
+
+        List<SingleSerie> series = new ArrayList<>();
+        for (Map.Entry<ThreadState, LongLongHashMap> entry : seriesByState.entrySet()) {
+            if (!hasNonZero(entry.getValue())) {
+                continue;
+            }
+            SingleSerie serie = TimeseriesUtils.buildSerie(entry.getKey().name(), entry.getValue());
+            TimeseriesUtils.remapTimeseriesBySteps(serie, CARRY_FORWARD_MARK);
+            series.add(serie);
+        }
+        return new TimeseriesData(series);
+    }
+
+    private static boolean hasNonZero(LongLongHashMap series) {
+        return series.values().anySatisfy(value -> value != 0);
+    }
+
+    private static List<FrameStat> topFrames(List<ParsedDump> dumps) {
+        Map<String, long[]> occurrences = new HashMap<>();
+        Map<String, Set<String>> distinctThreads = new HashMap<>();
+        for (ParsedDump dump : dumps) {
+            for (ParsedThread thread : dump.threads()) {
+                String top = thread.topFrame();
+                if (top == null) {
+                    continue;
+                }
+                occurrences.computeIfAbsent(top, key -> new long[1])[0]++;
+                distinctThreads.computeIfAbsent(top, key -> new HashSet<>()).add(thread.name());
+            }
+        }
+        return occurrences.entrySet().stream()
+                .map(entry -> new FrameStat(
+                        entry.getKey(), entry.getValue()[0], distinctThreads.get(entry.getKey()).size()))
+                .sorted(Comparator.comparingLong(FrameStat::occurrences).reversed())
+                .limit(MAX_TOP_FRAMES)
+                .toList();
+    }
+
+    private static List<DeadlockEntry> deadlocks(List<ParsedDump> dumps) {
+        List<DeadlockEntry> result = new ArrayList<>();
+        for (int i = 0; i < dumps.size(); i++) {
+            ParsedDump dump = dumps.get(i);
+            for (ParsedDump.Deadlock deadlock : dump.deadlocks()) {
+                result.add(new DeadlockEntry(
+                        i, dump.timeOffsetMillis(), deadlock.description(), deadlock.involvedThreads()));
+            }
+        }
+        return result;
+    }
+
+    private static List<LockContention> lockContention(List<ParsedDump> dumps) {
+        ParsedDump worst = null;
+        int worstWaiters = 0;
+        for (ParsedDump dump : dumps) {
+            int waiters = countWaiters(dump);
+            if (waiters > worstWaiters) {
+                worstWaiters = waiters;
+                worst = dump;
+            }
+        }
+        if (worst == null) {
+            return List.of();
+        }
+
+        Map<String, int[]> waiterCounts = new HashMap<>();
+        Map<String, String> monitorClasses = new HashMap<>();
+        Map<String, String> owners = new HashMap<>();
+        for (ParsedThread thread : worst.threads()) {
+            for (ThreadLock lock : thread.locks()) {
+                if (lock.monitorId() == null) {
+                    continue;
+                }
+                if (lock.monitorClass() != null) {
+                    monitorClasses.putIfAbsent(lock.monitorId(), lock.monitorClass());
+                }
+                if (lock.kind() == ThreadLock.Kind.LOCKED) {
+                    owners.putIfAbsent(lock.monitorId(), thread.name());
+                } else if (lock.kind() == ThreadLock.Kind.WAITING_TO_LOCK
+                        || lock.kind() == ThreadLock.Kind.PARKING_TO_WAIT) {
+                    waiterCounts.computeIfAbsent(lock.monitorId(), key -> new int[1])[0]++;
+                }
+            }
+        }
+
+        return waiterCounts.entrySet().stream()
+                .map(entry -> new LockContention(
+                        entry.getKey(),
+                        monitorClasses.get(entry.getKey()),
+                        entry.getValue()[0],
+                        owners.get(entry.getKey())))
+                .sorted(Comparator.comparingInt(LockContention::waiterCount).reversed())
+                .limit(MAX_LOCK_CONTENTION)
+                .toList();
+    }
+
+    private static int countWaiters(ParsedDump dump) {
+        int waiters = 0;
+        for (ParsedThread thread : dump.threads()) {
+            for (ThreadLock lock : thread.locks()) {
+                if (lock.kind() == ThreadLock.Kind.WAITING_TO_LOCK
+                        || lock.kind() == ThreadLock.Kind.PARKING_TO_WAIT) {
+                    waiters++;
+                }
+            }
+        }
+        return waiters;
+    }
+
+    private static List<StuckThread> stuckThreads(List<ParsedDump> dumps) {
+        List<Map<String, ParsedThread>> byName = byName(dumps);
+        Set<String> names = new java.util.LinkedHashSet<>();
+        byName.forEach(map -> names.addAll(map.keySet()));
+
+        List<StuckThread> result = new ArrayList<>();
+        for (String name : names) {
+            int bestLen = 0;
+            int bestStart = -1;
+            int bestEnd = -1;
+            int curLen = 0;
+            int curStart = -1;
+            int prevIdx = -2;
+            String curSignature = null;
+            for (int i = 0; i < dumps.size(); i++) {
+                ParsedThread thread = byName.get(i).get(name);
+                if (thread == null || thread.topFrame() == null) {
+                    curLen = 0;
+                    curSignature = null;
+                    prevIdx = -2;
+                    continue;
+                }
+                String signature = signature(thread);
+                if (curSignature != null && curSignature.equals(signature) && i == prevIdx + 1) {
+                    curLen++;
+                } else {
+                    curLen = 1;
+                    curStart = i;
+                    curSignature = signature;
+                }
+                prevIdx = i;
+                if (curLen > bestLen) {
+                    bestLen = curLen;
+                    bestStart = curStart;
+                    bestEnd = i;
+                }
+            }
+            if (bestLen >= MIN_STUCK_DUMPS) {
+                ParsedThread last = byName.get(bestEnd).get(name);
+                long stuckFor = dumps.get(bestEnd).timeOffsetMillis() - dumps.get(bestStart).timeOffsetMillis();
+                result.add(new StuckThread(name, last.state(), last.topFrame(), bestLen, stuckFor));
+            }
+        }
+        result.sort(Comparator.comparingInt(StuckThread::consecutiveDumps).reversed());
+        return result;
+    }
+
+    private static String signature(ParsedThread thread) {
+        List<String> frames = thread.frames();
+        return String.join("\n", frames.subList(0, Math.min(STUCK_SIGNATURE_FRAMES, frames.size())));
+    }
+
+    private static List<Map<String, ParsedThread>> byName(List<ParsedDump> dumps) {
+        List<Map<String, ParsedThread>> byName = new ArrayList<>(dumps.size());
+        for (ParsedDump dump : dumps) {
+            Map<String, ParsedThread> map = new HashMap<>();
+            for (ParsedThread thread : dump.threads()) {
+                map.putIfAbsent(thread.name(), thread);
+            }
+            byName.add(map);
+        }
+        return byName;
+    }
+
+    private static Heatmap heatmap(List<ParsedDump> dumps, List<StuckThread> stuckThreads) {
+        List<Map<String, ParsedThread>> byName = byName(dumps);
+        Map<String, Integer> presence = new LinkedHashMap<>();
+        Set<String> priority = new java.util.LinkedHashSet<>();
+        for (Map<String, ParsedThread> map : byName) {
+            for (ParsedThread thread : map.values()) {
+                presence.merge(thread.name(), 1, Integer::sum);
+                if (thread.state() == ThreadState.BLOCKED) {
+                    priority.add(thread.name());
+                }
+            }
+        }
+        stuckThreads.forEach(stuck -> priority.add(stuck.name()));
+
+        List<String> rowNames = new ArrayList<>(priority);
+        presence.entrySet().stream()
+                .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+                .map(Map.Entry::getKey)
+                .filter(name -> !priority.contains(name))
+                .forEach(rowNames::add);
+        if (rowNames.size() > MAX_HEATMAP_ROWS) {
+            rowNames = rowNames.subList(0, MAX_HEATMAP_ROWS);
+        }
+
+        List<Long> offsets = dumps.stream().map(ParsedDump::timeOffsetMillis).toList();
+        List<Heatmap.Row> rows = new ArrayList<>(rowNames.size());
+        for (String name : rowNames) {
+            List<ThreadState> states = new ArrayList<>(dumps.size());
+            for (Map<String, ParsedThread> map : byName) {
+                ParsedThread thread = map.get(name);
+                states.add(thread == null ? null : thread.state());
+            }
+            rows.add(new Heatmap.Row(name, states));
+        }
+        return new Heatmap(offsets, rows);
+    }
+
+    private static Header header(List<ParsedDump> dumps, int deadlockCount, int stuckCount) {
+        int peakThreads = dumps.stream().mapToInt(dump -> dump.threads().size()).max().orElse(0);
+        long firstOffset = dumps.isEmpty() ? 0 : dumps.getFirst().timeOffsetMillis();
+        long lastOffset = dumps.isEmpty() ? 0 : dumps.getLast().timeOffsetMillis();
+        return new Header(dumps.size(), peakThreads, deadlockCount, stuckCount, firstOffset, lastOffset);
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/thread/dump/ThreadDumpBuilder.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/thread/dump/ThreadDumpBuilder.java
@@ -1,0 +1,59 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.thread.dump;
+
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.provider.profile.api.RecordBuilder;
+import cafe.jeffrey.shared.common.Json;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Collects raw {@code jdk.ThreadDump} occurrences (offset + dump text), capped. Parsing and aggregation
+ * are done downstream by {@link ThreadDumpParser} / {@link ThreadDumpAnalyzer}, keeping this builder lean.
+ */
+public class ThreadDumpBuilder implements RecordBuilder<GenericRecord, List<RawDump>> {
+
+    private static final String RESULT_FIELD = "result";
+
+    private final int maxDumps;
+    private final List<RawDump> dumps = new ArrayList<>();
+
+    public ThreadDumpBuilder(int maxDumps) {
+        if (maxDumps <= 0) {
+            throw new IllegalArgumentException("maxDumps must be positive: " + maxDumps);
+        }
+        this.maxDumps = maxDumps;
+    }
+
+    @Override
+    public void onRecord(GenericRecord record) {
+        if (dumps.size() >= maxDumps) {
+            return;
+        }
+        String text = Json.readString(record.jsonFields(), RESULT_FIELD);
+        dumps.add(new RawDump(record.timestampFromStart().toMillis(), text == null ? "" : text));
+    }
+
+    @Override
+    public List<RawDump> build() {
+        return dumps;
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/thread/dump/ThreadDumpParser.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/thread/dump/ThreadDumpParser.java
@@ -1,0 +1,185 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.thread.dump;
+
+import cafe.jeffrey.profile.manager.model.thread.dump.ParsedDump.Deadlock;
+import cafe.jeffrey.profile.manager.model.thread.dump.ParsedDump.ParsedThread;
+import cafe.jeffrey.profile.manager.model.thread.dump.ParsedDump.ThreadLock;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parses the {@code jdk.ThreadDump.result} text (a {@code jstack}-style dump) into structured threads,
+ * lock operations and JVM-reported deadlocks.
+ * <p>
+ * The format is not contractual, so parsing is heuristic and degrades gracefully: a line is a thread
+ * header only when it starts with a quoted name <em>and</em> carries thread metadata ({@code tid=} /
+ * {@code nid=} / {@code prio=} / {@code #<id>}) — which distinguishes real headers from the quoted names
+ * inside the deadlock summary. Anything unrecognized is ignored, and the caller always retains the raw
+ * text.
+ */
+public final class ThreadDumpParser {
+
+    private static final String STATE_MARKER = "java.lang.Thread.State:";
+    private static final String FRAME_PREFIX = "at ";
+    private static final String DEADLOCK_MARKER = "Java-level deadlock";
+    private static final String DEADLOCK_STACKS_BOUNDARY = "Java stack information for the threads listed above";
+
+    private static final Pattern HEADER_METADATA = Pattern.compile("tid=|nid=|prio=|\" #\\d+");
+    private static final Pattern MONITOR_ID = Pattern.compile("<(0x[0-9a-fA-F]+)>");
+    private static final Pattern MONITOR_CLASS = Pattern.compile("\\(a ([^)]+)\\)");
+    private static final Pattern QUOTED_NAME = Pattern.compile("\"([^\"]+)\"");
+
+    private ThreadDumpParser() {
+    }
+
+    public static ParsedDump parse(long timeOffsetMillis, String text) {
+        if (text == null || text.isBlank()) {
+            return new ParsedDump(timeOffsetMillis, List.of(), List.of(), text == null ? "" : text);
+        }
+
+        String[] lines = text.split("\n", -1);
+        List<ParsedThread> threads = parseThreads(lines);
+        List<Deadlock> deadlocks = parseDeadlocks(lines);
+        return new ParsedDump(timeOffsetMillis, threads, deadlocks, text);
+    }
+
+    private static List<ParsedThread> parseThreads(String[] lines) {
+        List<ParsedThread> threads = new ArrayList<>();
+        ThreadAccumulator current = null;
+        for (String line : lines) {
+            if (isThreadHeader(line)) {
+                if (current != null) {
+                    threads.add(current.toThread());
+                }
+                current = new ThreadAccumulator(threadName(line));
+            } else if (current != null) {
+                current.consume(line);
+            }
+        }
+        if (current != null) {
+            threads.add(current.toThread());
+        }
+        return threads;
+    }
+
+    private static boolean isThreadHeader(String line) {
+        return !line.isEmpty() && line.charAt(0) == '"' && HEADER_METADATA.matcher(line).find();
+    }
+
+    private static String threadName(String headerLine) {
+        int close = headerLine.indexOf('"', 1);
+        return close > 0 ? headerLine.substring(1, close) : headerLine;
+    }
+
+    private static List<Deadlock> parseDeadlocks(String[] lines) {
+        List<Deadlock> deadlocks = new ArrayList<>();
+        for (int i = 0; i < lines.length; i++) {
+            if (!lines[i].contains(DEADLOCK_MARKER)) {
+                continue;
+            }
+            StringBuilder description = new StringBuilder();
+            Set<String> involved = new java.util.LinkedHashSet<>();
+            int j = i;
+            for (; j < lines.length && !lines[j].contains(DEADLOCK_STACKS_BOUNDARY); j++) {
+                description.append(lines[j]).append('\n');
+                Matcher nameMatcher = QUOTED_NAME.matcher(lines[j]);
+                while (nameMatcher.find()) {
+                    involved.add(nameMatcher.group(1));
+                }
+            }
+            deadlocks.add(new Deadlock(description.toString().strip(), List.copyOf(involved)));
+            i = j;
+        }
+        return deadlocks;
+    }
+
+    /**
+     * Strips a trailing pool index from a thread name so worker threads collapse into one group, e.g.
+     * {@code http-nio-8080-exec-7} → {@code http-nio-8080-exec} and {@code ForkJoinPool-1-worker-3} →
+     * {@code ForkJoinPool-1-worker}.
+     */
+    static String poolGroup(String name) {
+        String group = name.replaceAll("[-#]?\\d+$", "");
+        group = group.replaceAll("[-#]$", "");
+        return group.isBlank() ? name : group;
+    }
+
+    private static final class ThreadAccumulator {
+        private final String name;
+        private ThreadState state = ThreadState.UNKNOWN;
+        private final List<String> frames = new ArrayList<>();
+        private final List<ThreadLock> locks = new ArrayList<>();
+
+        private ThreadAccumulator(String name) {
+            this.name = name;
+        }
+
+        private void consume(String line) {
+            String trimmed = line.strip();
+            int stateAt = line.indexOf(STATE_MARKER);
+            if (stateAt >= 0) {
+                state = ThreadState.fromLabel(line.substring(stateAt + STATE_MARKER.length()));
+            } else if (trimmed.startsWith(FRAME_PREFIX)) {
+                frames.add(trimmed.substring(FRAME_PREFIX.length()).strip());
+            } else if (trimmed.startsWith("- ")) {
+                ThreadLock lock = parseLock(trimmed);
+                if (lock != null) {
+                    locks.add(lock);
+                }
+            }
+        }
+
+        private ParsedThread toThread() {
+            return new ParsedThread(name, poolGroup(name), state, List.copyOf(frames), List.copyOf(locks));
+        }
+    }
+
+    private static ThreadLock parseLock(String trimmed) {
+        ThreadLock.Kind kind = lockKind(trimmed);
+        if (kind == null) {
+            return null;
+        }
+        Matcher idMatcher = MONITOR_ID.matcher(trimmed);
+        String monitorId = idMatcher.find() ? idMatcher.group(1) : null;
+        Matcher classMatcher = MONITOR_CLASS.matcher(trimmed);
+        String monitorClass = classMatcher.find() ? classMatcher.group(1) : null;
+        return new ThreadLock(kind, monitorId, monitorClass);
+    }
+
+    private static ThreadLock.Kind lockKind(String trimmed) {
+        if (trimmed.startsWith("- locked")) {
+            return ThreadLock.Kind.LOCKED;
+        }
+        if (trimmed.startsWith("- waiting to lock")) {
+            return ThreadLock.Kind.WAITING_TO_LOCK;
+        }
+        if (trimmed.startsWith("- parking to wait for")) {
+            return ThreadLock.Kind.PARKING_TO_WAIT;
+        }
+        if (trimmed.startsWith("- waiting on")) {
+            return ThreadLock.Kind.WAITING_ON;
+        }
+        return null;
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/thread/dump/ThreadState.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/thread/dump/ThreadState.java
@@ -1,0 +1,53 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.thread.dump;
+
+/**
+ * Java thread state as reported by a {@code java.lang.Thread.State:} line in a thread dump. JVM/GC and
+ * other native threads have no such line and map to {@link #UNKNOWN}.
+ */
+public enum ThreadState {
+    RUNNABLE,
+    BLOCKED,
+    WAITING,
+    TIMED_WAITING,
+    NEW,
+    TERMINATED,
+    UNKNOWN;
+
+    /**
+     * Resolves the state from the token following {@code java.lang.Thread.State:} (e.g.
+     * {@code "WAITING (parking)"} → {@link #WAITING}). Returns {@link #UNKNOWN} for anything unparseable.
+     */
+    public static ThreadState fromLabel(String label) {
+        if (label == null) {
+            return UNKNOWN;
+        }
+        String token = label.trim();
+        int cut = token.indexOf(' ');
+        if (cut > 0) {
+            token = token.substring(0, cut);
+        }
+        try {
+            return valueOf(token);
+        } catch (IllegalArgumentException e) {
+            return UNKNOWN;
+        }
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/thread/dump/ThreadDumpAnalyzerTest.java
+++ b/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/thread/dump/ThreadDumpAnalyzerTest.java
@@ -1,0 +1,131 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.thread.dump;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import cafe.jeffrey.profile.manager.model.thread.dump.ThreadDumpAnalysis.StuckThread;
+import cafe.jeffrey.shared.common.model.time.RelativeTimeRange;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("ThreadDumpAnalyzer")
+class ThreadDumpAnalyzerTest {
+
+    private static final RelativeTimeRange TIME_RANGE = new RelativeTimeRange(0, 600_000);
+
+    // A "stuck" worker parked at the same frame, plus a "main" thread whose stack moves between dumps.
+    private static String dumpText(String mainFrame) {
+        return String.join("\n",
+                "\"main\" #1 prio=5 tid=0x01 nid=0x1 runnable",
+                "   java.lang.Thread.State: RUNNABLE",
+                "\tat " + mainFrame,
+                "",
+                "\"worker-1\" #12 prio=5 tid=0x02 nid=0x2 waiting on condition",
+                "   java.lang.Thread.State: WAITING (parking)",
+                "\tat jdk.internal.misc.Unsafe.park(Native Method)",
+                "");
+    }
+
+    private static List<RawDump> threeDumps() {
+        return List.of(
+                new RawDump(0, dumpText("app.Main.a(Main.java:1)")),
+                new RawDump(60_000, dumpText("app.Main.b(Main.java:2)")),
+                new RawDump(120_000, dumpText("app.Main.c(Main.java:3)")));
+    }
+
+    @Test
+    @DisplayName("Builds per-state timeline series and ranks top frames")
+    void timelineAndFrames() {
+        ThreadDumpAnalysis analysis = ThreadDumpAnalyzer.analyze(threeDumps(), TIME_RANGE);
+
+        assertEquals(3, analysis.header().dumpCount());
+        assertEquals(2, analysis.header().peakThreadCount());
+
+        List<String> seriesNames = analysis.stateTimeline().series().stream().map(s -> s.name()).toList();
+        assertTrue(seriesNames.contains("RUNNABLE"));
+        assertTrue(seriesNames.contains("WAITING"));
+
+        // Unsafe.park is the top frame in all 3 dumps (one distinct thread).
+        var topFrame = analysis.topFrames().getFirst();
+        assertEquals("jdk.internal.misc.Unsafe.park(Native Method)", topFrame.frame());
+        assertEquals(3, topFrame.occurrences());
+        assertEquals(1, topFrame.distinctThreads());
+    }
+
+    @Test
+    @DisplayName("Flags a thread stuck at the same stack across consecutive dumps")
+    void detectsStuckThreads() {
+        ThreadDumpAnalysis analysis = ThreadDumpAnalyzer.analyze(threeDumps(), TIME_RANGE);
+
+        List<StuckThread> stuck = analysis.stuckThreads();
+        assertEquals(1, stuck.size());
+        StuckThread worker = stuck.getFirst();
+        assertEquals("worker-1", worker.name());
+        assertEquals(3, worker.consecutiveDumps());
+        assertEquals(120_000, worker.stuckForMillis());
+
+        // "main" changes frame every dump, so it is not stuck.
+        assertFalse(stuck.stream().anyMatch(s -> s.name().equals("main")));
+    }
+
+    @Test
+    @DisplayName("Ranks lock contention from the worst dump")
+    void ranksLockContention() {
+        String contended = String.join("\n",
+                "\"holder\" #1 prio=5 tid=0x01 nid=0x1 runnable",
+                "   java.lang.Thread.State: RUNNABLE",
+                "\tat app.Holder.run(Holder.java:1)",
+                "\t- locked <0x000000aa> (a app.Lock)",
+                "",
+                "\"waiter-1\" #2 prio=5 tid=0x02 nid=0x2 waiting for monitor entry",
+                "   java.lang.Thread.State: BLOCKED (on object monitor)",
+                "\tat app.Waiter.run(Waiter.java:1)",
+                "\t- waiting to lock <0x000000aa> (a app.Lock)",
+                "",
+                "\"waiter-2\" #3 prio=5 tid=0x03 nid=0x3 waiting for monitor entry",
+                "   java.lang.Thread.State: BLOCKED (on object monitor)",
+                "\tat app.Waiter.run(Waiter.java:1)",
+                "\t- waiting to lock <0x000000aa> (a app.Lock)",
+                "");
+
+        ThreadDumpAnalysis analysis = ThreadDumpAnalyzer.analyze(List.of(new RawDump(0, contended)), TIME_RANGE);
+
+        assertEquals(1, analysis.lockContention().size());
+        var contention = analysis.lockContention().getFirst();
+        assertEquals("0x000000aa", contention.monitorId());
+        assertEquals("app.Lock", contention.monitorClass());
+        assertEquals(2, contention.waiterCount());
+        assertEquals("holder", contention.owner());
+    }
+
+    @Test
+    @DisplayName("Builds a heatmap with one row per tracked thread aligned to dumps")
+    void buildsHeatmap() {
+        ThreadDumpAnalysis analysis = ThreadDumpAnalyzer.analyze(threeDumps(), TIME_RANGE);
+
+        assertEquals(3, analysis.heatmap().dumpOffsets().size());
+        assertFalse(analysis.heatmap().rows().isEmpty());
+        analysis.heatmap().rows().forEach(row -> assertEquals(3, row.states().size()));
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/thread/dump/ThreadDumpParserTest.java
+++ b/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/thread/dump/ThreadDumpParserTest.java
@@ -1,0 +1,120 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.thread.dump;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import cafe.jeffrey.profile.manager.model.thread.dump.ParsedDump.ParsedThread;
+import cafe.jeffrey.profile.manager.model.thread.dump.ParsedDump.ThreadLock;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("ThreadDumpParser")
+class ThreadDumpParserTest {
+
+    private static final String DUMP = String.join("\n",
+            "2024-01-01 00:00:00",
+            "Full thread dump OpenJDK 64-Bit Server VM:",
+            "",
+            "\"main\" #1 prio=5 os_prio=0 cpu=10ms tid=0x01 nid=0x1 runnable [0x7f00]",
+            "   java.lang.Thread.State: RUNNABLE",
+            "\tat app.Main.work(Main.java:10)",
+            "\tat app.Main.main(Main.java:5)",
+            "",
+            "\"worker-1\" #12 prio=5 tid=0x02 nid=0x2 waiting for monitor entry [0x7f10]",
+            "   java.lang.Thread.State: BLOCKED (on object monitor)",
+            "\tat app.Service.handle(Service.java:42)",
+            "\t- waiting to lock <0x000000abcd> (a app.Lock)",
+            "",
+            "\"pool-1-thread-3\" #20 daemon prio=5 tid=0x03 nid=0x3 waiting on condition [0x7f20]",
+            "   java.lang.Thread.State: TIMED_WAITING (parking)",
+            "\tat jdk.internal.misc.Unsafe.park(Native Method)",
+            "\t- parking to wait for <0x000000ef01> (a java.util.concurrent.SynchronousQueue)",
+            "",
+            "\"GC Thread#0\" os_prio=0 tid=0x04 nid=0x4 runnable",
+            "");
+
+    @Test
+    @DisplayName("Parses thread names, states, frames and locks")
+    void parsesThreads() {
+        ParsedDump dump = ThreadDumpParser.parse(1000, DUMP);
+
+        assertEquals(4, dump.threads().size());
+
+        ParsedThread main = dump.threads().getFirst();
+        assertEquals("main", main.name());
+        assertEquals(ThreadState.RUNNABLE, main.state());
+        assertEquals("app.Main.work(Main.java:10)", main.topFrame());
+        assertEquals(2, main.frames().size());
+
+        ParsedThread worker = dump.threads().get(1);
+        assertEquals(ThreadState.BLOCKED, worker.state());
+        assertEquals(1, worker.locks().size());
+        assertEquals(ThreadLock.Kind.WAITING_TO_LOCK, worker.locks().getFirst().kind());
+        assertEquals("0x000000abcd", worker.locks().getFirst().monitorId());
+        assertEquals("app.Lock", worker.locks().getFirst().monitorClass());
+
+        ParsedThread pool = dump.threads().get(2);
+        assertEquals(ThreadState.TIMED_WAITING, pool.state());
+        assertEquals("pool-1-thread", pool.group());
+        assertEquals(ThreadLock.Kind.PARKING_TO_WAIT, pool.locks().getFirst().kind());
+
+        // A native thread with no Thread.State line maps to UNKNOWN.
+        ParsedThread gc = dump.threads().get(3);
+        assertEquals(ThreadState.UNKNOWN, gc.state());
+    }
+
+    @Test
+    @DisplayName("Extracts a JVM-reported deadlock and its involved threads")
+    void parsesDeadlock() {
+        String dumpText = String.join("\n",
+                "Found one Java-level deadlock:",
+                "=============================",
+                "\"Thread-A\":",
+                "  waiting to lock monitor 0x01 (object 0x0a, a java.lang.Object),",
+                "  which is held by \"Thread-B\"",
+                "\"Thread-B\":",
+                "  waiting to lock monitor 0x02 (object 0x0b, a java.lang.Object),",
+                "  which is held by \"Thread-A\"",
+                "",
+                "Java stack information for the threads listed above:",
+                "===================================================",
+                "\"Thread-A\" #10 prio=5 tid=0x0a nid=0xa waiting for monitor entry",
+                "   java.lang.Thread.State: BLOCKED (on object monitor)",
+                "\tat app.A.run(A.java:1)",
+                "");
+
+        ParsedDump dump = ThreadDumpParser.parse(2000, dumpText);
+
+        assertEquals(1, dump.deadlocks().size());
+        ParsedDump.Deadlock deadlock = dump.deadlocks().getFirst();
+        assertTrue(deadlock.description().contains("Java-level deadlock"));
+        assertEquals(List.of("Thread-A", "Thread-B"), deadlock.involvedThreads());
+    }
+
+    @Test
+    @DisplayName("Handles empty / null text without throwing")
+    void handlesEmpty() {
+        assertEquals(0, ThreadDumpParser.parse(0, "").threads().size());
+        assertEquals(0, ThreadDumpParser.parse(0, null).threads().size());
+    }
+}

--- a/jeffrey-pages/src/router/index.ts
+++ b/jeffrey-pages/src/router/index.ts
@@ -248,6 +248,11 @@ const routes: RouteRecordRaw[] = [
         component: () => import('@/views/docs/microscope/profiles/ProfileNativeMemoryPage.vue')
       },
       {
+        path: 'microscope/profiles/thread-dumps',
+        name: 'DocsProfilesThreadDumps',
+        component: () => import('@/views/docs/microscope/profiles/ProfileThreadDumpsPage.vue')
+      },
+      {
         path: 'microscope/profiles/system',
         name: 'DocsProfilesSystem',
         component: () => import('@/views/docs/microscope/profiles/ProfileSystemPage.vue')

--- a/jeffrey-pages/src/views/docs/microscope/profiles/ProfileThreadDumpsPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/profiles/ProfileThreadDumpsPage.vue
@@ -1,0 +1,91 @@
+<!--
+  - Jeffrey
+  - Copyright (C) 2026 Petr Bouda
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as published by
+  - the Free Software Foundation, either version 3 of the License, or
+  - (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import DocsCallout from '@/components/docs/DocsCallout.vue';
+import DocsNavFooter from '@/components/docs/DocsNavFooter.vue';
+import DocsPageHeader from '@/components/docs/DocsPageHeader.vue';
+import { useDocHeadings } from '@/composables/useDocHeadings';
+
+const { setHeadings } = useDocHeadings();
+
+const headings = [
+  { id: 'overview', text: 'Overview', level: 2 },
+  { id: 'timeline', text: 'State Timeline', level: 2 },
+  { id: 'activity', text: 'Activity', level: 2 },
+  { id: 'locks', text: 'Locks & Deadlocks', level: 2 },
+  { id: 'stuck', text: 'Stuck Threads', level: 2 },
+  { id: 'heatmap', text: 'Heatmap', level: 2 },
+  { id: 'browse', text: 'Browse', level: 2 },
+  { id: 'events', text: 'Source Events', level: 2 }
+];
+
+onMounted(() => {
+  setHeadings(headings);
+});
+</script>
+
+<template>
+  <article class="docs-article">
+    <DocsPageHeader
+      title="Thread Dumps"
+      icon="bi bi-file-earmark-text"
+    />
+
+    <div class="docs-content">
+      <p>The JVM periodically emits a full textual thread dump (<code>jdk.ThreadDump</code>, the same content as <code>jstack</code>): every thread's state, stack, and held/awaited monitors. Jeffrey parses each dump and correlates them across the recording, turning a pile of text snapshots into trends, contention analysis, and hang detection.</p>
+
+      <DocsCallout type="tip">
+        <strong>Sampled, not continuous:</strong> dumps are periodic (~every 60s by default), so this is a coarse sample — ideal for hangs, deadlocks, and pool saturation, but not for sub-second spikes (use the flamegraph / wall-clock views for those).
+      </DocsCallout>
+
+      <h2 id="overview">Overview</h2>
+      <p>The header strip shows the number of dumps, peak thread count, deadlocks detected, and stuck threads found.</p>
+
+      <h2 id="timeline">State Timeline</h2>
+      <p>A stacked area of thread counts by state (RUNNABLE, BLOCKED, WAITING, TIMED_WAITING, …) across the dumps, carried forward between samples. A BLOCKED spike is a lock storm; a steadily climbing total is a thread leak; a pool sitting in WAITING is idle capacity.</p>
+
+      <h2 id="activity">Activity</h2>
+      <p>The stack frames threads sit at most often, aggregated across all dumps, with occurrences and distinct-thread counts. Many threads at one frame reveal an idle pool (parked), an I/O wait, or a genuine hotspot — a poor-man's wall-clock snapshot.</p>
+
+      <h2 id="locks">Locks &amp; Deadlocks</h2>
+      <p>Any JVM-reported "Found one Java-level deadlock" section is surfaced with its involved threads, plus a lock-contention table for the worst dump: the most-contended monitors with their waiter count and owning thread (parsed from <code>locked</code> / <code>waiting to lock</code> / <code>parking to wait for</code> lines).</p>
+
+      <h2 id="stuck">Stuck Threads</h2>
+      <p>Threads whose top stack frames stayed identical across three or more consecutive dumps — a hung, slow, or deadlocked thread. The longer the run (and the larger "stuck for"), the more suspicious.</p>
+
+      <h2 id="heatmap">Heatmap</h2>
+      <p>A grid of each tracked thread's state across the dump sequence (BLOCKED and stuck threads first). Spot a thread that turns and stays BLOCKED, or a pool that gradually fills with BLOCKED.</p>
+
+      <h2 id="browse">Browse</h2>
+      <p>A dump selector loads any single dump on demand: threads grouped with state badges and foldable stacks, filterable by state and name, plus a toggle to view the verbatim raw dump text.</p>
+
+      <h2 id="events">Source Events</h2>
+      <ul>
+        <li><code>jdk.ThreadDump</code> — periodic full textual thread dump (the <code>result</code> field).</li>
+      </ul>
+    </div>
+
+    <DocsNavFooter />
+  </article>
+</template>
+
+<style scoped>
+@import '@/views/docs/docs-page.css';
+</style>

--- a/jeffrey-pages/src/views/docs/microscope/profiles/ProfilesPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/profiles/ProfilesPage.vue
@@ -119,6 +119,11 @@ const folderStructure = `$JEFFREY_HOME/
           description="Per-thread CPU time, allocations, and state distribution. Visual timeline of thread activity to spot synchronization issues."
         />
         <DocsFeatureCard
+          icon="bi bi-file-earmark-text"
+          title="Thread Dumps"
+          description="Parses periodic jstack-style jdk.ThreadDump snapshots into a thread-state timeline, hot-frame activity, deadlock detection, lock contention, stuck-thread detection, and a per-thread state heatmap — see the thread dumps reference page."
+        />
+        <DocsFeatureCard
           icon="bi bi-bar-chart-line"
           title="Memory & Garbage Collection"
           description="Pause distribution, throughput / overhead, longest-pause table with cause attribution, concurrent cycles, and a searchable reference for every GC pause type — plus collector-specific G1 and ZGC deep-dive pages."

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/EventTypeName.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/EventTypeName.java
@@ -105,6 +105,7 @@ public abstract class EventTypeName {
     public static final String JAVA_THREAD_STATISTICS = "jdk.JavaThreadStatistics";
     public static final String THREAD_ALLOCATION_STATISTICS = "jdk.ThreadAllocationStatistics";
     public static final String THREAD_CPU_LOAD = "jdk.ThreadCPULoad";
+    public static final String THREAD_DUMP = "jdk.ThreadDump";
     public static final String COMPILER_STATISTICS = "jdk.CompilerStatistics";
     public static final String COMPILATION = "jdk.Compilation";
     public static final String DEOPTIMIZATION = "jdk.Deoptimization";

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/Type.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/Type.java
@@ -115,6 +115,7 @@ public record Type(String code, boolean calculated) {
     public static final Type JAVA_THREAD_STATISTICS = new Type(EventTypeName.JAVA_THREAD_STATISTICS);
     public static final Type THREAD_ALLOCATION_STATISTICS = new Type(EventTypeName.THREAD_ALLOCATION_STATISTICS);
     public static final Type THREAD_CPU_LOAD = new Type(EventTypeName.THREAD_CPU_LOAD);
+    public static final Type THREAD_DUMP = new Type(EventTypeName.THREAD_DUMP);
     public static final Type COMPILER_STATISTICS = new Type(EventTypeName.COMPILER_STATISTICS);
     public static final Type COMPILATION = new Type(EventTypeName.COMPILATION);
     public static final Type DEOPTIMIZATION = new Type(EventTypeName.DEOPTIMIZATION);
@@ -296,6 +297,7 @@ public record Type(String code, boolean calculated) {
                 JAVA_THREAD_STATISTICS,
                 THREAD_ALLOCATION_STATISTICS,
                 THREAD_CPU_LOAD,
+                THREAD_DUMP,
                 COMPILER_STATISTICS,
                 COMPILATION,
                 DEOPTIMIZATION,


### PR DESCRIPTION
## Summary

A new **Thread Dumps** page in the THREADS sidebar section that turns the periodic jstack-style `jdk.ThreadDump` snapshots into trends, contention analysis, and hang detection.

**JDK-26 verification (`jfr metadata`, Temurin 26.0.1):** `jdk.ThreadDump` carries `startTime` + `result` (the full dump text, same content as `jstack`), emitted ~every 60s by the default profiling config. Nothing consumed it before — all value comes from parsing that text.

The centerpiece is a standalone, tested **jstack-text parser** (`ThreadDumpParser`) + a cross-dump **analyzer** (`ThreadDumpAnalyzer`). The parser is heuristic and degrades gracefully (it distinguishes real thread headers from the quoted names in the deadlock summary; the raw text is always retained for the viewer).

## Views (tabs)
- **Timeline** — stacked area of thread counts by state (RUNNABLE/BLOCKED/WAITING/…) across dumps, carried forward between samples. BLOCKED spike = lock storm; climbing total = thread leak.
- **Activity** — the stack frames threads sit at most often (idle pool vs I/O wait vs hotspot).
- **Locks & Deadlocks** — JVM-reported "Found one Java-level deadlock" sections + a lock-contention table (most-contended monitors, waiters, owner) for the worst dump.
- **Stuck Threads** — threads whose top-K frames stayed identical across ≥3 consecutive dumps, with "stuck for".
- **Heatmap** — a thread×dump CSS grid colored by state (BLOCKED/stuck first).
- **Browse** — a dump selector that lazily loads one fully-parsed dump: grouped threads with foldable stacks, state/name filters, raw-text toggle.

No flamegraph (explicitly out of scope).

## Implementation
- Register `THREAD_DUMP` in `Type`/`EventTypeName` (+ `KNOWN_TYPES`).
- `manager/model/thread/dump/`: `ThreadDumpParser`, `ThreadDumpAnalyzer`, `ThreadDumpBuilder`, DTOs (`ParsedDump`, `ThreadDumpAnalysis`, `ThreadState`, `RawDump`).
- Two endpoints keep payloads small: `ThreadManager.threadDumpAnalysis()` → compact aggregates; `threadDump(index)` → one fully parsed dump (lazy, for the viewer). Methods on the existing manager — no new factory wiring. `ThreadController`: `GET /thread/dumps` and `/thread/dumps/{index}`.
- Frontend: `ProfileThreadDumps.vue` (custom stacked-area ApexCharts for the timeline; `DataTable`/`Badge`/`AboutPanel` elsewhere), `ProfileThreadClient.dumps()`/`dump(index)`, `ThreadDumpModels.ts`, route, sidebar entry.

## Tests
- `ThreadDumpParserTest` — threads/states/frames/locks, deadlock extraction, empty/null robustness.
- `ThreadDumpAnalyzerTest` — state timeline, top-frame ranking, stuck-thread runs, lock-contention ranking, heatmap shape.
- `ThreadControllerTest` — `/thread/dumps` + `/thread/dumps/{index}`.

## Verification
- Backend compiled + tested on **JDK 26** (`mvn -pl jeffrey-microscope/profiles/profile-management,jeffrey-microscope/core-microscope -am test`) — green.
- Frontend (`pages-microscope`): ESLint clean, Vite build passes. Docs (`jeffrey-pages`) build passes (Thread Dumps reference page + profiles index card).

## Note
jstack text format varies slightly across JVM versions, so parsing is heuristic; the Browse tab always exposes the verbatim raw dump as the source of truth. Worth one pass against a real multi-dump recording.

https://claude.ai/code/session_019PNnPZQ2oSTUGrEjFfsE4x

---
_Generated by [Claude Code](https://claude.ai/code/session_019PNnPZQ2oSTUGrEjFfsE4x)_