### PR TITLE
Add Unified Stop-The-World timeline

### DIFF
--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/StwTimelineController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/StwTimelineController.java
@@ -1,0 +1,67 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.microscope.core.web.controllers.profile;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
+import cafe.jeffrey.profile.manager.StwTimelineManager;
+import cafe.jeffrey.profile.manager.model.stw.StwEvent;
+import cafe.jeffrey.timeseries.TimeseriesData;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/internal/profiles/{profileId}/stw")
+public class StwTimelineController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StwTimelineController.class);
+
+    // Default floor for the per-event timeline: keep the payload to the pauses that matter (>= 1 ms).
+    private static final long DEFAULT_MIN_DURATION_NANOS = 1_000_000L;
+
+    private final ProfileManagerResolver resolver;
+
+    public StwTimelineController(ProfileManagerResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    @GetMapping("/timeline")
+    public List<StwEvent> timeline(
+            @PathVariable("profileId") String profileId,
+            @RequestParam(value = "minDurationNanos", defaultValue = "" + DEFAULT_MIN_DURATION_NANOS) long minDurationNanos) {
+        LOG.debug("Fetching STW timeline: minDurationNanos={}", minDurationNanos);
+        return mgr(profileId).timeline(minDurationNanos);
+    }
+
+    @GetMapping("/budget")
+    public TimeseriesData budget(@PathVariable("profileId") String profileId) {
+        LOG.debug("Fetching STW app-stop budget");
+        return mgr(profileId).budget();
+    }
+
+    private StwTimelineManager mgr(String profileId) {
+        return resolver.resolve(profileId).stwTimelineManager();
+    }
+}

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/StwTimelineControllerTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/StwTimelineControllerTest.java
@@ -1,0 +1,84 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.microscope.core.web.controllers.profile;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
+import cafe.jeffrey.profile.manager.ProfileManager;
+import cafe.jeffrey.profile.manager.StwTimelineManager;
+import cafe.jeffrey.shared.common.exception.Exceptions;
+import cafe.jeffrey.timeseries.TimeseriesData;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static cafe.jeffrey.microscope.core.web.MockMvcSupport.mockMvcTesterFor;
+
+@ExtendWith(MockitoExtension.class)
+class StwTimelineControllerTest {
+
+    @Mock
+    ProfileManagerResolver resolver;
+
+    @Mock
+    ProfileManager profileManager;
+
+    @Mock
+    StwTimelineManager stwManager;
+
+    @Test
+    void getsTimeline() {
+        when(resolver.resolve("p-1")).thenReturn(profileManager);
+        when(profileManager.stwTimelineManager()).thenReturn(stwManager);
+        when(stwManager.timeline(anyLong())).thenReturn(List.of());
+
+        MockMvcTester mvc = mockMvcTesterFor(new StwTimelineController(resolver));
+
+        assertThat(mvc.get().uri("/api/internal/profiles/p-1/stw/timeline")).hasStatusOk();
+    }
+
+    @Test
+    void getsBudget() {
+        when(resolver.resolve("p-1")).thenReturn(profileManager);
+        when(profileManager.stwTimelineManager()).thenReturn(stwManager);
+        when(stwManager.budget()).thenReturn(new TimeseriesData(List.of()));
+
+        MockMvcTester mvc = mockMvcTesterFor(new StwTimelineController(resolver));
+
+        assertThat(mvc.get().uri("/api/internal/profiles/p-1/stw/budget")).hasStatusOk();
+    }
+
+    @Test
+    void profileNotFoundReturns404() {
+        when(resolver.resolve("ghost")).thenThrow(Exceptions.profileNotFound("ghost"));
+
+        MockMvcTester mvc = mockMvcTesterFor(new StwTimelineController(resolver));
+
+        assertThat(mvc.get().uri("/api/internal/profiles/ghost/stw/timeline"))
+                .hasStatus(404)
+                .bodyJson()
+                .extractingPath("$.code").asString().isEqualTo("PROFILE_NOT_FOUND");
+    }
+}

--- a/jeffrey-microscope/pages-microscope/src/components/stw/StwDensityHeatmap.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/stw/StwDensityHeatmap.vue
@@ -1,0 +1,96 @@
+<template>
+  <div ref="chartEl" class="stw-density"></div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref, watch } from 'vue';
+import ApexCharts from 'apexcharts';
+import FormattingService from '@/services/FormattingService';
+import { STW_LANES } from '@/services/stw/stwLanes';
+import type { StwEvent } from '@/services/api/model/stw/StwModels';
+
+const props = defineProps<{
+  events: StwEvent[];
+}>();
+
+const chartEl = ref<HTMLElement | null>(null);
+let chart: ApexCharts | null = null;
+
+const NANOS_PER_MILLI = 1_000_000;
+const BUCKETS = 40;
+
+interface HeatPoint {
+  x: string;
+  y: number;
+}
+
+function buildSeries(): { name: string; data: HeatPoint[] }[] {
+  if (props.events.length === 0) {
+    return [];
+  }
+  const maxTime = props.events.reduce((max, event) => Math.max(max, event.timeOffsetMillis), 0) + 1;
+  const bucketWidth = Math.max(1, Math.ceil(maxTime / BUCKETS));
+  const bucketLabels: string[] = [];
+  for (let i = 0; i < BUCKETS; i++) {
+    bucketLabels.push(FormattingService.formatDurationMillisCoarse(i * bucketWidth));
+  }
+
+  // Lanes are listed bottom-to-top by ApexCharts, so reverse to keep GC on top.
+  return [...STW_LANES].reverse().map((lane) => {
+    const data: HeatPoint[] = bucketLabels.map((label) => ({ x: label, y: 0 }));
+    for (const event of props.events) {
+      if (event.category === lane.category) {
+        const bucket = Math.min(BUCKETS - 1, Math.floor(event.timeOffsetMillis / bucketWidth));
+        data[bucket].y += Math.round(event.durationNanos / NANOS_PER_MILLI);
+      }
+    }
+    return { name: lane.label, data };
+  });
+}
+
+function buildOptions(): ApexCharts.ApexOptions {
+  return {
+    chart: { type: 'heatmap', height: 280, toolbar: { show: false }, animations: { enabled: false } },
+    series: buildSeries(),
+    dataLabels: { enabled: false },
+    xaxis: {
+      type: 'category',
+      labels: { rotate: -45, hideOverlappingLabels: true }
+    },
+    tooltip: {
+      y: { formatter: (value: number) => FormattingService.formatDurationInMillis2Units(value) }
+    },
+    plotOptions: {
+      heatmap: { radius: 2, colorScale: { inverse: false } }
+    },
+    colors: ['rgb(228,87,46)']
+  };
+}
+
+function renderChart() {
+  if (!chartEl.value) {
+    return;
+  }
+  if (chart) {
+    chart.destroy();
+    chart = null;
+  }
+  chart = new ApexCharts(chartEl.value, buildOptions());
+  chart.render();
+}
+
+onMounted(renderChart);
+watch(() => props.events, renderChart);
+onUnmounted(() => {
+  if (chart) {
+    chart.destroy();
+    chart = null;
+  }
+});
+</script>
+
+<style scoped>
+.stw-density {
+  width: 100%;
+}
+</style>

--- a/jeffrey-microscope/pages-microscope/src/components/stw/StwLaneLegend.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/stw/StwLaneLegend.vue
@@ -1,0 +1,56 @@
+<template>
+  <div class="stw-legend">
+    <div v-for="lane in STW_LANES" :key="lane.category" class="stw-legend-item">
+      <span class="stw-legend-swatch" :style="{ backgroundColor: lane.color }"></span>
+      <span class="stw-legend-label">{{ lane.label }}</span>
+      <span class="stw-legend-count">{{ counts[lane.category] ?? 0 }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { STW_LANES } from '@/services/stw/stwLanes';
+import type { StwCategory, StwEvent } from '@/services/api/model/stw/StwModels';
+
+const props = defineProps<{
+  events: StwEvent[];
+}>();
+
+const counts = computed<Record<string, number>>(() => {
+  const result: Partial<Record<StwCategory, number>> = {};
+  for (const event of props.events) {
+    result[event.category] = (result[event.category] ?? 0) + 1;
+  }
+  return result as Record<string, number>;
+});
+</script>
+
+<style scoped>
+.stw-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.stw-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  color: var(--color-text);
+}
+
+.stw-legend-swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: var(--radius-sm);
+  display: inline-block;
+}
+
+.stw-legend-count {
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+</style>

--- a/jeffrey-microscope/pages-microscope/src/components/stw/StwMmuChart.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/stw/StwMmuChart.vue
@@ -1,0 +1,109 @@
+<template>
+  <div ref="chartEl" class="stw-mmu"></div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref, watch } from 'vue';
+import ApexCharts from 'apexcharts';
+import FormattingService from '@/services/FormattingService';
+import type { StwEvent } from '@/services/api/model/stw/StwModels';
+
+const props = defineProps<{
+  events: StwEvent[];
+}>();
+
+const chartEl = ref<HTMLElement | null>(null);
+let chart: ApexCharts | null = null;
+
+const NANOS_PER_MILLI = 1_000_000;
+// Window sizes (ms) for the Minimum Mutator Utilization curve.
+const WINDOWS_MS = [10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000];
+
+interface Stop {
+  start: number;
+  durMs: number;
+}
+
+function globalStops(): Stop[] {
+  return props.events
+    .filter((event) => event.category === 'GC_PAUSE' || event.category === 'VM_OPERATION')
+    .map((event) => ({ start: event.timeOffsetMillis, durMs: event.durationNanos / NANOS_PER_MILLI }))
+    .sort((a, b) => a.start - b.start);
+}
+
+// Worst-case total pause time within any window of length w, anchored at a pause start (sliding window).
+function maxPauseInWindow(stops: Stop[], windowMs: number): number {
+  let max = 0;
+  let j = 0;
+  let sum = 0;
+  for (let i = 0; i < stops.length; i++) {
+    if (j < i) {
+      j = i;
+      sum = 0;
+    }
+    while (j < stops.length && stops[j].start < stops[i].start + windowMs) {
+      sum += stops[j].durMs;
+      j++;
+    }
+    max = Math.max(max, sum);
+    sum -= stops[i].durMs;
+  }
+  return max;
+}
+
+function mmuSeries(): number[] {
+  const stops = globalStops();
+  return WINDOWS_MS.map((windowMs) => {
+    const worst = Math.min(maxPauseInWindow(stops, windowMs), windowMs);
+    return Math.max(0, (1 - worst / windowMs) * 100);
+  });
+}
+
+function buildOptions(): ApexCharts.ApexOptions {
+  return {
+    chart: { type: 'line', height: 320, toolbar: { show: false }, animations: { enabled: false } },
+    series: [{ name: 'Min Mutator Utilization', data: mmuSeries() }],
+    xaxis: {
+      categories: WINDOWS_MS.map((windowMs) => FormattingService.formatDurationMillisCoarse(windowMs)),
+      title: { text: 'Window size' }
+    },
+    yaxis: {
+      min: 0,
+      max: 100,
+      title: { text: 'Mutator utilization (%)' },
+      labels: { formatter: (value: number) => `${value.toFixed(0)}%` }
+    },
+    stroke: { curve: 'straight', width: 3 },
+    markers: { size: 4 },
+    dataLabels: { enabled: false },
+    colors: ['rgb(76,175,80)']
+  };
+}
+
+function renderChart() {
+  if (!chartEl.value) {
+    return;
+  }
+  if (chart) {
+    chart.destroy();
+    chart = null;
+  }
+  chart = new ApexCharts(chartEl.value, buildOptions());
+  chart.render();
+}
+
+onMounted(renderChart);
+watch(() => props.events, renderChart);
+onUnmounted(() => {
+  if (chart) {
+    chart.destroy();
+    chart = null;
+  }
+});
+</script>
+
+<style scoped>
+.stw-mmu {
+  width: 100%;
+}
+</style>

--- a/jeffrey-microscope/pages-microscope/src/components/stw/StwSwimlane.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/stw/StwSwimlane.vue
@@ -1,0 +1,135 @@
+<template>
+  <div ref="chartEl" class="stw-swimlane"></div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref, watch } from 'vue';
+import ApexCharts from 'apexcharts';
+import FormattingService from '@/services/FormattingService';
+import { STW_LANES, laneFor } from '@/services/stw/stwLanes';
+import type { StwEvent } from '@/services/api/model/stw/StwModels';
+
+const props = defineProps<{
+  events: StwEvent[];
+}>();
+
+const emit = defineEmits<{
+  select: [event: StwEvent];
+}>();
+
+const chartEl = ref<HTMLElement | null>(null);
+let chart: ApexCharts | null = null;
+
+// Parallel array: data point index -> source event, for click + tooltip lookups.
+let pointEvents: StwEvent[] = [];
+
+const ROW_HEIGHT_PX = 46;
+const MIN_HEIGHT_PX = 160;
+const NANOS_PER_MILLI = 1_000_000;
+
+interface RangePoint {
+  x: string;
+  y: [number, number];
+  fillColor: string;
+}
+
+function buildPoints(): RangePoint[] {
+  const points: RangePoint[] = [];
+  pointEvents = [];
+  for (const lane of STW_LANES) {
+    for (const event of props.events) {
+      if (event.category === lane.category) {
+        const start = event.timeOffsetMillis;
+        const end = start + event.durationNanos / NANOS_PER_MILLI;
+        points.push({ x: lane.label, y: [start, end], fillColor: lane.color });
+        pointEvents.push(event);
+      }
+    }
+  }
+  return points;
+}
+
+function presentLaneCount(): number {
+  const present = new Set(props.events.map((event) => event.category));
+  return STW_LANES.filter((lane) => present.has(lane.category)).length;
+}
+
+function buildOptions(): ApexCharts.ApexOptions {
+  return {
+    chart: {
+      type: 'rangeBar',
+      height: Math.max(MIN_HEIGHT_PX, presentLaneCount() * ROW_HEIGHT_PX),
+      animations: { enabled: false },
+      toolbar: { show: false },
+      events: {
+        dataPointSelection: (_event: unknown, _ctx: unknown, config: { dataPointIndex: number }) => {
+          const selected = pointEvents[config.dataPointIndex];
+          if (selected) {
+            emit('select', selected);
+          }
+        }
+      }
+    },
+    series: [{ name: 'Pauses', data: buildPoints() }],
+    plotOptions: {
+      bar: { horizontal: true, rangeBarGroupRows: true, barHeight: '60%' }
+    },
+    dataLabels: { enabled: false },
+    xaxis: {
+      type: 'numeric',
+      labels: {
+        formatter: (value: string | number) => FormattingService.formatDurationMillisCoarse(Number(value))
+      }
+    },
+    tooltip: {
+      custom: ({ dataPointIndex }: { dataPointIndex: number }) => {
+        const event = pointEvents[dataPointIndex];
+        if (!event) {
+          return '';
+        }
+        const lane = laneFor(event.category);
+        const duration = FormattingService.formatDuration2Units(event.durationNanos);
+        const at = FormattingService.formatDurationMillisCoarse(event.timeOffsetMillis);
+        const thread = event.thread ? `<div>Thread: ${event.thread}</div>` : '';
+        return (
+          `<div class="stw-tooltip">` +
+          `<div><strong>${lane.label}</strong></div>` +
+          `<div>${event.label}</div>` +
+          `<div>Duration: ${duration}</div>` +
+          `<div>At: +${at}</div>` +
+          thread +
+          `</div>`
+        );
+      }
+    },
+    legend: { show: false }
+  };
+}
+
+function renderChart() {
+  if (!chartEl.value) {
+    return;
+  }
+  if (chart) {
+    chart.destroy();
+    chart = null;
+  }
+  chart = new ApexCharts(chartEl.value, buildOptions());
+  chart.render();
+}
+
+onMounted(renderChart);
+watch(() => props.events, renderChart, { deep: false });
+onUnmounted(() => {
+  if (chart) {
+    chart.destroy();
+    chart = null;
+  }
+});
+</script>
+
+<style scoped>
+.stw-swimlane {
+  width: 100%;
+}
+</style>

--- a/jeffrey-microscope/pages-microscope/src/router/index.ts
+++ b/jeffrey-microscope/pages-microscope/src/router/index.ts
@@ -230,6 +230,12 @@ const profileChildRoutes = [
     meta: { layout: 'profile' }
   },
   {
+    path: 'stop-the-world',
+    name: 'profile-stw-timeline',
+    component: () => import('@/views/profiles/detail/ProfileStwTimeline.vue'),
+    meta: { layout: 'profile' }
+  },
+  {
     path: 'socket-io',
     name: 'profile-socket-io',
     component: () => import('@/views/profiles/detail/ProfileSocketIo.vue'),

--- a/jeffrey-microscope/pages-microscope/src/services/api/ProfileStwClient.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/ProfileStwClient.ts
@@ -1,0 +1,36 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import BaseProfileClient from '@/services/api/BaseProfileClient';
+import TimeseriesData from '@/services/timeseries/model/TimeseriesData';
+import type { StwEvent } from '@/services/api/model/stw/StwModels';
+
+export default class ProfileStwClient extends BaseProfileClient {
+  constructor(profileId: string) {
+    super(profileId, 'stw');
+  }
+
+  public getTimeline(minDurationNanos?: number): Promise<StwEvent[]> {
+    const params = minDurationNanos === undefined ? undefined : { minDurationNanos };
+    return this.get<StwEvent[]>('/timeline', params);
+  }
+
+  public getBudget(): Promise<TimeseriesData> {
+    return this.get<TimeseriesData>('/budget');
+  }
+}

--- a/jeffrey-microscope/pages-microscope/src/services/api/model/stw/StwModels.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/model/stw/StwModels.ts
@@ -1,0 +1,37 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export type StwScope = 'GLOBAL' | 'LOCAL';
+
+export type StwCategory =
+  | 'GC_PAUSE'
+  | 'VM_OPERATION'
+  | 'TIME_TO_SAFEPOINT'
+  | 'MONITOR'
+  | 'PARK'
+  | 'PINNED';
+
+export interface StwEvent {
+  category: StwCategory;
+  scope: StwScope;
+  timeOffsetMillis: number;
+  durationNanos: number;
+  label: string;
+  thread: string | null;
+  gcId: number | null;
+}

--- a/jeffrey-microscope/pages-microscope/src/services/stw/stwLanes.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/stw/stwLanes.ts
@@ -1,0 +1,52 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { StwCategory, StwScope } from '@/services/api/model/stw/StwModels';
+
+export interface StwLane {
+  category: StwCategory;
+  label: string;
+  scope: StwScope;
+  // Literal canvas/SVG fill colors (ApexCharts cannot resolve CSS var()); mirrors ThreadRow.ts.
+  color: string;
+}
+
+/**
+ * Lane order and presentation for the STW timeline — GLOBAL (whole-JVM) lanes first, then LOCAL
+ * (per-thread) stalls. Keyed lookups avoid scattering category metadata across components.
+ */
+export const STW_LANES: StwLane[] = [
+  { category: 'GC_PAUSE', label: 'GC Pause', scope: 'GLOBAL', color: 'rgb(245,166,35)' },
+  { category: 'VM_OPERATION', label: 'VM Operation', scope: 'GLOBAL', color: 'rgb(228,87,46)' },
+  { category: 'TIME_TO_SAFEPOINT', label: 'Time to Safepoint', scope: 'GLOBAL', color: 'rgb(142,68,173)' },
+  { category: 'MONITOR', label: 'Monitor Contention', scope: 'LOCAL', color: 'rgb(236,204,116)' },
+  { category: 'PARK', label: 'Thread Park', scope: 'LOCAL', color: 'rgb(134,173,225)' },
+  { category: 'PINNED', label: 'VThread Pinned', scope: 'LOCAL', color: 'rgb(241,135,168)' }
+];
+
+const LANE_BY_CATEGORY: Record<StwCategory, StwLane> = STW_LANES.reduce(
+  (acc, lane) => {
+    acc[lane.category] = lane;
+    return acc;
+  },
+  {} as Record<StwCategory, StwLane>
+);
+
+export function laneFor(category: StwCategory): StwLane {
+  return LANE_BY_CATEGORY[category];
+}

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/ProfileDetail.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/ProfileDetail.vue
@@ -217,6 +217,14 @@
                       <span>Blocking Operations</span>
                     </router-link>
                     <router-link
+                      :to="`/profiles/${profileId}/stop-the-world`"
+                      class="nav-item"
+                      active-class="active"
+                    >
+                      <i class="bi bi-pause-circle"></i>
+                      <span>Stop-The-World</span>
+                    </router-link>
+                    <router-link
                       :to="`/profiles/${profileId}/socket-io`"
                       class="nav-item"
                       active-class="active"

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileStwTimeline.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileStwTimeline.vue
@@ -162,6 +162,63 @@
         </template>
       </div>
 
+      <!-- Analysis -->
+      <div v-show="activeTab === 'analysis'">
+        <EmptyState
+          v-if="events.length === 0"
+          icon="bi-graph-up"
+          title="Nothing to analyze"
+          description="This recording has no stop-the-world pauses."
+        />
+        <template v-else>
+          <ChartSection title="Pause-Budget Simulator" icon="bi-sliders">
+            <div class="whatif">
+              <label class="whatif-label">
+                Max acceptable pause: <strong>{{ FormattingService.formatDurationMillisCoarse(whatIfThresholdMs) }}</strong>
+              </label>
+              <input
+                v-model.number="whatIfThresholdMs"
+                type="range"
+                min="0"
+                :max="Math.max(1, maxPauseMillis)"
+                step="1"
+                class="form-range whatif-range"
+              />
+              <div class="whatif-stats">
+                <div class="whatif-stat">
+                  <span class="whatif-value">{{ FormattingService.formatNumber(violations.length) }}</span>
+                  <span class="whatif-key">pauses exceed the limit</span>
+                </div>
+                <div class="whatif-stat">
+                  <span class="whatif-value">{{ FormattingService.formatDuration2Units(violationTotalNanos) }}</span>
+                  <span class="whatif-key">total time over the limit</span>
+                </div>
+                <div class="whatif-stat">
+                  <span class="whatif-value">{{ availabilityPercent.toFixed(3) }}%</span>
+                  <span class="whatif-key">app availability (global STW)</span>
+                </div>
+              </div>
+            </div>
+          </ChartSection>
+
+          <ChartSection title="Minimum Mutator Utilization" icon="bi-activity" class="mt-4">
+            <ChartDescription
+              shows="For each window size, the worst-case fraction of time the application actually ran (was not in a global STW pause)."
+              use-case="A low MMU at small windows means short, frequent pauses; a low MMU only at large windows means rare but very long pauses."
+            />
+            <StwMmuChart :events="events" />
+          </ChartSection>
+
+          <ChartSection title="Pause Density" icon="bi-grid-3x3" class="mt-4">
+            <ChartDescription
+              shows="Total pause time per lane across time buckets — darker cells are heavier stop concentration."
+              use-case="Spot clustering (a bad phase) vs. steady background pauses, even when individual pauses are tiny."
+            />
+            <StwDensityHeatmap :events="events" />
+          </ChartSection>
+        </template>
+      </div>
+
       <!-- How It Works -->
       <div v-show="activeTab === 'about'">
         <AboutPanel
@@ -271,6 +328,8 @@ import FeatureGrid from '@/components/about/FeatureGrid.vue';
 import FeatureCard from '@/components/about/FeatureCard.vue';
 import StwSwimlane from '@/components/stw/StwSwimlane.vue';
 import StwLaneLegend from '@/components/stw/StwLaneLegend.vue';
+import StwMmuChart from '@/components/stw/StwMmuChart.vue';
+import StwDensityHeatmap from '@/components/stw/StwDensityHeatmap.vue';
 import FormattingService from '@/services/FormattingService';
 import AxisFormatType from '@/services/timeseries/AxisFormatType';
 import { useTableView } from '@/composables/useTableView';
@@ -302,8 +361,11 @@ const NANOS_PER_MILLI = 1_000_000;
 const tabs: TabBarItem[] = [
   { id: 'timeline', label: 'Timeline', icon: 'bar-chart-steps' },
   { id: 'inventory', label: 'Inventory', icon: 'table' },
+  { id: 'analysis', label: 'Analysis', icon: 'graph-up' },
   { id: 'about', label: 'How It Works', icon: 'book' }
 ];
+
+const whatIfThresholdMs = ref(50);
 
 const globalBudget = computed<number[][]>(() => budget.value?.series?.[0]?.data ?? []);
 const localBudget = computed<number[][]>(() => budget.value?.series?.[1]?.data ?? []);
@@ -370,6 +432,41 @@ const concurrentEvents = computed<StwEvent[]>(() => {
 const inventoryView = useTableView<StwEvent>(() => events.value, {
   searchableText: (row) => `${laneFor(row.category).label} ${row.label} ${row.thread ?? ''}`
 });
+
+// --- Analysis: what-if budget simulator (global stop-the-world pauses only) ---
+const globalStops = computed<StwEvent[]>(() =>
+  events.value.filter((event) => event.category === 'GC_PAUSE' || event.category === 'VM_OPERATION')
+);
+
+const wallClockMillis = computed<number>(() =>
+  events.value.reduce(
+    (max, event) => Math.max(max, event.timeOffsetMillis + event.durationNanos / NANOS_PER_MILLI),
+    0
+  )
+);
+
+const maxPauseMillis = computed<number>(() =>
+  Math.ceil(globalStops.value.reduce((max, event) => Math.max(max, event.durationNanos / NANOS_PER_MILLI), 0))
+);
+
+const totalGlobalStopMillis = computed<number>(() =>
+  globalStops.value.reduce((sum, event) => sum + event.durationNanos / NANOS_PER_MILLI, 0)
+);
+
+const availabilityPercent = computed<number>(() => {
+  if (wallClockMillis.value <= 0) {
+    return 100;
+  }
+  return Math.max(0, (1 - totalGlobalStopMillis.value / wallClockMillis.value) * 100);
+});
+
+const violations = computed<StwEvent[]>(() =>
+  globalStops.value.filter((event) => event.durationNanos / NANOS_PER_MILLI > whatIfThresholdMs.value)
+);
+
+const violationTotalNanos = computed<number>(() =>
+  violations.value.reduce((sum, event) => sum + event.durationNanos, 0)
+);
 
 function badgeVariant(scope: StwScope): Variant {
   return scope === 'GLOBAL' ? 'danger' : 'warning';
@@ -452,6 +549,39 @@ onMounted(async () => {
   font-size: 0.7rem;
   text-transform: uppercase;
   letter-spacing: 0.4px;
+  color: var(--color-text-muted);
+}
+
+.whatif-label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.whatif-range {
+  max-width: 480px;
+}
+
+.whatif-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  margin-top: 0.75rem;
+}
+
+.whatif-stat {
+  display: flex;
+  flex-direction: column;
+}
+
+.whatif-value {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.whatif-key {
+  font-size: 0.75rem;
   color: var(--color-text-muted);
 }
 

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileStwTimeline.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileStwTimeline.vue
@@ -1,0 +1,464 @@
+<template>
+  <div class="stw-container">
+    <LoadingState v-if="loading" message="Loading stop-the-world data..." />
+    <ErrorState v-else-if="error" message="Failed to load stop-the-world data" />
+
+    <div v-else>
+      <PageHeader
+        title="Stop-The-World"
+        description="Every JVM pause on one timeline — GC pauses, safepoint operations, time-to-safepoint, and per-thread stalls — with the app-stop budget and click-to-explain drill-down"
+        icon="bi-pause-circle"
+      />
+
+      <TabBar v-model="activeTab" :tabs="tabs" class="mb-3" />
+
+      <!-- Timeline -->
+      <div v-show="activeTab === 'timeline'">
+        <EmptyState
+          v-if="events.length === 0"
+          icon="bi-pause-circle"
+          title="No stop-the-world pauses recorded"
+          description="This recording has no GC pauses, safepoint operations, or thread stalls above the display threshold."
+        />
+        <template v-else>
+          <ChartDescription
+            shows="The app-stop budget (frozen nanoseconds per second: whole-JVM 'Global STW' vs per-thread 'Local Stalls') above a swimlane of every individual pause."
+            use-case="Find when and why the app was frozen: brush the budget to zoom, then click any pause to see what else happened in that window."
+          />
+
+          <ChartSection title="App-Stop Budget" icon="bi-hourglass-split" :full-width="true">
+            <TimeSeriesChart
+              :primaryData="globalBudget"
+              primaryTitle="Global STW"
+              :secondaryData="localBudget"
+              secondaryTitle="Local Stalls"
+              :primaryAxisType="AxisFormatType.DURATION_IN_NANOS"
+              :secondaryAxisType="AxisFormatType.DURATION_IN_NANOS"
+              :visibleMinutes="60"
+              zoomEnabled
+              @update:timeRange="onTimeRange"
+            />
+          </ChartSection>
+
+          <StwLaneLegend :events="events" />
+          <StwSwimlane :events="visibleEvents" @select="openDrawer" />
+
+          <div class="rails mt-4">
+            <ChartSection title="Machine CPU" icon="bi-cpu">
+              <TimeSeriesChart
+                :primaryData="cpuSeries"
+                primaryTitle="Machine CPU"
+                :primaryAxisType="AxisFormatType.PERCENT_IN_HUNDREDTHS"
+                :visibleMinutes="60"
+              />
+            </ChartSection>
+            <ChartSection title="Context Switches" icon="bi-arrow-left-right">
+              <TimeSeriesChart
+                :primaryData="ctxSeries"
+                primaryTitle="Context Switches / sec"
+                :primaryAxisType="AxisFormatType.NUMBER"
+                :visibleMinutes="60"
+              />
+            </ChartSection>
+          </div>
+        </template>
+      </div>
+
+      <!-- Inventory -->
+      <div v-show="activeTab === 'inventory'">
+        <EmptyState
+          v-if="events.length === 0"
+          icon="bi-table"
+          title="No pauses to list"
+          description="This recording has no stop-the-world pauses above the display threshold."
+        />
+        <template v-else>
+          <div class="inventory-cards">
+            <ChartSection title="Longest Pauses" icon="bi-trophy">
+              <div class="table-responsive">
+                <table class="table table-sm table-hover mb-0">
+                  <thead>
+                    <tr>
+                      <th>Category</th>
+                      <th>Cause</th>
+                      <th class="text-end">Duration</th>
+                      <th class="text-end">At</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="(event, index) in leaderboard" :key="index" @click="openDrawer(event)" role="button">
+                      <td><Badge :value="laneFor(event.category).label" :variant="badgeVariant(event.scope)" size="xs" borderless /></td>
+                      <td class="cause-cell" :title="event.label">{{ event.label }}</td>
+                      <td class="text-end">{{ FormattingService.formatDuration2Units(event.durationNanos) }}</td>
+                      <td class="text-end">+{{ FormattingService.formatDurationMillisCoarse(event.timeOffsetMillis) }}</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </ChartSection>
+
+            <ChartSection title="Cause Attribution" icon="bi-pie-chart">
+              <div class="table-responsive">
+                <table class="table table-sm table-hover mb-0">
+                  <thead>
+                    <tr>
+                      <th>Category</th>
+                      <th>Cause</th>
+                      <th class="text-end">Count</th>
+                      <th class="text-end">Total Time</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="(row, index) in causeAttribution" :key="index">
+                      <td><Badge :value="laneFor(row.category).label" :variant="badgeVariant(laneFor(row.category).scope)" size="xs" borderless /></td>
+                      <td class="cause-cell" :title="row.label">{{ row.label }}</td>
+                      <td class="text-end">{{ FormattingService.formatNumber(row.count) }}</td>
+                      <td class="text-end">{{ FormattingService.formatDuration2Units(row.totalNanos) }}</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </ChartSection>
+          </div>
+
+          <DataTable class="mt-4">
+            <template #toolbar>
+              <TableToolbar v-model="inventoryView.query" search-placeholder="Filter pauses...">
+                <span class="toolbar-info">All pauses</span>
+                <template #filters>
+                  <Badge key-label="Total" :value="inventoryView.matchCount" variant="secondary" size="s" borderless />
+                </template>
+              </TableToolbar>
+            </template>
+            <thead>
+              <tr>
+                <th>At</th>
+                <th>Category</th>
+                <th>Cause</th>
+                <th class="text-end">Duration</th>
+                <th>Thread</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(event, index) in inventoryView.visible" :key="index" @click="openDrawer(event)" role="button">
+                <td>+{{ FormattingService.formatDurationMillisCoarse(event.timeOffsetMillis) }}</td>
+                <td><Badge :value="laneFor(event.category).label" :variant="badgeVariant(event.scope)" size="xs" borderless /></td>
+                <td class="cause-cell" :title="event.label">{{ event.label }}</td>
+                <td class="text-end">{{ FormattingService.formatDuration2Units(event.durationNanos) }}</td>
+                <td class="text-muted">{{ event.thread ?? '—' }}</td>
+              </tr>
+            </tbody>
+            <template #footer>
+              <TableShowMore
+                :shown="inventoryView.visible.length"
+                :match-count="inventoryView.matchCount"
+                :total="inventoryView.total"
+                :expanded="inventoryView.expanded"
+                :page-size="inventoryView.pageSize"
+                @toggle="inventoryView.toggle"
+              />
+            </template>
+          </DataTable>
+        </template>
+      </div>
+
+      <!-- How It Works -->
+      <div v-show="activeTab === 'about'">
+        <AboutPanel
+          icon="bi-question-circle"
+          title="Understanding Stop-The-World"
+          subtitle="Why your application threads stop, and how to read this page"
+        >
+          <AboutCallout variant="intro">
+            <p>
+              A "stop-the-world" (STW) pause freezes <em>every</em> application thread while the JVM does
+              something it can't do concurrently — a GC pause, or a safepoint operation. This page merges
+              all of those onto one axis, plus per-thread stalls, so you can see what froze the app and when.
+            </p>
+          </AboutCallout>
+
+          <AboutSection icon="bi-layers" title="The Lanes">
+            <FeatureGrid>
+              <FeatureCard icon="bi-recycle" variant="warning" title="GC Pause">
+                Stop-the-world collection time (uses sum-of-pauses, so concurrent GC time is excluded).
+              </FeatureCard>
+              <FeatureCard icon="bi-stopwatch" variant="danger" title="VM Operation">
+                Safepoint operations (the JVM stopped to run an internal operation).
+              </FeatureCard>
+              <FeatureCard icon="bi-hourglass-split" variant="primary" title="Time to Safepoint">
+                How long the JVM waited for all threads to reach the safepoint — latency to <em>stop</em>,
+                shown separately and excluded from the budget to avoid double-counting.
+              </FeatureCard>
+              <FeatureCard icon="bi-lock" variant="info" title="Local Stalls">
+                Per-thread (not whole-JVM): monitor contention, thread parking, virtual-thread pinning.
+              </FeatureCard>
+            </FeatureGrid>
+          </AboutSection>
+
+          <AboutSection icon="bi-broadcast" title="How JFR Emits This">
+            <ul>
+              <li><code>jdk.GarbageCollection</code> — GC pause time per collection.</li>
+              <li><code>jdk.ExecuteVMOperation</code> — safepoint VM operations.</li>
+              <li><code>jdk.SafepointStateSynchronization</code> — time-to-safepoint.</li>
+              <li><code>jdk.JavaMonitorEnter</code>, <code>jdk.ThreadPark</code>, <code>jdk.VirtualThreadPinned</code> — per-thread stalls.</li>
+            </ul>
+            <p>ZGC allocation stalls will join as a lane once that event support lands.</p>
+          </AboutSection>
+        </AboutPanel>
+      </div>
+    </div>
+
+    <!-- Click-a-pause drawer -->
+    <GenericModal modal-id="stwDetailModal" :show="showDrawer" size="lg" :show-footer="false" @update:show="showDrawer = $event">
+      <template #title>Pause detail</template>
+      <div v-if="selectedEvent" class="drawer-body">
+        <div class="drawer-grid">
+          <div><span class="drawer-key">Category</span><Badge :value="laneFor(selectedEvent.category).label" :variant="badgeVariant(selectedEvent.scope)" size="s" borderless /></div>
+          <div><span class="drawer-key">Scope</span>{{ selectedEvent.scope }}</div>
+          <div><span class="drawer-key">Cause</span>{{ selectedEvent.label }}</div>
+          <div><span class="drawer-key">Duration</span>{{ FormattingService.formatDuration2Units(selectedEvent.durationNanos) }}</div>
+          <div><span class="drawer-key">At</span>+{{ FormattingService.formatDurationMillisCoarse(selectedEvent.timeOffsetMillis) }}</div>
+          <div v-if="selectedEvent.thread"><span class="drawer-key">Thread</span>{{ selectedEvent.thread }}</div>
+          <div v-if="selectedEvent.gcId !== null"><span class="drawer-key">GC ID</span>{{ selectedEvent.gcId }}</div>
+        </div>
+
+        <h6 class="mt-3 mb-2">Concurrent in this window</h6>
+        <div class="table-responsive">
+          <table class="table table-sm table-hover mb-0">
+            <thead>
+              <tr><th>Category</th><th>Cause</th><th class="text-end">Duration</th><th class="text-end">At</th></tr>
+            </thead>
+            <tbody>
+              <tr v-for="(event, index) in concurrentEvents" :key="index">
+                <td><Badge :value="laneFor(event.category).label" :variant="badgeVariant(event.scope)" size="xs" borderless /></td>
+                <td class="cause-cell" :title="event.label">{{ event.label }}</td>
+                <td class="text-end">{{ FormattingService.formatDuration2Units(event.durationNanos) }}</td>
+                <td class="text-end">+{{ FormattingService.formatDurationMillisCoarse(event.timeOffsetMillis) }}</td>
+              </tr>
+              <tr v-if="concurrentEvents.length === 0">
+                <td colspan="4" class="text-muted text-center">No other pauses overlap this window.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </GenericModal>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { useRoute } from 'vue-router';
+
+import PageHeader from '@/components/layout/PageHeader.vue';
+import TabBar from '@/components/TabBar.vue';
+import type { TabBarItem } from '@/components/TabBar.vue';
+import TimeSeriesChart from '@/components/TimeSeriesChart.vue';
+import ChartSection from '@/components/ChartSection.vue';
+import ChartDescription from '@/components/ChartDescription.vue';
+import DataTable from '@/components/table/DataTable.vue';
+import TableToolbar from '@/components/table/TableToolbar.vue';
+import TableShowMore from '@/components/table/TableShowMore.vue';
+import Badge from '@/components/Badge.vue';
+import EmptyState from '@/components/EmptyState.vue';
+import LoadingState from '@/components/LoadingState.vue';
+import ErrorState from '@/components/ErrorState.vue';
+import GenericModal from '@/components/GenericModal.vue';
+import AboutPanel from '@/components/about/AboutPanel.vue';
+import AboutCallout from '@/components/about/AboutCallout.vue';
+import AboutSection from '@/components/about/AboutSection.vue';
+import FeatureGrid from '@/components/about/FeatureGrid.vue';
+import FeatureCard from '@/components/about/FeatureCard.vue';
+import StwSwimlane from '@/components/stw/StwSwimlane.vue';
+import StwLaneLegend from '@/components/stw/StwLaneLegend.vue';
+import FormattingService from '@/services/FormattingService';
+import AxisFormatType from '@/services/timeseries/AxisFormatType';
+import { useTableView } from '@/composables/useTableView';
+import { laneFor } from '@/services/stw/stwLanes';
+import ProfileStwClient from '@/services/api/ProfileStwClient';
+import ProfileSystemClient from '@/services/api/ProfileSystemClient';
+import type { StwEvent, StwScope } from '@/services/api/model/stw/StwModels';
+import type { Variant } from '@/types/ui';
+import type TimeseriesData from '@/services/timeseries/model/TimeseriesData';
+
+const route = useRoute();
+
+const loading = ref(true);
+const error = ref(false);
+const activeTab = ref('timeline');
+
+const events = ref<StwEvent[]>([]);
+const budget = ref<TimeseriesData>();
+const cpu = ref<TimeseriesData>();
+const ctx = ref<TimeseriesData>();
+
+const selectedEvent = ref<StwEvent | null>(null);
+const showDrawer = ref(false);
+const visibleRange = ref<{ start: number; end: number } | null>(null);
+
+const MILLIS_PER_SECOND = 1000;
+const NANOS_PER_MILLI = 1_000_000;
+
+const tabs: TabBarItem[] = [
+  { id: 'timeline', label: 'Timeline', icon: 'bar-chart-steps' },
+  { id: 'inventory', label: 'Inventory', icon: 'table' },
+  { id: 'about', label: 'How It Works', icon: 'book' }
+];
+
+const globalBudget = computed<number[][]>(() => budget.value?.series?.[0]?.data ?? []);
+const localBudget = computed<number[][]>(() => budget.value?.series?.[1]?.data ?? []);
+const cpuSeries = computed<number[][]>(() => cpu.value?.series?.[0]?.data ?? []);
+const ctxSeries = computed<number[][]>(() => ctx.value?.series?.[0]?.data ?? []);
+
+// Brush selection (budget x-axis is per-second) filters the swimlane; falls back to all on any mismatch.
+const visibleEvents = computed<StwEvent[]>(() => {
+  const range = visibleRange.value;
+  if (!range) {
+    return events.value;
+  }
+  const startMs = range.start * MILLIS_PER_SECOND;
+  const endMs = range.end * MILLIS_PER_SECOND;
+  const filtered = events.value.filter(
+    (event) => event.timeOffsetMillis >= startMs && event.timeOffsetMillis <= endMs
+  );
+  return filtered.length > 0 ? filtered : events.value;
+});
+
+const leaderboard = computed<StwEvent[]>(() =>
+  [...events.value].sort((a, b) => b.durationNanos - a.durationNanos).slice(0, 15)
+);
+
+interface CauseRow {
+  category: StwEvent['category'];
+  label: string;
+  count: number;
+  totalNanos: number;
+}
+
+const causeAttribution = computed<CauseRow[]>(() => {
+  const byCause = new Map<string, CauseRow>();
+  for (const event of events.value) {
+    const key = `${event.category}::${event.label}`;
+    const existing = byCause.get(key);
+    if (existing) {
+      existing.count += 1;
+      existing.totalNanos += event.durationNanos;
+    } else {
+      byCause.set(key, { category: event.category, label: event.label, count: 1, totalNanos: event.durationNanos });
+    }
+  }
+  return [...byCause.values()].sort((a, b) => b.totalNanos - a.totalNanos).slice(0, 25);
+});
+
+const concurrentEvents = computed<StwEvent[]>(() => {
+  const selected = selectedEvent.value;
+  if (!selected) {
+    return [];
+  }
+  const start = selected.timeOffsetMillis;
+  const end = start + selected.durationNanos / NANOS_PER_MILLI;
+  return events.value.filter((event) => {
+    if (event === selected) {
+      return false;
+    }
+    const eventStart = event.timeOffsetMillis;
+    const eventEnd = eventStart + event.durationNanos / NANOS_PER_MILLI;
+    return eventStart <= end && eventEnd >= start;
+  });
+});
+
+const inventoryView = useTableView<StwEvent>(() => events.value, {
+  searchableText: (row) => `${laneFor(row.category).label} ${row.label} ${row.thread ?? ''}`
+});
+
+function badgeVariant(scope: StwScope): Variant {
+  return scope === 'GLOBAL' ? 'danger' : 'warning';
+}
+
+function onTimeRange(payload: { start: number; end: number; isZoomed: boolean }) {
+  visibleRange.value = payload.isZoomed ? { start: payload.start, end: payload.end } : null;
+}
+
+function openDrawer(event: StwEvent) {
+  selectedEvent.value = event;
+  showDrawer.value = true;
+}
+
+onMounted(async () => {
+  try {
+    const profileId = route.params.profileId as string;
+    const stwClient = new ProfileStwClient(profileId);
+    const systemClient = new ProfileSystemClient(profileId);
+
+    const [timelineResult, budgetResult, cpuResult, ctxResult] = await Promise.all([
+      stwClient.getTimeline(),
+      stwClient.getBudget(),
+      systemClient.getCpuTimeline(),
+      systemClient.getContextSwitchTimeline()
+    ]);
+
+    events.value = timelineResult;
+    budget.value = budgetResult;
+    cpu.value = cpuResult;
+    ctx.value = ctxResult;
+    loading.value = false;
+  } catch (e) {
+    console.error('Failed to load stop-the-world data:', e);
+    error.value = true;
+    loading.value = false;
+  }
+});
+</script>
+
+<style scoped>
+.stw-container {
+  width: 100%;
+  color: var(--color-text);
+}
+
+.rails {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.inventory-cards {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.toolbar-info {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--color-text);
+}
+
+.cause-cell {
+  max-width: 360px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.drawer-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem 1.5rem;
+}
+
+.drawer-key {
+  display: block;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: var(--color-text-muted);
+}
+
+@media (max-width: 992px) {
+  .rails,
+  .inventory-cards {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/configuration/ProfileFactoriesConfiguration.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/configuration/ProfileFactoriesConfiguration.java
@@ -147,7 +147,8 @@ public class ProfileFactoriesConfiguration {
             AllocationManager.Factory allocationFactory,
             LeakCandidatesManager.Factory leakCandidatesFactory,
             SecurityManager.Factory securityFactory,
-            SpanManager.Factory spanFactory) {
+            SpanManager.Factory spanFactory,
+            StwTimelineManager.Factory stwTimelineFactory) {
 
         return new JvmInsightFactories(
                 gcFactory,
@@ -169,7 +170,8 @@ public class ProfileFactoriesConfiguration {
                 allocationFactory,
                 leakCandidatesFactory,
                 securityFactory,
-                spanFactory);
+                spanFactory,
+                stwTimelineFactory);
     }
 
     /**
@@ -515,6 +517,17 @@ public class ProfileFactoriesConfiguration {
             return new GarbageCollectionManagerImpl(
                     profileInfo,
                     profileRepositories.newEventRepository(profileDb),
+                    profileRepositories.newEventStreamRepository(profileDb));
+        };
+    }
+
+    @Bean
+    public StwTimelineManager.Factory stwTimelineManagerFactory() {
+
+        return profileInfo -> {
+            DataSource profileDb = databaseManagerResolver.open(profileInfo);
+            return new StwTimelineManagerImpl(
+                    profileInfo,
                     profileRepositories.newEventStreamRepository(profileDb));
         };
     }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/ProfileManager.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/ProfileManager.java
@@ -75,6 +75,8 @@ public interface ProfileManager {
 
     VmOperationManager vmOperationManager();
 
+    StwTimelineManager stwTimelineManager();
+
     BlockingManager blockingManager();
 
     VirtualThreadManager virtualThreadManager();

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/ProfileManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/ProfileManagerImpl.java
@@ -162,6 +162,11 @@ public class ProfileManagerImpl implements ProfileManager {
     }
 
     @Override
+    public StwTimelineManager stwTimelineManager() {
+        return registry.jvmInsight().stwTimeline().apply(profileInfo);
+    }
+
+    @Override
     public BlockingManager blockingManager() {
         return registry.jvmInsight().blocking().apply(profileInfo);
     }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/StwTimelineManager.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/StwTimelineManager.java
@@ -1,0 +1,50 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager;
+
+import cafe.jeffrey.profile.manager.model.stw.StwEvent;
+import cafe.jeffrey.shared.common.model.ProfileInfo;
+import cafe.jeffrey.timeseries.TimeseriesData;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * The Unified Stop-The-World view for a single profile: every JVM pause source (GC pauses, safepoint
+ * VM operations, time-to-safepoint, monitor contention, thread parking, virtual-thread pinning) merged
+ * onto one time axis, plus the aggregate app-stop budget.
+ */
+public interface StwTimelineManager {
+
+    @FunctionalInterface
+    interface Factory extends Function<ProfileInfo, StwTimelineManager> {
+    }
+
+    /**
+     * Every pause at least {@code minDurationNanos} long, in chronological order — powers the swimlane
+     * timeline, inventory, leaderboard and cause attribution.
+     */
+    List<StwEvent> timeline(long minDurationNanos);
+
+    /**
+     * Frozen time per second as two series — "Global STW" (whole-JVM) and "Local Stalls" (per-thread).
+     * Sums all pauses regardless of duration, so it is complete even when {@link #timeline} is thresholded.
+     */
+    TimeseriesData budget();
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/StwTimelineManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/StwTimelineManagerImpl.java
@@ -1,0 +1,61 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager;
+
+import cafe.jeffrey.profile.manager.model.stw.StwBudgetBuilder;
+import cafe.jeffrey.profile.manager.model.stw.StwClassifier;
+import cafe.jeffrey.profile.manager.model.stw.StwEvent;
+import cafe.jeffrey.profile.manager.model.stw.StwTimelineBuilder;
+import cafe.jeffrey.provider.profile.api.EventQueryConfigurer;
+import cafe.jeffrey.provider.profile.api.ProfileEventStreamRepository;
+import cafe.jeffrey.shared.common.model.ProfileInfo;
+import cafe.jeffrey.shared.common.model.time.RelativeTimeRange;
+import cafe.jeffrey.timeseries.TimeseriesData;
+
+import java.util.List;
+
+public class StwTimelineManagerImpl implements StwTimelineManager {
+
+    private final ProfileInfo profileInfo;
+    private final ProfileEventStreamRepository eventStreamRepository;
+
+    public StwTimelineManagerImpl(
+            ProfileInfo profileInfo,
+            ProfileEventStreamRepository eventStreamRepository) {
+        this.profileInfo = profileInfo;
+        this.eventStreamRepository = eventStreamRepository;
+    }
+
+    @Override
+    public List<StwEvent> timeline(long minDurationNanos) {
+        EventQueryConfigurer configurer = new EventQueryConfigurer()
+                .withEventTypes(StwClassifier.SOURCE_TYPES)
+                .withJsonFields();
+        return eventStreamRepository.genericStreaming(configurer, new StwTimelineBuilder(minDurationNanos));
+    }
+
+    @Override
+    public TimeseriesData budget() {
+        RelativeTimeRange timeRange = new RelativeTimeRange(profileInfo.profilingStartEnd());
+        EventQueryConfigurer configurer = new EventQueryConfigurer()
+                .withEventTypes(StwClassifier.SOURCE_TYPES)
+                .withJsonFields();
+        return eventStreamRepository.genericStreaming(configurer, new StwBudgetBuilder(timeRange));
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/stw/StwBudgetBuilder.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/stw/StwBudgetBuilder.java
@@ -1,0 +1,69 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.stw;
+
+import org.eclipse.collections.impl.map.mutable.primitive.LongLongHashMap;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.provider.profile.api.RecordBuilder;
+import cafe.jeffrey.shared.common.model.time.RelativeTimeRange;
+import cafe.jeffrey.timeseries.SingleSerie;
+import cafe.jeffrey.timeseries.TimeseriesData;
+import cafe.jeffrey.timeseries.TimeseriesUtils;
+
+/**
+ * The app-stop budget: frozen nanoseconds summed per second into two series — "Global STW" (whole-JVM
+ * pauses: GC + safepoint VM operations) and "Local Stalls" (per-thread: monitor / park / pinning).
+ * Sums <em>every</em> classified event (no duration threshold) so the band is complete even when the
+ * per-event timeline is thresholded. Time-to-safepoint is excluded (see {@link StwCategory#stopBudget}).
+ */
+public class StwBudgetBuilder implements RecordBuilder<GenericRecord, TimeseriesData> {
+
+    private static final String GLOBAL_SERIES_NAME = "Global STW";
+    private static final String LOCAL_SERIES_NAME = "Local Stalls";
+    private static final long MILLIS_PER_SECOND = 1000;
+
+    private final LongLongHashMap globalBySecond;
+    private final LongLongHashMap localBySecond;
+
+    public StwBudgetBuilder(RelativeTimeRange timeRange) {
+        this.globalBySecond = TimeseriesUtils.initWithZeros(timeRange);
+        this.localBySecond = TimeseriesUtils.initWithZeros(timeRange);
+    }
+
+    @Override
+    public void onRecord(GenericRecord record) {
+        StwEvent event = StwClassifier.classify(record);
+        if (event == null) {
+            return;
+        }
+        long second = event.timeOffsetMillis() / MILLIS_PER_SECOND;
+        if (event.category().stopBudget()) {
+            globalBySecond.addToValue(second, event.durationNanos());
+        } else if (event.scope() == StwScope.LOCAL) {
+            localBySecond.addToValue(second, event.durationNanos());
+        }
+    }
+
+    @Override
+    public TimeseriesData build() {
+        SingleSerie global = TimeseriesUtils.buildSerie(GLOBAL_SERIES_NAME, globalBySecond);
+        SingleSerie local = TimeseriesUtils.buildSerie(LOCAL_SERIES_NAME, localBySecond);
+        return new TimeseriesData(global, local);
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/stw/StwCategory.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/stw/StwCategory.java
@@ -1,0 +1,61 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.stw;
+
+/**
+ * The lanes of the Unified Stop-The-World timeline. Each category groups one pause source.
+ *
+ * <p>{@code stopBudget} marks the categories whose durations are summed into the global "app-stop
+ * budget" — the actual time the whole JVM was frozen. Time-to-safepoint is reported as its own GLOBAL
+ * lane but excluded from the budget: it is the latency to <em>reach</em> a safepoint, distinct from (and
+ * not double-counted with) the operation pause that follows.
+ */
+public enum StwCategory {
+    GC_PAUSE("GC Pause", StwScope.GLOBAL, true),
+    VM_OPERATION("VM Operation", StwScope.GLOBAL, true),
+    TIME_TO_SAFEPOINT("Time to Safepoint", StwScope.GLOBAL, false),
+    MONITOR("Monitor Contention", StwScope.LOCAL, false),
+    PARK("Thread Park", StwScope.LOCAL, false),
+    PINNED("VThread Pinned", StwScope.LOCAL, false);
+
+    private final String label;
+    private final StwScope scope;
+    private final boolean stopBudget;
+
+    StwCategory(String label, StwScope scope, boolean stopBudget) {
+        this.label = label;
+        this.scope = scope;
+        this.stopBudget = stopBudget;
+    }
+
+    public String label() {
+        return label;
+    }
+
+    public StwScope scope() {
+        return scope;
+    }
+
+    /**
+     * Whether this category contributes to the global app-stop budget (whole-JVM frozen time).
+     */
+    public boolean stopBudget() {
+        return stopBudget;
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/stw/StwClassifier.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/stw/StwClassifier.java
@@ -1,0 +1,138 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.stw;
+
+import tools.jackson.databind.node.ObjectNode;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.shared.common.Json;
+import cafe.jeffrey.shared.common.model.Type;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Normalizes raw pause events ({@code jdk.GarbageCollection}, {@code jdk.ExecuteVMOperation},
+ * {@code jdk.SafepointStateSynchronization}, {@code jdk.JavaMonitorEnter}, {@code jdk.ThreadPark},
+ * {@code jdk.VirtualThreadPinned}) into a single {@link StwEvent} shape so the timeline and budget
+ * builders share one classification path.
+ */
+public final class StwClassifier {
+
+    private static final String CAUSE_FIELD = "cause";
+    private static final String OPERATION_FIELD = "operation";
+    private static final String SAFEPOINT_FIELD = "safepoint";
+    private static final String MONITOR_CLASS_FIELD = "monitorClass";
+    private static final String PARKED_CLASS_FIELD = "parkedClass";
+    private static final String EVENT_THREAD_FIELD = "eventThread";
+    private static final String GC_ID_FIELD = "gcId";
+    private static final String SUM_OF_PAUSES_FIELD = "sumOfPauses";
+    private static final String SAFEPOINT_SYNC_LABEL = "Safepoint sync";
+
+    /**
+     * Per-source extraction rules. {@code labelField == null} means use the category label verbatim.
+     */
+    private record Descriptor(
+            StwCategory category,
+            String labelField,
+            String threadField,
+            boolean readGcId,
+            boolean preferSumOfPauses,
+            boolean requireSafepoint) {
+    }
+
+    private static final Map<Type, Descriptor> DESCRIPTORS = Map.of(
+            Type.GARBAGE_COLLECTION,
+            new Descriptor(StwCategory.GC_PAUSE, CAUSE_FIELD, null, true, true, false),
+            Type.EXECUTE_VM_OPERATION,
+            new Descriptor(StwCategory.VM_OPERATION, OPERATION_FIELD, null, false, false, true),
+            Type.SAFEPOINT_STATE_SYNCHRONIZATION,
+            new Descriptor(StwCategory.TIME_TO_SAFEPOINT, null, null, false, false, false),
+            Type.JAVA_MONITOR_ENTER,
+            new Descriptor(StwCategory.MONITOR, MONITOR_CLASS_FIELD, EVENT_THREAD_FIELD, false, false, false),
+            Type.THREAD_PARK,
+            new Descriptor(StwCategory.PARK, PARKED_CLASS_FIELD, EVENT_THREAD_FIELD, false, false, false),
+            Type.VIRTUAL_THREAD_PINNED,
+            new Descriptor(StwCategory.PINNED, null, EVENT_THREAD_FIELD, false, false, false));
+
+    /** The event types the timeline streams; pass to {@code EventQueryConfigurer.withEventTypes}. */
+    public static final List<Type> SOURCE_TYPES = List.copyOf(DESCRIPTORS.keySet());
+
+    private StwClassifier() {
+    }
+
+    /**
+     * Maps a raw record to an {@link StwEvent}, or {@code null} when the record is not a pause source or
+     * is a non-safepoint VM operation (which does not stop the world).
+     */
+    public static StwEvent classify(GenericRecord record) {
+        Descriptor descriptor = DESCRIPTORS.get(record.type());
+        if (descriptor == null) {
+            return null;
+        }
+
+        ObjectNode fields = record.jsonFields();
+        if (descriptor.requireSafepoint() && !Json.readBoolean(fields, SAFEPOINT_FIELD)) {
+            return null;
+        }
+
+        long durationNanos = resolveDurationNanos(record, fields, descriptor);
+        String label = resolveLabel(fields, descriptor);
+        String thread = descriptor.threadField() == null ? null : Json.readString(fields, descriptor.threadField());
+        Long gcId = resolveGcId(fields, descriptor);
+
+        return new StwEvent(
+                descriptor.category(),
+                descriptor.category().scope(),
+                record.timestampFromStart().toMillis(),
+                durationNanos,
+                label,
+                thread,
+                gcId);
+    }
+
+    private static long resolveDurationNanos(GenericRecord record, ObjectNode fields, Descriptor descriptor) {
+        if (descriptor.preferSumOfPauses()) {
+            long sumOfPauses = Json.readLong(fields, SUM_OF_PAUSES_FIELD);
+            if (sumOfPauses > 0) {
+                return sumOfPauses;
+            }
+        }
+        Duration duration = record.duration();
+        return duration == null ? 0 : duration.toNanos();
+    }
+
+    private static String resolveLabel(ObjectNode fields, Descriptor descriptor) {
+        if (descriptor.labelField() == null) {
+            return descriptor.category() == StwCategory.TIME_TO_SAFEPOINT
+                    ? SAFEPOINT_SYNC_LABEL
+                    : descriptor.category().label();
+        }
+        String value = Json.readString(fields, descriptor.labelField());
+        return value == null ? descriptor.category().label() : value;
+    }
+
+    private static Long resolveGcId(ObjectNode fields, Descriptor descriptor) {
+        if (!descriptor.readGcId()) {
+            return null;
+        }
+        long gcId = Json.readLong(fields, GC_ID_FIELD);
+        return gcId >= 0 ? gcId : null;
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/stw/StwEvent.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/stw/StwEvent.java
@@ -1,0 +1,41 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.stw;
+
+/**
+ * One pause on the Unified Stop-The-World timeline: a single occurrence of a pause source, normalized
+ * across GC / safepoint / VM-operation / blocking events so they share one time axis.
+ *
+ * @param category         which lane this belongs to
+ * @param scope            global (whole-JVM) vs local (single-thread) stall
+ * @param timeOffsetMillis start offset from the recording start
+ * @param durationNanos    pause duration
+ * @param label            human-readable cause (GC cause, VM operation name, monitor class, …)
+ * @param thread           the affected thread, when the source carries one (else {@code null})
+ * @param gcId             the GC id for {@code GC_PAUSE} events (else {@code null})
+ */
+public record StwEvent(
+        StwCategory category,
+        StwScope scope,
+        long timeOffsetMillis,
+        long durationNanos,
+        String label,
+        String thread,
+        Long gcId) {
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/stw/StwScope.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/stw/StwScope.java
@@ -1,0 +1,28 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.stw;
+
+/**
+ * Whether a pause stops the whole JVM ({@code GLOBAL} — every application thread is frozen) or stalls a
+ * single thread ({@code LOCAL} — monitor contention, parking, virtual-thread pinning).
+ */
+public enum StwScope {
+    GLOBAL,
+    LOCAL
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/stw/StwTimelineBuilder.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/stw/StwTimelineBuilder.java
@@ -1,0 +1,59 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.stw;
+
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.provider.profile.api.RecordBuilder;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Collects every pause source into one chronological list of {@link StwEvent}s, keeping only pauses at
+ * least {@code minDurationNanos} long so the timeline payload stays bounded (the complete frozen-time
+ * picture lives in {@link StwBudgetBuilder}, which sums everything).
+ */
+public class StwTimelineBuilder implements RecordBuilder<GenericRecord, List<StwEvent>> {
+
+    private final long minDurationNanos;
+    private final List<StwEvent> events = new ArrayList<>();
+
+    public StwTimelineBuilder(long minDurationNanos) {
+        if (minDurationNanos < 0) {
+            throw new IllegalArgumentException("minDurationNanos must be non-negative: " + minDurationNanos);
+        }
+        this.minDurationNanos = minDurationNanos;
+    }
+
+    @Override
+    public void onRecord(GenericRecord record) {
+        StwEvent event = StwClassifier.classify(record);
+        if (event != null && event.durationNanos() >= minDurationNanos) {
+            events.add(event);
+        }
+    }
+
+    @Override
+    public List<StwEvent> build() {
+        events.sort(Comparator.comparingLong(StwEvent::timeOffsetMillis)
+                .thenComparingLong(StwEvent::durationNanos));
+        return events;
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/registry/JvmInsightFactories.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/registry/JvmInsightFactories.java
@@ -35,6 +35,7 @@ import cafe.jeffrey.profile.manager.HeapMemoryManager;
 import cafe.jeffrey.profile.manager.JITCompilationManager;
 import cafe.jeffrey.profile.manager.JITDeoptimizationManager;
 import cafe.jeffrey.profile.manager.SpanManager;
+import cafe.jeffrey.profile.manager.StwTimelineManager;
 import cafe.jeffrey.profile.manager.ThreadManager;
 import cafe.jeffrey.profile.manager.VirtualThreadManager;
 import cafe.jeffrey.profile.manager.VmOperationManager;
@@ -59,5 +60,6 @@ public record JvmInsightFactories(
         AllocationManager.Factory allocation,
         LeakCandidatesManager.Factory leakCandidates,
         SecurityManager.Factory security,
-        SpanManager.Factory span) {
+        SpanManager.Factory span,
+        StwTimelineManager.Factory stwTimeline) {
 }

--- a/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/stw/StwBudgetBuilderTest.java
+++ b/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/stw/StwBudgetBuilderTest.java
@@ -1,0 +1,89 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.stw;
+
+import tools.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.shared.common.Json;
+import cafe.jeffrey.shared.common.model.Type;
+import cafe.jeffrey.shared.common.model.time.RelativeTimeRange;
+import cafe.jeffrey.timeseries.SingleSerie;
+import cafe.jeffrey.timeseries.TimeseriesData;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DisplayName("StwBudgetBuilder")
+class StwBudgetBuilderTest {
+
+    private static GenericRecord record(Type type, long offsetMillis, long durationNanos, ObjectNode fields) {
+        return new GenericRecord(
+                type, type.code(), Instant.EPOCH, Duration.ofMillis(offsetMillis),
+                Duration.ofNanos(durationNanos), null, null, 0, 0, fields);
+    }
+
+    private static long valueAtSecond(SingleSerie serie, long second) {
+        return serie.data().stream()
+                .filter(point -> point.get(0) == second)
+                .map(point -> point.get(1))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No bucket for second " + second));
+    }
+
+    @Test
+    @DisplayName("Sums global STW and local stalls into separate per-second series; excludes time-to-safepoint")
+    void sumsBudget() {
+        StwBudgetBuilder builder = new StwBudgetBuilder(new RelativeTimeRange(0L, 10_000L));
+
+        ObjectNode gc = Json.createObject();
+        gc.put("sumOfPauses", 5_000_000L);
+        builder.onRecord(record(Type.GARBAGE_COLLECTION, 1000, 1, gc));
+
+        ObjectNode vmOp = Json.createObject();
+        vmOp.put("operation", "G1CollectForAllocation");
+        vmOp.put("safepoint", true);
+        builder.onRecord(record(Type.EXECUTE_VM_OPERATION, 1200, 2_000_000, vmOp));
+
+        // Time-to-safepoint in the same second must NOT be added to the budget.
+        builder.onRecord(record(Type.SAFEPOINT_STATE_SYNCHRONIZATION, 1300, 9_000_000, Json.createObject()));
+
+        ObjectNode monitor = Json.createObject();
+        monitor.put("monitorClass", "java.lang.Object");
+        monitor.put("eventThread", "worker-1");
+        builder.onRecord(record(Type.JAVA_MONITOR_ENTER, 3000, 4_000_000, monitor));
+
+        TimeseriesData data = builder.build();
+        SingleSerie global = data.series().get(0);
+        SingleSerie local = data.series().get(1);
+
+        assertEquals("Global STW", global.name());
+        assertEquals("Local Stalls", local.name());
+        // Second 1: GC 5ms + VM op 2ms = 7ms; TTSP excluded.
+        assertEquals(7_000_000L, valueAtSecond(global, 1));
+        assertEquals(0L, valueAtSecond(local, 1));
+        // Second 3: monitor 4ms local; no global.
+        assertEquals(4_000_000L, valueAtSecond(local, 3));
+        assertEquals(0L, valueAtSecond(global, 3));
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/stw/StwTimelineBuilderTest.java
+++ b/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/stw/StwTimelineBuilderTest.java
@@ -1,0 +1,116 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.stw;
+
+import tools.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.shared.common.Json;
+import cafe.jeffrey.shared.common.model.Type;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("StwTimelineBuilder")
+class StwTimelineBuilderTest {
+
+    private static GenericRecord record(Type type, long offsetMillis, long durationNanos, ObjectNode fields) {
+        return new GenericRecord(
+                type, type.code(), Instant.EPOCH, Duration.ofMillis(offsetMillis),
+                Duration.ofNanos(durationNanos), null, null, 0, 0, fields);
+    }
+
+    private static ObjectNode gcFields(long gcId, String cause, long sumOfPausesNanos) {
+        ObjectNode fields = Json.createObject();
+        fields.put("gcId", gcId);
+        fields.put("cause", cause);
+        fields.put("sumOfPauses", sumOfPausesNanos);
+        return fields;
+    }
+
+    private static ObjectNode vmOpFields(String operation, boolean safepoint) {
+        ObjectNode fields = Json.createObject();
+        fields.put("operation", operation);
+        fields.put("safepoint", safepoint);
+        return fields;
+    }
+
+    private static ObjectNode monitorFields(String monitorClass, String thread) {
+        ObjectNode fields = Json.createObject();
+        fields.put("monitorClass", monitorClass);
+        fields.put("eventThread", thread);
+        return fields;
+    }
+
+    @Test
+    @DisplayName("Classifies each source, prefers GC sumOfPauses, drops non-safepoint VM ops, orders by time")
+    void classifies() {
+        StwTimelineBuilder builder = new StwTimelineBuilder(0);
+        builder.onRecord(record(Type.GARBAGE_COLLECTION, 1000, 9_999, gcFields(7, "G1 Evacuation Pause", 5_000_000)));
+        builder.onRecord(record(Type.EXECUTE_VM_OPERATION, 2000, 2_000_000, vmOpFields("G1CollectForAllocation", true)));
+        builder.onRecord(record(Type.EXECUTE_VM_OPERATION, 2500, 9_000_000, vmOpFields("ThreadDump", false)));
+        builder.onRecord(record(Type.SAFEPOINT_STATE_SYNCHRONIZATION, 1500, 500_000, Json.createObject()));
+        builder.onRecord(record(Type.JAVA_MONITOR_ENTER, 3000, 3_000_000, monitorFields("java.lang.Object", "worker-1")));
+
+        List<StwEvent> result = builder.build();
+
+        // Non-safepoint VM operation dropped → 4 events, ordered by time offset.
+        assertEquals(4, result.size());
+        assertEquals(
+                List.of(1000L, 1500L, 2000L, 3000L),
+                result.stream().map(StwEvent::timeOffsetMillis).toList());
+
+        StwEvent gc = result.getFirst();
+        assertEquals(StwCategory.GC_PAUSE, gc.category());
+        assertEquals(StwScope.GLOBAL, gc.scope());
+        assertEquals(5_000_000, gc.durationNanos(), "GC must prefer sumOfPauses over the raw duration");
+        assertEquals("G1 Evacuation Pause", gc.label());
+        assertEquals(7L, gc.gcId());
+
+        StwEvent ttsp = result.get(1);
+        assertEquals(StwCategory.TIME_TO_SAFEPOINT, ttsp.category());
+        assertEquals("Safepoint sync", ttsp.label());
+        assertNull(ttsp.gcId());
+
+        StwEvent monitor = result.get(3);
+        assertEquals(StwCategory.MONITOR, monitor.category());
+        assertEquals(StwScope.LOCAL, monitor.scope());
+        assertEquals("java.lang.Object", monitor.label());
+        assertEquals("worker-1", monitor.thread());
+    }
+
+    @Test
+    @DisplayName("Drops pauses shorter than the threshold")
+    void appliesThreshold() {
+        StwTimelineBuilder builder = new StwTimelineBuilder(1_000_000);
+        builder.onRecord(record(Type.SAFEPOINT_STATE_SYNCHRONIZATION, 100, 500_000, Json.createObject()));
+        builder.onRecord(record(Type.JAVA_MONITOR_ENTER, 200, 2_000_000, monitorFields("C", "t")));
+
+        List<StwEvent> result = builder.build();
+
+        assertEquals(1, result.size());
+        assertTrue(result.getFirst().durationNanos() >= 1_000_000);
+    }
+}

--- a/jeffrey-pages/src/router/index.ts
+++ b/jeffrey-pages/src/router/index.ts
@@ -283,6 +283,11 @@ const routes: RouteRecordRaw[] = [
         component: () => import('@/views/docs/microscope/profiles/ProfileSecurityPage.vue')
       },
       {
+        path: 'microscope/profiles/stop-the-world',
+        name: 'DocsProfilesStopTheWorld',
+        component: () => import('@/views/docs/microscope/profiles/ProfileStwTimelinePage.vue')
+      },
+      {
         path: 'microscope/profiles/socket-io',
         name: 'DocsProfilesSocketIo',
         component: () => import('@/views/docs/microscope/profiles/ProfileSocketIoPage.vue')

--- a/jeffrey-pages/src/views/docs/microscope/profiles/ProfileStwTimelinePage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/profiles/ProfileStwTimelinePage.vue
@@ -1,0 +1,94 @@
+<!--
+  - Jeffrey
+  - Copyright (C) 2026 Petr Bouda
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as published by
+  - the Free Software Foundation, either version 3 of the License, or
+  - (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import DocsCallout from '@/components/docs/DocsCallout.vue';
+import DocsNavFooter from '@/components/docs/DocsNavFooter.vue';
+import DocsPageHeader from '@/components/docs/DocsPageHeader.vue';
+import { useDocHeadings } from '@/composables/useDocHeadings';
+
+const { setHeadings } = useDocHeadings();
+
+const headings = [
+  { id: 'overview', text: 'Overview', level: 2 },
+  { id: 'timeline', text: 'Timeline & Budget', level: 2 },
+  { id: 'lanes', text: 'The Lanes', level: 2 },
+  { id: 'inventory', text: 'Inventory & Drawer', level: 2 },
+  { id: 'analysis', text: 'Analysis', level: 2 },
+  { id: 'events', text: 'Source Events', level: 2 }
+];
+
+onMounted(() => {
+  setHeadings(headings);
+});
+</script>
+
+<template>
+  <article class="docs-article">
+    <DocsPageHeader title="Stop-The-World" icon="bi bi-pause-circle" />
+
+    <div class="docs-content">
+      <p>The Stop-The-World page is the single place to answer <em>"when was my application frozen, and by what?"</em> It merges every JVM pause source — GC pauses, safepoint VM operations, time-to-safepoint, and per-thread stalls — onto one shared time axis, so a latency spike caused by several pauses landing together becomes obvious instead of being scattered across separate pages.</p>
+
+      <h2 id="overview">Overview</h2>
+      <p>A "stop-the-world" (STW) pause freezes every application thread while the JVM does something it cannot do concurrently. This page separates whole-JVM pauses (<em>Global STW</em>) from single-thread stalls (<em>Local Stalls</em>) and lets you brush, zoom, and click into any pause to see what else happened at that moment.</p>
+
+      <h2 id="timeline">Timeline &amp; Budget</h2>
+      <p>The <strong>app-stop budget</strong> band charts frozen nanoseconds per second as two series — Global STW (GC + safepoint operations) and Local Stalls (monitor / park / pinning). Brushing the budget zooms the swimlane below it to the same window. The <strong>swimlane</strong> draws each individual pause as a bar on its category's lane, so you can see overlap and clustering at a glance.</p>
+
+      <h2 id="lanes">The Lanes</h2>
+      <ul>
+        <li><strong>GC Pause</strong> — stop-the-world collection time (uses the per-collection sum-of-pauses, so concurrent GC work is excluded).</li>
+        <li><strong>VM Operation</strong> — safepoint operations the JVM stopped to run.</li>
+        <li><strong>Time to Safepoint</strong> — how long the JVM waited for all threads to reach the safepoint. Shown as its own lane and <em>excluded</em> from the budget so it is not double-counted with the operation pause that follows.</li>
+        <li><strong>Local Stalls</strong> — per-thread, not whole-JVM: monitor contention, thread parking, and virtual-thread pinning.</li>
+      </ul>
+
+      <DocsCallout type="tip">
+        Time-to-safepoint spikes are one of the most useful and least-known signals: a long sync time means some thread was slow to reach a safepoint (a JNI call, a counted loop, a page fault) while the rest of the JVM waited.
+      </DocsCallout>
+
+      <h2 id="inventory">Inventory &amp; Drawer</h2>
+      <p>The Inventory tab lists every pause in a searchable table, plus a longest-pauses leaderboard and a cause-attribution breakdown (grouped by category and cause). Clicking any pause — in the swimlane, the leaderboard, or the table — opens a drawer with its detail and every other pause overlapping its window, the latency-outlier drill-down.</p>
+
+      <h2 id="analysis">Analysis</h2>
+      <p>The Analysis tab adds three diagnostics computed from the loaded pauses:</p>
+      <ul>
+        <li><strong>Pause-budget simulator</strong> — drag a max-acceptable-pause slider to see how many pauses violate it, their total time, and the resulting global-STW availability.</li>
+        <li><strong>Minimum Mutator Utilization (MMU)</strong> — for each window size, the worst-case fraction of time the application actually ran. Low MMU at small windows means short, frequent pauses; low MMU only at large windows means rare but very long ones.</li>
+        <li><strong>Pause density</strong> — total pause time per lane across time buckets, so clustering pops out even when individual pauses are tiny.</li>
+      </ul>
+
+      <h2 id="events">Source Events</h2>
+      <ul>
+        <li><code>jdk.GarbageCollection</code> — stop-the-world GC pause time per collection.</li>
+        <li><code>jdk.ExecuteVMOperation</code> — safepoint VM operations.</li>
+        <li><code>jdk.SafepointStateSynchronization</code> — time-to-safepoint.</li>
+        <li><code>jdk.JavaMonitorEnter</code>, <code>jdk.ThreadPark</code>, <code>jdk.VirtualThreadPinned</code> — per-thread stalls.</li>
+      </ul>
+      <p>ZGC allocation stalls (<code>jdk.ZAllocationStall</code>) will join as a lane once that event support lands.</p>
+    </div>
+
+    <DocsNavFooter />
+  </article>
+</template>
+
+<style scoped>
+@import '@/views/docs/docs-page.css';
+</style>

--- a/jeffrey-pages/src/views/docs/microscope/profiles/ProfilesPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/profiles/ProfilesPage.vue
@@ -189,6 +189,11 @@ const folderStructure = `$JEFFREY_HOME/
           description="Where application threads block — lock contention by monitor class, Object.wait(), thread parks, sleeps, and virtual-thread pinning."
         />
         <DocsFeatureCard
+          icon="bi bi-pause-circle"
+          title="Stop-The-World"
+          description="Every JVM pause on one timeline — GC pauses, safepoint operations, time-to-safepoint, and per-thread stalls — with the app-stop budget, MMU curve, and click-to-explain drill-down."
+        />
+        <DocsFeatureCard
           icon="bi bi-ethernet"
           title="Socket I/O"
           description="Blocking network I/O — read/write throughput over time, the slowest operations, and the busiest peers (host:port)."
@@ -222,6 +227,8 @@ const folderStructure = `$JEFFREY_HOME/
         <router-link to="/docs/microscope/profiles/virtual-threads">Read the Virtual Threads reference &rarr;</router-link>
         &nbsp;·&nbsp;
         <router-link to="/docs/microscope/profiles/security">Read the Security &amp; TLS reference &rarr;</router-link>
+        &nbsp;·&nbsp;
+        <router-link to="/docs/microscope/profiles/stop-the-world">Read the Stop-The-World reference &rarr;</router-link>
       </p>
 
       <h2 id="technologies">Technologies</h2>


### PR DESCRIPTION
Builds the roadmap's flagship cross-cutting view (§4.1) plus the latency-outlier drill (§4.2): a single page that merges every JVM pause source onto one shared time axis, so a latency spike caused by several pauses landing together is obvious instead of scattered across separate pages.

Page: JVM Internals → Stop-The-World (`/profiles/{id}/stop-the-world`).

## ⚠️ TODO before this is complete
- **Add ZGC allocation stalls (`jdk.ZAllocationStall`) as a lane.** This is the single most important low-latency STW signal and the timeline is not complete without it. The event support currently lives in PR #88; once that lands, register `Type.Z_ALLOCATION_STALL` in `StwClassifier` (a `GLOBAL` / `stopBudget` category) — the lane registry is already structured to drop it in.

## Backend (Phase 1)
- Normalized model (`StwEvent` / `StwCategory` / `StwScope`) + a shared `StwClassifier` (descriptor-map, no switch/equals ladders) merging GC pauses, safepoint VM operations, time-to-safepoint, and per-thread stalls (monitor / park / vthread-pinned) into one stream.
- `StwTimelineBuilder` (thresholded per-event list) + `StwBudgetBuilder` (per-second Global-STW vs Local-Stalls frozen time; time-to-safepoint excluded to avoid double-counting the operation pause that follows).
- `StwTimelineManager` wired through the factory registry / `ProfileManager`, exposed via `StwTimelineController` at `/api/internal/profiles/{id}/stw/{timeline,budget}`.

## Frontend (Phase 2 — Standard)
- App-stop budget band (brush zooms the swimlane), ApexCharts `rangeBar` swimlane (lane per category), lane legend, CPU + context-switch correlation rails.
- Inventory tab: searchable table + longest-pauses leaderboard + cause attribution.
- Click any pause → drawer with its detail and every pause overlapping its window (the latency-outlier drill).

## Analysis (Phase 3 — fast-follows, all client-side)
- Pause-budget what-if simulator (max-pause slider → violations + availability), Minimum Mutator Utilization curve, and a pause-density heatmap.

## Docs (Phase 4)
- Stop-The-World reference page + docs route + Profiles listing.

## Tests & verification
- `StwTimelineBuilderTest`, `StwBudgetBuilderTest`, `StwTimelineControllerTest`; backend reactor green on JDK 26.
- Frontend lint (0 errors) + production build green; docs build green.

## Notes
- Not yet visually verified against a live recording (no dev server in the authoring env) — the ApexCharts `rangeBar` swimlane, the brush→window mapping, and the heatmap config are worth an eyeball pass on a recording with GC activity before merge.

https://claude.ai/code/session_019PNnPZQ2oSTUGrEjFfsE4x