### PR TITLE
Surface six Tier-3 JFR events across existing pages

### DIFF
--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/GarbageCollectionController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/GarbageCollectionController.java
@@ -28,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
 import cafe.jeffrey.profile.manager.GarbageCollectionManager;
 import cafe.jeffrey.profile.manager.model.gc.GCOverviewData;
+import cafe.jeffrey.profile.manager.model.gc.GCPhaseParallelAggregate;
 import cafe.jeffrey.profile.manager.model.gc.GCTimeseriesType;
 import cafe.jeffrey.profile.manager.model.gc.configuration.GCConfigurationData;
 import cafe.jeffrey.profile.manager.model.gc.g1.G1AnalysisData;
@@ -38,6 +39,8 @@ import cafe.jeffrey.profile.manager.model.gc.tuning.ReferenceProcessingData;
 import cafe.jeffrey.profile.manager.model.gc.tuning.TenuringData;
 import cafe.jeffrey.profile.manager.model.gc.zgc.ZgcAnalysisData;
 import cafe.jeffrey.timeseries.TimeseriesData;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/internal/profiles/{profileId}/gc")
@@ -111,6 +114,12 @@ public class GarbageCollectionController {
     public ReferenceProcessingData referenceProcessing(@PathVariable("profileId") String profileId) {
         LOG.debug("Fetching GC reference-processing data");
         return mgr(profileId).referenceProcessing();
+    }
+
+    @GetMapping("/phase-parallel")
+    public List<GCPhaseParallelAggregate> phaseParallel(@PathVariable("profileId") String profileId) {
+        LOG.debug("Fetching GC parallel sub-phase breakdown");
+        return mgr(profileId).phaseParallel();
     }
 
     private GarbageCollectionManager mgr(String profileId) {

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/GarbageCollectionController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/GarbageCollectionController.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
 import cafe.jeffrey.profile.manager.GarbageCollectionManager;
+import cafe.jeffrey.profile.manager.model.gc.G1PlabStatistics;
 import cafe.jeffrey.profile.manager.model.gc.GCOverviewData;
 import cafe.jeffrey.profile.manager.model.gc.GCPhaseParallelAggregate;
 import cafe.jeffrey.profile.manager.model.gc.GCTimeseriesType;
@@ -120,6 +121,12 @@ public class GarbageCollectionController {
     public List<GCPhaseParallelAggregate> phaseParallel(@PathVariable("profileId") String profileId) {
         LOG.debug("Fetching GC parallel sub-phase breakdown");
         return mgr(profileId).phaseParallel();
+    }
+
+    @GetMapping("/plab-statistics")
+    public List<G1PlabStatistics> plabStatistics(@PathVariable("profileId") String profileId) {
+        LOG.debug("Fetching G1 PLAB evacuation statistics");
+        return mgr(profileId).plabStatistics();
     }
 
     private GarbageCollectionManager mgr(String profileId) {

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/IoController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/IoController.java
@@ -26,6 +26,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
 import cafe.jeffrey.profile.manager.IoManager;
+import cafe.jeffrey.profile.manager.model.io.FileForceStats;
 import cafe.jeffrey.profile.manager.model.io.IoEndpoint;
 import cafe.jeffrey.profile.manager.model.io.IoKind;
 import cafe.jeffrey.profile.manager.model.io.IoOperation;
@@ -74,6 +75,12 @@ public class IoController {
     public List<IoEndpoint> directories(@PathVariable("profileId") String profileId) {
         LOG.debug("Fetching file I/O directories");
         return mgr(profileId).directories();
+    }
+
+    @GetMapping("/file/force")
+    public FileForceStats fileForce(@PathVariable("profileId") String profileId) {
+        LOG.debug("Fetching file force (fsync) stats");
+        return mgr(profileId).fileForce();
     }
 
     private IoManager mgr(String profileId) {

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/SystemResourcesController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/SystemResourcesController.java
@@ -27,6 +27,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
 import cafe.jeffrey.profile.manager.SystemResourcesManager;
+import cafe.jeffrey.profile.manager.model.system.LaunchedProcessInfo;
+import cafe.jeffrey.profile.manager.model.system.ModuleEdge;
+import cafe.jeffrey.profile.manager.model.system.ModuleExport;
 import cafe.jeffrey.profile.manager.model.system.SystemOverview;
 import cafe.jeffrey.profile.manager.model.system.SystemProcessInfo;
 import cafe.jeffrey.timeseries.TimeseriesData;
@@ -81,6 +84,30 @@ public class SystemResourcesController {
     public List<SystemProcessInfo> processes(@PathVariable("profileId") String profileId) {
         LOG.debug("Fetching host processes");
         return mgr(profileId).processes();
+    }
+
+    @GetMapping("/swap/timeline")
+    public TimeseriesData swapTimeline(@PathVariable("profileId") String profileId) {
+        LOG.debug("Fetching swap-space timeline");
+        return mgr(profileId).swapTimeline();
+    }
+
+    @GetMapping("/launched-processes")
+    public List<LaunchedProcessInfo> launchedProcesses(@PathVariable("profileId") String profileId) {
+        LOG.debug("Fetching launched subprocesses");
+        return mgr(profileId).launchedProcesses();
+    }
+
+    @GetMapping("/modules/requires")
+    public List<ModuleEdge> moduleRequires(@PathVariable("profileId") String profileId) {
+        LOG.debug("Fetching module requires");
+        return mgr(profileId).moduleRequires();
+    }
+
+    @GetMapping("/modules/exports")
+    public List<ModuleExport> moduleExports(@PathVariable("profileId") String profileId) {
+        LOG.debug("Fetching module exports");
+        return mgr(profileId).moduleExports();
     }
 
     private SystemResourcesManager mgr(String profileId) {

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/ThreadController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/ThreadController.java
@@ -26,6 +26,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
 import cafe.jeffrey.profile.manager.ThreadManager;
+import cafe.jeffrey.profile.manager.model.thread.ReservedStackActivation;
 import cafe.jeffrey.profile.manager.model.thread.ThreadCpuLoads;
 import cafe.jeffrey.profile.manager.model.thread.ThreadStats;
 import cafe.jeffrey.profile.manager.model.thread.ThreadWithCpuLoad;
@@ -96,6 +97,12 @@ public class ThreadController {
             @PathVariable("index") int index) {
         LOG.debug("Fetching thread dump: index={}", index);
         return mgr(profileId).threadDump(index);
+    }
+
+    @GetMapping("/reserved-stack")
+    public List<ReservedStackActivation> reservedStack(@PathVariable("profileId") String profileId) {
+        LOG.debug("Fetching reserved-stack activations");
+        return mgr(profileId).reservedStackActivations();
     }
 
     private ThreadManager mgr(String profileId) {

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/GarbageCollectionControllerTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/GarbageCollectionControllerTest.java
@@ -128,6 +128,17 @@ class GarbageCollectionControllerTest {
         assertThat(mvc.get().uri("/api/internal/profiles/p-1/gc/reference-processing")).hasStatusOk();
     }
 
+    @Test
+    void getsPhaseParallelBreakdown() {
+        when(resolver.resolve("p-1")).thenReturn(profileManager);
+        when(profileManager.gcManager()).thenReturn(gcManager);
+        when(gcManager.phaseParallel()).thenReturn(List.of());
+
+        MockMvcTester mvc = mockMvcTesterFor(new GarbageCollectionController(resolver));
+
+        assertThat(mvc.get().uri("/api/internal/profiles/p-1/gc/phase-parallel")).hasStatusOk();
+    }
+
     private static G1AnalysisData emptyG1Analysis() {
         return new G1AnalysisData(
                 new G1Header(0, 0, 0, 0, 0, 0, 0, 0, 0),

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/GarbageCollectionControllerTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/GarbageCollectionControllerTest.java
@@ -154,6 +154,17 @@ class GarbageCollectionControllerTest {
     }
 
     @Test
+    void getsPlabStatistics() {
+        when(resolver.resolve("p-1")).thenReturn(profileManager);
+        when(profileManager.gcManager()).thenReturn(gcManager);
+        when(gcManager.plabStatistics()).thenReturn(List.of());
+
+        MockMvcTester mvc = mockMvcTesterFor(new GarbageCollectionController(resolver));
+
+        assertThat(mvc.get().uri("/api/internal/profiles/p-1/gc/plab-statistics")).hasStatusOk();
+    }
+
+    @Test
     void profileNotFoundReturns404() {
         when(resolver.resolve("ghost")).thenThrow(Exceptions.profileNotFound("ghost"));
 

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/IoControllerTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/IoControllerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.microscope.core.web.controllers.profile;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
+import cafe.jeffrey.profile.manager.IoManager;
+import cafe.jeffrey.profile.manager.ProfileManager;
+import cafe.jeffrey.profile.manager.model.io.FileForceStats;
+import cafe.jeffrey.shared.common.exception.Exceptions;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static cafe.jeffrey.microscope.core.web.MockMvcSupport.mockMvcTesterFor;
+
+@ExtendWith(MockitoExtension.class)
+class IoControllerTest {
+
+    @Mock
+    ProfileManagerResolver resolver;
+
+    @Mock
+    ProfileManager profileManager;
+
+    @Mock
+    IoManager ioManager;
+
+    @Test
+    void getsFileForceStats() {
+        when(resolver.resolve("p-1")).thenReturn(profileManager);
+        when(profileManager.ioManager()).thenReturn(ioManager);
+        when(ioManager.fileForce()).thenReturn(new FileForceStats(0, 0, 0, 0, 0, List.of()));
+
+        MockMvcTester mvc = mockMvcTesterFor(new IoController(resolver));
+
+        assertThat(mvc.get().uri("/api/internal/profiles/p-1/io/file/force"))
+                .hasStatusOk()
+                .bodyJson()
+                .extractingPath("$.count").isEqualTo(0);
+    }
+
+    @Test
+    void profileNotFoundReturns404() {
+        when(resolver.resolve("ghost")).thenThrow(Exceptions.profileNotFound("ghost"));
+
+        MockMvcTester mvc = mockMvcTesterFor(new IoController(resolver));
+
+        assertThat(mvc.get().uri("/api/internal/profiles/ghost/io/file/force"))
+                .hasStatus(404)
+                .bodyJson()
+                .extractingPath("$.code").asString().isEqualTo("PROFILE_NOT_FOUND");
+    }
+}

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/SystemResourcesControllerTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/SystemResourcesControllerTest.java
@@ -1,0 +1,91 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.microscope.core.web.controllers.profile;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
+import cafe.jeffrey.profile.manager.ProfileManager;
+import cafe.jeffrey.profile.manager.SystemResourcesManager;
+import cafe.jeffrey.shared.common.exception.Exceptions;
+import cafe.jeffrey.timeseries.TimeseriesData;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static cafe.jeffrey.microscope.core.web.MockMvcSupport.mockMvcTesterFor;
+
+@ExtendWith(MockitoExtension.class)
+class SystemResourcesControllerTest {
+
+    @Mock
+    ProfileManagerResolver resolver;
+
+    @Mock
+    ProfileManager profileManager;
+
+    @Mock
+    SystemResourcesManager systemManager;
+
+    private MockMvcTester mvc() {
+        when(resolver.resolve("p-1")).thenReturn(profileManager);
+        when(profileManager.systemResourcesManager()).thenReturn(systemManager);
+        return mockMvcTesterFor(new SystemResourcesController(resolver));
+    }
+
+    @Test
+    void getsSwapTimeline() {
+        when(systemManager.swapTimeline()).thenReturn(new TimeseriesData(List.of()));
+        assertThat(mvc().get().uri("/api/internal/profiles/p-1/system/swap/timeline")).hasStatusOk();
+    }
+
+    @Test
+    void getsLaunchedProcesses() {
+        when(systemManager.launchedProcesses()).thenReturn(List.of());
+        assertThat(mvc().get().uri("/api/internal/profiles/p-1/system/launched-processes")).hasStatusOk();
+    }
+
+    @Test
+    void getsModuleRequires() {
+        when(systemManager.moduleRequires()).thenReturn(List.of());
+        assertThat(mvc().get().uri("/api/internal/profiles/p-1/system/modules/requires")).hasStatusOk();
+    }
+
+    @Test
+    void getsModuleExports() {
+        when(systemManager.moduleExports()).thenReturn(List.of());
+        assertThat(mvc().get().uri("/api/internal/profiles/p-1/system/modules/exports")).hasStatusOk();
+    }
+
+    @Test
+    void profileNotFoundReturns404() {
+        when(resolver.resolve("ghost")).thenThrow(Exceptions.profileNotFound("ghost"));
+
+        MockMvcTester mvc = mockMvcTesterFor(new SystemResourcesController(resolver));
+
+        assertThat(mvc.get().uri("/api/internal/profiles/ghost/system/swap/timeline"))
+                .hasStatus(404)
+                .bodyJson()
+                .extractingPath("$.code").asString().isEqualTo("PROFILE_NOT_FOUND");
+    }
+}

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/ThreadControllerTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/ThreadControllerTest.java
@@ -90,6 +90,17 @@ class ThreadControllerTest {
     }
 
     @Test
+    void getsReservedStackActivations() {
+        when(resolver.resolve("p-1")).thenReturn(profileManager);
+        when(profileManager.threadManager()).thenReturn(threadManager);
+        when(threadManager.reservedStackActivations()).thenReturn(List.of());
+
+        MockMvcTester mvc = mockMvcTesterFor(new ThreadController(resolver));
+
+        assertThat(mvc.get().uri("/api/internal/profiles/p-1/thread/reserved-stack")).hasStatusOk();
+    }
+
+    @Test
     void profileNotFoundReturns404() {
         when(resolver.resolve("ghost")).thenThrow(Exceptions.profileNotFound("ghost"));
 

--- a/jeffrey-microscope/pages-microscope/src/services/api/ProfileFileIoClient.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/ProfileFileIoClient.ts
@@ -18,7 +18,12 @@
 
 import BaseProfileClient from '@/services/api/BaseProfileClient';
 import TimeseriesData from '@/services/timeseries/model/TimeseriesData';
-import type { IoEndpoint, IoOperation, IoOverview } from '@/services/api/model/IoModels';
+import type {
+  FileForceStats,
+  IoEndpoint,
+  IoOperation,
+  IoOverview
+} from '@/services/api/model/IoModels';
 
 export default class ProfileFileIoClient extends BaseProfileClient {
   constructor(profileId: string) {
@@ -43,5 +48,9 @@ export default class ProfileFileIoClient extends BaseProfileClient {
 
   public getDirectories(): Promise<IoEndpoint[]> {
     return this.get<IoEndpoint[]>('/directories');
+  }
+
+  public getForce(): Promise<FileForceStats> {
+    return this.get<FileForceStats>('/force');
   }
 }

--- a/jeffrey-microscope/pages-microscope/src/services/api/ProfileGCClient.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/ProfileGCClient.ts
@@ -22,6 +22,7 @@ import GCConfigurationData from '@/services/api/model/GCConfigurationData';
 import GCTimeseriesType from '@/services/api/model/GCTimeseriesType';
 import TimeseriesData from '@/services/timeseries/model/TimeseriesData';
 import type GCPhaseParallelAggregate from '@/services/api/model/GCPhaseParallelAggregate';
+import type G1PlabStatistics from '@/services/api/model/G1PlabStatistics';
 import type { IhopData, TenuringData } from '@/services/api/model/GCTuningModels';
 import type G1AnalysisData from '@/services/api/model/G1AnalysisData';
 import type ZgcAnalysisData from '@/services/api/model/ZgcAnalysisData';
@@ -75,5 +76,9 @@ export default class ProfileGCClient extends BaseProfileClient {
 
   public getPhaseParallel(): Promise<GCPhaseParallelAggregate[]> {
     return this.get<GCPhaseParallelAggregate[]>('/phase-parallel');
+  }
+
+  public getPlabStatistics(): Promise<G1PlabStatistics[]> {
+    return this.get<G1PlabStatistics[]>('/plab-statistics');
   }
 }

--- a/jeffrey-microscope/pages-microscope/src/services/api/ProfileGCClient.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/ProfileGCClient.ts
@@ -21,6 +21,7 @@ import GCOverviewData from '@/services/api/model/GCOverviewData';
 import GCConfigurationData from '@/services/api/model/GCConfigurationData';
 import GCTimeseriesType from '@/services/api/model/GCTimeseriesType';
 import TimeseriesData from '@/services/timeseries/model/TimeseriesData';
+import type GCPhaseParallelAggregate from '@/services/api/model/GCPhaseParallelAggregate';
 import type { IhopData, TenuringData } from '@/services/api/model/GCTuningModels';
 import type G1AnalysisData from '@/services/api/model/G1AnalysisData';
 import type ZgcAnalysisData from '@/services/api/model/ZgcAnalysisData';
@@ -70,5 +71,9 @@ export default class ProfileGCClient extends BaseProfileClient {
 
   public getReferenceProcessing(): Promise<ReferenceProcessingData> {
     return this.get<ReferenceProcessingData>('/reference-processing');
+  }
+
+  public getPhaseParallel(): Promise<GCPhaseParallelAggregate[]> {
+    return this.get<GCPhaseParallelAggregate[]>('/phase-parallel');
   }
 }

--- a/jeffrey-microscope/pages-microscope/src/services/api/ProfileSystemClient.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/ProfileSystemClient.ts
@@ -18,7 +18,13 @@
 
 import BaseProfileClient from '@/services/api/BaseProfileClient';
 import TimeseriesData from '@/services/timeseries/model/TimeseriesData';
-import type { SystemOverview, SystemProcessInfo } from '@/services/api/model/SystemModels';
+import type {
+  LaunchedProcessInfo,
+  ModuleEdge,
+  ModuleExport,
+  SystemOverview,
+  SystemProcessInfo
+} from '@/services/api/model/SystemModels';
 
 export default class ProfileSystemClient extends BaseProfileClient {
   constructor(profileId: string) {
@@ -47,5 +53,21 @@ export default class ProfileSystemClient extends BaseProfileClient {
 
   public getProcesses(): Promise<SystemProcessInfo[]> {
     return this.get<SystemProcessInfo[]>('/processes');
+  }
+
+  public getSwapTimeline(): Promise<TimeseriesData> {
+    return this.get<TimeseriesData>('/swap/timeline');
+  }
+
+  public getLaunchedProcesses(): Promise<LaunchedProcessInfo[]> {
+    return this.get<LaunchedProcessInfo[]>('/launched-processes');
+  }
+
+  public getModuleRequires(): Promise<ModuleEdge[]> {
+    return this.get<ModuleEdge[]>('/modules/requires');
+  }
+
+  public getModuleExports(): Promise<ModuleExport[]> {
+    return this.get<ModuleExport[]>('/modules/exports');
   }
 }

--- a/jeffrey-microscope/pages-microscope/src/services/api/ProfileThreadClient.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/ProfileThreadClient.ts
@@ -21,6 +21,7 @@ import ThreadResponse from '@/services/api/model/ThreadResponse';
 import ThreadStatisticsResponse from '@/services/api/model/ThreadStatisticsResponse';
 import Serie from '@/services/timeseries/model/Serie';
 import type { ParsedDump, ThreadDumpAnalysis } from '@/services/api/model/ThreadDumpModels';
+import type ReservedStackActivation from '@/services/api/model/ReservedStackActivation';
 
 export default class ProfileThreadClient extends BaseProfileClient {
   constructor(profileId: string) {
@@ -45,5 +46,9 @@ export default class ProfileThreadClient extends BaseProfileClient {
 
   public dump(index: number): Promise<ParsedDump> {
     return this.get<ParsedDump>(`/dumps/${index}`);
+  }
+
+  public reservedStack(): Promise<ReservedStackActivation[]> {
+    return this.get<ReservedStackActivation[]>('/reserved-stack');
   }
 }

--- a/jeffrey-microscope/pages-microscope/src/services/api/model/G1PlabStatistics.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/model/G1PlabStatistics.ts
@@ -1,0 +1,31 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export default interface G1PlabStatistics {
+  gcId: number;
+  generation: string;
+  allocated: number;
+  used: number;
+  totalWasted: number;
+  wastePercent: number;
+  directAllocated: number;
+  regionsRefilled: number;
+  numPlabsFilled: number;
+  failureUsed: number;
+  failureWaste: number;
+}

--- a/jeffrey-microscope/pages-microscope/src/services/api/model/GCPhaseParallelAggregate.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/model/GCPhaseParallelAggregate.ts
@@ -16,44 +16,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export interface IoOverview {
-  bytesRead: number;
-  bytesWritten: number;
-  opCount: number;
-  slowestNanos: number;
-  slowestTarget: string | null;
-  hasEvents: boolean;
-}
-
-export interface IoOperation {
-  kind: string;
-  target: string;
-  bytes: number;
-  durationNanos: number;
-  thread: string | null;
-}
-
-export interface IoEndpoint {
-  target: string;
-  opCount: number;
-  bytes: number;
-  totalNanos: number;
-  maxNanos: number;
-}
-
-export interface FileForceOp {
-  timeOffsetMillis: number;
-  path: string | null;
-  metaData: boolean;
-  durationNanos: number;
-  thread: string | null;
-}
-
-export interface FileForceStats {
+export default interface GCPhaseParallelAggregate {
+  name: string;
   count: number;
   totalNanos: number;
   avgNanos: number;
   maxNanos: number;
-  metadataCount: number;
-  slowest: FileForceOp[];
+  percentOfTotal: number;
 }

--- a/jeffrey-microscope/pages-microscope/src/services/api/model/ReservedStackActivation.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/model/ReservedStackActivation.ts
@@ -16,44 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export interface IoOverview {
-  bytesRead: number;
-  bytesWritten: number;
-  opCount: number;
-  slowestNanos: number;
-  slowestTarget: string | null;
-  hasEvents: boolean;
-}
-
-export interface IoOperation {
-  kind: string;
-  target: string;
-  bytes: number;
-  durationNanos: number;
-  thread: string | null;
-}
-
-export interface IoEndpoint {
-  target: string;
-  opCount: number;
-  bytes: number;
-  totalNanos: number;
-  maxNanos: number;
-}
-
-export interface FileForceOp {
+export default interface ReservedStackActivation {
   timeOffsetMillis: number;
-  path: string | null;
-  metaData: boolean;
-  durationNanos: number;
   thread: string | null;
-}
-
-export interface FileForceStats {
-  count: number;
-  totalNanos: number;
-  avgNanos: number;
-  maxNanos: number;
-  metadataCount: number;
-  slowest: FileForceOp[];
+  method: string | null;
 }

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileFileIo.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileFileIo.vue
@@ -48,7 +48,13 @@
             <TableToolbar v-model="filesView.query" search-placeholder="Filter files...">
               <span class="toolbar-info">Files</span>
               <template #filters>
-                <Badge key-label="Total" :value="filesView.matchCount" variant="secondary" size="s" borderless />
+                <Badge
+                  key-label="Total"
+                  :value="filesView.matchCount"
+                  variant="secondary"
+                  size="s"
+                  borderless
+                />
               </template>
             </TableToolbar>
           </template>
@@ -72,10 +78,15 @@
               <td class="text-end">{{ FormattingService.formatBytes(file.bytes) }}</td>
               <td>
                 <div class="share-bar">
-                  <div class="share-bar-fill" :style="{ width: shareWidth(file.bytes, maxFileBytes) + '%' }"></div>
+                  <div
+                    class="share-bar-fill"
+                    :style="{ width: shareWidth(file.bytes, maxFileBytes) + '%' }"
+                  ></div>
                 </div>
               </td>
-              <td class="text-end">{{ FormattingService.formatDuration2Units(file.totalNanos) }}</td>
+              <td class="text-end">
+                {{ FormattingService.formatDuration2Units(file.totalNanos) }}
+              </td>
               <td class="text-end">{{ FormattingService.formatDuration2Units(file.maxNanos) }}</td>
             </tr>
           </tbody>
@@ -102,10 +113,19 @@
         />
         <DataTable v-else>
           <template #toolbar>
-            <TableToolbar v-model="directoriesView.query" search-placeholder="Filter directories...">
+            <TableToolbar
+              v-model="directoriesView.query"
+              search-placeholder="Filter directories..."
+            >
               <span class="toolbar-info">By directory</span>
               <template #filters>
-                <Badge key-label="Total" :value="directoriesView.matchCount" variant="secondary" size="s" borderless />
+                <Badge
+                  key-label="Total"
+                  :value="directoriesView.matchCount"
+                  variant="secondary"
+                  size="s"
+                  borderless
+                />
               </template>
             </TableToolbar>
           </template>
@@ -126,7 +146,10 @@
               <td class="text-end">{{ FormattingService.formatBytes(dir.bytes) }}</td>
               <td>
                 <div class="share-bar">
-                  <div class="share-bar-fill" :style="{ width: shareWidth(dir.bytes, maxDirBytes) + '%' }"></div>
+                  <div
+                    class="share-bar-fill"
+                    :style="{ width: shareWidth(dir.bytes, maxDirBytes) + '%' }"
+                  ></div>
                 </div>
               </td>
               <td class="text-end">{{ FormattingService.formatDuration2Units(dir.totalNanos) }}</td>
@@ -159,7 +182,13 @@
             <TableToolbar v-model="slowestView.query" search-placeholder="Filter operations...">
               <span class="toolbar-info">Slowest operations</span>
               <template #filters>
-                <Badge key-label="Showing" :value="slowestView.matchCount" variant="secondary" size="s" borderless />
+                <Badge
+                  key-label="Showing"
+                  :value="slowestView.matchCount"
+                  variant="secondary"
+                  size="s"
+                  borderless
+                />
               </template>
             </TableToolbar>
           </template>
@@ -174,10 +203,14 @@
           </thead>
           <tbody>
             <tr v-for="(op, index) in slowestView.visible" :key="index">
-              <td><Badge :value="op.kind" :variant="kindVariant(op.kind)" size="xs" borderless /></td>
+              <td>
+                <Badge :value="op.kind" :variant="kindVariant(op.kind)" size="xs" borderless />
+              </td>
               <td class="target-cell" :title="op.target">{{ op.target }}</td>
               <td class="text-end">{{ FormattingService.formatBytes(op.bytes) }}</td>
-              <td class="text-end">{{ FormattingService.formatDuration2Units(op.durationNanos) }}</td>
+              <td class="text-end">
+                {{ FormattingService.formatDuration2Units(op.durationNanos) }}
+              </td>
               <td class="text-muted">{{ op.thread ?? '—' }}</td>
             </tr>
           </tbody>
@@ -194,6 +227,80 @@
         </DataTable>
       </div>
 
+      <!-- Fsync -->
+      <div v-show="activeTab === 'fsync'">
+        <ChartDescription
+          shows="File force (fsync) operations from jdk.FileForce — flushing buffered writes (and optionally metadata) durably to disk. Unlike reads/writes, force carries no bytes, only latency."
+          use-case="Slow or frequent fsyncs are a classic durability bottleneck (commit logs, databases, flush-on-every-write). A high metadata-flush share means extra inode updates."
+        />
+        <EmptyState
+          v-if="!fileForce || fileForce.count === 0"
+          icon="bi-arrow-repeat"
+          title="No fsync operations recorded"
+          description="This recording has no jdk.FileForce events (often disabled by default)."
+        />
+        <div v-else>
+          <div class="mb-4">
+            <StatsTable :metrics="forceMetrics" />
+          </div>
+          <DataTable>
+            <template #toolbar>
+              <TableToolbar v-model="forceView.query" search-placeholder="Filter forces...">
+                <span class="toolbar-info">Slowest forces</span>
+                <template #filters>
+                  <Badge
+                    key-label="Showing"
+                    :value="forceView.matchCount"
+                    variant="secondary"
+                    size="s"
+                    borderless
+                  />
+                </template>
+              </TableToolbar>
+            </template>
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th>File</th>
+                <th>Flush</th>
+                <th class="text-end">Duration</th>
+                <th>Thread</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(op, index) in forceView.visible" :key="index">
+                <td>
+                  {{ FormattingService.formatDuration2Units(op.timeOffsetMillis * 1_000_000) }}
+                </td>
+                <td class="target-cell" :title="op.path ?? ''">{{ op.path ?? '—' }}</td>
+                <td>
+                  <Badge
+                    :value="op.metaData ? 'data + metadata' : 'data'"
+                    :variant="op.metaData ? 'warning' : 'secondary'"
+                    size="xs"
+                    borderless
+                  />
+                </td>
+                <td class="text-end">
+                  {{ FormattingService.formatDuration2Units(op.durationNanos) }}
+                </td>
+                <td class="text-muted">{{ op.thread ?? '—' }}</td>
+              </tr>
+            </tbody>
+            <template #footer>
+              <TableShowMore
+                :shown="forceView.visible.length"
+                :match-count="forceView.matchCount"
+                :total="forceView.total"
+                :expanded="forceView.expanded"
+                :page-size="forceView.pageSize"
+                @toggle="forceView.toggle"
+              />
+            </template>
+          </DataTable>
+        </div>
+      </div>
+
       <!-- How It Works -->
       <div v-show="activeTab === 'about'">
         <AboutPanel
@@ -203,29 +310,29 @@
         >
           <AboutCallout variant="intro">
             <p>
-              A file read or write blocks the calling thread until the OS satisfies it — instantly from
-              the page cache, or slowly from disk on a cache miss or <code>fsync</code>. This page
-              attributes that wait to the files and directories your application touches.
+              A file read or write blocks the calling thread until the OS satisfies it — instantly
+              from the page cache, or slowly from disk on a cache miss or <code>fsync</code>. This
+              page attributes that wait to the files and directories your application touches.
             </p>
           </AboutCallout>
 
           <AboutSection icon="bi-hdd" title="What the Views Show">
             <FeatureGrid>
               <FeatureCard icon="bi-graph-up" variant="primary" title="Throughput">
-                Bytes read vs written per second. Heavy sustained writes can mean logging or flushing;
-                heavy reads on the same files suggest a missing in-memory cache.
+                Bytes read vs written per second. Heavy sustained writes can mean logging or
+                flushing; heavy reads on the same files suggest a missing in-memory cache.
               </FeatureCard>
               <FeatureCard icon="bi-file-earmark" variant="info" title="Top Files">
                 Individual files ranked by bytes, with a share bar. A single file dominating is the
                 cue to cache it, batch writes, or move it off the hot path.
               </FeatureCard>
               <FeatureCard icon="bi-folder" variant="success" title="By Directory">
-                The same I/O rolled up per parent directory — surfaces a hot log dir or data dir even
-                when it's spread across many rotating files.
+                The same I/O rolled up per parent directory — surfaces a hot log dir or data dir
+                even when it's spread across many rotating files.
               </FeatureCard>
               <FeatureCard icon="bi-hourglass-split" variant="warning" title="Slowest Operations">
-                Individual reads/writes by duration. A slow write is often an <code>fsync</code>/flush;
-                a slow read is a page-cache miss hitting the disk.
+                Individual reads/writes by duration. A slow write is often an
+                <code>fsync</code>/flush; a slow read is a page-cache miss hitting the disk.
               </FeatureCard>
             </FeatureGrid>
           </AboutSection>
@@ -233,10 +340,16 @@
           <AboutSection icon="bi-broadcast" title="How JFR Emits This">
             <ul>
               <li>
-                <code>jdk.FileRead</code> — path, <code>bytesRead</code>, an end-of-stream flag and the
-                operation <code>duration</code>.
+                <code>jdk.FileRead</code> — path, <code>bytesRead</code>, an end-of-stream flag and
+                the operation <code>duration</code>.
               </li>
-              <li><code>jdk.FileWrite</code> — path and <code>bytesWritten</code> with duration.</li>
+              <li>
+                <code>jdk.FileWrite</code> — path and <code>bytesWritten</code> with duration.
+              </li>
+              <li>
+                <code>jdk.FileForce</code> — an fsync: path, a <code>metaData</code> flag and the
+                flush <code>duration</code> (no byte count). Powers the Fsync tab.
+              </li>
             </ul>
             <p>
               Both are <strong>threshold-gated</strong> and frequently disabled in default recording
@@ -275,7 +388,13 @@ import FormattingService from '@/services/FormattingService';
 import AxisFormatType from '@/services/timeseries/AxisFormatType';
 import { useTableView } from '@/composables/useTableView';
 import ProfileFileIoClient from '@/services/api/ProfileFileIoClient';
-import type { IoEndpoint, IoOperation, IoOverview } from '@/services/api/model/IoModels';
+import type {
+  FileForceOp,
+  FileForceStats,
+  IoEndpoint,
+  IoOperation,
+  IoOverview
+} from '@/services/api/model/IoModels';
 import type { Variant } from '@/types/ui';
 import type TimeseriesData from '@/services/timeseries/model/TimeseriesData';
 
@@ -289,15 +408,21 @@ const timeline = ref<TimeseriesData>();
 const slowest = ref<IoOperation[]>([]);
 const files = ref<IoEndpoint[]>([]);
 const directories = ref<IoEndpoint[]>([]);
+const fileForce = ref<FileForceStats>();
+
+const forceSlowest = computed<FileForceOp[]>(() => fileForce.value?.slowest ?? []);
+const forceView = useTableView<FileForceOp>(forceSlowest, {
+  searchableText: r => `${r.path ?? ''} ${r.thread ?? ''}`
+});
 
 const slowestView = useTableView<IoOperation>(slowest, {
-  searchableText: (r) => `${r.target} ${r.thread ?? ''}`
+  searchableText: r => `${r.target} ${r.thread ?? ''}`
 });
 const filesView = useTableView<IoEndpoint>(files, {
-  searchableText: (r) => r.target
+  searchableText: r => r.target
 });
 const directoriesView = useTableView<IoEndpoint>(directories, {
-  searchableText: (r) => r.target
+  searchableText: r => r.target
 });
 
 const activeTab = ref('throughput');
@@ -329,8 +454,50 @@ const tabs = computed<TabBarItem[]>(() => [
     icon: 'hourglass-split',
     badge: slowest.value.length || undefined
   },
+  {
+    id: 'fsync',
+    label: 'Fsync',
+    icon: 'arrow-repeat',
+    badge: fileForce.value?.count || undefined
+  },
   { id: 'about', label: 'How It Works', icon: 'book' }
 ]);
+
+const forceMetrics = computed(() => {
+  const f = fileForce.value;
+  if (!f) {
+    return [];
+  }
+  return [
+    {
+      icon: 'arrow-repeat',
+      title: 'Force Operations',
+      value: FormattingService.formatNumber(f.count),
+      variant: 'highlight' as const,
+      breakdown: [
+        { label: 'Metadata Flushes', value: FormattingService.formatNumber(f.metadataCount) }
+      ]
+    },
+    {
+      icon: 'hourglass-split',
+      title: 'Avg Latency',
+      value: FormattingService.formatDuration2Units(f.avgNanos),
+      variant: 'info' as const
+    },
+    {
+      icon: 'hourglass-bottom',
+      title: 'Max Latency',
+      value: FormattingService.formatDuration2Units(f.maxNanos),
+      variant: 'warning' as const
+    },
+    {
+      icon: 'clock-history',
+      title: 'Total Time',
+      value: FormattingService.formatDuration2Units(f.totalNanos),
+      variant: 'success' as const
+    }
+  ];
+});
 
 const kindVariant = (kind: string): Variant => (kind.includes('Write') ? 'warning' : 'info');
 
@@ -385,20 +552,28 @@ onMounted(async () => {
     const profileId = route.params.profileId as string;
     const client = new ProfileFileIoClient(profileId);
 
-    const [overviewResult, timelineResult, slowestResult, filesResult, directoriesResult] =
-      await Promise.all([
-        client.getOverview(),
-        client.getTimeline(),
-        client.getSlowest(),
-        client.getFiles(),
-        client.getDirectories()
-      ]);
+    const [
+      overviewResult,
+      timelineResult,
+      slowestResult,
+      filesResult,
+      directoriesResult,
+      forceResult
+    ] = await Promise.all([
+      client.getOverview(),
+      client.getTimeline(),
+      client.getSlowest(),
+      client.getFiles(),
+      client.getDirectories(),
+      client.getForce()
+    ]);
 
     overview.value = overviewResult;
     timeline.value = timelineResult;
     slowest.value = slowestResult;
     files.value = filesResult;
     directories.value = directoriesResult;
+    fileForce.value = forceResult;
 
     loading.value = false;
   } catch (e) {

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileGarbageCollection.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileGarbageCollection.vue
@@ -78,7 +78,13 @@
           <TableToolbar v-model="longestPausesView.query" search-placeholder="Filter by cause...">
             <span class="toolbar-info">Longest pauses</span>
             <template #filters>
-              <Badge key-label="Total" :value="longestPausesView.matchCount" variant="secondary" size="s" borderless />
+              <Badge
+                key-label="Total"
+                :value="longestPausesView.matchCount"
+                variant="secondary"
+                size="s"
+                borderless
+              />
             </template>
           </TableToolbar>
         </template>
@@ -123,7 +129,13 @@
                     :variant="getConcurrentBadgeVariant(event.concurrent)"
                     size="s"
                   />
-                  <Badge v-if="event.type" :value="event.type" variant="secondary" size="s" borderless />
+                  <Badge
+                    v-if="event.type"
+                    :value="event.type"
+                    variant="secondary"
+                    size="s"
+                    borderless
+                  />
                 </div>
                 <span class="timestamp-path text-muted small">{{
                   FormattingService.formatTimestamp(event.timestamp)
@@ -185,10 +197,19 @@
       />
       <DataTable v-else>
         <template #toolbar>
-          <TableToolbar v-model="concurrentEventsView.query" search-placeholder="Filter by collector...">
+          <TableToolbar
+            v-model="concurrentEventsView.query"
+            search-placeholder="Filter by collector..."
+          >
             <span class="toolbar-info">Concurrent cycles</span>
             <template #filters>
-              <Badge key-label="Total" :value="concurrentEventsView.matchCount" variant="secondary" size="s" borderless />
+              <Badge
+                key-label="Total"
+                :value="concurrentEventsView.matchCount"
+                variant="secondary"
+                size="s"
+                borderless
+              />
             </template>
           </TableToolbar>
         </template>
@@ -259,7 +280,13 @@
             <TableToolbar :show-search="false">
               <span class="toolbar-info">Survivor-age distribution</span>
               <template #filters>
-                <Badge key-label="Collections" :value="tenuringGcsView.total" variant="secondary" size="s" borderless />
+                <Badge
+                  key-label="Collections"
+                  :value="tenuringGcsView.total"
+                  variant="secondary"
+                  size="s"
+                  borderless
+                />
               </template>
             </TableToolbar>
           </template>
@@ -334,7 +361,13 @@
             <TableToolbar :show-search="false">
               <span class="toolbar-info">GC CPU time</span>
               <template #filters>
-                <Badge key-label="Collections" :value="cpuTimesView.total" variant="secondary" size="s" borderless />
+                <Badge
+                  key-label="Collections"
+                  :value="cpuTimesView.total"
+                  variant="secondary"
+                  size="s"
+                  borderless
+                />
               </template>
             </TableToolbar>
           </template>
@@ -349,9 +382,15 @@
           <tbody>
             <tr v-for="entry in cpuTimesView.visible" :key="entry.gcId">
               <td>{{ entry.gcId }}</td>
-              <td class="text-end">{{ FormattingService.formatDuration2Units(entry.userNanos) }}</td>
-              <td class="text-end">{{ FormattingService.formatDuration2Units(entry.systemNanos) }}</td>
-              <td class="text-end">{{ FormattingService.formatDuration2Units(entry.realNanos) }}</td>
+              <td class="text-end">
+                {{ FormattingService.formatDuration2Units(entry.userNanos) }}
+              </td>
+              <td class="text-end">
+                {{ FormattingService.formatDuration2Units(entry.systemNanos) }}
+              </td>
+              <td class="text-end">
+                {{ FormattingService.formatDuration2Units(entry.realNanos) }}
+              </td>
             </tr>
           </tbody>
           <template #footer>
@@ -371,7 +410,13 @@
             <TableToolbar :show-search="false">
               <span class="toolbar-info">Pause-target adherence (MMU)</span>
               <template #filters>
-                <Badge key-label="Collections" :value="mmuView.total" variant="secondary" size="s" borderless />
+                <Badge
+                  key-label="Collections"
+                  :value="mmuView.total"
+                  variant="secondary"
+                  size="s"
+                  borderless
+                />
               </template>
             </TableToolbar>
           </template>
@@ -384,10 +429,18 @@
             </tr>
           </thead>
           <tbody>
-            <tr v-for="entry in mmuView.visible" :key="entry.gcId" :class="{ 'table-danger': entry.gcTimeNanos > entry.pauseTargetNanos }">
+            <tr
+              v-for="entry in mmuView.visible"
+              :key="entry.gcId"
+              :class="{ 'table-danger': entry.gcTimeNanos > entry.pauseTargetNanos }"
+            >
               <td>{{ entry.gcId }}</td>
-              <td class="text-end">{{ FormattingService.formatDuration2Units(entry.gcTimeNanos) }}</td>
-              <td class="text-end">{{ FormattingService.formatDuration2Units(entry.pauseTargetNanos) }}</td>
+              <td class="text-end">
+                {{ FormattingService.formatDuration2Units(entry.gcTimeNanos) }}
+              </td>
+              <td class="text-end">
+                {{ FormattingService.formatDuration2Units(entry.pauseTargetNanos) }}
+              </td>
               <td class="text-end">
                 <Badge
                   v-if="entry.gcTimeNanos > entry.pauseTargetNanos"
@@ -412,6 +465,65 @@
           </template>
         </DataTable>
       </template>
+    </div>
+
+    <div v-show="activeTab === 'phase-parallel'">
+      <ChartDescription
+        shows="Parallel GC sub-phases (jdk.GCPhaseParallel) aggregated by name across all GC worker threads and collections — e.g. Ext Root Scanning, Object Copy, Termination."
+        use-case="Find which sub-phase dominates a stop-the-world pause: heavy Object Copy points at high promotion, heavy Termination at worker load imbalance."
+      />
+      <EmptyState
+        v-if="!phaseParallelData || phaseParallelData.length === 0"
+        icon="bi-layers"
+        title="No parallel sub-phase events"
+        description="This recording has no jdk.GCPhaseParallel events (sub-phase detail is off in many GC configs)."
+      />
+      <DataTable v-else>
+        <template #toolbar>
+          <TableToolbar v-model="phaseParallelView.query" search-placeholder="Filter phases...">
+            <span class="toolbar-info">GC sub-phases</span>
+            <template #filters>
+              <Badge
+                key-label="Phases"
+                :value="phaseParallelView.matchCount"
+                variant="secondary"
+                size="s"
+                borderless
+              />
+            </template>
+          </TableToolbar>
+        </template>
+        <thead>
+          <tr>
+            <th>Phase</th>
+            <th class="text-end">Samples</th>
+            <th class="text-end">Total Time</th>
+            <th class="text-end">Avg Time</th>
+            <th class="text-end">Max Time</th>
+            <th class="text-end">% of Total</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(phase, index) in phaseParallelView.visible" :key="index">
+            <td>{{ phase.name }}</td>
+            <td class="text-end">{{ FormattingService.formatNumber(phase.count) }}</td>
+            <td class="text-end">{{ FormattingService.formatDuration2Units(phase.totalNanos) }}</td>
+            <td class="text-end">{{ FormattingService.formatDuration2Units(phase.avgNanos) }}</td>
+            <td class="text-end">{{ FormattingService.formatDuration2Units(phase.maxNanos) }}</td>
+            <td class="text-end">{{ phase.percentOfTotal.toFixed(1) }}%</td>
+          </tr>
+        </tbody>
+        <template #footer>
+          <TableShowMore
+            :shown="phaseParallelView.visible.length"
+            :match-count="phaseParallelView.matchCount"
+            :total="phaseParallelView.total"
+            :expanded="phaseParallelView.expanded"
+            :page-size="phaseParallelView.pageSize"
+            @toggle="phaseParallelView.toggle"
+          />
+        </template>
+      </DataTable>
     </div>
 
     <div v-show="activeTab === 'pause-types'">
@@ -527,7 +639,8 @@
           <FeatureGrid>
             <FeatureCard icon="bi-egg" variant="info" title="Eden">
               Where almost all objects are born. Cheap bump-pointer allocation; a young collection
-              sweeps it whenever it fills. Most objects die here ("the weak generational hypothesis").
+              sweeps it whenever it fills. Most objects die here ("the weak generational
+              hypothesis").
             </FeatureCard>
             <FeatureCard icon="bi-arrow-left-right" variant="success" title="Survivor">
               Two spaces that ping-pong surviving young objects, ageing them one GC at a time. The
@@ -547,35 +660,40 @@
         <AboutSection icon="bi-stopwatch" title="Stop-the-World vs Concurrent">
           <FeatureGrid>
             <FeatureCard icon="bi-pause-circle" variant="danger" title="Stop-the-world (STW) pause">
-              Every application thread is frozen at a safepoint while the collector works. This is the
-              latency you feel; the <em>Pause Distribution</em> and <em>Longest Pauses</em> tabs are
-              all about these windows.
+              Every application thread is frozen at a safepoint while the collector works. This is
+              the latency you feel; the <em>Pause Distribution</em> and <em>Longest Pauses</em> tabs
+              are all about these windows.
             </FeatureCard>
             <FeatureCard icon="bi-arrow-repeat" variant="success" title="Concurrent phase">
               Work the collector does <em>while your app runs</em> (G1 marking, ZGC/Shenandoah
-              relocation). It trades CPU for shorter pauses — visible on the <em>Concurrent Cycles</em>
+              relocation). It trades CPU for shorter pauses — visible on the
+              <em>Concurrent Cycles</em>
               tab.
             </FeatureCard>
           </FeatureGrid>
           <AboutCallout variant="tip" title="Sum of pauses ≠ duration" icon="bi-lightbulb-fill">
             A single collection can have several STW sub-pauses around concurrent work. "Sum of
-            pauses" is the total STW time charged to your app; "duration" is wall-clock start-to-end.
-            For low-latency collectors the two diverge sharply — that's the whole point of going
-            concurrent.
+            pauses" is the total STW time charged to your app; "duration" is wall-clock
+            start-to-end. For low-latency collectors the two diverge sharply — that's the whole
+            point of going concurrent.
           </AboutCallout>
         </AboutSection>
 
         <AboutSection icon="bi-graph-up" title="Reading the Charts">
           <FeatureGrid>
             <FeatureCard icon="bi-bar-chart" variant="primary" title="Pause Distribution">
-              A histogram of pause lengths. A tight cluster of short pauses is healthy; a long tail is
-              what hurts p99 latency. Cross-reference the longest ones with their cause.
+              A histogram of pause lengths. A tight cluster of short pauses is healthy; a long tail
+              is what hurts p99 latency. Cross-reference the longest ones with their cause.
             </FeatureCard>
             <FeatureCard icon="bi-pie-chart" variant="success" title="GC Efficiency">
               Throughput (time in app) vs overhead (time in GC). Sustained overhead above a few
               percent means the heap is too small or allocation too high.
             </FeatureCard>
-            <FeatureCard icon="bi-arrow-up-circle" variant="warning" title="Promotion &amp; Tenuring">
+            <FeatureCard
+              icon="bi-arrow-up-circle"
+              variant="warning"
+              title="Promotion &amp; Tenuring"
+            >
               Stacked surviving bytes per survivor age. A tall, top-heavy stack means objects are
               promoted too young — survivor spaces too small or allocation spikes.
             </FeatureCard>
@@ -597,7 +715,8 @@
               cost of longer pauses.
             </FeatureCard>
             <FeatureCard icon="bi-diagram-3" variant="primary" title="G1 (default)">
-              Region-based, balances throughput and pause goals via a soft <code>MaxGCPauseMillis</code>
+              Region-based, balances throughput and pause goals via a soft
+              <code>MaxGCPauseMillis</code>
               target. The IHOP/MMU/tenuring tabs are G1-specific.
             </FeatureCard>
             <FeatureCard icon="bi-lightning-charge" variant="success" title="ZGC / Shenandoah">
@@ -609,8 +728,8 @@
 
         <AboutSection icon="bi-broadcast" title="How JFR Emits This">
           <p>
-            Core GC events are <strong>on by default</strong> in every JFR configuration, so this page
-            works for any recording:
+            Core GC events are <strong>on by default</strong> in every JFR configuration, so this
+            page works for any recording:
           </p>
           <ul>
             <li>
@@ -622,8 +741,8 @@
               <code>jdk.G1GarbageCollection</code> — collector-specific detail.
             </li>
             <li>
-              <code>jdk.GCHeapSummary</code> — before/after heap occupancy (drives the efficiency and
-              difference columns); <code>jdk.GCConfiguration</code> identifies the collector.
+              <code>jdk.GCHeapSummary</code> — before/after heap occupancy (drives the efficiency
+              and difference columns); <code>jdk.GCConfiguration</code> identifies the collector.
             </li>
           </ul>
           <p>
@@ -685,6 +804,7 @@ import FeatureGrid from '@/components/about/FeatureGrid.vue';
 import FeatureCard from '@/components/about/FeatureCard.vue';
 import AxisFormatType from '@/services/timeseries/AxisFormatType';
 import type { IhopData, TenuringData } from '@/services/api/model/GCTuningModels';
+import type GCPhaseParallelAggregate from '@/services/api/model/GCPhaseParallelAggregate';
 import ProfileGCClient from '@/services/api/ProfileGCClient';
 import GCOverviewData from '@/services/api/model/GCOverviewData';
 import ConcurrentEvent from '@/services/api/model/ConcurrentEvent';
@@ -716,6 +836,7 @@ const gcTabs = [
   { id: 'concurrent-cycles', label: 'Concurrent Cycles', icon: 'layers' },
   { id: 'tenuring', label: 'Promotion & Tenuring', icon: 'arrow-up-circle' },
   { id: 'ihop', label: 'G1 IHOP & CPU', icon: 'sliders' },
+  { id: 'phase-parallel', label: 'Sub-Phases', icon: 'layers' },
   { id: 'pause-types', label: 'Pause Types', icon: 'info-circle' },
   { id: 'about', label: 'How It Works', icon: 'book' }
 ];
@@ -1082,6 +1203,7 @@ const createEfficiencyChart = async () => {
 // Deep-tuning tab data, loaded lazily on first visit so the main page stays fast.
 const tenuringData = ref<TenuringData | null>(null);
 const ihopData = ref<IhopData | null>(null);
+const phaseParallelData = ref<GCPhaseParallelAggregate[] | null>(null);
 
 const ihopThresholdSeries = computed<number[][]>(
   () => ihopData.value?.ihopTimeline?.series?.[0]?.data ?? []
@@ -1089,21 +1211,25 @@ const ihopThresholdSeries = computed<number[][]>(
 const ihopOccupancySeries = computed<number[][]>(
   () => ihopData.value?.ihopTimeline?.series?.[1]?.data ?? []
 );
-const hasIhopTimeline = computed(() =>
-  ihopOccupancySeries.value.some(point => point[1] > 0)
-);
+const hasIhopTimeline = computed(() => ihopOccupancySeries.value.some(point => point[1] > 0));
 
 // Full-text filtering + "show 50 then all" views for the GC tables. Numeric-only tables
 // (tenuring by GC id, CPU time, MMU) get a row window but no search box.
 const longestPausesView = useTableView(() => gcOverviewData.value?.longestPauses ?? [], {
   searchableText: event => event.cause
 });
-const concurrentEventsView = useTableView(() => gcOverviewData.value?.longestConcurrentEvents ?? [], {
-  searchableText: event => event.collectorName ?? ''
-});
+const concurrentEventsView = useTableView(
+  () => gcOverviewData.value?.longestConcurrentEvents ?? [],
+  {
+    searchableText: event => event.collectorName ?? ''
+  }
+);
 const tenuringGcsView = useTableView(() => tenuringData.value?.gcs ?? []);
 const cpuTimesView = useTableView(() => ihopData.value?.cpuTimes ?? []);
 const mmuView = useTableView(() => ihopData.value?.mmu ?? []);
+const phaseParallelView = useTableView(() => phaseParallelData.value ?? [], {
+  searchableText: phase => phase.name
+});
 const pauseTypesView = useTableView(() => filteredPauseTypes.value);
 
 // Collapse the pause-types window whenever the existing search/chip filter changes.
@@ -1200,6 +1326,20 @@ const loadIhopData = async () => {
   }
 };
 
+const loadPhaseParallelData = async () => {
+  if (phaseParallelData.value) {
+    return;
+  }
+  try {
+    if (!client) {
+      client = new ProfileGCClient(route.params.profileId as string);
+    }
+    phaseParallelData.value = await client.getPhaseParallel();
+  } catch (err) {
+    console.error('Error loading GC parallel sub-phase data:', err);
+  }
+};
+
 // Re-render the relevant chart when the user switches into a chart-backed tab.
 watch(activeTab, newId => {
   if (newId === 'distribution') {
@@ -1210,6 +1350,8 @@ watch(activeTab, newId => {
     loadTenuringData();
   } else if (newId === 'ihop') {
     loadIhopData();
+  } else if (newId === 'phase-parallel') {
+    loadPhaseParallelData();
   }
 });
 

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileGarbageCollection.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileGarbageCollection.vue
@@ -526,6 +526,78 @@
       </DataTable>
     </div>
 
+    <div v-show="activeTab === 'plab'">
+      <ChartDescription
+        shows="G1 promotion-buffer (PLAB) evacuation statistics per young/old evacuation (jdk.G1EvacuationYoungStatistics, jdk.G1EvacuationOldStatistics) — bytes allocated for copying survivors vs. bytes wasted (alignment, refill, undo, evacuation failure), with a waste %."
+        use-case="High waste % means PLABs are poorly sized — tune -XX:*PLABSize / -XX:+ResizePLAB. Non-zero failure bytes indicate to-space exhaustion (evacuation failure), the usual cause of surprise Full GCs."
+      />
+      <EmptyState
+        v-if="!plabData || plabData.length === 0"
+        icon="bi-speedometer"
+        title="No G1 PLAB statistics"
+        description="This recording has no jdk.G1EvacuationYoungStatistics / jdk.G1EvacuationOldStatistics events — emitted only by the G1 collector, and in the JFR 'Detailed' category (off in most configs)."
+      />
+      <DataTable v-else>
+        <template #toolbar>
+          <TableToolbar v-model="plabView.query" search-placeholder="Filter by generation...">
+            <span class="toolbar-info">PLAB allocation &amp; waste</span>
+            <template #filters>
+              <Badge key-label="Evacuations" :value="plabView.matchCount" variant="secondary" size="s" borderless />
+            </template>
+          </TableToolbar>
+        </template>
+        <thead>
+          <tr>
+            <th>GC ID</th>
+            <th>Generation</th>
+            <th class="text-end">Allocated</th>
+            <th class="text-end">Used</th>
+            <th class="text-end">Wasted</th>
+            <th class="text-end">Waste %</th>
+            <th class="text-end">Direct Alloc</th>
+            <th class="text-end">Regions Refilled</th>
+            <th class="text-end">PLABs Filled</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(row, index) in plabView.visible" :key="index">
+            <td>{{ row.gcId }}</td>
+            <td>
+              <Badge
+                :value="row.generation"
+                :variant="row.generation === 'Young' ? 'success' : 'warning'"
+                size="s"
+              />
+            </td>
+            <td class="text-end">{{ FormattingService.formatBytes(row.allocated) }}</td>
+            <td class="text-end">{{ FormattingService.formatBytes(row.used) }}</td>
+            <td class="text-end">{{ FormattingService.formatBytes(row.totalWasted) }}</td>
+            <td class="text-end">
+              <Badge
+                :value="row.wastePercent.toFixed(1) + '%'"
+                :variant="row.wastePercent > 20 ? 'danger' : 'secondary'"
+                size="s"
+                borderless
+              />
+            </td>
+            <td class="text-end">{{ FormattingService.formatBytes(row.directAllocated) }}</td>
+            <td class="text-end">{{ FormattingService.formatNumber(row.regionsRefilled) }}</td>
+            <td class="text-end">{{ FormattingService.formatNumber(row.numPlabsFilled) }}</td>
+          </tr>
+        </tbody>
+        <template #footer>
+          <TableShowMore
+            :shown="plabView.visible.length"
+            :match-count="plabView.matchCount"
+            :total="plabView.total"
+            :expanded="plabView.expanded"
+            :page-size="plabView.pageSize"
+            @toggle="plabView.toggle"
+          />
+        </template>
+      </DataTable>
+    </div>
+
     <div v-show="activeTab === 'pause-types'">
       <p class="pause-types-intro text-muted">
         Reference for every GC cause the JVM may emit via Java Flight Recorder. Filter by name or
@@ -805,6 +877,7 @@ import FeatureCard from '@/components/about/FeatureCard.vue';
 import AxisFormatType from '@/services/timeseries/AxisFormatType';
 import type { IhopData, TenuringData } from '@/services/api/model/GCTuningModels';
 import type GCPhaseParallelAggregate from '@/services/api/model/GCPhaseParallelAggregate';
+import type G1PlabStatistics from '@/services/api/model/G1PlabStatistics';
 import ProfileGCClient from '@/services/api/ProfileGCClient';
 import GCOverviewData from '@/services/api/model/GCOverviewData';
 import ConcurrentEvent from '@/services/api/model/ConcurrentEvent';
@@ -837,6 +910,7 @@ const gcTabs = [
   { id: 'tenuring', label: 'Promotion & Tenuring', icon: 'arrow-up-circle' },
   { id: 'ihop', label: 'G1 IHOP & CPU', icon: 'sliders' },
   { id: 'phase-parallel', label: 'Sub-Phases', icon: 'layers' },
+  { id: 'plab', label: 'G1 PLAB', icon: 'speedometer' },
   { id: 'pause-types', label: 'Pause Types', icon: 'info-circle' },
   { id: 'about', label: 'How It Works', icon: 'book' }
 ];
@@ -1204,6 +1278,7 @@ const createEfficiencyChart = async () => {
 const tenuringData = ref<TenuringData | null>(null);
 const ihopData = ref<IhopData | null>(null);
 const phaseParallelData = ref<GCPhaseParallelAggregate[] | null>(null);
+const plabData = ref<G1PlabStatistics[] | null>(null);
 
 const ihopThresholdSeries = computed<number[][]>(
   () => ihopData.value?.ihopTimeline?.series?.[0]?.data ?? []
@@ -1229,6 +1304,9 @@ const cpuTimesView = useTableView(() => ihopData.value?.cpuTimes ?? []);
 const mmuView = useTableView(() => ihopData.value?.mmu ?? []);
 const phaseParallelView = useTableView(() => phaseParallelData.value ?? [], {
   searchableText: phase => phase.name
+});
+const plabView = useTableView(() => plabData.value ?? [], {
+  searchableText: row => row.generation
 });
 const pauseTypesView = useTableView(() => filteredPauseTypes.value);
 
@@ -1340,6 +1418,20 @@ const loadPhaseParallelData = async () => {
   }
 };
 
+const loadPlabData = async () => {
+  if (plabData.value) {
+    return;
+  }
+  try {
+    if (!client) {
+      client = new ProfileGCClient(route.params.profileId as string);
+    }
+    plabData.value = await client.getPlabStatistics();
+  } catch (err) {
+    console.error('Error loading G1 PLAB statistics data:', err);
+  }
+};
+
 // Re-render the relevant chart when the user switches into a chart-backed tab.
 watch(activeTab, newId => {
   if (newId === 'distribution') {
@@ -1352,6 +1444,8 @@ watch(activeTab, newId => {
     loadIhopData();
   } else if (newId === 'phase-parallel') {
     loadPhaseParallelData();
+  } else if (newId === 'plab') {
+    loadPlabData();
   }
 });
 

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileSystem.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileSystem.vue
@@ -91,6 +91,31 @@
         </div>
       </div>
 
+      <!-- Swap -->
+      <div v-show="activeTab === 'swap'">
+        <ChartDescription
+          shows="OS swap space — total swap and how much is in use, over the recording."
+          use-case="Rising used-swap on a JVM host is a red flag: paging the heap to disk causes huge GC pauses and latency. Ideally used swap stays flat near zero."
+        />
+        <EmptyState
+          v-if="!hasSwapData"
+          icon="bi-hdd"
+          title="No swap data recorded"
+          description="This recording has no jdk.SwapSpace events (swap tracking is platform-dependent)."
+        />
+        <div v-else class="chart-container">
+          <TimeSeriesChart
+            :primaryData="swapUsedSeries"
+            primaryTitle="Used"
+            :secondaryData="swapTotalSeries"
+            secondaryTitle="Total"
+            :primaryAxisType="AxisFormatType.BYTES"
+            :secondaryAxisType="AxisFormatType.BYTES"
+            :visibleMinutes="60"
+          />
+        </div>
+      </div>
+
       <!-- Host Processes -->
       <div v-show="activeTab === 'processes'">
         <EmptyState
@@ -104,7 +129,13 @@
             <TableToolbar v-model="processesView.query" search-placeholder="Filter processes...">
               <span class="toolbar-info">Host processes</span>
               <template #filters>
-                <Badge key-label="Total" :value="processesView.matchCount" variant="secondary" size="s" borderless />
+                <Badge
+                  key-label="Total"
+                  :value="processesView.matchCount"
+                  variant="secondary"
+                  size="s"
+                  borderless
+                />
               </template>
             </TableToolbar>
           </template>
@@ -136,6 +167,180 @@
             />
           </template>
         </DataTable>
+
+        <h6 class="subsection-title">Launched during recording</h6>
+        <EmptyState
+          v-if="launchedProcesses.length === 0"
+          icon="bi-terminal"
+          title="No subprocesses launched"
+          description="The JVM started no child processes during the recording (no jdk.ProcessStart events)."
+        />
+        <DataTable v-else>
+          <template #toolbar>
+            <TableToolbar
+              v-model="launchedProcessesView.query"
+              search-placeholder="Filter subprocesses..."
+            >
+              <span class="toolbar-info">Launched subprocesses</span>
+              <template #filters>
+                <Badge
+                  key-label="Total"
+                  :value="launchedProcessesView.matchCount"
+                  variant="secondary"
+                  size="s"
+                  borderless
+                />
+              </template>
+            </TableToolbar>
+          </template>
+          <thead>
+            <tr>
+              <th>Time</th>
+              <th class="pid-column">PID</th>
+              <th>Command</th>
+              <th>Directory</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(proc, index) in launchedProcessesView.visible" :key="index">
+              <td>
+                {{ FormattingService.formatDuration2Units(proc.timeOffsetMillis * 1_000_000) }}
+              </td>
+              <td class="text-muted">{{ proc.pid }}</td>
+              <td :title="proc.command ?? ''">
+                <code class="path-name">{{ proc.command ?? '—' }}</code>
+              </td>
+              <td class="text-muted" :title="proc.directory ?? ''">{{ proc.directory ?? '—' }}</td>
+            </tr>
+          </tbody>
+          <template #footer>
+            <TableShowMore
+              :shown="launchedProcessesView.visible.length"
+              :match-count="launchedProcessesView.matchCount"
+              :total="launchedProcessesView.total"
+              :expanded="launchedProcessesView.expanded"
+              :page-size="launchedProcessesView.pageSize"
+              @toggle="launchedProcessesView.toggle"
+            />
+          </template>
+        </DataTable>
+      </div>
+
+      <!-- Modules -->
+      <div v-show="activeTab === 'modules'">
+        <ChartDescription
+          shows="The module graph from jdk.ModuleRequire (dependencies) and jdk.ModuleExport (package exports), captured at JVM startup."
+          use-case="Confirm which modules a JItPL app reads and what's exported (and to whom) — useful when chasing IllegalAccess / module-resolution issues or auditing the runtime module set."
+        />
+        <h6 class="subsection-title">Requires</h6>
+        <EmptyState
+          v-if="moduleRequires.length === 0"
+          icon="bi-box"
+          title="No module dependencies recorded"
+          description="This recording has no jdk.ModuleRequire events."
+        />
+        <DataTable v-else>
+          <template #toolbar>
+            <TableToolbar
+              v-model="moduleRequiresView.query"
+              search-placeholder="Filter dependencies..."
+            >
+              <span class="toolbar-info">Module dependencies</span>
+              <template #filters>
+                <Badge
+                  key-label="Edges"
+                  :value="moduleRequiresView.matchCount"
+                  variant="secondary"
+                  size="s"
+                  borderless
+                />
+              </template>
+            </TableToolbar>
+          </template>
+          <thead>
+            <tr>
+              <th>Source Module</th>
+              <th>Requires</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(edge, index) in moduleRequiresView.visible" :key="index">
+              <td>
+                <code>{{ edge.source ?? 'unnamed' }}</code>
+              </td>
+              <td>
+                <code>{{ edge.required ?? 'unnamed' }}</code>
+              </td>
+            </tr>
+          </tbody>
+          <template #footer>
+            <TableShowMore
+              :shown="moduleRequiresView.visible.length"
+              :match-count="moduleRequiresView.matchCount"
+              :total="moduleRequiresView.total"
+              :expanded="moduleRequiresView.expanded"
+              :page-size="moduleRequiresView.pageSize"
+              @toggle="moduleRequiresView.toggle"
+            />
+          </template>
+        </DataTable>
+
+        <h6 class="subsection-title">Exports</h6>
+        <EmptyState
+          v-if="moduleExports.length === 0"
+          icon="bi-box-arrow-up-right"
+          title="No package exports recorded"
+          description="This recording has no jdk.ModuleExport events."
+        />
+        <DataTable v-else>
+          <template #toolbar>
+            <TableToolbar v-model="moduleExportsView.query" search-placeholder="Filter exports...">
+              <span class="toolbar-info">Package exports</span>
+              <template #filters>
+                <Badge
+                  key-label="Exports"
+                  :value="moduleExportsView.matchCount"
+                  variant="secondary"
+                  size="s"
+                  borderless
+                />
+              </template>
+            </TableToolbar>
+          </template>
+          <thead>
+            <tr>
+              <th>Exported Package</th>
+              <th>Target</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(exp, index) in moduleExportsView.visible" :key="index">
+              <td>
+                <code>{{ exp.packageName ?? '—' }}</code>
+              </td>
+              <td>
+                <Badge
+                  v-if="!exp.targetModule"
+                  value="unqualified"
+                  variant="info"
+                  size="xs"
+                  borderless
+                />
+                <code v-else>{{ exp.targetModule }}</code>
+              </td>
+            </tr>
+          </tbody>
+          <template #footer>
+            <TableShowMore
+              :shown="moduleExportsView.visible.length"
+              :match-count="moduleExportsView.matchCount"
+              :total="moduleExportsView.total"
+              :expanded="moduleExportsView.expanded"
+              :page-size="moduleExportsView.pageSize"
+              @toggle="moduleExportsView.toggle"
+            />
+          </template>
+        </DataTable>
       </div>
 
       <!-- How It Works Tab -->
@@ -148,55 +353,62 @@
           <AboutCallout variant="intro">
             <p>
               Your JVM rarely has the machine to itself. This page separates <em>your</em> CPU usage
-              from total <em>machine</em> usage, so you can tell whether a slowdown is your code or a
-              noisy neighbour, and surfaces the host-level signals — network, context switches, other
-              processes — that the in-JVM views can't see.
+              from total <em>machine</em> usage, so you can tell whether a slowdown is your code or
+              a noisy neighbour, and surfaces the host-level signals — network, context switches,
+              other processes — that the in-JVM views can't see.
             </p>
           </AboutCallout>
 
           <AboutSection icon="bi-cpu" title="What the Signals Mean">
             <FeatureGrid>
               <FeatureCard icon="bi-cpu-fill" variant="primary" title="JVM vs Machine CPU">
-                JVM user+system is what your process consumes; machine total is the whole box. A large
-                gap (machine high, JVM low) is the noisy-neighbour signature — something else on the
-                host is competing for CPU.
+                JVM user+system is what your process consumes; machine total is the whole box. A
+                large gap (machine high, JVM low) is the noisy-neighbour signature — something else
+                on the host is competing for CPU.
               </FeatureCard>
               <FeatureCard icon="bi-arrow-left-right" variant="warning" title="Context Switches">
-                How often the OS swaps threads on/off cores. A high rate means oversubscription or heavy
-                blocking/wakeups — threads spend time scheduling instead of working.
+                How often the OS swaps threads on/off cores. A high rate means oversubscription or
+                heavy blocking/wakeups — threads spend time scheduling instead of working.
               </FeatureCard>
               <FeatureCard icon="bi-ethernet" variant="info" title="Network Utilization">
-                Per-interface read/write rates (bits per second). Plateaus that coincide with latency
-                point at a saturated link rather than CPU.
+                Per-interface read/write rates (bits per second). Plateaus that coincide with
+                latency point at a saturated link rather than CPU.
               </FeatureCard>
               <FeatureCard icon="bi-diagram-2" variant="neutral" title="Host Processes">
-                Other processes the JVM saw on the host — useful for attributing the "other-process" CPU
-                share to a concrete culprit (a sidecar, a cron job).
+                Other processes the JVM saw on the host — useful for attributing the "other-process"
+                CPU share to a concrete culprit (a sidecar, a cron job).
               </FeatureCard>
             </FeatureGrid>
           </AboutSection>
 
           <AboutCallout variant="tip" title="Is it me or the box?" icon="bi-lightbulb-fill">
-            High machine CPU with low JVM CPU = the host is the bottleneck (or a container CPU limit —
-            see Container Configuration). High JVM CPU = profile your own code (flame graphs, allocation,
-            GC).
+            High machine CPU with low JVM CPU = the host is the bottleneck (or a container CPU limit
+            — see Container Configuration). High JVM CPU = profile your own code (flame graphs,
+            allocation, GC).
           </AboutCallout>
 
           <AboutSection icon="bi-broadcast" title="How JFR Emits This">
             <ul>
               <li>
-                <code>jdk.CPULoad</code> — periodic JVM user/system and machine-total CPU. Enabled by
-                default.
+                <code>jdk.CPULoad</code> — periodic JVM user/system and machine-total CPU. Enabled
+                by default.
+              </li>
+              <li><code>jdk.ThreadContextSwitchRate</code> — context switches per second.</li>
+              <li><code>jdk.NetworkUtilization</code> — per-interface read/write rates.</li>
+              <li>
+                <code>jdk.SystemProcess</code> — a periodic snapshot of host processes (pid +
+                command line), de-duplicated to the latest per pid.
               </li>
               <li>
-                <code>jdk.ThreadContextSwitchRate</code> — context switches per second.
+                <code>jdk.ProcessStart</code> — a subprocess the JVM launched (pid, command,
+                directory), shown under Host Processes as "Launched during recording".
               </li>
               <li>
-                <code>jdk.NetworkUtilization</code> — per-interface read/write rates.
+                <code>jdk.SwapSpace</code> — periodic OS swap total/free, behind the Swap tab.
               </li>
               <li>
-                <code>jdk.SystemProcess</code> — a periodic snapshot of host processes (pid + command
-                line), de-duplicated to the latest per pid.
+                <code>jdk.ModuleRequire</code> / <code>jdk.ModuleExport</code> — the startup module
+                graph (dependencies and package exports), behind the Modules tab.
               </li>
             </ul>
           </AboutSection>
@@ -231,7 +443,13 @@ import ErrorState from '@/components/ErrorState.vue';
 import FormattingService from '@/services/FormattingService';
 import AxisFormatType from '@/services/timeseries/AxisFormatType';
 import ProfileSystemClient from '@/services/api/ProfileSystemClient';
-import type { SystemOverview, SystemProcessInfo } from '@/services/api/model/SystemModels';
+import type {
+  LaunchedProcessInfo,
+  ModuleEdge,
+  ModuleExport,
+  SystemOverview,
+  SystemProcessInfo
+} from '@/services/api/model/SystemModels';
 import type TimeseriesData from '@/services/timeseries/model/TimeseriesData';
 import { useTableView } from '@/composables/useTableView';
 
@@ -247,9 +465,22 @@ const selectedInterface = ref<string>('');
 const networkTimeline = ref<TimeseriesData>();
 const contextSwitchTimeline = ref<TimeseriesData>();
 const processes = ref<SystemProcessInfo[]>([]);
+const launchedProcesses = ref<LaunchedProcessInfo[]>([]);
+const swapTimeline = ref<TimeseriesData>();
+const moduleRequires = ref<ModuleEdge[]>([]);
+const moduleExports = ref<ModuleExport[]>([]);
 
 const processesView = useTableView<SystemProcessInfo>(processes, {
   searchableText: r => `${r.pid} ${r.commandLine}`
+});
+const launchedProcessesView = useTableView<LaunchedProcessInfo>(launchedProcesses, {
+  searchableText: r => `${r.pid} ${r.command ?? ''} ${r.directory ?? ''}`
+});
+const moduleRequiresView = useTableView<ModuleEdge>(moduleRequires, {
+  searchableText: r => `${r.source ?? ''} ${r.required ?? ''}`
+});
+const moduleExportsView = useTableView<ModuleExport>(moduleExports, {
+  searchableText: r => `${r.packageName ?? ''} ${r.targetModule ?? ''}`
 });
 
 const activeTab = ref('cpu');
@@ -259,9 +490,18 @@ let client: ProfileSystemClient;
 const machineCpuSeries = computed<number[][]>(() => cpuTimeline.value?.series?.[0]?.data ?? []);
 const jvmUserSeries = computed<number[][]>(() => cpuTimeline.value?.series?.[1]?.data ?? []);
 const jvmSystemSeries = computed<number[][]>(() => cpuTimeline.value?.series?.[2]?.data ?? []);
-const networkReadSeries = computed<number[][]>(() => networkTimeline.value?.series?.[0]?.data ?? []);
-const networkWriteSeries = computed<number[][]>(() => networkTimeline.value?.series?.[1]?.data ?? []);
-const contextSwitchSeries = computed<number[][]>(() => contextSwitchTimeline.value?.series?.[0]?.data ?? []);
+const networkReadSeries = computed<number[][]>(
+  () => networkTimeline.value?.series?.[0]?.data ?? []
+);
+const networkWriteSeries = computed<number[][]>(
+  () => networkTimeline.value?.series?.[1]?.data ?? []
+);
+const contextSwitchSeries = computed<number[][]>(
+  () => contextSwitchTimeline.value?.series?.[0]?.data ?? []
+);
+const swapTotalSeries = computed<number[][]>(() => swapTimeline.value?.series?.[0]?.data ?? []);
+const swapUsedSeries = computed<number[][]>(() => swapTimeline.value?.series?.[1]?.data ?? []);
+const hasSwapData = computed<boolean>(() => swapTotalSeries.value.some(point => point[1] > 0));
 
 const tabs = computed<TabBarItem[]>(() => [
   { id: 'cpu', label: 'CPU', icon: 'cpu' },
@@ -272,11 +512,18 @@ const tabs = computed<TabBarItem[]>(() => [
     badge: networkInterfaces.value.length || undefined
   },
   { id: 'context-switches', label: 'Context Switches', icon: 'arrow-left-right' },
+  { id: 'swap', label: 'Swap', icon: 'hdd' },
   {
     id: 'processes',
     label: 'Host Processes',
     icon: 'pc-display',
     badge: processes.value.length || undefined
+  },
+  {
+    id: 'modules',
+    label: 'Modules',
+    icon: 'boxes',
+    badge: moduleRequires.value.length || undefined
   },
   { id: 'about', label: 'How It Works', icon: 'book' }
 ]);
@@ -326,7 +573,10 @@ const metricsData = computed(() => {
       value: FormattingService.formatNumber(o.processCount),
       variant: 'success' as const,
       breakdown: [
-        { label: 'Network Interfaces', value: FormattingService.formatNumber(o.networkInterfaceCount) }
+        {
+          label: 'Network Interfaces',
+          value: FormattingService.formatNumber(o.networkInterfaceCount)
+        }
       ]
     }
   ];
@@ -352,20 +602,37 @@ onMounted(async () => {
     const profileId = route.params.profileId as string;
     client = new ProfileSystemClient(profileId);
 
-    const [overviewResult, cpuResult, interfacesResult, contextSwitchResult, processesResult] =
-      await Promise.all([
-        client.getOverview(),
-        client.getCpuTimeline(),
-        client.getNetworkInterfaces(),
-        client.getContextSwitchTimeline(),
-        client.getProcesses()
-      ]);
+    const [
+      overviewResult,
+      cpuResult,
+      interfacesResult,
+      contextSwitchResult,
+      processesResult,
+      swapResult,
+      launchedResult,
+      moduleRequiresResult,
+      moduleExportsResult
+    ] = await Promise.all([
+      client.getOverview(),
+      client.getCpuTimeline(),
+      client.getNetworkInterfaces(),
+      client.getContextSwitchTimeline(),
+      client.getProcesses(),
+      client.getSwapTimeline(),
+      client.getLaunchedProcesses(),
+      client.getModuleRequires(),
+      client.getModuleExports()
+    ]);
 
     overview.value = overviewResult;
     cpuTimeline.value = cpuResult;
     networkInterfaces.value = interfacesResult;
     contextSwitchTimeline.value = contextSwitchResult;
     processes.value = processesResult;
+    swapTimeline.value = swapResult;
+    launchedProcesses.value = launchedResult;
+    moduleRequires.value = moduleRequiresResult;
+    moduleExports.value = moduleExportsResult;
 
     if (interfacesResult.length > 0) {
       selectedInterface.value = interfacesResult[0];
@@ -402,6 +669,15 @@ onMounted(async () => {
   font-weight: 600;
   font-size: 0.9rem;
   color: var(--color-text);
+}
+
+.subsection-title {
+  margin: 1.5rem 0 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: var(--color-text-muted);
 }
 
 .path-display {

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileThreadStatistics.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileThreadStatistics.vue
@@ -16,132 +16,132 @@
       <TabBar v-model="activeTab" :tabs="tabs" class="mb-3" />
 
       <div v-show="activeTab === 'overview'">
-      <!-- Summary Stats -->
-      <div class="mb-4">
-        <StatsTable :metrics="metricsData" />
-      </div>
+        <!-- Summary Stats -->
+        <div class="mb-4">
+          <StatsTable :metrics="metricsData" />
+        </div>
 
-      <!-- Thread Activity Chart -->
-      <ChartSection title="Active Threads Over Time" icon="bi-graph-up" :full-width="true">
-        <TimeSeriesChart
-          :primary-data="threadSerie"
-          primary-title="Active Threads"
-          :primary-axis-type="AxisFormatType.NUMBER"
-          :visible-minutes="60"
-          primary-color="#4285F4"
-        />
-      </ChartSection>
+        <!-- Thread Activity Chart -->
+        <ChartSection title="Active Threads Over Time" icon="bi-graph-up" :full-width="true">
+          <TimeSeriesChart
+            :primary-data="threadSerie"
+            primary-title="Active Threads"
+            :primary-axis-type="AxisFormatType.NUMBER"
+            :visible-minutes="60"
+            primary-color="#4285F4"
+          />
+        </ChartSection>
 
-      <!-- Thread Tables Container -->
-      <div class="thread-tables-container mb-4">
-        <!-- Top Allocating Threads -->
-        <div class="data-table-card">
-          <div class="chart-card-header">
-            <h5><i class="bi bi-memory me-2"></i>Top Allocators</h5>
-          </div>
-          <div class="thread-list">
-            <div v-for="(thread, index) in topAllocatingThreads" :key="index" class="thread-item">
-              <div class="thread-info">
-                <span class="thread-name" :title="thread.threadInfo.name">
-                  {{ thread.threadInfo.name }}
-                </span>
+        <!-- Thread Tables Container -->
+        <div class="thread-tables-container mb-4">
+          <!-- Top Allocating Threads -->
+          <div class="data-table-card">
+            <div class="chart-card-header">
+              <h5><i class="bi bi-memory me-2"></i>Top Allocators</h5>
+            </div>
+            <div class="thread-list">
+              <div v-for="(thread, index) in topAllocatingThreads" :key="index" class="thread-item">
+                <div class="thread-info">
+                  <span class="thread-name" :title="thread.threadInfo.name">
+                    {{ thread.threadInfo.name }}
+                  </span>
+                </div>
+                <div class="thread-actions">
+                  <span class="allocation-badge">
+                    {{ FormattingService.formatBytes(thread.allocatedBytes) }}
+                  </span>
+                  <button
+                    class="flame-btn"
+                    @click="viewThreadAllocationFlamegraph(thread)"
+                    title="View thread allocation flamegraph"
+                    :disabled="!allocationType"
+                  >
+                    <i class="bi bi-fire"></i>
+                  </button>
+                </div>
               </div>
-              <div class="thread-actions">
-                <span class="allocation-badge">
-                  {{ FormattingService.formatBytes(thread.allocatedBytes) }}
-                </span>
-                <button
-                  class="flame-btn"
-                  @click="viewThreadAllocationFlamegraph(thread)"
-                  title="View thread allocation flamegraph"
-                  :disabled="!allocationType"
+              <div v-if="topAllocatingThreads.length === 0" class="empty-message">
+                <i class="bi bi-inbox"></i>
+                <span>No allocation data available</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Top CPU Load Threads -->
+          <div class="data-table-card">
+            <div class="chart-card-header">
+              <h5><i class="bi bi-cpu me-2"></i>Top CPU Load Threads</h5>
+            </div>
+
+            <!-- User CPU Load Section -->
+            <div class="cpu-section">
+              <div class="section-header">
+                <i class="bi bi-person-fill"></i>
+                <span>User CPU Load</span>
+              </div>
+              <div class="thread-list">
+                <div
+                  v-for="(thread, index) in topUserCpuThreads"
+                  :key="`user-${index}`"
+                  class="thread-item cpu-item"
                 >
-                  <i class="bi bi-fire"></i>
-                </button>
-              </div>
-            </div>
-            <div v-if="topAllocatingThreads.length === 0" class="empty-message">
-              <i class="bi bi-inbox"></i>
-              <span>No allocation data available</span>
-            </div>
-          </div>
-        </div>
-
-        <!-- Top CPU Load Threads -->
-        <div class="data-table-card">
-          <div class="chart-card-header">
-            <h5><i class="bi bi-cpu me-2"></i>Top CPU Load Threads</h5>
-          </div>
-
-          <!-- User CPU Load Section -->
-          <div class="cpu-section">
-            <div class="section-header">
-              <i class="bi bi-person-fill"></i>
-              <span>User CPU Load</span>
-            </div>
-            <div class="thread-list">
-              <div
-                v-for="(thread, index) in topUserCpuThreads"
-                :key="`user-${index}`"
-                class="thread-item cpu-item"
-              >
-                <div class="thread-info">
-                  <span class="timestamp-badge">{{
-                    FormattingService.formatTimeOfDay(thread.timestamp)
-                  }}</span>
-                  <span class="thread-name" :title="thread.threadInfo.name">
-                    {{ thread.threadInfo.name }}
-                  </span>
-                </div>
-                <div class="thread-actions">
-                  <span class="cpu-badge"> {{ (thread.cpuLoad * 100).toFixed(2) }}% </span>
-                  <button
-                    class="flame-btn"
-                    @click="viewThreadCpuProfile(thread)"
-                    title="View thread CPU flamegraph"
-                  >
-                    <i class="bi bi-fire"></i>
-                  </button>
+                  <div class="thread-info">
+                    <span class="timestamp-badge">{{
+                      FormattingService.formatTimeOfDay(thread.timestamp)
+                    }}</span>
+                    <span class="thread-name" :title="thread.threadInfo.name">
+                      {{ thread.threadInfo.name }}
+                    </span>
+                  </div>
+                  <div class="thread-actions">
+                    <span class="cpu-badge"> {{ (thread.cpuLoad * 100).toFixed(2) }}% </span>
+                    <button
+                      class="flame-btn"
+                      @click="viewThreadCpuProfile(thread)"
+                      title="View thread CPU flamegraph"
+                    >
+                      <i class="bi bi-fire"></i>
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
 
-          <!-- System CPU Load Section -->
-          <div class="cpu-section">
-            <div class="section-header">
-              <i class="bi bi-gear-fill"></i>
-              <span>System CPU Load</span>
-            </div>
-            <div class="thread-list">
-              <div
-                v-for="(thread, index) in topSystemCpuThreads"
-                :key="`system-${index}`"
-                class="thread-item cpu-item"
-              >
-                <div class="thread-info">
-                  <span class="timestamp-badge">{{
-                    FormattingService.formatTimeOfDay(thread.timestamp)
-                  }}</span>
-                  <span class="thread-name" :title="thread.threadInfo.name">
-                    {{ thread.threadInfo.name }}
-                  </span>
-                </div>
-                <div class="thread-actions">
-                  <span class="cpu-badge"> {{ (thread.cpuLoad * 100).toFixed(2) }}% </span>
-                  <button
-                    class="flame-btn"
-                    @click="viewThreadCpuProfile(thread)"
-                    title="View thread CPU flamegraph"
-                  >
-                    <i class="bi bi-fire"></i>
-                  </button>
+            <!-- System CPU Load Section -->
+            <div class="cpu-section">
+              <div class="section-header">
+                <i class="bi bi-gear-fill"></i>
+                <span>System CPU Load</span>
+              </div>
+              <div class="thread-list">
+                <div
+                  v-for="(thread, index) in topSystemCpuThreads"
+                  :key="`system-${index}`"
+                  class="thread-item cpu-item"
+                >
+                  <div class="thread-info">
+                    <span class="timestamp-badge">{{
+                      FormattingService.formatTimeOfDay(thread.timestamp)
+                    }}</span>
+                    <span class="thread-name" :title="thread.threadInfo.name">
+                      {{ thread.threadInfo.name }}
+                    </span>
+                  </div>
+                  <div class="thread-actions">
+                    <span class="cpu-badge"> {{ (thread.cpuLoad * 100).toFixed(2) }}% </span>
+                    <button
+                      class="flame-btn"
+                      @click="viewThreadCpuProfile(thread)"
+                      title="View thread CPU flamegraph"
+                    >
+                      <i class="bi bi-fire"></i>
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
       </div>
 
       <!-- Flamegraph Modal -->
@@ -183,6 +183,44 @@
         </div>
       </GenericModal>
 
+      <!-- Reserved Stack Tab -->
+      <div v-show="activeTab === 'reserved-stack'">
+        <ChartDescription
+          shows="Reserved-stack activations from jdk.ReservedStackActivation — a thread executing a @ReservedStackAccess method (typically lock internals) entered the reserved stack zone"
+          use-case="Each entry is a near stack-overflow: deep recursion or runaway stack growth that nearly corrupted a critical section. No entries is the healthy, expected case"
+        />
+        <div class="table-responsive">
+          <table class="table table-sm table-hover mb-0">
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th>Thread</th>
+                <th>Method</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(activation, index) in reservedStackActivations" :key="index">
+                <td>
+                  {{
+                    FormattingService.formatDuration2Units(activation.timeOffsetMillis * 1_000_000)
+                  }}
+                </td>
+                <td>{{ activation.thread ?? '—' }}</td>
+                <td>
+                  <code>{{ activation.method ?? '—' }}</code>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <EmptyState
+          v-if="reservedStackActivations.length === 0"
+          icon="bi-shield-check"
+          title="No reserved-stack activations"
+          description="No thread came close to a stack overflow in a @ReservedStackAccess method — this is the healthy case."
+        />
+      </div>
+
       <!-- How It Works Tab -->
       <div v-show="activeTab === 'about'">
         <AboutPanel
@@ -192,9 +230,9 @@
         >
           <AboutCallout variant="intro">
             <p>
-              Threads are where your application does work. JFR samples the live thread count over time
-              and attributes CPU and allocation to individual threads, so you can find the threads that
-              dominate the machine — and tell platform threads from virtual ones.
+              Threads are where your application does work. JFR samples the live thread count over
+              time and attributes CPU and allocation to individual threads, so you can find the
+              threads that dominate the machine — and tell platform threads from virtual ones.
             </p>
           </AboutCallout>
 
@@ -205,16 +243,20 @@
                 A climbing platform-thread count is a thread leak or an unbounded pool.
               </FeatureCard>
               <FeatureCard icon="bi-stack" variant="success" title="Virtual threads">
-                Cheap, JVM-scheduled threads (Project Loom) multiplexed onto a small carrier pool. Huge
-                counts are normal; their risk is <em>pinning</em> (see JVM Pauses &amp; Locks).
+                Cheap, JVM-scheduled threads (Project Loom) multiplexed onto a small carrier pool.
+                Huge counts are normal; their risk is <em>pinning</em> (see JVM Pauses &amp; Locks).
               </FeatureCard>
               <FeatureCard icon="bi-activity" variant="info" title="Thread states">
-                RUNNABLE (on CPU or runnable), BLOCKED (waiting on a monitor), WAITING / TIMED_WAITING
-                (parked or sleeping). Lots of BLOCKED threads = contention.
+                RUNNABLE (on CPU or runnable), BLOCKED (waiting on a monitor), WAITING /
+                TIMED_WAITING (parked or sleeping). Lots of BLOCKED threads = contention.
               </FeatureCard>
-              <FeatureCard icon="bi-memory" variant="warning" title="Per-thread CPU &amp; allocation">
-                Which threads burn CPU and which allocate the most — the starting point for targeting a
-                flame graph or cutting allocation churn.
+              <FeatureCard
+                icon="bi-memory"
+                variant="warning"
+                title="Per-thread CPU &amp; allocation"
+              >
+                Which threads burn CPU and which allocate the most — the starting point for
+                targeting a flame graph or cutting allocation churn.
               </FeatureCard>
             </FeatureGrid>
           </AboutSection>
@@ -222,8 +264,8 @@
           <AboutSection icon="bi-broadcast" title="How JFR Emits This">
             <ul>
               <li>
-                <code>jdk.JavaThreadStatistics</code> — periodic live/daemon thread counts that drive
-                the activity chart. Enabled by default.
+                <code>jdk.JavaThreadStatistics</code> — periodic live/daemon thread counts that
+                drive the activity chart. Enabled by default.
               </li>
               <li>
                 <code>jdk.ThreadStart</code> / <code>jdk.ThreadEnd</code> — thread lifecycle events.
@@ -261,6 +303,9 @@ import AboutCallout from '@/components/about/AboutCallout.vue';
 import AboutSection from '@/components/about/AboutSection.vue';
 import FeatureGrid from '@/components/about/FeatureGrid.vue';
 import FeatureCard from '@/components/about/FeatureCard.vue';
+import ChartDescription from '@/components/ChartDescription.vue';
+import EmptyState from '@/components/EmptyState.vue';
+import type ReservedStackActivation from '@/services/api/model/ReservedStackActivation';
 import FlamegraphComponent from '@/components/FlamegraphComponent.vue';
 import SearchBarComponent from '@/components/SearchBarComponent.vue';
 import PrimaryFlamegraphClient from '@/services/api/PrimaryFlamegraphClient';
@@ -282,6 +327,7 @@ const loading = ref<boolean>(true);
 const activeTab = ref('overview');
 const tabs = [
   { id: 'overview', label: 'Statistics', icon: 'graph-up' },
+  { id: 'reserved-stack', label: 'Reserved Stack', icon: 'shield-exclamation' },
   { id: 'about', label: 'How It Works', icon: 'book' }
 ];
 const threadSerie = ref<number[][]>();
@@ -311,6 +357,9 @@ const topSystemCpuThreads = ref<ThreadWithCpuLoad[]>([]);
 
 // State for allocation type from ThreadStatisticsResponse
 const allocationType = ref<string>('');
+
+// Reserved-stack activations (stack-overflow near-misses)
+const reservedStackActivations = ref<ReservedStackActivation[]>([]);
 
 // Computed metrics for StatsTable
 const metricsData = computed(() => {
@@ -367,11 +416,14 @@ const loadThreadStatistics = async (): Promise<void> => {
 
     const client = new ProfileThreadClient(profileId);
 
-    // Call both APIs in parallel
-    const [statisticsResponse, timeseriesResponse] = await Promise.all([
+    // Call APIs in parallel
+    const [statisticsResponse, timeseriesResponse, reservedStackResponse] = await Promise.all([
       client.statistics(),
-      client.timeseries()
+      client.timeseries(),
+      client.reservedStack()
     ]);
+
+    reservedStackActivations.value = reservedStackResponse;
 
     // Update thread statistics
     threadStats.value = statisticsResponse.statistics;

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/GarbageCollectionManager.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/GarbageCollectionManager.java
@@ -20,6 +20,7 @@ package cafe.jeffrey.profile.manager;
 
 import cafe.jeffrey.profile.common.event.GarbageCollectorType;
 import cafe.jeffrey.shared.common.model.ProfileInfo;
+import cafe.jeffrey.profile.manager.model.gc.G1PlabStatistics;
 import cafe.jeffrey.profile.manager.model.gc.GCPhaseParallelAggregate;
 import cafe.jeffrey.profile.manager.model.gc.GCTimeseriesType;
 import cafe.jeffrey.profile.manager.model.gc.configuration.GCConfigurationData;
@@ -103,4 +104,12 @@ public interface GarbageCollectionManager {
      * (parallel-phase detail is off in many configs).
      */
     List<GCPhaseParallelAggregate> phaseParallel();
+
+    /**
+     * G1 PLAB (promotion-buffer) evacuation statistics, per young/old evacuation
+     * ({@code jdk.G1EvacuationYoungStatistics} / {@code jdk.G1EvacuationOldStatistics}) — allocated vs.
+     * wasted buffer bytes and waste %. Empty for non-G1 recordings or when the (Detailed-category)
+     * events are not enabled.
+     */
+    List<G1PlabStatistics> plabStatistics();
 }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/GarbageCollectionManager.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/GarbageCollectionManager.java
@@ -20,6 +20,7 @@ package cafe.jeffrey.profile.manager;
 
 import cafe.jeffrey.profile.common.event.GarbageCollectorType;
 import cafe.jeffrey.shared.common.model.ProfileInfo;
+import cafe.jeffrey.profile.manager.model.gc.GCPhaseParallelAggregate;
 import cafe.jeffrey.profile.manager.model.gc.GCTimeseriesType;
 import cafe.jeffrey.profile.manager.model.gc.configuration.GCConfigurationData;
 import cafe.jeffrey.profile.manager.model.gc.GCOverviewData;
@@ -32,6 +33,7 @@ import cafe.jeffrey.profile.manager.model.gc.tuning.TenuringData;
 import cafe.jeffrey.profile.manager.model.gc.zgc.ZgcAnalysisData;
 import cafe.jeffrey.timeseries.TimeseriesData;
 
+import java.util.List;
 import java.util.function.Function;
 
 public interface GarbageCollectionManager {
@@ -94,4 +96,11 @@ public interface GarbageCollectionManager {
      * reference counts as per-type totals, a per-second timeline, and a per-collection breakdown.
      */
     ReferenceProcessingData referenceProcessing();
+
+    /**
+     * Parallel GC sub-phase breakdown ({@code jdk.GCPhaseParallel}) aggregated by phase name across all
+     * worker threads and collections, longest total first. Empty when the event is not recorded
+     * (parallel-phase detail is off in many configs).
+     */
+    List<GCPhaseParallelAggregate> phaseParallel();
 }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/GarbageCollectionManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/GarbageCollectionManagerImpl.java
@@ -29,6 +29,8 @@ import cafe.jeffrey.profile.manager.builder.GCConfigurationEventBuilder;
 import cafe.jeffrey.profile.manager.builder.NonConcurrentGCOverviewEventBuilder;
 import cafe.jeffrey.profile.manager.model.gc.GCGenerationTimeseriesBuilder;
 import cafe.jeffrey.profile.manager.model.gc.GCOverviewData;
+import cafe.jeffrey.profile.manager.model.gc.G1PlabStatistics;
+import cafe.jeffrey.profile.manager.model.gc.G1PlabStatisticsBuilder;
 import cafe.jeffrey.profile.manager.model.gc.GCPhaseParallelAggregate;
 import cafe.jeffrey.profile.manager.model.gc.GCPhaseParallelBuilder;
 import cafe.jeffrey.profile.manager.model.gc.GCTimeseriesType;
@@ -319,5 +321,15 @@ public class GarbageCollectionManagerImpl implements GarbageCollectionManager {
                 .withEventType(Type.GC_PHASE_PARALLEL)
                 .withJsonFields();
         return eventStreamRepository.genericStreaming(configurer, new GCPhaseParallelBuilder());
+    }
+
+    @Override
+    public List<G1PlabStatistics> plabStatistics() {
+        EventQueryConfigurer configurer = new EventQueryConfigurer()
+                .withEventTypes(List.of(
+                        Type.G1_EVACUATION_YOUNG_STATISTICS,
+                        Type.G1_EVACUATION_OLD_STATISTICS))
+                .withJsonFields();
+        return eventStreamRepository.genericStreaming(configurer, new G1PlabStatisticsBuilder());
     }
 }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/GarbageCollectionManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/GarbageCollectionManagerImpl.java
@@ -29,6 +29,8 @@ import cafe.jeffrey.profile.manager.builder.GCConfigurationEventBuilder;
 import cafe.jeffrey.profile.manager.builder.NonConcurrentGCOverviewEventBuilder;
 import cafe.jeffrey.profile.manager.model.gc.GCGenerationTimeseriesBuilder;
 import cafe.jeffrey.profile.manager.model.gc.GCOverviewData;
+import cafe.jeffrey.profile.manager.model.gc.GCPhaseParallelAggregate;
+import cafe.jeffrey.profile.manager.model.gc.GCPhaseParallelBuilder;
 import cafe.jeffrey.profile.manager.model.gc.GCTimeseriesType;
 import cafe.jeffrey.profile.manager.model.gc.configuration.GCConfigurationData;
 import cafe.jeffrey.profile.manager.model.gc.g1.G1AnalysisBuilder;
@@ -309,5 +311,13 @@ public class GarbageCollectionManagerImpl implements GarbageCollectionManager {
                 .withJsonFields();
 
         return eventStreamRepository.genericStreaming(configurer, new FinalizerStatsBuilder(MAX_FINALIZER_CLASSES));
+    }
+
+    @Override
+    public List<GCPhaseParallelAggregate> phaseParallel() {
+        EventQueryConfigurer configurer = new EventQueryConfigurer()
+                .withEventType(Type.GC_PHASE_PARALLEL)
+                .withJsonFields();
+        return eventStreamRepository.genericStreaming(configurer, new GCPhaseParallelBuilder());
     }
 }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/IoManager.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/IoManager.java
@@ -18,6 +18,7 @@
 
 package cafe.jeffrey.profile.manager;
 
+import cafe.jeffrey.profile.manager.model.io.FileForceStats;
 import cafe.jeffrey.profile.manager.model.io.IoEndpoint;
 import cafe.jeffrey.profile.manager.model.io.IoKind;
 import cafe.jeffrey.profile.manager.model.io.IoOperation;
@@ -65,4 +66,10 @@ public interface IoManager {
      * File I/O aggregated by parent directory, ranked by bytes; empty when no file events are present.
      */
     List<IoEndpoint> directories();
+
+    /**
+     * Fsync (file-force) latency summary from {@code jdk.FileForce} — count, latency stats, and slowest
+     * forces. Force events carry no bytes, so they are reported separately from read/write throughput.
+     */
+    FileForceStats fileForce();
 }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/IoManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/IoManagerImpl.java
@@ -18,6 +18,8 @@
 
 package cafe.jeffrey.profile.manager;
 
+import cafe.jeffrey.profile.manager.model.io.FileForceBuilder;
+import cafe.jeffrey.profile.manager.model.io.FileForceStats;
 import cafe.jeffrey.profile.manager.model.io.IoDirectoriesBuilder;
 import cafe.jeffrey.profile.manager.model.io.IoEndpoint;
 import cafe.jeffrey.profile.manager.model.io.IoEndpointsBuilder;
@@ -40,6 +42,7 @@ import java.util.List;
 public class IoManagerImpl implements IoManager {
 
     private static final int MAX_SLOWEST_OPERATIONS = 50;
+    private static final int MAX_SLOWEST_FORCES = 50;
 
     private final ProfileInfo profileInfo;
     private final ProfileEventRepository eventRepository;
@@ -99,6 +102,14 @@ public class IoManagerImpl implements IoManager {
                 .withEventTypes(IoKind.FILE.types())
                 .withJsonFields();
         return eventStreamRepository.genericStreaming(configurer, new IoDirectoriesBuilder());
+    }
+
+    @Override
+    public FileForceStats fileForce() {
+        EventQueryConfigurer configurer = new EventQueryConfigurer()
+                .withEventType(Type.FILE_FORCE)
+                .withJsonFields();
+        return eventStreamRepository.genericStreaming(configurer, new FileForceBuilder(MAX_SLOWEST_FORCES));
     }
 
     private boolean hasAny(List<Type> types) {

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/SystemResourcesManager.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/SystemResourcesManager.java
@@ -18,6 +18,9 @@
 
 package cafe.jeffrey.profile.manager;
 
+import cafe.jeffrey.profile.manager.model.system.LaunchedProcessInfo;
+import cafe.jeffrey.profile.manager.model.system.ModuleEdge;
+import cafe.jeffrey.profile.manager.model.system.ModuleExport;
 import cafe.jeffrey.profile.manager.model.system.SystemOverview;
 import cafe.jeffrey.profile.manager.model.system.SystemProcessInfo;
 import cafe.jeffrey.shared.common.model.ProfileInfo;
@@ -68,4 +71,25 @@ public interface SystemResourcesManager {
      * Host processes observed alongside the JVM (latest snapshot per pid).
      */
     List<SystemProcessInfo> processes();
+
+    /**
+     * OS swap-space timeline (total and used bytes) from {@code jdk.SwapSpace}. Empty when swap tracking
+     * is unavailable on the host.
+     */
+    TimeseriesData swapTimeline();
+
+    /**
+     * Subprocesses the JVM launched during the recording, from {@code jdk.ProcessStart}, in time order.
+     */
+    List<LaunchedProcessInfo> launchedProcesses();
+
+    /**
+     * Module dependency edges from {@code jdk.ModuleRequire} (source requires required), de-duplicated.
+     */
+    List<ModuleEdge> moduleRequires();
+
+    /**
+     * Package exports from {@code jdk.ModuleExport} (package exported to target, or unqualified).
+     */
+    List<ModuleExport> moduleExports();
 }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/SystemResourcesManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/SystemResourcesManagerImpl.java
@@ -21,8 +21,15 @@ package cafe.jeffrey.profile.manager;
 import cafe.jeffrey.profile.manager.model.system.ContextSwitchTimeseriesBuilder;
 import cafe.jeffrey.profile.manager.model.system.CpuLoadStatsBuilder;
 import cafe.jeffrey.profile.manager.model.system.CpuLoadTimeseriesBuilder;
+import cafe.jeffrey.profile.manager.model.system.LaunchedProcessInfo;
+import cafe.jeffrey.profile.manager.model.system.LaunchedProcessesBuilder;
+import cafe.jeffrey.profile.manager.model.system.ModuleEdge;
+import cafe.jeffrey.profile.manager.model.system.ModuleExport;
+import cafe.jeffrey.profile.manager.model.system.ModuleExportsBuilder;
+import cafe.jeffrey.profile.manager.model.system.ModuleRequiresBuilder;
 import cafe.jeffrey.profile.manager.model.system.NetworkInterfacesBuilder;
 import cafe.jeffrey.profile.manager.model.system.NetworkRateTimeseriesBuilder;
+import cafe.jeffrey.profile.manager.model.system.SwapTimeseriesBuilder;
 import cafe.jeffrey.profile.manager.model.system.SystemOverview;
 import cafe.jeffrey.profile.manager.model.system.SystemProcessInfo;
 import cafe.jeffrey.profile.manager.model.system.SystemProcessesBuilder;
@@ -119,6 +126,44 @@ public class SystemResourcesManagerImpl implements SystemResourcesManager {
                 .orderedByTime();
 
         return eventStreamRepository.genericStreaming(configurer, new SystemProcessesBuilder());
+    }
+
+    @Override
+    public TimeseriesData swapTimeline() {
+        RelativeTimeRange timeRange = new RelativeTimeRange(profileInfo.profilingStartEnd());
+        EventQueryConfigurer configurer = new EventQueryConfigurer()
+                .withEventType(Type.SWAP_SPACE)
+                .withJsonFields();
+
+        return eventStreamRepository.genericStreaming(configurer, new SwapTimeseriesBuilder(timeRange));
+    }
+
+    @Override
+    public List<LaunchedProcessInfo> launchedProcesses() {
+        EventQueryConfigurer configurer = new EventQueryConfigurer()
+                .withEventType(Type.PROCESS_START)
+                .withJsonFields()
+                .orderedByTime();
+
+        return eventStreamRepository.genericStreaming(configurer, new LaunchedProcessesBuilder());
+    }
+
+    @Override
+    public List<ModuleEdge> moduleRequires() {
+        EventQueryConfigurer configurer = new EventQueryConfigurer()
+                .withEventType(Type.MODULE_REQUIRE)
+                .withJsonFields();
+
+        return eventStreamRepository.genericStreaming(configurer, new ModuleRequiresBuilder());
+    }
+
+    @Override
+    public List<ModuleExport> moduleExports() {
+        EventQueryConfigurer configurer = new EventQueryConfigurer()
+                .withEventType(Type.MODULE_EXPORT)
+                .withJsonFields();
+
+        return eventStreamRepository.genericStreaming(configurer, new ModuleExportsBuilder());
     }
 
     private static long maxSerieValue(TimeseriesData data) {

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/ThreadManager.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/ThreadManager.java
@@ -20,6 +20,7 @@ package cafe.jeffrey.profile.manager;
 
 import cafe.jeffrey.shared.common.model.ProfileInfo;
 import cafe.jeffrey.shared.common.model.Type;
+import cafe.jeffrey.profile.manager.model.thread.ReservedStackActivation;
 import cafe.jeffrey.profile.manager.model.thread.ThreadCpuLoads;
 import cafe.jeffrey.profile.manager.model.thread.ThreadStats;
 import cafe.jeffrey.profile.manager.model.thread.dump.ParsedDump;
@@ -61,4 +62,10 @@ public interface ThreadManager {
      * viewer. Returns an empty dump when the index is out of range.
      */
     ParsedDump threadDump(int index);
+
+    /**
+     * Reserved-stack activations ({@code jdk.ReservedStackActivation}) in time order — stack-overflow
+     * near-misses in {@code @ReservedStackAccess} methods. Empty in the common (healthy) case.
+     */
+    List<ReservedStackActivation> reservedStackActivations();
 }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/ThreadManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/ThreadManagerImpl.java
@@ -25,6 +25,8 @@ import cafe.jeffrey.shared.common.model.Type;
 import cafe.jeffrey.shared.common.model.time.RelativeTimeRange;
 import cafe.jeffrey.profile.manager.builder.CPULoadBuilder;
 import cafe.jeffrey.profile.manager.builder.ThreadTimeseriesBuilder;
+import cafe.jeffrey.profile.manager.model.thread.ReservedStackActivation;
+import cafe.jeffrey.profile.manager.model.thread.ReservedStackActivationBuilder;
 import cafe.jeffrey.profile.manager.model.thread.ThreadCpuLoads;
 import cafe.jeffrey.profile.manager.model.thread.ThreadStats;
 import cafe.jeffrey.profile.manager.model.thread.dump.ParsedDump;
@@ -157,6 +159,16 @@ public class ThreadManagerImpl implements ThreadManager {
         }
         RawDump raw = dumps.get(index);
         return ThreadDumpParser.parse(raw.timeOffsetMillis(), raw.text());
+    }
+
+    @Override
+    public List<ReservedStackActivation> reservedStackActivations() {
+        EventQueryConfigurer configurer = new EventQueryConfigurer()
+                .withEventType(Type.RESERVED_STACK_ACTIVATION)
+                .withJsonFields()
+                .orderedByTime();
+
+        return eventStreamRepository.genericStreaming(configurer, new ReservedStackActivationBuilder());
     }
 
     private List<RawDump> rawDumps() {

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/gc/G1PlabStatistics.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/gc/G1PlabStatistics.java
@@ -1,0 +1,55 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.gc;
+
+/**
+ * One G1 promotion-buffer (PLAB) evacuation summary, from {@code jdk.G1EvacuationYoungStatistics} /
+ * {@code jdk.G1EvacuationOldStatistics} (each wraps a {@code jdk.types.G1EvacuationStatistics} struct).
+ * PLABs are the thread-local buffers G1 uses to copy surviving objects during a collection; the waste
+ * fields expose how much of that buffer space was thrown away (alignment, refill, undo, evacuation
+ * failure), which is the signal for PLAB-sizing tuning.
+ *
+ * @param gcId            the collection id this evacuation belongs to
+ * @param generation      "Young" or "Old"
+ * @param allocated       total bytes allocated by PLABs
+ * @param used            bytes actually occupied by copied objects
+ * @param totalWasted     wasted + undoWaste + regionEndWaste + failureWaste
+ * @param wastePercent    {@code totalWasted / allocated} as a percentage
+ * @param directAllocated bytes allocated directly (outside PLABs)
+ * @param regionsRefilled number of regions refilled
+ * @param numPlabsFilled  number of PLABs filled
+ * @param failureUsed     bytes occupied by objects in regions where evacuation failed
+ * @param failureWaste    bytes left unused in regions where evacuation failed
+ */
+public record G1PlabStatistics(
+        long gcId,
+        String generation,
+        long allocated,
+        long used,
+        long totalWasted,
+        double wastePercent,
+        long directAllocated,
+        long regionsRefilled,
+        long numPlabsFilled,
+        long failureUsed,
+        long failureWaste) {
+
+    public static final String YOUNG = "Young";
+    public static final String OLD = "Old";
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/gc/G1PlabStatisticsBuilder.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/gc/G1PlabStatisticsBuilder.java
@@ -1,0 +1,90 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.gc;
+
+import tools.jackson.databind.node.ObjectNode;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.provider.profile.api.RecordBuilder;
+import cafe.jeffrey.shared.common.Json;
+import cafe.jeffrey.shared.common.model.Type;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Builds per-evacuation {@link G1PlabStatistics} rows from {@code jdk.G1EvacuationYoungStatistics} and
+ * {@code jdk.G1EvacuationOldStatistics}. The nested {@code statistics} struct is flattened to dotted JSON
+ * keys ({@code statistics.allocated}, …) by the event-to-JSON mapper. Rows are ordered by gcId, then
+ * generation (Young before Old).
+ */
+public class G1PlabStatisticsBuilder implements RecordBuilder<GenericRecord, List<G1PlabStatistics>> {
+
+    private static final String STATS_PREFIX = "statistics.";
+    private static final String GC_ID_FIELD = STATS_PREFIX + "gcId";
+    private static final String ALLOCATED_FIELD = STATS_PREFIX + "allocated";
+    private static final String USED_FIELD = STATS_PREFIX + "used";
+    private static final String WASTED_FIELD = STATS_PREFIX + "wasted";
+    private static final String UNDO_WASTE_FIELD = STATS_PREFIX + "undoWaste";
+    private static final String REGION_END_WASTE_FIELD = STATS_PREFIX + "regionEndWaste";
+    private static final String DIRECT_ALLOCATED_FIELD = STATS_PREFIX + "directAllocated";
+    private static final String REGIONS_REFILLED_FIELD = STATS_PREFIX + "regionsRefilled";
+    private static final String NUM_PLABS_FILLED_FIELD = STATS_PREFIX + "numPlabsFilled";
+    private static final String FAILURE_USED_FIELD = STATS_PREFIX + "failureUsed";
+    private static final String FAILURE_WASTE_FIELD = STATS_PREFIX + "failureWaste";
+
+    private final List<G1PlabStatistics> rows = new ArrayList<>();
+
+    @Override
+    public void onRecord(GenericRecord record) {
+        ObjectNode fields = record.jsonFields();
+
+        String generation = Type.G1_EVACUATION_YOUNG_STATISTICS.equals(record.type())
+                ? G1PlabStatistics.YOUNG
+                : G1PlabStatistics.OLD;
+
+        long allocated = Math.max(0, Json.readLong(fields, ALLOCATED_FIELD));
+        long failureWaste = Math.max(0, Json.readLong(fields, FAILURE_WASTE_FIELD));
+        long totalWasted = Math.max(0, Json.readLong(fields, WASTED_FIELD))
+                + Math.max(0, Json.readLong(fields, UNDO_WASTE_FIELD))
+                + Math.max(0, Json.readLong(fields, REGION_END_WASTE_FIELD))
+                + failureWaste;
+        double wastePercent = allocated > 0 ? (totalWasted * 100.0) / allocated : 0;
+
+        rows.add(new G1PlabStatistics(
+                Json.readLong(fields, GC_ID_FIELD),
+                generation,
+                allocated,
+                Math.max(0, Json.readLong(fields, USED_FIELD)),
+                totalWasted,
+                wastePercent,
+                Math.max(0, Json.readLong(fields, DIRECT_ALLOCATED_FIELD)),
+                Math.max(0, Json.readLong(fields, REGIONS_REFILLED_FIELD)),
+                Math.max(0, Json.readLong(fields, NUM_PLABS_FILLED_FIELD)),
+                Math.max(0, Json.readLong(fields, FAILURE_USED_FIELD)),
+                failureWaste));
+    }
+
+    @Override
+    public List<G1PlabStatistics> build() {
+        rows.sort(Comparator.comparingLong(G1PlabStatistics::gcId)
+                .thenComparingInt(row -> G1PlabStatistics.YOUNG.equals(row.generation()) ? 0 : 1));
+        return rows;
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/gc/GCPhaseParallelAggregate.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/gc/GCPhaseParallelAggregate.java
@@ -1,0 +1,39 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.gc;
+
+/**
+ * Aggregated timing for one parallel GC sub-phase ({@code jdk.GCPhaseParallel}), summed across all GC
+ * worker threads and all collections — e.g. "Ext Root Scanning", "Object Copy", "Termination".
+ *
+ * @param name          the sub-phase name
+ * @param count         number of (worker, collection) samples for this phase
+ * @param totalNanos    summed duration across all samples
+ * @param avgNanos      mean sample duration
+ * @param maxNanos      slowest single sample
+ * @param percentOfTotal share of total parallel sub-phase time
+ */
+public record GCPhaseParallelAggregate(
+        String name,
+        long count,
+        long totalNanos,
+        long avgNanos,
+        long maxNanos,
+        double percentOfTotal) {
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/gc/GCPhaseParallelBuilder.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/gc/GCPhaseParallelBuilder.java
@@ -1,0 +1,83 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.gc;
+
+import tools.jackson.databind.node.ObjectNode;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.provider.profile.api.RecordBuilder;
+import cafe.jeffrey.shared.common.Json;
+
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Aggregates {@code jdk.GCPhaseParallel} events by sub-phase {@code name}, summing duration across all GC
+ * worker threads and collections. Returns one {@link GCPhaseParallelAggregate} per phase, longest total
+ * first.
+ */
+public class GCPhaseParallelBuilder implements RecordBuilder<GenericRecord, List<GCPhaseParallelAggregate>> {
+
+    private static final String NAME_FIELD = "name";
+    private static final String UNKNOWN_PHASE = "<unknown>";
+
+    private static final class PhaseAccumulator {
+        private long count;
+        private long totalNanos;
+        private long maxNanos;
+
+        private void add(long durationNanos) {
+            count++;
+            totalNanos += durationNanos;
+            maxNanos = Math.max(maxNanos, durationNanos);
+        }
+    }
+
+    private final Map<String, PhaseAccumulator> phases = new HashMap<>();
+    private long grandTotalNanos;
+
+    @Override
+    public void onRecord(GenericRecord record) {
+        ObjectNode fields = record.jsonFields();
+        String name = Json.readString(fields, NAME_FIELD);
+        if (name == null) {
+            name = UNKNOWN_PHASE;
+        }
+        Duration duration = record.duration();
+        long durationNanos = duration == null ? 0 : duration.toNanos();
+
+        phases.computeIfAbsent(name, key -> new PhaseAccumulator()).add(durationNanos);
+        grandTotalNanos += durationNanos;
+    }
+
+    @Override
+    public List<GCPhaseParallelAggregate> build() {
+        return phases.entrySet().stream()
+                .map(entry -> {
+                    PhaseAccumulator acc = entry.getValue();
+                    long avg = acc.count > 0 ? acc.totalNanos / acc.count : 0;
+                    double percent = grandTotalNanos > 0 ? (acc.totalNanos * 100.0) / grandTotalNanos : 0;
+                    return new GCPhaseParallelAggregate(entry.getKey(), acc.count, acc.totalNanos, avg, acc.maxNanos, percent);
+                })
+                .sorted(Comparator.comparingLong(GCPhaseParallelAggregate::totalNanos).reversed())
+                .toList();
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/io/FileForceBuilder.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/io/FileForceBuilder.java
@@ -1,0 +1,92 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.io;
+
+import tools.jackson.databind.node.ObjectNode;
+import cafe.jeffrey.profile.manager.model.io.FileForceStats.FileForceOp;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.provider.profile.api.RecordBuilder;
+import cafe.jeffrey.shared.common.Json;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.PriorityQueue;
+
+/**
+ * Aggregates {@code jdk.FileForce} (fsync) events into count + latency stats and keeps the slowest forces
+ * in a bounded min-heap, returned longest-first.
+ */
+public class FileForceBuilder implements RecordBuilder<GenericRecord, FileForceStats> {
+
+    private static final String PATH_FIELD = "path";
+    private static final String METADATA_FIELD = "metaData";
+    private static final String EVENT_THREAD_FIELD = "eventThread";
+
+    private final int maxEntries;
+    private final PriorityQueue<FileForceOp> slowest =
+            new PriorityQueue<>(Comparator.comparingLong(FileForceOp::durationNanos));
+
+    private long count;
+    private long totalNanos;
+    private long maxNanos;
+    private long metadataCount;
+
+    public FileForceBuilder(int maxEntries) {
+        if (maxEntries <= 0) {
+            throw new IllegalArgumentException("maxEntries must be positive: " + maxEntries);
+        }
+        this.maxEntries = maxEntries;
+    }
+
+    @Override
+    public void onRecord(GenericRecord record) {
+        ObjectNode fields = record.jsonFields();
+        Duration duration = record.duration();
+        long durationNanos = duration == null ? 0 : duration.toNanos();
+        boolean metaData = Json.readBoolean(fields, METADATA_FIELD);
+
+        count++;
+        totalNanos += durationNanos;
+        maxNanos = Math.max(maxNanos, durationNanos);
+        if (metaData) {
+            metadataCount++;
+        }
+
+        FileForceOp op = new FileForceOp(
+                record.timestampFromStart().toMillis(),
+                Json.readString(fields, PATH_FIELD),
+                metaData,
+                durationNanos,
+                Json.readString(fields, EVENT_THREAD_FIELD));
+        slowest.offer(op);
+        if (slowest.size() > maxEntries) {
+            slowest.poll();
+        }
+    }
+
+    @Override
+    public FileForceStats build() {
+        List<FileForceOp> ordered = new ArrayList<>(slowest);
+        ordered.sort(Comparator.comparingLong(FileForceOp::durationNanos).reversed());
+        long avgNanos = count > 0 ? totalNanos / count : 0;
+        return new FileForceStats(count, totalNanos, avgNanos, maxNanos, metadataCount, ordered);
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/io/FileForceStats.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/io/FileForceStats.java
@@ -1,0 +1,63 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.io;
+
+import java.util.List;
+
+/**
+ * Fsync (file-force) latency summary from {@code jdk.FileForce}. Unlike read/write, force events carry no
+ * byte count — the signal is purely latency, so this is a dedicated stat block rather than part of the
+ * read/write throughput model.
+ *
+ * @param count         number of force operations
+ * @param totalNanos    summed force duration
+ * @param avgNanos      mean force duration
+ * @param maxNanos      slowest single force
+ * @param metadataCount how many forces also flushed file metadata ({@code metaData == true})
+ * @param slowest       the slowest force operations, longest first
+ */
+public record FileForceStats(
+        long count,
+        long totalNanos,
+        long avgNanos,
+        long maxNanos,
+        long metadataCount,
+        List<FileForceOp> slowest) {
+
+    public boolean hasEvents() {
+        return count > 0;
+    }
+
+    /**
+     * A single force operation.
+     *
+     * @param timeOffsetMillis offset from recording start
+     * @param path             the file being forced
+     * @param metaData         whether file metadata was also flushed
+     * @param durationNanos    force duration
+     * @param thread           the thread that issued the force
+     */
+    public record FileForceOp(
+            long timeOffsetMillis,
+            String path,
+            boolean metaData,
+            long durationNanos,
+            String thread) {
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/system/LaunchedProcessInfo.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/system/LaunchedProcessInfo.java
@@ -16,36 +16,21 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/** CPU values are basis points (percent x 100), e.g. 442 = 4.42%. */
-export interface SystemOverview {
-  avgMachineCpuBp: number;
-  maxMachineCpuBp: number;
-  avgJvmCpuBp: number;
-  avgOtherCpuBp: number;
-  maxContextSwitchRateHz: number;
-  processCount: number;
-  networkInterfaceCount: number;
-}
+package cafe.jeffrey.profile.manager.model.system;
 
-export interface SystemProcessInfo {
-  pid: string;
-  commandLine: string;
-}
-
-export interface LaunchedProcessInfo {
-  timeOffsetMillis: number;
-  pid: number;
-  command: string | null;
-  directory: string | null;
-  thread: string | null;
-}
-
-export interface ModuleEdge {
-  source: string | null;
-  required: string | null;
-}
-
-export interface ModuleExport {
-  packageName: string | null;
-  targetModule: string | null;
+/**
+ * A subprocess launched by the JVM during the recording, from {@code jdk.ProcessStart}.
+ *
+ * @param timeOffsetMillis offset from recording start
+ * @param pid              the started process id
+ * @param command          the executed command
+ * @param directory        the working directory
+ * @param thread           the JVM thread that launched it
+ */
+public record LaunchedProcessInfo(
+        long timeOffsetMillis,
+        long pid,
+        String command,
+        String directory,
+        String thread) {
 }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/system/LaunchedProcessesBuilder.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/system/LaunchedProcessesBuilder.java
@@ -1,0 +1,57 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.system;
+
+import tools.jackson.databind.node.ObjectNode;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.provider.profile.api.RecordBuilder;
+import cafe.jeffrey.shared.common.Json;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Collects {@code jdk.ProcessStart} events — subprocesses the JVM launched during the recording — in
+ * chronological order.
+ */
+public class LaunchedProcessesBuilder implements RecordBuilder<GenericRecord, List<LaunchedProcessInfo>> {
+
+    private static final String PID_FIELD = "pid";
+    private static final String COMMAND_FIELD = "command";
+    private static final String DIRECTORY_FIELD = "directory";
+    private static final String EVENT_THREAD_FIELD = "eventThread";
+
+    private final List<LaunchedProcessInfo> processes = new ArrayList<>();
+
+    @Override
+    public void onRecord(GenericRecord record) {
+        ObjectNode fields = record.jsonFields();
+        processes.add(new LaunchedProcessInfo(
+                record.timestampFromStart().toMillis(),
+                Json.readLong(fields, PID_FIELD),
+                Json.readString(fields, COMMAND_FIELD),
+                Json.readString(fields, DIRECTORY_FIELD),
+                Json.readString(fields, EVENT_THREAD_FIELD)));
+    }
+
+    @Override
+    public List<LaunchedProcessInfo> build() {
+        return processes;
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/system/ModuleEdge.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/system/ModuleEdge.java
@@ -16,36 +16,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/** CPU values are basis points (percent x 100), e.g. 442 = 4.42%. */
-export interface SystemOverview {
-  avgMachineCpuBp: number;
-  maxMachineCpuBp: number;
-  avgJvmCpuBp: number;
-  avgOtherCpuBp: number;
-  maxContextSwitchRateHz: number;
-  processCount: number;
-  networkInterfaceCount: number;
-}
+package cafe.jeffrey.profile.manager.model.system;
 
-export interface SystemProcessInfo {
-  pid: string;
-  commandLine: string;
-}
-
-export interface LaunchedProcessInfo {
-  timeOffsetMillis: number;
-  pid: number;
-  command: string | null;
-  directory: string | null;
-  thread: string | null;
-}
-
-export interface ModuleEdge {
-  source: string | null;
-  required: string | null;
-}
-
-export interface ModuleExport {
-  packageName: string | null;
-  targetModule: string | null;
+/**
+ * A module dependency edge from {@code jdk.ModuleRequire}: {@code source} requires {@code required}.
+ * The unnamed module is represented as {@code null}.
+ */
+public record ModuleEdge(String source, String required) {
 }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/system/ModuleExport.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/system/ModuleExport.java
@@ -16,36 +16,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/** CPU values are basis points (percent x 100), e.g. 442 = 4.42%. */
-export interface SystemOverview {
-  avgMachineCpuBp: number;
-  maxMachineCpuBp: number;
-  avgJvmCpuBp: number;
-  avgOtherCpuBp: number;
-  maxContextSwitchRateHz: number;
-  processCount: number;
-  networkInterfaceCount: number;
-}
+package cafe.jeffrey.profile.manager.model.system;
 
-export interface SystemProcessInfo {
-  pid: string;
-  commandLine: string;
-}
-
-export interface LaunchedProcessInfo {
-  timeOffsetMillis: number;
-  pid: number;
-  command: string | null;
-  directory: string | null;
-  thread: string | null;
-}
-
-export interface ModuleEdge {
-  source: string | null;
-  required: string | null;
-}
-
-export interface ModuleExport {
-  packageName: string | null;
-  targetModule: string | null;
+/**
+ * A package export from {@code jdk.ModuleExport}: {@code packageName} is exported to {@code targetModule}.
+ * A {@code null} target means the package is exported unqualifiedly (to everyone).
+ */
+public record ModuleExport(String packageName, String targetModule) {
 }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/system/ModuleExportsBuilder.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/system/ModuleExportsBuilder.java
@@ -1,0 +1,60 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.system;
+
+import tools.jackson.databind.node.ObjectNode;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.provider.profile.api.RecordBuilder;
+import cafe.jeffrey.shared.common.Json;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Collects package exports from {@code jdk.ModuleExport}, de-duplicated, sorted by package then target.
+ * The {@code exportedPackage} (Package) and {@code targetModule} (Module) struct fields are flattened to
+ * names by the event-to-JSON mapper; a {@code null} target means an unqualified export.
+ */
+public class ModuleExportsBuilder implements RecordBuilder<GenericRecord, List<ModuleExport>> {
+
+    private static final String EXPORTED_PACKAGE_FIELD = "exportedPackage";
+    private static final String TARGET_MODULE_FIELD = "targetModule";
+
+    private final Set<ModuleExport> exports = new LinkedHashSet<>();
+
+    @Override
+    public void onRecord(GenericRecord record) {
+        ObjectNode fields = record.jsonFields();
+        exports.add(new ModuleExport(
+                Json.readString(fields, EXPORTED_PACKAGE_FIELD),
+                Json.readString(fields, TARGET_MODULE_FIELD)));
+    }
+
+    @Override
+    public List<ModuleExport> build() {
+        List<ModuleExport> result = new ArrayList<>(exports);
+        result.sort(Comparator
+                .comparing(ModuleExport::packageName, Comparator.nullsFirst(String.CASE_INSENSITIVE_ORDER))
+                .thenComparing(ModuleExport::targetModule, Comparator.nullsFirst(String.CASE_INSENSITIVE_ORDER)));
+        return result;
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/system/ModuleRequiresBuilder.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/system/ModuleRequiresBuilder.java
@@ -1,0 +1,60 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.system;
+
+import tools.jackson.databind.node.ObjectNode;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.provider.profile.api.RecordBuilder;
+import cafe.jeffrey.shared.common.Json;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Collects module dependency edges from {@code jdk.ModuleRequire}, de-duplicated, sorted by source then
+ * required module. The {@code source}/{@code requiredModule} struct fields are flattened to module names
+ * by the event-to-JSON mapper.
+ */
+public class ModuleRequiresBuilder implements RecordBuilder<GenericRecord, List<ModuleEdge>> {
+
+    private static final String SOURCE_FIELD = "source";
+    private static final String REQUIRED_MODULE_FIELD = "requiredModule";
+
+    private final Set<ModuleEdge> edges = new LinkedHashSet<>();
+
+    @Override
+    public void onRecord(GenericRecord record) {
+        ObjectNode fields = record.jsonFields();
+        edges.add(new ModuleEdge(
+                Json.readString(fields, SOURCE_FIELD),
+                Json.readString(fields, REQUIRED_MODULE_FIELD)));
+    }
+
+    @Override
+    public List<ModuleEdge> build() {
+        List<ModuleEdge> result = new ArrayList<>(edges);
+        result.sort(Comparator
+                .comparing(ModuleEdge::source, Comparator.nullsFirst(String.CASE_INSENSITIVE_ORDER))
+                .thenComparing(ModuleEdge::required, Comparator.nullsFirst(String.CASE_INSENSITIVE_ORDER)));
+        return result;
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/system/SwapTimeseriesBuilder.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/system/SwapTimeseriesBuilder.java
@@ -1,0 +1,69 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.system;
+
+import org.eclipse.collections.impl.map.mutable.primitive.LongLongHashMap;
+import tools.jackson.databind.node.ObjectNode;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.provider.profile.api.RecordBuilder;
+import cafe.jeffrey.shared.common.Json;
+import cafe.jeffrey.shared.common.model.time.RelativeTimeRange;
+import cafe.jeffrey.timeseries.SingleSerie;
+import cafe.jeffrey.timeseries.TimeseriesData;
+import cafe.jeffrey.timeseries.TimeseriesUtils;
+
+/**
+ * Builds the OS swap-space timeline from periodic {@code jdk.SwapSpace} events: total swap and used swap
+ * ({@code totalSize - freeSize}) in bytes, so the UI can spot a host that starts paging.
+ */
+public class SwapTimeseriesBuilder implements RecordBuilder<GenericRecord, TimeseriesData> {
+
+    private static final String TOTAL_SERIES_NAME = "Total";
+    private static final String USED_SERIES_NAME = "Used";
+    private static final String TOTAL_SIZE_FIELD = "totalSize";
+    private static final String FREE_SIZE_FIELD = "freeSize";
+
+    private final LongLongHashMap totalTimeseries;
+    private final LongLongHashMap usedTimeseries;
+
+    public SwapTimeseriesBuilder(RelativeTimeRange timeRange) {
+        this.totalTimeseries = TimeseriesUtils.initWithZeros(timeRange);
+        this.usedTimeseries = TimeseriesUtils.initWithZeros(timeRange);
+    }
+
+    @Override
+    public void onRecord(GenericRecord record) {
+        ObjectNode fields = record.jsonFields();
+        long seconds = record.timestampFromStart().toSeconds();
+
+        long total = Math.max(0, Json.readLong(fields, TOTAL_SIZE_FIELD));
+        long free = Math.max(0, Json.readLong(fields, FREE_SIZE_FIELD));
+        long used = Math.max(0, total - free);
+
+        totalTimeseries.updateValue(seconds, 0, existing -> Math.max(existing, total));
+        usedTimeseries.updateValue(seconds, 0, existing -> Math.max(existing, used));
+    }
+
+    @Override
+    public TimeseriesData build() {
+        SingleSerie totalSerie = TimeseriesUtils.buildSerie(TOTAL_SERIES_NAME, totalTimeseries);
+        SingleSerie usedSerie = TimeseriesUtils.buildSerie(USED_SERIES_NAME, usedTimeseries);
+        return new TimeseriesData(totalSerie, usedSerie);
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/thread/ReservedStackActivation.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/thread/ReservedStackActivation.java
@@ -16,36 +16,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/** CPU values are basis points (percent x 100), e.g. 442 = 4.42%. */
-export interface SystemOverview {
-  avgMachineCpuBp: number;
-  maxMachineCpuBp: number;
-  avgJvmCpuBp: number;
-  avgOtherCpuBp: number;
-  maxContextSwitchRateHz: number;
-  processCount: number;
-  networkInterfaceCount: number;
-}
+package cafe.jeffrey.profile.manager.model.thread;
 
-export interface SystemProcessInfo {
-  pid: string;
-  commandLine: string;
-}
-
-export interface LaunchedProcessInfo {
-  timeOffsetMillis: number;
-  pid: number;
-  command: string | null;
-  directory: string | null;
-  thread: string | null;
-}
-
-export interface ModuleEdge {
-  source: string | null;
-  required: string | null;
-}
-
-export interface ModuleExport {
-  packageName: string | null;
-  targetModule: string | null;
+/**
+ * A reserved-stack activation ({@code jdk.ReservedStackActivation}): a thread executing a
+ * {@code @ReservedStackAccess} method entered the reserved stack zone because it was close to a stack
+ * overflow — a near-miss worth investigating (deep recursion, runaway stack growth).
+ *
+ * @param timeOffsetMillis offset from recording start
+ * @param thread           the affected thread
+ * @param method           the {@code @ReservedStackAccess} method ({@code <class>#<method>})
+ */
+public record ReservedStackActivation(long timeOffsetMillis, String thread, String method) {
 }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/thread/ReservedStackActivationBuilder.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/thread/ReservedStackActivationBuilder.java
@@ -1,0 +1,52 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.thread;
+
+import tools.jackson.databind.node.ObjectNode;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.provider.profile.api.RecordBuilder;
+import cafe.jeffrey.shared.common.Json;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Collects {@code jdk.ReservedStackActivation} events in chronological order.
+ */
+public class ReservedStackActivationBuilder implements RecordBuilder<GenericRecord, List<ReservedStackActivation>> {
+
+    private static final String EVENT_THREAD_FIELD = "eventThread";
+    private static final String METHOD_FIELD = "method";
+
+    private final List<ReservedStackActivation> activations = new ArrayList<>();
+
+    @Override
+    public void onRecord(GenericRecord record) {
+        ObjectNode fields = record.jsonFields();
+        activations.add(new ReservedStackActivation(
+                record.timestampFromStart().toMillis(),
+                Json.readString(fields, EVENT_THREAD_FIELD),
+                Json.readString(fields, METHOD_FIELD)));
+    }
+
+    @Override
+    public List<ReservedStackActivation> build() {
+        return activations;
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/gc/G1PlabStatisticsBuilderTest.java
+++ b/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/gc/G1PlabStatisticsBuilderTest.java
@@ -1,0 +1,93 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.gc;
+
+import tools.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.shared.common.Json;
+import cafe.jeffrey.shared.common.model.Type;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DisplayName("G1PlabStatisticsBuilder")
+class G1PlabStatisticsBuilderTest {
+
+    private static GenericRecord evacuation(
+            Type type, long gcId, long allocated, long used,
+            long wasted, long undoWaste, long regionEndWaste, long failureWaste) {
+        ObjectNode fields = Json.createObject();
+        fields.put("statistics.gcId", gcId);
+        fields.put("statistics.allocated", allocated);
+        fields.put("statistics.used", used);
+        fields.put("statistics.wasted", wasted);
+        fields.put("statistics.undoWaste", undoWaste);
+        fields.put("statistics.regionEndWaste", regionEndWaste);
+        fields.put("statistics.failureWaste", failureWaste);
+        fields.put("statistics.directAllocated", 0);
+        fields.put("statistics.regionsRefilled", 3);
+        fields.put("statistics.numPlabsFilled", 7);
+        fields.put("statistics.failureUsed", 0);
+        return new GenericRecord(
+                type, "G1 Evacuation", Instant.EPOCH, Duration.ofMillis(1),
+                Duration.ZERO, null, null, 0, 0, fields);
+    }
+
+    @Test
+    @DisplayName("Maps generation, sums total waste, computes waste %, orders by gcId then Young-before-Old")
+    void aggregates() {
+        G1PlabStatisticsBuilder builder = new G1PlabStatisticsBuilder();
+        // gcId 2 old, gcId 1 young — order must come out 1-Young then 2-Old.
+        builder.onRecord(evacuation(Type.G1_EVACUATION_OLD_STATISTICS, 2, 1000, 600, 100, 50, 50, 0));
+        builder.onRecord(evacuation(Type.G1_EVACUATION_YOUNG_STATISTICS, 1, 1000, 700, 100, 0, 0, 100));
+
+        List<G1PlabStatistics> result = builder.build();
+
+        assertEquals(2, result.size());
+
+        G1PlabStatistics young = result.getFirst();
+        assertEquals(1, young.gcId());
+        assertEquals(G1PlabStatistics.YOUNG, young.generation());
+        // wasted 100 + undo 0 + regionEnd 0 + failureWaste 100 = 200 of 1000 = 20%.
+        assertEquals(200, young.totalWasted());
+        assertEquals(20.0, young.wastePercent(), 0.001);
+        assertEquals(100, young.failureWaste());
+
+        G1PlabStatistics old = result.get(1);
+        assertEquals(2, old.gcId());
+        assertEquals(G1PlabStatistics.OLD, old.generation());
+        // 100 + 50 + 50 + 0 = 200 of 1000 = 20%.
+        assertEquals(200, old.totalWasted());
+        assertEquals(20.0, old.wastePercent(), 0.001);
+    }
+
+    @Test
+    @DisplayName("Zero allocated yields 0% rather than dividing by zero")
+    void zeroAllocated() {
+        G1PlabStatisticsBuilder builder = new G1PlabStatisticsBuilder();
+        builder.onRecord(evacuation(Type.G1_EVACUATION_YOUNG_STATISTICS, 1, 0, 0, 0, 0, 0, 0));
+
+        assertEquals(0.0, builder.build().getFirst().wastePercent(), 0.001);
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/gc/GCPhaseParallelBuilderTest.java
+++ b/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/gc/GCPhaseParallelBuilderTest.java
@@ -1,0 +1,66 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.gc;
+
+import tools.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.shared.common.Json;
+import cafe.jeffrey.shared.common.model.Type;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DisplayName("GCPhaseParallelBuilder")
+class GCPhaseParallelBuilderTest {
+
+    private static GenericRecord phase(String name, long durationNanos) {
+        ObjectNode fields = Json.createObject();
+        fields.put("name", name);
+        return new GenericRecord(
+                Type.GC_PHASE_PARALLEL, "GC Phase Parallel", Instant.EPOCH, Duration.ofMillis(5),
+                Duration.ofNanos(durationNanos), null, null, 0, 0, fields);
+    }
+
+    @Test
+    @DisplayName("Groups by phase name with totals, average, max and percent share, longest first")
+    void aggregatesByName() {
+        GCPhaseParallelBuilder builder = new GCPhaseParallelBuilder();
+        builder.onRecord(phase("Object Copy", 100));
+        builder.onRecord(phase("Object Copy", 300));
+        builder.onRecord(phase("Ext Root Scanning", 200));
+
+        List<GCPhaseParallelAggregate> result = builder.build();
+
+        assertEquals(2, result.size());
+        // Object Copy = 400 total dominates Ext Root Scanning = 200.
+        GCPhaseParallelAggregate top = result.getFirst();
+        assertEquals("Object Copy", top.name());
+        assertEquals(2, top.count());
+        assertEquals(400, top.totalNanos());
+        assertEquals(200, top.avgNanos());
+        assertEquals(300, top.maxNanos());
+        // 400 of 600 total = 66.6%.
+        assertEquals(66.0, top.percentOfTotal(), 1.0);
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/io/FileForceBuilderTest.java
+++ b/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/io/FileForceBuilderTest.java
@@ -1,0 +1,80 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.io;
+
+import tools.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import cafe.jeffrey.profile.manager.model.io.FileForceStats.FileForceOp;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.shared.common.Json;
+import cafe.jeffrey.shared.common.model.Type;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("FileForceBuilder")
+class FileForceBuilderTest {
+
+    private static GenericRecord forceEvent(String path, boolean metaData, long durationNanos) {
+        ObjectNode fields = Json.createObject();
+        fields.put("path", path);
+        fields.put("metaData", metaData);
+        fields.put("eventThread", "main");
+        return new GenericRecord(
+                Type.FILE_FORCE, "File Force", Instant.EPOCH, Duration.ofMillis(10),
+                Duration.ofNanos(durationNanos), null, null, 0, 0, fields);
+    }
+
+    @Test
+    @DisplayName("Aggregates count, latency stats and metadata flushes, slowest first")
+    void aggregates() {
+        FileForceBuilder builder = new FileForceBuilder(10);
+        builder.onRecord(forceEvent("/a.log", false, 100));
+        builder.onRecord(forceEvent("/b.log", true, 300));
+        builder.onRecord(forceEvent("/c.log", false, 200));
+
+        FileForceStats stats = builder.build();
+
+        assertTrue(stats.hasEvents());
+        assertEquals(3, stats.count());
+        assertEquals(600, stats.totalNanos());
+        assertEquals(200, stats.avgNanos());
+        assertEquals(300, stats.maxNanos());
+        assertEquals(1, stats.metadataCount());
+
+        assertEquals(3, stats.slowest().size());
+        FileForceOp slowest = stats.slowest().getFirst();
+        assertEquals("/b.log", slowest.path());
+        assertTrue(slowest.metaData());
+        assertEquals(300, slowest.durationNanos());
+    }
+
+    @Test
+    @DisplayName("Empty stream produces a zeroed, event-free summary")
+    void empty() {
+        FileForceStats stats = new FileForceBuilder(10).build();
+        assertEquals(0, stats.count());
+        assertEquals(0, stats.avgNanos());
+        org.junit.jupiter.api.Assertions.assertFalse(stats.hasEvents());
+    }
+}

--- a/jeffrey-pages/src/views/docs/microscope/profiles/ProfileFileIoPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/profiles/ProfileFileIoPage.vue
@@ -31,6 +31,7 @@ const headings = [
   { id: 'files', text: 'Top Files', level: 2 },
   { id: 'directories', text: 'By Directory', level: 2 },
   { id: 'slowest', text: 'Slowest Operations', level: 2 },
+  { id: 'fsync', text: 'Fsync', level: 2 },
   { id: 'events', text: 'Source Events', level: 2 }
 ];
 
@@ -65,10 +66,14 @@ onMounted(() => {
       <h2 id="slowest">Slowest Operations</h2>
       <p>The slowest individual reads/writes by duration. A slow write is often an <code>fsync</code>/flush; a slow read is a page-cache miss hitting the disk.</p>
 
+      <h2 id="fsync">Fsync</h2>
+      <p>File force (fsync) operations from <code>jdk.FileForce</code> — flushing buffered writes (and optionally file metadata) durably to disk. Unlike reads and writes, a force carries no byte count, only latency, so it gets a dedicated stat block (count, average/max/total latency, metadata-flush share) and a slowest-forces table. Slow or frequent fsyncs are a classic durability bottleneck for commit logs, databases, and flush-on-every-write code.</p>
+
       <h2 id="events">Source Events</h2>
       <ul>
         <li><code>jdk.FileRead</code> — path, bytes read, end-of-stream and duration (threshold-gated, often disabled by default).</li>
         <li><code>jdk.FileWrite</code> — path, bytes written and duration (threshold-gated, often disabled by default).</li>
+        <li><code>jdk.FileForce</code> — path, a metadata flag and the flush duration (no byte count); powers the Fsync tab.</li>
       </ul>
     </div>
 

--- a/jeffrey-pages/src/views/docs/microscope/profiles/ProfileGarbageCollectionPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/profiles/ProfileGarbageCollectionPage.vue
@@ -35,6 +35,7 @@ const headings = [
   { id: 'ihop', text: 'G1 IHOP & CPU', level: 2 },
   { id: 'reference-processing', text: 'Reference Processing', level: 2 },
   { id: 'sub-phases', text: 'Sub-Phases', level: 2 },
+  { id: 'plab', text: 'G1 PLAB Statistics', level: 2 },
   { id: 'pause-types', text: 'Pause Types Reference', level: 2 }
 ];
 
@@ -85,6 +86,9 @@ onMounted(() => {
 
       <h2 id="sub-phases">Sub-Phases</h2>
       <p>A breakdown of the parallel sub-phases that make up stop-the-world pauses (<code>jdk.GCPhaseParallel</code>) — e.g. Ext Root Scanning, Object Copy, Termination — aggregated by phase name across all GC worker threads and collections, with count, total/average/max time and share of total. Find which sub-phase dominates a pause: heavy Object Copy points at high promotion volume, heavy Termination at worker load imbalance. The event is off in many GC configurations, so this tab may be empty.</p>
+
+      <h2 id="plab">G1 PLAB Statistics</h2>
+      <p>For the G1 collector: per-evacuation promotion-buffer (PLAB) statistics from <code>jdk.G1EvacuationYoungStatistics</code> and <code>jdk.G1EvacuationOldStatistics</code>. PLABs are the thread-local buffers G1 uses to copy surviving objects during a collection; each row shows the GC id, generation (young/old), bytes allocated for PLABs, bytes actually used, total wasted bytes (alignment + refill + undo + evacuation-failure waste) and the resulting waste percentage, plus direct allocations, regions refilled and PLABs filled. A high waste percentage means PLABs are poorly sized (tune <code>-XX:+ResizePLAB</code> / the PLAB-size flags); non-zero failure bytes signal to-space exhaustion (evacuation failure), the usual cause of surprise Full GCs. These events are in the JFR <em>Detailed</em> category and off in most recording configs, so the tab is empty unless they were explicitly enabled under G1.</p>
 
       <h2 id="pause-types">Pause Types Reference</h2>
       <p>A searchable, category-filterable reference for every GC cause the JVM may emit. Use the search input to filter by cause name, or click the category chips to narrow to a single group:</p>

--- a/jeffrey-pages/src/views/docs/microscope/profiles/ProfileGarbageCollectionPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/profiles/ProfileGarbageCollectionPage.vue
@@ -34,6 +34,7 @@ const headings = [
   { id: 'tenuring', text: 'Promotion & Tenuring', level: 2 },
   { id: 'ihop', text: 'G1 IHOP & CPU', level: 2 },
   { id: 'reference-processing', text: 'Reference Processing', level: 2 },
+  { id: 'sub-phases', text: 'Sub-Phases', level: 2 },
   { id: 'pause-types', text: 'Pause Types Reference', level: 2 }
 ];
 
@@ -81,6 +82,9 @@ onMounted(() => {
 
       <h2 id="reference-processing">Reference Processing</h2>
       <p>A dedicated page (under <strong>Garbage Collection → Reference Processing</strong>) for <code>jdk.GCReferenceStatistics</code> — the count of Soft, Weak, Final and Phantom references each collection processes. On JDK 26 the event carries only the processed count per type and the GC id (no per-phase time), so the views are count-based: a stacked-by-type <strong>timeline</strong> (Soft-reference bursts track heap-pressure episodes; rising Final/Phantom volume points at finalizer/cleaner load), a <strong>by-type</strong> totals/averages table, and a <strong>per-GC</strong> breakdown ranking the collections that processed the most references.</p>
+
+      <h2 id="sub-phases">Sub-Phases</h2>
+      <p>A breakdown of the parallel sub-phases that make up stop-the-world pauses (<code>jdk.GCPhaseParallel</code>) — e.g. Ext Root Scanning, Object Copy, Termination — aggregated by phase name across all GC worker threads and collections, with count, total/average/max time and share of total. Find which sub-phase dominates a pause: heavy Object Copy points at high promotion volume, heavy Termination at worker load imbalance. The event is off in many GC configurations, so this tab may be empty.</p>
 
       <h2 id="pause-types">Pause Types Reference</h2>
       <p>A searchable, category-filterable reference for every GC cause the JVM may emit. Use the search input to filter by cause name, or click the category chips to narrow to a single group:</p>

--- a/jeffrey-pages/src/views/docs/microscope/profiles/ProfileSystemPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/profiles/ProfileSystemPage.vue
@@ -30,7 +30,9 @@ const headings = [
   { id: 'cpu', text: 'CPU', level: 2 },
   { id: 'network', text: 'Network', level: 2 },
   { id: 'context-switches', text: 'Context Switches', level: 2 },
+  { id: 'swap', text: 'Swap', level: 2 },
   { id: 'host-processes', text: 'Host Processes', level: 2 },
+  { id: 'modules', text: 'Modules', level: 2 },
   { id: 'events', text: 'Source Events', level: 2 }
 ];
 
@@ -65,8 +67,14 @@ onMounted(() => {
       <h2 id="context-switches">Context Switches</h2>
       <p>Thread context switches per second from <code>jdk.ThreadContextSwitchRate</code>. A persistently high rate signals thread oversubscription or heavy lock churn — threads spending their quantum fighting for the scheduler rather than doing work.</p>
 
+      <h2 id="swap">Swap</h2>
+      <p>OS swap space — total and in-use bytes over the recording, from periodic <code>jdk.SwapSpace</code> samples. Rising used-swap on a JVM host is a red flag: paging heap pages to disk turns ordinary GC into multi-second stalls. Ideally the used line stays flat near zero. (Swap tracking is platform-dependent, so the tab may be empty.)</p>
+
       <h2 id="host-processes">Host Processes</h2>
-      <p>The other processes running on the host during the recording, from periodic <code>jdk.SystemProcess</code> snapshots (latest snapshot per pid). This is where the noisy neighbor gets a name.</p>
+      <p>The other processes running on the host during the recording, from periodic <code>jdk.SystemProcess</code> snapshots (latest snapshot per pid) — this is where the noisy neighbor gets a name. A second table lists subprocesses the JVM itself launched during the recording (<code>jdk.ProcessStart</code>), with command, working directory and the launching thread.</p>
+
+      <h2 id="modules">Modules</h2>
+      <p>The startup module graph: module dependencies from <code>jdk.ModuleRequire</code> (source module → required module) and package exports from <code>jdk.ModuleExport</code> (exported package → target module, or unqualified). Useful for auditing the runtime module set or chasing module-resolution / illegal-access issues.</p>
 
       <h2 id="events">Source Events</h2>
       <ul>
@@ -74,6 +82,9 @@ onMounted(() => {
         <li><code>jdk.NetworkUtilization</code> — per-interface read/write rates.</li>
         <li><code>jdk.ThreadContextSwitchRate</code> — OS context switches per second.</li>
         <li><code>jdk.SystemProcess</code> — processes running on the host.</li>
+        <li><code>jdk.ProcessStart</code> — subprocesses the JVM launched (pid, command, directory).</li>
+        <li><code>jdk.SwapSpace</code> — periodic OS swap total/free.</li>
+        <li><code>jdk.ModuleRequire</code> / <code>jdk.ModuleExport</code> — the startup module dependency/export graph.</li>
       </ul>
     </div>
 

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/jfr/EventFieldsToJsonMapper.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/jfr/EventFieldsToJsonMapper.java
@@ -60,6 +60,11 @@ public class EventFieldsToJsonMapper implements EventFieldsMapper {
     private static final String MODULE_TYPE_NAME = "jdk.types.Module";
     private static final String PACKAGE_TYPE_NAME = "jdk.types.Package";
     private static final String STRUCT_NAME_FIELD = "name";
+    private static final String G1_EVACUATION_STATISTICS_TYPE_NAME = "jdk.types.G1EvacuationStatistics";
+    private static final List<String> G1_EVACUATION_STAT_FIELDS = List.of(
+            "gcId", "allocated", "wasted", "used", "undoWaste", "regionEndWaste",
+            "regionsRefilled", "numPlabsFilled", "directAllocated", "numDirectAllocated",
+            "failureUsed", "failureWaste");
     private static final String BOOLEAN_TYPE_NAME = "boolean";
     private static final Set<String> INTEGRAL_TYPE_NAMES = Set.of("long", "int");
 
@@ -163,6 +168,10 @@ public class EventFieldsToJsonMapper implements EventFieldsMapper {
             // The JFR Module/Package structs would otherwise fall through to a verbose toString() dump.
             // Flatten each to its identifying name (the module/package name); absent for the unnamed module.
             return (event, node) -> node.put(name, structName(event.getValue(name)));
+        } else if (G1_EVACUATION_STATISTICS_TYPE_NAME.equals(typeName)) {
+            // The G1 PLAB statistics struct carries ~12 numeric sub-fields; flatten each to a dotted
+            // key (e.g. "statistics.allocated") instead of dumping the whole struct via toString().
+            return (event, node) -> flattenG1EvacuationStatistics(event.getValue(name), name, node);
         } else if (activeSettingEvent && ACTIVE_SETTING_ID_FIELD.equals(name)) {
             return (event, node) -> {
                 long eventId = event.getValue(name);
@@ -258,6 +267,23 @@ public class EventFieldsToJsonMapper implements EventFieldsMapper {
             return null;
         }
         return struct.getString(STRUCT_NAME_FIELD);
+    }
+
+    /**
+     * Flattens the JFR {@code jdk.types.G1EvacuationStatistics} struct (carried by
+     * {@code jdk.G1EvacuationYoungStatistics} / {@code jdk.G1EvacuationOldStatistics}) by lifting each of
+     * its numeric sub-fields to a dotted key under the parent field name, e.g.
+     * {@code statistics.allocated}. Absent when the struct is missing.
+     */
+    private static void flattenG1EvacuationStatistics(Object value, String fieldName, ObjectNode node) {
+        if (!(value instanceof RecordedObject struct)) {
+            return;
+        }
+        for (String subField : G1_EVACUATION_STAT_FIELDS) {
+            if (struct.hasField(subField)) {
+                node.put(fieldName + "." + subField, struct.getLong(subField));
+            }
+        }
     }
 
     /**

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/jfr/EventFieldsToJsonMapper.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/jfr/EventFieldsToJsonMapper.java
@@ -57,6 +57,9 @@ public class EventFieldsToJsonMapper implements EventFieldsMapper {
     private static final String OLD_OBJECT_TYPE_NAME = "jdk.types.OldObject";
     private static final String OLD_OBJECT_TYPE_FIELD = "type";
     private static final String METHOD_TYPE_NAME = "jdk.types.Method";
+    private static final String MODULE_TYPE_NAME = "jdk.types.Module";
+    private static final String PACKAGE_TYPE_NAME = "jdk.types.Package";
+    private static final String STRUCT_NAME_FIELD = "name";
     private static final String BOOLEAN_TYPE_NAME = "boolean";
     private static final Set<String> INTEGRAL_TYPE_NAMES = Set.of("long", "int");
 
@@ -156,6 +159,10 @@ public class EventFieldsToJsonMapper implements EventFieldsMapper {
                     node.put(name, method.getType().getName() + "#" + method.getName());
                 }
             };
+        } else if (MODULE_TYPE_NAME.equals(typeName) || PACKAGE_TYPE_NAME.equals(typeName)) {
+            // The JFR Module/Package structs would otherwise fall through to a verbose toString() dump.
+            // Flatten each to its identifying name (the module/package name); absent for the unnamed module.
+            return (event, node) -> node.put(name, structName(event.getValue(name)));
         } else if (activeSettingEvent && ACTIVE_SETTING_ID_FIELD.equals(name)) {
             return (event, node) -> {
                 long eventId = event.getValue(name);
@@ -239,6 +246,18 @@ public class EventFieldsToJsonMapper implements EventFieldsMapper {
             return typeName;
         }
         return typeName + " (" + name + ")";
+    }
+
+    /**
+     * Flattens a JFR struct that carries a {@code name} field (e.g. {@code jdk.types.Module},
+     * {@code jdk.types.Package}) to that name, or {@code null} when the struct is absent (the unnamed
+     * module / a qualified export with no target).
+     */
+    private static String structName(Object value) {
+        if (!(value instanceof RecordedObject struct)) {
+            return null;
+        }
+        return struct.getString(STRUCT_NAME_FIELD);
     }
 
     /**

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/EventTypeName.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/EventTypeName.java
@@ -42,6 +42,7 @@ public abstract class EventTypeName {
     public static final String SOCKET_WRITE = "jdk.SocketWrite";
     public static final String FILE_READ = "jdk.FileRead";
     public static final String FILE_WRITE = "jdk.FileWrite";
+    public static final String FILE_FORCE = "jdk.FileForce";
     public static final String LIVE_OBJECTS = "profiler.LiveObject";
     public static final String ACTIVE_RECORDING = "jdk.ActiveRecording";
     public static final String ACTIVE_SETTING = "jdk.ActiveSetting";
@@ -62,6 +63,7 @@ public abstract class EventTypeName {
     public static final String Z_YOUNG_GARBAGE_COLLECTION = "jdk.ZYoungGarbageCollection";
     public static final String Z_OLD_GARBAGE_COLLECTION = "jdk.ZOldGarbageCollection";
     public static final String GC_PHASE_CONCURRENT = "jdk.GCPhaseConcurrent";
+    public static final String GC_PHASE_PARALLEL = "jdk.GCPhaseParallel";
     public static final String TENURING_DISTRIBUTION = "jdk.TenuringDistribution";
     public static final String GC_REFERENCE_STATISTICS = "jdk.GCReferenceStatistics";
     public static final String GC_CPU_TIME = "jdk.GCCPUTime";
@@ -121,12 +123,17 @@ public abstract class EventTypeName {
     public static final String VIRTUAL_THREAD_START = "jdk.VirtualThreadStart";
     public static final String VIRTUAL_THREAD_END = "jdk.VirtualThreadEnd";
     public static final String VIRTUAL_THREAD_SUBMIT_FAILED = "jdk.VirtualThreadSubmitFailed";
+    public static final String RESERVED_STACK_ACTIVATION = "jdk.ReservedStackActivation";
 
     // System & host events
     public static final String CPU_LOAD = "jdk.CPULoad";
     public static final String NETWORK_UTILIZATION = "jdk.NetworkUtilization";
     public static final String THREAD_CONTEXT_SWITCH_RATE = "jdk.ThreadContextSwitchRate";
     public static final String SYSTEM_PROCESS = "jdk.SystemProcess";
+    public static final String PROCESS_START = "jdk.ProcessStart";
+    public static final String SWAP_SPACE = "jdk.SwapSpace";
+    public static final String MODULE_REQUIRE = "jdk.ModuleRequire";
+    public static final String MODULE_EXPORT = "jdk.ModuleExport";
 
     // Native memory events
     public static final String RESIDENT_SET_SIZE = "jdk.ResidentSetSize";

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/EventTypeName.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/EventTypeName.java
@@ -85,7 +85,6 @@ public abstract class EventTypeName {
     public static final String GC_PHASE_PAUSE_LEVEL_2 = "jdk.GCPhasePauseLevel2";
     public static final String GC_PHASE_PAUSE_LEVEL_3 = "jdk.GCPhasePauseLevel3";
     public static final String GC_PHASE_PAUSE_LEVEL_4 = "jdk.GCPhasePauseLevel4";
-    public static final String GC_PHASE_PARALLEL = "jdk.GCPhaseParallel";
     public static final String SYSTEM_GC = "jdk.SystemGC";
     public static final String GC_LOCKER = "jdk.GCLocker";
 
@@ -96,6 +95,10 @@ public abstract class EventTypeName {
     public static final String Z_RELOCATION_SET_GROUP = "jdk.ZRelocationSetGroup";
     public static final String Z_UNCOMMIT = "jdk.ZUncommit";
     public static final String Z_THREAD_PHASE = "jdk.ZThreadPhase";
+
+    // G1 PLAB / evacuation statistics
+    public static final String G1_EVACUATION_YOUNG_STATISTICS = "jdk.G1EvacuationYoungStatistics";
+    public static final String G1_EVACUATION_OLD_STATISTICS = "jdk.G1EvacuationOldStatistics";
 
     public static final String YOUNG_GENERATION_CONFIGURATION = "jdk.YoungGenerationConfiguration";
     public static final String COMPILER_CONFIGURATION = "jdk.CompilerConfiguration";

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/Type.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/Type.java
@@ -91,7 +91,6 @@ public record Type(String code, boolean calculated) {
     public static final Type GC_PHASE_PAUSE_LEVEL_2 = new Type(EventTypeName.GC_PHASE_PAUSE_LEVEL_2);
     public static final Type GC_PHASE_PAUSE_LEVEL_3 = new Type(EventTypeName.GC_PHASE_PAUSE_LEVEL_3);
     public static final Type GC_PHASE_PAUSE_LEVEL_4 = new Type(EventTypeName.GC_PHASE_PAUSE_LEVEL_4);
-    public static final Type GC_PHASE_PARALLEL = new Type(EventTypeName.GC_PHASE_PARALLEL);
     public static final Type SYSTEM_GC = new Type(EventTypeName.SYSTEM_GC);
     public static final Type GC_LOCKER = new Type(EventTypeName.GC_LOCKER);
 
@@ -108,6 +107,10 @@ public record Type(String code, boolean calculated) {
     public static final Type SYMBOL_TABLE_STATISTICS = new Type(EventTypeName.SYMBOL_TABLE_STATISTICS);
     public static final Type FINALIZER_STATISTICS = new Type(EventTypeName.FINALIZER_STATISTICS);
     public static final Type STRING_DEDUPLICATION = new Type(EventTypeName.STRING_DEDUPLICATION);
+
+    // G1 PLAB / evacuation statistics
+    public static final Type G1_EVACUATION_YOUNG_STATISTICS = new Type(EventTypeName.G1_EVACUATION_YOUNG_STATISTICS);
+    public static final Type G1_EVACUATION_OLD_STATISTICS = new Type(EventTypeName.G1_EVACUATION_OLD_STATISTICS);
     public static final Type YOUNG_GENERATION_CONFIGURATION = new Type(EventTypeName.YOUNG_GENERATION_CONFIGURATION);
     public static final Type COMPILER_CONFIGURATION = new Type(EventTypeName.COMPILER_CONFIGURATION);
     public static final Type JVM_INFORMATION = new Type(EventTypeName.JVM_INFORMATION);
@@ -288,7 +291,6 @@ public record Type(String code, boolean calculated) {
                 GC_PHASE_PAUSE_LEVEL_2,
                 GC_PHASE_PAUSE_LEVEL_3,
                 GC_PHASE_PAUSE_LEVEL_4,
-                GC_PHASE_PARALLEL,
                 SYSTEM_GC,
                 GC_LOCKER,
                 Z_ALLOCATION_STALL,
@@ -297,6 +299,8 @@ public record Type(String code, boolean calculated) {
                 Z_RELOCATION_SET_GROUP,
                 Z_UNCOMMIT,
                 Z_THREAD_PHASE,
+                G1_EVACUATION_YOUNG_STATISTICS,
+                G1_EVACUATION_OLD_STATISTICS,
                 YOUNG_GENERATION_CONFIGURATION,
                 COMPILER_CONFIGURATION,
                 JVM_INFORMATION,

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/Type.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/Type.java
@@ -52,6 +52,7 @@ public record Type(String code, boolean calculated) {
     public static final Type SOCKET_WRITE = new Type(EventTypeName.SOCKET_WRITE);
     public static final Type FILE_READ = new Type(EventTypeName.FILE_READ);
     public static final Type FILE_WRITE = new Type(EventTypeName.FILE_WRITE);
+    public static final Type FILE_FORCE = new Type(EventTypeName.FILE_FORCE);
     public static final Type LIVE_OBJECTS = new Type(EventTypeName.LIVE_OBJECTS);
     public static final Type ACTIVE_RECORDING = new Type(EventTypeName.ACTIVE_RECORDING);
     public static final Type ACTIVE_SETTING = new Type(EventTypeName.ACTIVE_SETTING);
@@ -72,6 +73,7 @@ public record Type(String code, boolean calculated) {
     public static final Type Z_YOUNG_GARBAGE_COLLECTION = new Type(EventTypeName.Z_YOUNG_GARBAGE_COLLECTION);
     public static final Type Z_OLD_GARBAGE_COLLECTION = new Type(EventTypeName.Z_OLD_GARBAGE_COLLECTION);
     public static final Type GC_PHASE_CONCURRENT = new Type(EventTypeName.GC_PHASE_CONCURRENT);
+    public static final Type GC_PHASE_PARALLEL = new Type(EventTypeName.GC_PHASE_PARALLEL);
     public static final Type TENURING_DISTRIBUTION = new Type(EventTypeName.TENURING_DISTRIBUTION);
     public static final Type GC_REFERENCE_STATISTICS = new Type(EventTypeName.GC_REFERENCE_STATISTICS);
     public static final Type GC_CPU_TIME = new Type(EventTypeName.GC_CPU_TIME);
@@ -131,12 +133,17 @@ public record Type(String code, boolean calculated) {
     public static final Type VIRTUAL_THREAD_START = new Type(EventTypeName.VIRTUAL_THREAD_START);
     public static final Type VIRTUAL_THREAD_END = new Type(EventTypeName.VIRTUAL_THREAD_END);
     public static final Type VIRTUAL_THREAD_SUBMIT_FAILED = new Type(EventTypeName.VIRTUAL_THREAD_SUBMIT_FAILED);
+    public static final Type RESERVED_STACK_ACTIVATION = new Type(EventTypeName.RESERVED_STACK_ACTIVATION);
 
     // System & host events
     public static final Type CPU_LOAD = new Type(EventTypeName.CPU_LOAD);
     public static final Type NETWORK_UTILIZATION = new Type(EventTypeName.NETWORK_UTILIZATION);
     public static final Type THREAD_CONTEXT_SWITCH_RATE = new Type(EventTypeName.THREAD_CONTEXT_SWITCH_RATE);
     public static final Type SYSTEM_PROCESS = new Type(EventTypeName.SYSTEM_PROCESS);
+    public static final Type PROCESS_START = new Type(EventTypeName.PROCESS_START);
+    public static final Type SWAP_SPACE = new Type(EventTypeName.SWAP_SPACE);
+    public static final Type MODULE_REQUIRE = new Type(EventTypeName.MODULE_REQUIRE);
+    public static final Type MODULE_EXPORT = new Type(EventTypeName.MODULE_EXPORT);
 
     // Native memory events
     public static final Type RESIDENT_SET_SIZE = new Type(EventTypeName.RESIDENT_SET_SIZE);
@@ -242,6 +249,7 @@ public record Type(String code, boolean calculated) {
                 SOCKET_WRITE,
                 FILE_READ,
                 FILE_WRITE,
+                FILE_FORCE,
                 LIVE_OBJECTS,
                 ACTIVE_RECORDING,
                 ACTIVE_SETTING,
@@ -260,6 +268,7 @@ public record Type(String code, boolean calculated) {
                 Z_YOUNG_GARBAGE_COLLECTION,
                 Z_OLD_GARBAGE_COLLECTION,
                 GC_PHASE_CONCURRENT,
+                GC_PHASE_PARALLEL,
                 TENURING_DISTRIBUTION,
                 GC_REFERENCE_STATISTICS,
                 GC_CPU_TIME,
@@ -313,10 +322,15 @@ public record Type(String code, boolean calculated) {
                 VIRTUAL_THREAD_START,
                 VIRTUAL_THREAD_END,
                 VIRTUAL_THREAD_SUBMIT_FAILED,
+                RESERVED_STACK_ACTIVATION,
                 CPU_LOAD,
                 NETWORK_UTILIZATION,
                 THREAD_CONTEXT_SWITCH_RATE,
                 SYSTEM_PROCESS,
+                PROCESS_START,
+                SWAP_SPACE,
+                MODULE_REQUIRE,
+                MODULE_EXPORT,
                 RESIDENT_SET_SIZE,
                 DIRECT_BUFFER_STATISTICS,
                 NATIVE_LIBRARY,

--- a/shared/common/src/test/java/cafe/jeffrey/shared/common/jfr/EventFieldsToJsonMapperTest.java
+++ b/shared/common/src/test/java/cafe/jeffrey/shared/common/jfr/EventFieldsToJsonMapperTest.java
@@ -53,6 +53,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 /**
  * Verifies that the plan-based {@link EventFieldsToJsonMapper} produces JSON
@@ -211,6 +212,49 @@ class EventFieldsToJsonMapperTest {
                 assertTrue(node.has("id"));
                 assertTrue(node.has("label"));
             }
+        }
+    }
+
+    @Nested
+    class ModuleStructFields {
+
+        @Test
+        void flattensModuleAndPackageStructsToTheirName() throws IOException {
+            Path dumpFile = Files.createTempFile("module-events-mapper-test", ".jfr");
+            List<RecordedEvent> moduleEvents;
+            List<EventType> eventTypes;
+            try (Recording recording = new Recording()) {
+                recording.enable("jdk.ModuleRequire");
+                recording.enable("jdk.ModuleExport");
+                recording.start();
+                recording.stop();
+                recording.dump(dumpFile);
+            }
+            moduleEvents = RecordingFile.readAllEvents(dumpFile);
+            eventTypes = moduleEvents.stream().map(RecordedEvent::getEventType).distinct().toList();
+            Files.deleteIfExists(dumpFile);
+
+            List<RecordedEvent> requires = moduleEvents.stream()
+                    .filter(e -> "jdk.ModuleRequire".equals(e.getEventType().getName()))
+                    .toList();
+            // The module graph is dumped at chunk start; bail out gracefully if a JVM does not emit it.
+            assumeFalse(requires.isEmpty(), "Recording is expected to contain jdk.ModuleRequire events");
+
+            EventFieldsToJsonMapper mapper = new EventFieldsToJsonMapper();
+            mapper.update(eventTypes);
+
+            boolean sawJavaBase = false;
+            for (RecordedEvent event : requires) {
+                ObjectNode node = mapper.map(event);
+                // requiredModule is a Module struct; it must flatten to a plain name, not a RecordedObject dump.
+                if (node.hasNonNull("requiredModule")) {
+                    String required = node.get("requiredModule").asString();
+                    assertFalse(required.contains("{"), "Module struct must not be a toString() blob: " + required);
+                    assertFalse(required.contains("="), "Module struct must not be a toString() blob: " + required);
+                    sawJavaBase = sawJavaBase || "java.base".equals(required);
+                }
+            }
+            assertTrue(sawJavaBase, "Every module requires java.base, so it should appear as a flattened name");
         }
     }
 

--- a/shared/common/src/test/java/cafe/jeffrey/shared/common/jfr/EventFieldsToJsonMapperTest.java
+++ b/shared/common/src/test/java/cafe/jeffrey/shared/common/jfr/EventFieldsToJsonMapperTest.java
@@ -46,6 +46,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -255,6 +256,53 @@ class EventFieldsToJsonMapperTest {
                 }
             }
             assertTrue(sawJavaBase, "Every module requires java.base, so it should appear as a flattened name");
+        }
+    }
+
+    @Nested
+    class G1EvacuationStatisticsStructFields {
+
+        @Test
+        void flattensG1EvacuationStatisticsStructToDottedNumericKeys() throws IOException {
+            // The G1 evacuation events only fire under the G1 collector; on other collectors no events
+            // are produced and the test skips at the assumeFalse below.
+            Path dumpFile = Files.createTempFile("g1-plab-mapper-test", ".jfr");
+            List<RecordedEvent> events;
+            List<EventType> eventTypes;
+            try (Recording recording = new Recording()) {
+                recording.enable("jdk.G1EvacuationYoungStatistics");
+                recording.enable("jdk.G1EvacuationOldStatistics");
+                recording.start();
+                // Allocate enough short-lived garbage to force at least one young collection.
+                List<byte[]> sink = new ArrayList<>();
+                for (int i = 0; i < 256; i++) {
+                    sink.add(new byte[1024 * 1024]);
+                    if (sink.size() > 8) {
+                        sink.clear();
+                    }
+                }
+                System.gc();
+                recording.stop();
+                recording.dump(dumpFile);
+            }
+            events = RecordingFile.readAllEvents(dumpFile);
+            eventTypes = events.stream().map(RecordedEvent::getEventType).distinct().toList();
+            Files.deleteIfExists(dumpFile);
+
+            List<RecordedEvent> evacuations = events.stream()
+                    .filter(e -> "jdk.G1EvacuationYoungStatistics".equals(e.getEventType().getName()))
+                    .toList();
+            assumeFalse(evacuations.isEmpty(), "No young evacuation occurred during the test run");
+
+            EventFieldsToJsonMapper mapper = new EventFieldsToJsonMapper();
+            mapper.update(eventTypes);
+
+            ObjectNode node = mapper.map(evacuations.getFirst());
+            // The nested struct must be flattened to dotted numeric keys, not a toString() blob.
+            assertTrue(node.has("statistics.allocated"), "expected flattened statistics.allocated key");
+            assertTrue(node.get("statistics.allocated").isNumber(), "statistics.allocated must be numeric");
+            assertTrue(node.has("statistics.gcId"), "expected flattened statistics.gcId key");
+            assertFalse(node.has("statistics"), "the raw struct field must not survive as a blob");
         }
     }
 


### PR DESCRIPTION
Clears the Tier-3 quick wins from the JVM-internals roadmap — six JFR events that were already parsed into the DB but never shown in the UI. Each is folded into the most relevant existing page rather than getting a page of its own. All six verified present in JDK 26 via `jfr metadata`.

## Events and placement
| Event | Page | Surface |
|---|---|---|
| `jdk.FileForce` | File I/O | new **Fsync** tab — fsync count + latency stats + slowest forces (force carries no bytes, so it is a dedicated block, not part of read/write throughput) |
| `jdk.GCPhaseParallel` | Garbage Collection | new **Sub-Phases** tab — parallel sub-phases aggregated by name (count/total/avg/max/% share) |
| `jdk.SwapSpace` | System & Host | new **Swap** tab — total vs used timeline |
| `jdk.ProcessStart` | System & Host | **Host Processes** tab gains a "Launched during recording" table |
| `jdk.ModuleRequire` / `jdk.ModuleExport` | System & Host | new **Modules** tab — requires + exports tables |
| `jdk.ReservedStackActivation` | Threads → Statistics | new **Reserved Stack** tab — stack-overflow near-misses |

**Dropped from the original list:** UDP `SocketReceive`/`SocketSend` — no such JFR event exists in the JDK (only `jdk.SocketRead`/`jdk.SocketWrite`, already covered by the Socket I/O page).

## Shared backend change
`EventFieldsToJsonMapper` now flattens the JFR `jdk.types.Module` and `jdk.types.Package` structs to their `name` field (mirroring the existing Method/ClassLoader flatteners) instead of dumping a `toString()` blob — required for the module events to be readable, and reusable by future struct-bearing events.

## Per-event wiring
Each event is registered in `Type`/`EventTypeName` (+ `KNOWN_TYPES`), read by a focused `RecordBuilder`, exposed via a new manager method and REST endpoint, and wired into the corresponding Vue page + API client + TS model. Docs reference pages (File I/O, GC, System) updated with the new sections and source events.

## Tests
- `EventFieldsToJsonMapperTest` — Module/Package flatten via a real module-graph recording
- `FileForceBuilderTest`, `GCPhaseParallelBuilderTest`
- Controller tests for every new endpoint (`IoController`, `GarbageCollectionController`, `SystemResourcesController`, `ThreadController`)

Full backend reactor green (JDK 26); frontend lint/build and docs build green.

https://claude.ai/code/session_019PNnPZQ2oSTUGrEjFfsE4x

---
_Generated by [Claude Code](https://claude.ai/code/session_019PNnPZQ2oSTUGrEjFfsE4x)_