### PR TITLE
Microscope JFR Recording Dashboard — mockups + implementation

### DIFF
--- a/dashboard-mockups/README.md
+++ b/dashboard-mockups/README.md
@@ -1,0 +1,29 @@
+# Microscope JFR — Initial Recording Dashboard (Mockups)
+
+Five HTML mockups exploring an "initial" dashboard for a JFR recording in
+**jeffrey-microscope**. Open any file in a browser.
+
+Each mockup is self-contained (Poppins + Bootstrap Icons via CDN) and uses
+Jeffrey's real design tokens (`#5e64ff` primary, the card/border/shadow system,
+`Poppins` typography). All identity fields come from the `jeffrey.AppInformation`
+JFR event (PR #104): `workspaceId, projectId, projectName, projectLabel,
+instanceId, sessionId, sessionOrder, attributes, provisionedAt, jvmStartedAt`.
+
+When the event is absent the identity panel falls back to
+**"Recording not handled by Jeffrey"** (demonstrated in mockups 2 and 5).
+
+| # | File | Idea |
+|---|------|------|
+| 1 | `mockup-1-mission-control.html`  | Gradient identity hero + KPI tiles + bento grid (top-5 events, event-over-time sparkline, JVM/GC/attributes) |
+| 2 | `mockup-2-identity-spotlight.html` | Sticky "passport" identity card + stat tiles + conic event-distribution donut; shows the fallback state |
+| 3 | `mockup-3-dense-analyst.html` | Closest to the current app — PageHeader, identity+GC sidebar, mini-stat grid, DataTable-style top events |
+| 4 | `mockup-4-timeline-first.html` | Slim identity strip + large layered events-over-time area chart as the hero |
+| 5 | `mockup-5-glass-cards.html` | Glassmorphism hero + gradient stat cards with sparklines; styled fallback variant |
+
+## Data surfaced
+Application identity · total events + type count · duration · size · event source ·
+chunk count · top-5 event types (count + share) · events-over-time · JVM / vendor /
+GC / heap · OS / cores / container · GC summary (collections, p99 pause, overhead) ·
+CPU avg/peak · threads (incl. virtual) · custom attributes.
+
+> These are design mockups only — no application wiring yet.

--- a/dashboard-mockups/mockup-1-mission-control.html
+++ b/dashboard-mockups/mockup-1-mission-control.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Mockup 1 · Mission Control — Jeffrey Recording Dashboard</title>
+<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+<style>
+:root{
+  --primary:#5e64ff;--primary-hover:#4c52db;
+  --success:#00d27a;--danger:#e63757;--warning:#f5803e;--info:#39afd1;--purple:#6f42c1;
+  --dark:#0b1727;--text:#5e6e82;--muted:#748194;
+  --bg:#edf2f9;--card:#fff;--light:#f9fafd;--border:#eaedf1;
+  --radius:8px;--radius-lg:12px;
+  --shadow:0 0 .375rem 0 rgba(0,0,0,.1);--shadow-md:0 .25rem .5rem rgba(0,0,0,.1);
+}
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:'Poppins',-apple-system,sans-serif;background:var(--bg);color:var(--text);font-size:.875rem;padding:24px;line-height:1.5}
+.wrap{max-width:1280px;margin:0 auto}
+
+/* ===== Hero identity banner ===== */
+.hero{
+  position:relative;overflow:hidden;border-radius:var(--radius-lg);padding:22px 26px;margin-bottom:18px;
+  background:linear-gradient(135deg,#1e1b4b 0%,#312e81 42%,#4338ca 72%,#5e64ff 100%);
+  box-shadow:0 10px 30px rgba(49,46,129,.35);
+}
+.hero::after{content:"";position:absolute;right:-60px;top:-60px;width:260px;height:260px;border-radius:50%;background:radial-gradient(circle,rgba(255,255,255,.12),transparent 70%)}
+.hero-top{display:flex;align-items:center;gap:16px;position:relative;z-index:1}
+.hero-logo{width:52px;height:52px;border-radius:14px;background:rgba(255,255,255,.12);backdrop-filter:blur(10px);border:1px solid rgba(255,255,255,.18);display:grid;place-items:center;font-size:1.6rem;color:#fff}
+.hero-title{color:#fff;font-size:1.45rem;font-weight:700;letter-spacing:-.02em;line-height:1.1}
+.hero-sub{color:rgba(255,255,255,.62);font-size:.78rem;margin-top:2px}
+.hero-pills{margin-left:auto;display:flex;gap:8px;flex-wrap:wrap;justify-content:flex-end;position:relative;z-index:1}
+.hpill{font-size:.62rem;font-weight:600;padding:5px 11px;border-radius:20px;background:rgba(255,255,255,.12);border:1px solid rgba(255,255,255,.2);color:#fff;display:flex;align-items:center;gap:5px}
+.hpill.ok{background:rgba(0,210,122,.2);border-color:rgba(0,210,122,.35);color:#6ee7b7}
+.hero-meta{display:grid;grid-template-columns:repeat(5,1fr);gap:1px;margin-top:18px;background:rgba(255,255,255,.1);border-radius:10px;overflow:hidden;position:relative;z-index:1}
+.hm{background:rgba(17,15,48,.28);backdrop-filter:blur(6px);padding:11px 14px}
+.hm .k{font-size:.6rem;text-transform:uppercase;letter-spacing:.06em;color:rgba(255,255,255,.55);font-weight:600}
+.hm .v{font-size:.86rem;color:#fff;font-weight:600;margin-top:3px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.hm .v small{color:rgba(255,255,255,.6);font-weight:400}
+
+/* ===== Bento grid ===== */
+.bento{display:grid;grid-template-columns:repeat(4,1fr);gap:14px}
+.card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius);box-shadow:var(--shadow)}
+.card-h{display:flex;align-items:center;gap:9px;padding:12px 16px;background:var(--light);border-bottom:1px solid var(--border);border-radius:var(--radius) var(--radius) 0 0}
+.card-h i{color:var(--primary);font-size:1.05rem}
+.card-h .t{font-weight:600;color:var(--text);font-size:.84rem}
+.card-h .badge{margin-left:auto}
+.badge{font-size:.62rem;font-weight:600;padding:3px 9px;border-radius:6px;border:1px solid}
+.b-primary{background:#e2e7fd;border-color:#9ba8ff;color:#1565c0}
+.b-grey{background:#f5f5f5;border-color:#bdbdbd;color:#424242}
+.card-b{padding:16px}
+
+/* KPI tiles */
+.kpi{grid-column:span 1;padding:16px;display:flex;flex-direction:column;gap:6px;position:relative;overflow:hidden}
+.kpi .icon{width:38px;height:38px;border-radius:10px;display:grid;place-items:center;font-size:1.1rem;color:#fff}
+.kpi .num{font-size:1.7rem;font-weight:700;color:var(--dark);line-height:1;letter-spacing:-.02em}
+.kpi .lbl{font-size:.72rem;color:var(--muted);font-weight:500}
+.kpi .trend{position:absolute;top:14px;right:14px;font-size:.62rem;font-weight:600;padding:2px 7px;border-radius:6px}
+.t-up{background:rgba(0,210,122,.1);color:var(--success)}
+.t-warn{background:rgba(245,128,62,.1);color:var(--warning)}
+.bg-primary2{background:linear-gradient(135deg,#5e64ff,#4c52db)}
+.bg-success2{background:linear-gradient(135deg,#00d27a,#00a863)}
+.bg-warn2{background:linear-gradient(135deg,#f5803e,#e4702d)}
+.bg-info2{background:linear-gradient(135deg,#39afd1,#2e9bb8)}
+
+.span2{grid-column:span 2}
+.span4{grid-column:span 4}
+
+/* table */
+table{width:100%;border-collapse:collapse;font-size:.8rem}
+th{text-align:left;font-size:.64rem;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);font-weight:600;padding:7px 8px;border-bottom:2px solid var(--border)}
+td{padding:9px 8px;border-bottom:1px solid var(--border);color:var(--dark)}
+tr:last-child td{border-bottom:none}
+.evt{font-family:'SF Mono',Monaco,monospace;font-size:.74rem;color:var(--dark);font-weight:500}
+.bar{height:6px;border-radius:4px;background:linear-gradient(90deg,#5e64ff,#9ba8ff)}
+.num-cell{text-align:right;font-weight:600;font-variant-numeric:tabular-nums}
+.pct{color:var(--muted);font-size:.72rem;text-align:right;font-variant-numeric:tabular-nums}
+
+/* sparkline timeseries */
+.spark{display:flex;align-items:flex-end;gap:3px;height:90px;padding-top:8px}
+.spark .b{flex:1;border-radius:3px 3px 0 0;background:linear-gradient(180deg,#5e64ff,#a5abff);min-height:4px;transition:.2s;position:relative}
+.spark .b:hover{filter:brightness(1.1)}
+.axis{display:flex;justify-content:space-between;font-size:.62rem;color:var(--muted);margin-top:7px}
+
+/* info rows */
+.irow{display:flex;justify-content:space-between;padding:8px 0;border-bottom:1px solid var(--border);font-size:.78rem}
+.irow:last-child{border-bottom:none}
+.irow .k{color:var(--muted);font-weight:500}
+.irow .v{color:var(--dark);font-weight:600}
+.dot{display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:6px}
+.chip{display:inline-block;font-size:.68rem;font-weight:500;padding:3px 8px;border-radius:6px;background:#e8eaf6;color:#3f51b5;margin:2px 3px 2px 0}
+.legend{font-size:.7rem;color:var(--muted);margin-top:6px;text-align:center}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <!-- ============ HERO: jeffrey.AppInformation ============ -->
+  <div class="hero">
+    <div class="hero-top">
+      <div class="hero-logo"><i class="bi bi-box-seam"></i></div>
+      <div>
+        <div class="hero-title">Payments API <span style="opacity:.6;font-weight:500">(prod)</span></div>
+        <div class="hero-sub"><i class="bi bi-patch-check-fill"></i> Identified via <code style="color:#a5abff">jeffrey.AppInformation</code> · self-describing recording</div>
+      </div>
+      <div class="hero-pills">
+        <span class="hpill ok"><i class="bi bi-check-circle-fill"></i> Handled by Jeffrey</span>
+        <span class="hpill"><i class="bi bi-diagram-3"></i> Session #3</span>
+        <span class="hpill"><i class="bi bi-cpu"></i> async-profiler</span>
+      </div>
+    </div>
+    <div class="hero-meta">
+      <div class="hm"><div class="k">Workspace</div><div class="v">$default</div></div>
+      <div class="hm"><div class="k">Project</div><div class="v">payments-api</div></div>
+      <div class="hm"><div class="k">Instance</div><div class="v">pod-7c9f4</div></div>
+      <div class="hm"><div class="k">Session</div><div class="v">aaaaaaaa… <small>#3</small></div></div>
+      <div class="hm"><div class="k">JVM Started</div><div class="v">2026-06-25 09:14 <small>UTC</small></div></div>
+    </div>
+  </div>
+
+  <!-- ============ KPI ROW ============ -->
+  <div class="bento" style="margin-bottom:14px">
+    <div class="card kpi">
+      <div class="icon bg-primary2"><i class="bi bi-stack"></i></div>
+      <div class="num">2.42M</div><div class="lbl">Total events</div>
+      <span class="trend t-up">42 types</span>
+    </div>
+    <div class="card kpi">
+      <div class="icon bg-info2"><i class="bi bi-stopwatch"></i></div>
+      <div class="num">5m 32s</div><div class="lbl">Recording duration</div>
+      <span class="trend t-up">09:14→09:20</span>
+    </div>
+    <div class="card kpi">
+      <div class="icon bg-success2"><i class="bi bi-hdd"></i></div>
+      <div class="num">184 MB</div><div class="lbl">Recording size</div>
+      <span class="trend t-up">3 chunks</span>
+    </div>
+    <div class="card kpi">
+      <div class="icon bg-warn2"><i class="bi bi-cpu-fill"></i></div>
+      <div class="num">47%</div><div class="lbl">Avg machine CPU</div>
+      <span class="trend t-warn">peak 82%</span>
+    </div>
+  </div>
+
+  <!-- ============ MAIN BENTO ============ -->
+  <div class="bento">
+
+    <!-- Top event types -->
+    <div class="card span2">
+      <div class="card-h"><i class="bi bi-bar-chart-steps"></i><span class="t">Top 5 Event Types</span><span class="badge b-primary">by sample count</span></div>
+      <div class="card-b" style="padding-top:8px">
+        <table>
+          <thead><tr><th>Event</th><th style="width:34%"></th><th class="num-cell">Count</th><th class="pct">%</th></tr></thead>
+          <tbody>
+            <tr><td class="evt">jdk.ExecutionSample</td><td><div class="bar" style="width:100%"></div></td><td class="num-cell">1,204,332</td><td class="pct">49.7%</td></tr>
+            <tr><td class="evt">jdk.ObjectAllocationSample</td><td><div class="bar" style="width:51%"></div></td><td class="num-cell">612,004</td><td class="pct">25.3%</td></tr>
+            <tr><td class="evt">jdk.JavaMonitorEnter</td><td><div class="bar" style="width:8%"></div></td><td class="num-cell">88,210</td><td class="pct">3.6%</td></tr>
+            <tr><td class="evt">jdk.ThreadPark</td><td><div class="bar" style="width:5%"></div></td><td class="num-cell">54,120</td><td class="pct">2.2%</td></tr>
+            <tr><td class="evt">jdk.SocketRead</td><td><div class="bar" style="width:3%"></div></td><td class="num-cell">31,402</td><td class="pct">1.3%</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- Event generation timeseries -->
+    <div class="card span2">
+      <div class="card-h"><i class="bi bi-activity"></i><span class="t">Events Generated Over Time</span><span class="badge b-grey">10s buckets</span></div>
+      <div class="card-b">
+        <div class="spark">
+          <div class="b" style="height:34%"></div><div class="b" style="height:48%"></div><div class="b" style="height:61%"></div>
+          <div class="b" style="height:55%"></div><div class="b" style="height:72%"></div><div class="b" style="height:88%"></div>
+          <div class="b" style="height:100%"></div><div class="b" style="height:79%"></div><div class="b" style="height:64%"></div>
+          <div class="b" style="height:58%"></div><div class="b" style="height:70%"></div><div class="b" style="height:52%"></div>
+          <div class="b" style="height:44%"></div><div class="b" style="height:38%"></div><div class="b" style="height:30%"></div>
+        </div>
+        <div class="axis"><span>09:14:00</span><span>09:17:00</span><span>09:20:00</span></div>
+      </div>
+    </div>
+
+    <!-- JVM / Runtime -->
+    <div class="card span2">
+      <div class="card-h"><i class="bi bi-gear-wide-connected"></i><span class="t">Runtime &amp; JVM</span></div>
+      <div class="card-b" style="padding-top:6px">
+        <div class="irow"><span class="k">JVM</span><span class="v">OpenJDK 25.0.1 · Amazon Corretto</span></div>
+        <div class="irow"><span class="k">Garbage Collector</span><span class="v"><span class="dot" style="background:var(--success)"></span>G1 (young + old)</span></div>
+        <div class="irow"><span class="k">Heap (max / initial)</span><span class="v">4.0 GB / 512 MB</span></div>
+        <div class="irow"><span class="k">OS</span><span class="v">Linux 6.18 · x86_64 · 8 cores</span></div>
+        <div class="irow"><span class="k">Container</span><span class="v">2 vCPU · 4 GB limit (cgroup v2)</span></div>
+      </div>
+    </div>
+
+    <!-- GC + attributes -->
+    <div class="card">
+      <div class="card-h"><i class="bi bi-recycle"></i><span class="t">Garbage Collection</span></div>
+      <div class="card-b" style="padding-top:6px">
+        <div class="irow"><span class="k">Collections</span><span class="v">142</span></div>
+        <div class="irow"><span class="k">p99 pause</span><span class="v">38 ms</span></div>
+        <div class="irow"><span class="k">GC overhead</span><span class="v" style="color:var(--success)">1.2%</span></div>
+        <div class="irow"><span class="k">Freed total</span><span class="v">11.4 GB</span></div>
+      </div>
+    </div>
+
+    <!-- attributes -->
+    <div class="card">
+      <div class="card-h"><i class="bi bi-tags"></i><span class="t">Attributes</span></div>
+      <div class="card-b">
+        <span class="chip">cluster=eu-west</span>
+        <span class="chip">namespace=prod</span>
+        <span class="chip">env=production</span>
+        <span class="chip">region=eu</span>
+        <div class="irow" style="margin-top:8px"><span class="k">Provisioned</span><span class="v">09:13:58 UTC</span></div>
+      </div>
+    </div>
+
+  </div>
+</div>
+</body>
+</html>

--- a/dashboard-mockups/mockup-2-identity-spotlight.html
+++ b/dashboard-mockups/mockup-2-identity-spotlight.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Mockup 2 · Identity Spotlight — Jeffrey Recording Dashboard</title>
+<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+<style>
+:root{
+  --primary:#5e64ff;--success:#00d27a;--danger:#e63757;--warning:#f5803e;--info:#39afd1;--purple:#7b1fa2;
+  --dark:#0b1727;--text:#5e6e82;--muted:#748194;
+  --bg:#edf2f9;--card:#fff;--light:#f9fafd;--border:#eaedf1;
+  --radius:8px;--shadow:0 0 .375rem 0 rgba(0,0,0,.1);
+}
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:'Poppins',-apple-system,sans-serif;background:var(--bg);color:var(--text);font-size:.875rem;padding:24px;line-height:1.5}
+.wrap{max-width:1180px;margin:0 auto;display:grid;grid-template-columns:360px 1fr;gap:18px}
+
+/* ===== Identity spotlight card (left) ===== */
+.identity{border-radius:14px;overflow:hidden;box-shadow:0 12px 34px rgba(49,46,129,.28);align-self:start;position:sticky;top:24px}
+.id-head{background:linear-gradient(150deg,#1e1b4b,#312e81 55%,#4338ca);padding:24px 22px;color:#fff;position:relative;overflow:hidden}
+.id-head::after{content:"";position:absolute;right:-40px;bottom:-50px;width:180px;height:180px;border-radius:50%;background:radial-gradient(circle,rgba(94,100,255,.4),transparent 70%)}
+.id-badge{display:inline-flex;align-items:center;gap:6px;font-size:.62rem;font-weight:600;padding:5px 11px;border-radius:20px;background:rgba(0,210,122,.2);border:1px solid rgba(0,210,122,.35);color:#6ee7b7;position:relative;z-index:1}
+.id-logo{width:58px;height:58px;border-radius:16px;background:rgba(255,255,255,.12);border:1px solid rgba(255,255,255,.2);display:grid;place-items:center;font-size:1.7rem;margin:16px 0 12px;position:relative;z-index:1}
+.id-name{font-size:1.5rem;font-weight:700;letter-spacing:-.02em;position:relative;z-index:1}
+.id-slug{font-size:.74rem;color:rgba(255,255,255,.6);font-family:'SF Mono',monospace;margin-top:3px;position:relative;z-index:1}
+.id-body{background:var(--card);padding:6px 22px 18px}
+.id-row{display:flex;align-items:center;gap:11px;padding:11px 0;border-bottom:1px solid var(--border)}
+.id-row:last-child{border-bottom:none}
+.id-row .ic{width:32px;height:32px;border-radius:9px;background:#eef0ff;color:var(--primary);display:grid;place-items:center;font-size:.95rem;flex-shrink:0}
+.id-row .k{font-size:.64rem;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);font-weight:600}
+.id-row .v{font-size:.84rem;color:var(--dark);font-weight:600;word-break:break-all}
+.attrs{padding:14px 22px;background:var(--light);border-top:1px solid var(--border)}
+.attrs .lbl{font-size:.62rem;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);font-weight:600;margin-bottom:8px}
+.chip{display:inline-block;font-size:.68rem;font-weight:500;padding:4px 9px;border-radius:6px;background:#e8eaf6;color:#3f51b5;margin:0 4px 4px 0}
+
+/* ===== Right column ===== */
+.col{display:flex;flex-direction:column;gap:18px}
+.card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius);box-shadow:var(--shadow)}
+.card-h{display:flex;align-items:center;gap:9px;padding:13px 18px;background:var(--light);border-bottom:1px solid var(--border);border-radius:var(--radius) var(--radius) 0 0}
+.card-h i{color:var(--primary);font-size:1.05rem}.card-h .t{font-weight:600;color:var(--text);font-size:.86rem}
+.card-h .badge{margin-left:auto;font-size:.62rem;font-weight:600;padding:3px 9px;border-radius:6px;background:#e2e7fd;border:1px solid #9ba8ff;color:#1565c0}
+.card-b{padding:18px}
+
+/* stat strip */
+.stats{display:grid;grid-template-columns:repeat(4,1fr);gap:14px}
+.stat{background:var(--card);border:1px solid var(--border);border-radius:var(--radius);box-shadow:var(--shadow);padding:15px 16px;position:relative}
+.stat .ic{position:absolute;right:14px;top:14px;font-size:1.3rem;opacity:.22}
+.stat .num{font-size:1.55rem;font-weight:700;color:var(--dark);letter-spacing:-.02em;line-height:1}
+.stat .lbl{font-size:.7rem;color:var(--muted);margin-top:5px;font-weight:500}
+.c1{color:var(--primary)}.c2{color:var(--info)}.c3{color:var(--success)}.c4{color:var(--warning)}
+
+/* donut + legend */
+.donut-wrap{display:flex;align-items:center;gap:26px}
+.donut{width:170px;height:170px;border-radius:50%;flex-shrink:0;
+  background:conic-gradient(#5e64ff 0 50%,#39afd1 50% 75%,#00d27a 75% 87%,#f5803e 87% 94%,#e63757 94% 100%);
+  position:relative;display:grid;place-items:center}
+.donut::after{content:"";position:absolute;width:104px;height:104px;border-radius:50%;background:var(--card)}
+.donut .ctr{position:relative;z-index:1;text-align:center}
+.donut .ctr b{font-size:1.3rem;color:var(--dark);font-weight:700;display:block;line-height:1}
+.donut .ctr span{font-size:.62rem;color:var(--muted)}
+.lgnd{flex:1}
+.lg{display:flex;align-items:center;gap:9px;padding:7px 0;border-bottom:1px solid var(--border);font-size:.78rem}
+.lg:last-child{border-bottom:none}
+.lg .sw{width:11px;height:11px;border-radius:3px;flex-shrink:0}
+.lg .nm{font-family:'SF Mono',monospace;font-size:.74rem;color:var(--dark);flex:1}
+.lg .ct{font-weight:600;color:var(--dark);font-variant-numeric:tabular-nums}
+.lg .pc{color:var(--muted);font-size:.72rem;width:46px;text-align:right}
+
+.irow{display:flex;justify-content:space-between;padding:9px 0;border-bottom:1px solid var(--border);font-size:.8rem}
+.irow:last-child{border-bottom:none}.irow .k{color:var(--muted)}.irow .v{color:var(--dark);font-weight:600}
+.grid2{display:grid;grid-template-columns:1fr 1fr;gap:0 26px}
+
+/* fallback note */
+.fallback{margin-top:18px;border:1.5px dashed #d8e2ef;border-radius:var(--radius);background:repeating-linear-gradient(45deg,#fbfcfe,#fbfcfe 10px,#f6f8fc 10px,#f6f8fc 20px);padding:18px 20px;display:flex;gap:14px;align-items:center}
+.fallback .ic{width:42px;height:42px;border-radius:11px;background:#fff3e0;color:#ef6c00;display:grid;place-items:center;font-size:1.3rem;flex-shrink:0}
+.fallback .tt{font-weight:600;color:var(--dark);font-size:.84rem}
+.fallback .ds{font-size:.74rem;color:var(--muted);margin-top:2px}
+.tag{font-size:.6rem;font-weight:600;padding:2px 7px;border-radius:5px;background:#f5f5f5;border:1px solid #bdbdbd;color:#424242;margin-left:8px}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <!-- ============ LEFT: jeffrey.AppInformation spotlight ============ -->
+  <div>
+    <div class="identity">
+      <div class="id-head">
+        <span class="id-badge"><i class="bi bi-patch-check-fill"></i> jeffrey.AppInformation detected</span>
+        <div class="id-logo"><i class="bi bi-box-seam"></i></div>
+        <div class="id-name">Payments API <span style="opacity:.55;font-weight:500">(prod)</span></div>
+        <div class="id-slug">payments-api</div>
+      </div>
+      <div class="id-body">
+        <div class="id-row"><div class="ic"><i class="bi bi-folder2"></i></div><div><div class="k">Workspace</div><div class="v">$default</div></div></div>
+        <div class="id-row"><div class="ic"><i class="bi bi-hdd-network"></i></div><div><div class="k">Instance</div><div class="v">pod-7c9f4</div></div></div>
+        <div class="id-row"><div class="ic"><i class="bi bi-diagram-3"></i></div><div><div class="k">Session · order #3</div><div class="v">aaaaaaaa-bbbb-cccc-dddd-…</div></div></div>
+        <div class="id-row"><div class="ic"><i class="bi bi-clock-history"></i></div><div><div class="k">JVM started</div><div class="v">2026-06-25 09:14:02 UTC</div></div></div>
+        <div class="id-row"><div class="ic"><i class="bi bi-rocket-takeoff"></i></div><div><div class="k">Provisioned at</div><div class="v">2026-06-25 09:13:58 UTC</div></div></div>
+      </div>
+      <div class="attrs">
+        <div class="lbl">Custom Attributes</div>
+        <span class="chip">cluster=eu-west</span><span class="chip">namespace=prod</span><span class="chip">env=production</span>
+      </div>
+    </div>
+
+    <!-- Fallback state preview (shown when event absent) -->
+    <div class="fallback">
+      <div class="ic"><i class="bi bi-question-circle"></i></div>
+      <div>
+        <div class="tt">Fallback state <span class="tag">no event</span></div>
+        <div class="ds">Recording not handled by Jeffrey — <code>jeffrey.AppInformation</code> was not found in any chunk.</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ============ RIGHT ============ -->
+  <div class="col">
+
+    <div class="stats">
+      <div class="stat"><i class="bi bi-stack ic c1"></i><div class="num c1">2.42M</div><div class="lbl">Total events</div></div>
+      <div class="stat"><i class="bi bi-stopwatch ic c2"></i><div class="num c2">5m 32s</div><div class="lbl">Duration</div></div>
+      <div class="stat"><i class="bi bi-hdd ic c3"></i><div class="num c3">184 MB</div><div class="lbl">Size</div></div>
+      <div class="stat"><i class="bi bi-list-columns ic c4"></i><div class="num c4">42</div><div class="lbl">Event types</div></div>
+    </div>
+
+    <div class="card">
+      <div class="card-h"><i class="bi bi-pie-chart-fill"></i><span class="t">Event Distribution — Top 5</span><span class="badge">by samples</span></div>
+      <div class="card-b">
+        <div class="donut-wrap">
+          <div class="donut"><div class="ctr"><b>2.42M</b><span>events</span></div></div>
+          <div class="lgnd">
+            <div class="lg"><span class="sw" style="background:#5e64ff"></span><span class="nm">jdk.ExecutionSample</span><span class="ct">1,204,332</span><span class="pc">49.7%</span></div>
+            <div class="lg"><span class="sw" style="background:#39afd1"></span><span class="nm">jdk.ObjectAllocationSample</span><span class="ct">612,004</span><span class="pc">25.3%</span></div>
+            <div class="lg"><span class="sw" style="background:#00d27a"></span><span class="nm">jdk.JavaMonitorEnter</span><span class="ct">88,210</span><span class="pc">3.6%</span></div>
+            <div class="lg"><span class="sw" style="background:#f5803e"></span><span class="nm">jdk.ThreadPark</span><span class="ct">54,120</span><span class="pc">2.2%</span></div>
+            <div class="lg"><span class="sw" style="background:#e63757"></span><span class="nm">jdk.SocketRead</span><span class="ct">31,402</span><span class="pc">1.3%</span></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-h"><i class="bi bi-cpu"></i><span class="t">Environment &amp; Runtime</span></div>
+      <div class="card-b">
+        <div class="grid2">
+          <div>
+            <div class="irow"><span class="k">JVM version</span><span class="v">OpenJDK 25.0.1</span></div>
+            <div class="irow"><span class="k">Vendor</span><span class="v">Amazon Corretto</span></div>
+            <div class="irow"><span class="k">GC</span><span class="v">G1</span></div>
+            <div class="irow"><span class="k">Heap max</span><span class="v">4.0 GB</span></div>
+          </div>
+          <div>
+            <div class="irow"><span class="k">OS</span><span class="v">Linux 6.18 · x86_64</span></div>
+            <div class="irow"><span class="k">CPU cores</span><span class="v">8</span></div>
+            <div class="irow"><span class="k">Avg / peak CPU</span><span class="v">47% / 82%</span></div>
+            <div class="irow"><span class="k">GC overhead</span><span class="v" style="color:var(--success)">1.2%</span></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+</body>
+</html>

--- a/dashboard-mockups/mockup-3-dense-analyst.html
+++ b/dashboard-mockups/mockup-3-dense-analyst.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Mockup 3 · Dense Analyst — Jeffrey Recording Dashboard</title>
+<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+<style>
+:root{
+  --primary:#5e64ff;--success:#00d27a;--danger:#e63757;--warning:#f5803e;--info:#39afd1;
+  --dark:#0b1727;--text:#5e6e82;--muted:#748194;
+  --bg:#edf2f9;--card:#fff;--light:#f9fafd;--border:#eaedf1;
+  --radius:8px;--shadow:0 0 .375rem 0 rgba(0,0,0,.1);
+}
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:'Poppins',-apple-system,sans-serif;background:var(--bg);color:var(--text);font-size:.85rem;padding:20px;line-height:1.45}
+.wrap{max-width:1240px;margin:0 auto}
+
+/* page header (PageHeader.vue style) */
+.phead{display:flex;align-items:center;gap:14px;background:linear-gradient(135deg,#f9fafd,#fff);border:1px solid var(--border);border-left:4px solid var(--primary);border-radius:var(--radius);padding:14px 20px;margin-bottom:16px;box-shadow:var(--shadow)}
+.phead .ic{width:42px;height:42px;border-radius:11px;background:linear-gradient(135deg,#5e64ff,#4c52db);color:#fff;display:grid;place-items:center;font-size:1.25rem}
+.phead h1{font-size:1.15rem;font-weight:700;color:var(--dark);letter-spacing:-.01em}
+.phead .sub{font-size:.74rem;color:var(--muted)}
+.phead .right{margin-left:auto;display:flex;gap:8px;align-items:center}
+.bdg{font-size:.64rem;font-weight:600;padding:4px 10px;border-radius:6px;border:1px solid;display:inline-flex;align-items:center;gap:5px}
+.bdg.ok{background:rgba(0,210,122,.1);border-color:var(--success);color:var(--success)}
+.bdg.pr{background:#e2e7fd;border-color:#9ba8ff;color:#1565c0}
+.bdg.gr{background:#f5f5f5;border-color:#bdbdbd;color:#424242}
+
+.layout{display:grid;grid-template-columns:300px 1fr;gap:16px}
+.card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius);box-shadow:var(--shadow);margin-bottom:16px}
+.card-h{display:flex;align-items:center;gap:8px;padding:11px 15px;background:var(--light);border-bottom:1px solid var(--border);border-radius:var(--radius) var(--radius) 0 0}
+.card-h i{color:var(--primary)}.card-h .t{font-weight:600;color:var(--text);font-size:.8rem}
+.card-h .badge{margin-left:auto;font-size:.6rem;font-weight:600;padding:2px 8px;border-radius:5px;background:#e2e7fd;border:1px solid #9ba8ff;color:#1565c0}
+.card-b{padding:13px 15px}
+
+/* identity rows */
+.ir{display:flex;flex-direction:column;padding:8px 0;border-bottom:1px solid var(--border)}
+.ir:last-child{border-bottom:none}
+.ir .k{font-size:.6rem;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);font-weight:600}
+.ir .v{font-size:.82rem;color:var(--dark);font-weight:600;margin-top:2px;word-break:break-all}
+.ir .v.mono{font-family:'SF Mono',monospace;font-size:.74rem}
+.chip{display:inline-block;font-size:.66rem;font-weight:500;padding:3px 8px;border-radius:5px;background:#e8eaf6;color:#3f51b5;margin:2px 3px 0 0}
+
+/* mini stat grid */
+.mini{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin-bottom:16px}
+.m{background:var(--card);border:1px solid var(--border);border-radius:var(--radius);box-shadow:var(--shadow);padding:12px 14px;display:flex;align-items:center;gap:11px}
+.m .ic{width:36px;height:36px;border-radius:9px;display:grid;place-items:center;font-size:1.05rem;color:#fff;flex-shrink:0}
+.m .num{font-size:1.15rem;font-weight:700;color:var(--dark);line-height:1.1}
+.m .lbl{font-size:.66rem;color:var(--muted)}
+.bp{background:linear-gradient(135deg,#5e64ff,#4c52db)}.bi2{background:linear-gradient(135deg,#39afd1,#2e9bb8)}
+.bs{background:linear-gradient(135deg,#00d27a,#00a863)}.bw{background:linear-gradient(135deg,#f5803e,#e4702d)}
+.bv{background:linear-gradient(135deg,#8b5cf6,#7c3aed)}.bd{background:linear-gradient(135deg,#e63757,#d12548)}
+
+/* tables */
+table{width:100%;border-collapse:collapse;font-size:.78rem}
+thead th{text-align:left;font-size:.6rem;text-transform:uppercase;letter-spacing:.04em;color:var(--muted);font-weight:600;padding:8px 12px;background:var(--light);border-bottom:1px solid var(--border)}
+tbody td{padding:8px 12px;border-bottom:1px solid var(--border);color:var(--dark)}
+tbody tr:hover{background:var(--light)}
+tbody tr:last-child td{border-bottom:none}
+.evt{font-family:'SF Mono',monospace;font-size:.74rem;font-weight:500}
+.rt{text-align:right;font-variant-numeric:tabular-nums;font-weight:600}
+.muted{color:var(--muted);font-weight:400}
+.minibar{height:5px;border-radius:3px;background:#eef0ff;overflow:hidden;margin-top:4px}
+.minibar i{display:block;height:100%;border-radius:3px;background:linear-gradient(90deg,#5e64ff,#9ba8ff)}
+.src{font-size:.58rem;font-weight:600;padding:1px 6px;border-radius:4px}
+.src.jdk{background:#e8f5e8;color:#2e7d32}.src.ap{background:#fff3e0;color:#ef6c00}
+
+/* timeline */
+.tl{display:flex;align-items:flex-end;gap:2px;height:64px}
+.tl i{flex:1;background:linear-gradient(180deg,#5e64ff,#c3c7ff);border-radius:2px 2px 0 0;min-height:3px}
+.tl-ax{display:flex;justify-content:space-between;font-size:.6rem;color:var(--muted);margin-top:5px}
+
+.two{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+.kv{display:flex;justify-content:space-between;padding:7px 0;border-bottom:1px solid var(--border);font-size:.78rem}
+.kv:last-child{border-bottom:none}.kv .k{color:var(--muted)}.kv .v{color:var(--dark);font-weight:600}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <!-- header -->
+  <div class="phead">
+    <div class="ic"><i class="bi bi-speedometer2"></i></div>
+    <div>
+      <h1>Recording Overview</h1>
+      <div class="sub">Payments API (prod) · recording <code>rec-2026-0625-0914</code></div>
+    </div>
+    <div class="right">
+      <span class="bdg ok"><i class="bi bi-patch-check-fill"></i> Handled by Jeffrey</span>
+      <span class="bdg pr"><i class="bi bi-cpu"></i> async-profiler</span>
+      <span class="bdg gr"><i class="bi bi-layers"></i> 3 chunks</span>
+    </div>
+  </div>
+
+  <div class="layout">
+    <!-- LEFT sidebar: jeffrey.AppInformation -->
+    <div>
+      <div class="card">
+        <div class="card-h"><i class="bi bi-fingerprint"></i><span class="t">Application Identity</span><span class="badge">AppInformation</span></div>
+        <div class="card-b">
+          <div class="ir"><span class="k">Project label</span><span class="v">Payments API (prod)</span></div>
+          <div class="ir"><span class="k">Project name</span><span class="v mono">payments-api</span></div>
+          <div class="ir"><span class="k">Workspace</span><span class="v mono">$default</span></div>
+          <div class="ir"><span class="k">Project ID</span><span class="v mono">11111111-2222-…-555555555555</span></div>
+          <div class="ir"><span class="k">Instance</span><span class="v mono">pod-7c9f4</span></div>
+          <div class="ir"><span class="k">Session · order</span><span class="v mono">aaaaaaaa-… · #3</span></div>
+          <div class="ir"><span class="k">JVM started</span><span class="v">2026-06-25 09:14:02</span></div>
+          <div class="ir"><span class="k">Provisioned</span><span class="v">2026-06-25 09:13:58</span></div>
+          <div class="ir"><span class="k">Attributes</span><span class="v">
+            <span class="chip">cluster=eu-west</span><span class="chip">namespace=prod</span><span class="chip">env=production</span>
+          </span></div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-h"><i class="bi bi-recycle"></i><span class="t">Garbage Collection</span></div>
+        <div class="card-b" style="padding-top:4px">
+          <div class="kv"><span class="k">Collections</span><span class="v">142</span></div>
+          <div class="kv"><span class="k">Young / Old / Full</span><span class="v">128 / 12 / 2</span></div>
+          <div class="kv"><span class="k">Max pause</span><span class="v">61 ms</span></div>
+          <div class="kv"><span class="k">p99 pause</span><span class="v">38 ms</span></div>
+          <div class="kv"><span class="k">Overhead</span><span class="v" style="color:var(--success)">1.2%</span></div>
+          <div class="kv"><span class="k">Freed total</span><span class="v">11.4 GB</span></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- RIGHT main -->
+    <div>
+      <div class="mini">
+        <div class="m"><div class="ic bp"><i class="bi bi-stack"></i></div><div><div class="num">2,421,068</div><div class="lbl">Total events</div></div></div>
+        <div class="m"><div class="ic bi2"><i class="bi bi-stopwatch"></i></div><div><div class="num">5m 32s</div><div class="lbl">Duration</div></div></div>
+        <div class="m"><div class="ic bs"><i class="bi bi-hdd"></i></div><div><div class="num">184 MB</div><div class="lbl">Size on disk</div></div></div>
+        <div class="m"><div class="ic bw"><i class="bi bi-cpu-fill"></i></div><div><div class="num">47% / 82%</div><div class="lbl">CPU avg / peak</div></div></div>
+        <div class="m"><div class="ic bv"><i class="bi bi-list-columns"></i></div><div><div class="num">42</div><div class="lbl">Event types</div></div></div>
+        <div class="m"><div class="ic bd"><i class="bi bi-diagram-2"></i></div><div><div class="num">318</div><div class="lbl">Threads (14 virtual)</div></div></div>
+      </div>
+
+      <div class="card">
+        <div class="card-h"><i class="bi bi-activity"></i><span class="t">Event Generation Timeline</span><span class="badge">10s buckets · all types</span></div>
+        <div class="card-b">
+          <div class="tl">
+            <i style="height:30%"></i><i style="height:42%"></i><i style="height:55%"></i><i style="height:49%"></i><i style="height:66%"></i><i style="height:80%"></i><i style="height:92%"></i><i style="height:100%"></i><i style="height:84%"></i><i style="height:71%"></i><i style="height:62%"></i><i style="height:70%"></i><i style="height:58%"></i><i style="height:50%"></i><i style="height:44%"></i><i style="height:38%"></i><i style="height:48%"></i><i style="height:40%"></i><i style="height:33%"></i><i style="height:27%"></i>
+          </div>
+          <div class="tl-ax"><span>09:14:00</span><span>09:16:00</span><span>09:18:00</span><span>09:20:00</span></div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-h"><i class="bi bi-bar-chart-line-fill"></i><span class="t">Top Event Types</span><span class="badge">5 of 42</span></div>
+        <table>
+          <thead><tr><th>Event type</th><th>Source</th><th style="width:26%">Share</th><th class="rt">Count</th><th class="rt">%</th></tr></thead>
+          <tbody>
+            <tr><td class="evt">jdk.ExecutionSample</td><td><span class="src jdk">JDK</span></td><td><div class="minibar"><i style="width:100%"></i></div></td><td class="rt">1,204,332</td><td class="rt muted">49.7%</td></tr>
+            <tr><td class="evt">jdk.ObjectAllocationSample</td><td><span class="src jdk">JDK</span></td><td><div class="minibar"><i style="width:51%"></i></div></td><td class="rt">612,004</td><td class="rt muted">25.3%</td></tr>
+            <tr><td class="evt">jdk.JavaMonitorEnter</td><td><span class="src jdk">JDK</span></td><td><div class="minibar"><i style="width:8%"></i></div></td><td class="rt">88,210</td><td class="rt muted">3.6%</td></tr>
+            <tr><td class="evt">jdk.ThreadPark</td><td><span class="src jdk">JDK</span></td><td><div class="minibar"><i style="width:5%"></i></div></td><td class="rt">54,120</td><td class="rt muted">2.2%</td></tr>
+            <tr><td class="evt">jdk.SocketRead</td><td><span class="src ap">A-P</span></td><td><div class="minibar"><i style="width:3%"></i></div></td><td class="rt">31,402</td><td class="rt muted">1.3%</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="two">
+        <div class="card">
+          <div class="card-h"><i class="bi bi-gear-wide-connected"></i><span class="t">JVM &amp; Heap</span></div>
+          <div class="card-b" style="padding-top:5px">
+            <div class="kv"><span class="k">Version</span><span class="v">OpenJDK 25.0.1</span></div>
+            <div class="kv"><span class="k">Vendor</span><span class="v">Amazon Corretto</span></div>
+            <div class="kv"><span class="k">GC</span><span class="v">G1 (young + old)</span></div>
+            <div class="kv"><span class="k">Heap min / max</span><span class="v">512 MB / 4.0 GB</span></div>
+            <div class="kv"><span class="k">Compressed oops</span><span class="v">Zero based</span></div>
+          </div>
+        </div>
+        <div class="card">
+          <div class="card-h"><i class="bi bi-hdd-rack"></i><span class="t">OS &amp; Host</span></div>
+          <div class="card-b" style="padding-top:5px">
+            <div class="kv"><span class="k">OS</span><span class="v">Linux 6.18</span></div>
+            <div class="kv"><span class="k">Arch / cores</span><span class="v">x86_64 · 8</span></div>
+            <div class="kv"><span class="k">Container limit</span><span class="v">2 vCPU · 4 GB</span></div>
+            <div class="kv"><span class="k">Context switches</span><span class="v">12.4k/s peak</span></div>
+            <div class="kv"><span class="k">Processes seen</span><span class="v">37</span></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/dashboard-mockups/mockup-4-timeline-first.html
+++ b/dashboard-mockups/mockup-4-timeline-first.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Mockup 4 · Timeline First — Jeffrey Recording Dashboard</title>
+<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+<style>
+:root{
+  --primary:#5e64ff;--success:#00d27a;--danger:#e63757;--warning:#f5803e;--info:#39afd1;
+  --dark:#0b1727;--text:#5e6e82;--muted:#748194;
+  --bg:#edf2f9;--card:#fff;--light:#f9fafd;--border:#eaedf1;
+  --radius:8px;--shadow:0 0 .375rem 0 rgba(0,0,0,.1);
+}
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:'Poppins',-apple-system,sans-serif;background:var(--bg);color:var(--text);font-size:.875rem;padding:24px;line-height:1.5}
+.wrap{max-width:1200px;margin:0 auto}
+
+/* slim identity strip */
+.strip{display:flex;align-items:center;gap:14px;background:var(--card);border:1px solid var(--border);border-radius:var(--radius);box-shadow:var(--shadow);padding:12px 18px;margin-bottom:14px}
+.strip .lg{width:40px;height:40px;border-radius:11px;background:linear-gradient(135deg,#1e1b4b,#4338ca);color:#fff;display:grid;place-items:center;font-size:1.15rem;flex-shrink:0}
+.strip .nm{font-size:1.02rem;font-weight:700;color:var(--dark);line-height:1.1}
+.strip .mt{font-size:.72rem;color:var(--muted)}
+.strip .sep{width:1px;height:34px;background:var(--border);margin:0 4px}
+.strip .f{display:flex;flex-direction:column}
+.strip .f .k{font-size:.58rem;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);font-weight:600}
+.strip .f .v{font-size:.8rem;color:var(--dark);font-weight:600}
+.strip .ok{margin-left:auto;font-size:.64rem;font-weight:600;padding:5px 11px;border-radius:20px;background:rgba(0,210,122,.1);border:1px solid var(--success);color:var(--success);display:flex;align-items:center;gap:6px}
+
+/* big timeline hero */
+.hero-chart{background:var(--card);border:1px solid var(--border);border-radius:var(--radius);box-shadow:var(--shadow);margin-bottom:14px;overflow:hidden}
+.hc-head{display:flex;align-items:center;gap:10px;padding:14px 20px;border-bottom:1px solid var(--border)}
+.hc-head i{color:var(--primary);font-size:1.15rem}
+.hc-head .t{font-weight:600;color:var(--dark);font-size:.95rem}
+.hc-head .leg{margin-left:auto;display:flex;gap:14px;font-size:.7rem;color:var(--muted)}
+.hc-head .leg span{display:flex;align-items:center;gap:6px}
+.hc-head .leg .sw{width:10px;height:10px;border-radius:3px}
+.chart{padding:20px 20px 14px;position:relative}
+.chart svg{width:100%;height:200px;display:block}
+.gl{stroke:var(--border);stroke-width:1}
+.chart .ax{display:flex;justify-content:space-between;font-size:.64rem;color:var(--muted);margin-top:8px;padding:0 4px}
+.yl{position:absolute;left:6px;top:18px;font-size:.6rem;color:var(--muted)}
+
+/* bottom grid */
+.grid{display:grid;grid-template-columns:1.3fr 1fr;gap:14px}
+.card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius);box-shadow:var(--shadow)}
+.card-h{display:flex;align-items:center;gap:9px;padding:12px 16px;background:var(--light);border-bottom:1px solid var(--border);border-radius:var(--radius) var(--radius) 0 0}
+.card-h i{color:var(--primary)}.card-h .t{font-weight:600;color:var(--text);font-size:.82rem}
+.card-h .badge{margin-left:auto;font-size:.6rem;font-weight:600;padding:2px 8px;border-radius:5px;background:#e2e7fd;border:1px solid #9ba8ff;color:#1565c0}
+
+table{width:100%;border-collapse:collapse;font-size:.8rem}
+th{text-align:left;font-size:.62rem;text-transform:uppercase;letter-spacing:.04em;color:var(--muted);font-weight:600;padding:8px 14px;border-bottom:2px solid var(--border)}
+td{padding:9px 14px;border-bottom:1px solid var(--border);color:var(--dark)}
+tr:last-child td{border-bottom:none}
+.evt{font-family:'SF Mono',monospace;font-size:.74rem;font-weight:500}
+.rt{text-align:right;font-weight:600;font-variant-numeric:tabular-nums}
+.rk{width:22px;height:22px;border-radius:6px;background:#eef0ff;color:var(--primary);font-size:.68rem;font-weight:700;display:inline-grid;place-items:center}
+
+/* quick stats column */
+.qs{padding:6px 16px 14px}
+.q{display:flex;align-items:center;gap:12px;padding:11px 0;border-bottom:1px solid var(--border)}
+.q:last-child{border-bottom:none}
+.q .ic{width:38px;height:38px;border-radius:10px;display:grid;place-items:center;font-size:1.05rem;color:#fff;flex-shrink:0}
+.q .num{font-size:1.15rem;font-weight:700;color:var(--dark);line-height:1}
+.q .lbl{font-size:.7rem;color:var(--muted)}
+.q .ex{margin-left:auto;font-size:.66rem;font-weight:600;padding:2px 8px;border-radius:6px;background:var(--light);color:var(--muted)}
+.bp{background:linear-gradient(135deg,#5e64ff,#4c52db)}.bi2{background:linear-gradient(135deg,#39afd1,#2e9bb8)}
+.bs{background:linear-gradient(135deg,#00d27a,#00a863)}.bw{background:linear-gradient(135deg,#f5803e,#e4702d)}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <!-- identity strip -->
+  <div class="strip">
+    <div class="lg"><i class="bi bi-box-seam"></i></div>
+    <div><div class="nm">Payments API (prod)</div><div class="mt">payments-api · pod-7c9f4</div></div>
+    <div class="sep"></div>
+    <div class="f"><span class="k">Workspace</span><span class="v">$default</span></div>
+    <div class="sep"></div>
+    <div class="f"><span class="k">Session</span><span class="v">#3 · aaaaaaaa…</span></div>
+    <div class="sep"></div>
+    <div class="f"><span class="k">JVM started</span><span class="v">09:14:02 UTC</span></div>
+    <div class="sep"></div>
+    <div class="f"><span class="k">Source</span><span class="v">async-profiler</span></div>
+    <span class="ok"><i class="bi bi-patch-check-fill"></i> jeffrey.AppInformation</span>
+  </div>
+
+  <!-- BIG timeline hero -->
+  <div class="hero-chart">
+    <div class="hc-head">
+      <i class="bi bi-graph-up-arrow"></i><span class="t">Events Generated Over Recording</span>
+      <div class="leg">
+        <span><span class="sw" style="background:#5e64ff"></span>Execution samples</span>
+        <span><span class="sw" style="background:#39afd1"></span>Allocations</span>
+        <span><span class="sw" style="background:#f5803e"></span>All other</span>
+      </div>
+    </div>
+    <div class="chart">
+      <span class="yl">events / sec</span>
+      <svg viewBox="0 0 1000 200" preserveAspectRatio="none">
+        <line class="gl" x1="0" y1="50" x2="1000" y2="50"/><line class="gl" x1="0" y1="100" x2="1000" y2="100"/><line class="gl" x1="0" y1="150" x2="1000" y2="150"/>
+        <!-- other (bottom) -->
+        <path d="M0,200 L0,180 C120,176 200,170 300,160 C420,148 520,150 640,140 C760,130 860,150 1000,158 L1000,200 Z" fill="rgba(245,128,62,.18)" stroke="#f5803e" stroke-width="1.5"/>
+        <!-- allocations -->
+        <path d="M0,200 L0,150 C140,140 240,120 360,108 C480,96 560,118 680,110 C800,102 900,128 1000,140 L1000,200 Z" fill="rgba(57,175,209,.18)" stroke="#39afd1" stroke-width="1.5"/>
+        <!-- execution samples (front) -->
+        <path d="M0,200 L0,120 C120,104 220,70 340,48 C440,30 520,72 640,58 C780,42 880,96 1000,108 L1000,200 Z" fill="rgba(94,100,255,.22)" stroke="#5e64ff" stroke-width="2"/>
+      </svg>
+      <div class="ax"><span>09:14:00</span><span>09:15:30</span><span>09:17:00</span><span>09:18:30</span><span>09:20:00</span></div>
+    </div>
+  </div>
+
+  <div class="grid">
+    <!-- top events -->
+    <div class="card">
+      <div class="card-h"><i class="bi bi-bar-chart-line-fill"></i><span class="t">Top 5 Event Types</span><span class="badge">2.42M total</span></div>
+      <table>
+        <thead><tr><th>#</th><th>Event type</th><th class="rt">Count</th><th class="rt">Share</th></tr></thead>
+        <tbody>
+          <tr><td><span class="rk">1</span></td><td class="evt">jdk.ExecutionSample</td><td class="rt">1,204,332</td><td class="rt">49.7%</td></tr>
+          <tr><td><span class="rk">2</span></td><td class="evt">jdk.ObjectAllocationSample</td><td class="rt">612,004</td><td class="rt">25.3%</td></tr>
+          <tr><td><span class="rk">3</span></td><td class="evt">jdk.JavaMonitorEnter</td><td class="rt">88,210</td><td class="rt">3.6%</td></tr>
+          <tr><td><span class="rk">4</span></td><td class="evt">jdk.ThreadPark</td><td class="rt">54,120</td><td class="rt">2.2%</td></tr>
+          <tr><td><span class="rk">5</span></td><td class="evt">jdk.SocketRead</td><td class="rt">31,402</td><td class="rt">1.3%</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- quick stats -->
+    <div class="card">
+      <div class="card-h"><i class="bi bi-clipboard-data"></i><span class="t">At a Glance</span></div>
+      <div class="qs">
+        <div class="q"><div class="ic bp"><i class="bi bi-stack"></i></div><div><div class="num">2.42M</div><div class="lbl">Total events · 42 types</div></div><span class="ex">3 chunks</span></div>
+        <div class="q"><div class="ic bi2"><i class="bi bi-stopwatch"></i></div><div><div class="num">5m 32s</div><div class="lbl">Duration · 184 MB</div></div><span class="ex">09:14→09:20</span></div>
+        <div class="q"><div class="ic bs"><i class="bi bi-cpu"></i></div><div><div class="num">G1 · 4 GB</div><div class="lbl">OpenJDK 25.0.1 · 8 cores</div></div><span class="ex">1.2% GC</span></div>
+        <div class="q"><div class="ic bw"><i class="bi bi-graph-up"></i></div><div><div class="num">47% / 82%</div><div class="lbl">CPU avg / peak</div></div><span class="ex">12.4k ctx/s</span></div>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/dashboard-mockups/mockup-5-glass-cards.html
+++ b/dashboard-mockups/mockup-5-glass-cards.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Mockup 5 · Glass Cards — Jeffrey Recording Dashboard</title>
+<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+<style>
+:root{
+  --primary:#5e64ff;--success:#00d27a;--danger:#e63757;--warning:#f5803e;--info:#39afd1;
+  --dark:#0b1727;--text:#5e6e82;--muted:#748194;--border:#eaedf1;--radius:14px;
+}
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:'Poppins',-apple-system,sans-serif;font-size:.875rem;line-height:1.5;color:var(--text);
+  background:radial-gradient(1200px 600px at 80% -10%,#e7e9ff,transparent),radial-gradient(900px 500px at -10% 110%,#dff7ec,transparent),#eef1f9;
+  padding:26px;min-height:100vh}
+.wrap{max-width:1240px;margin:0 auto}
+
+/* hero identity */
+.hero{position:relative;overflow:hidden;border-radius:20px;padding:26px 30px;margin-bottom:20px;color:#fff;
+  background:linear-gradient(125deg,#312e81,#4338ca 45%,#5e64ff 100%)}
+.hero::before{content:"";position:absolute;inset:0;background:
+  radial-gradient(420px 220px at 88% 0%,rgba(0,210,122,.35),transparent),
+  radial-gradient(360px 240px at 10% 120%,rgba(139,92,246,.4),transparent)}
+.hero>*{position:relative;z-index:1}
+.hero-top{display:flex;align-items:center;gap:18px}
+.hlogo{width:62px;height:62px;border-radius:18px;background:rgba(255,255,255,.14);border:1px solid rgba(255,255,255,.22);backdrop-filter:blur(12px);display:grid;place-items:center;font-size:1.9rem}
+.htitle{font-size:1.7rem;font-weight:800;letter-spacing:-.02em;line-height:1}
+.hsub{font-size:.8rem;color:rgba(255,255,255,.65);margin-top:5px}
+.hsub code{color:#a5abff;background:rgba(255,255,255,.08);padding:1px 7px;border-radius:5px}
+.hok{margin-left:auto;display:flex;flex-direction:column;gap:7px;align-items:flex-end}
+.pill{font-size:.64rem;font-weight:600;padding:6px 13px;border-radius:20px;background:rgba(255,255,255,.14);border:1px solid rgba(255,255,255,.24);display:inline-flex;align-items:center;gap:6px}
+.pill.ok{background:rgba(0,210,122,.22);border-color:rgba(0,210,122,.4);color:#9af5cd}
+.hglass{display:grid;grid-template-columns:repeat(6,1fr);gap:12px;margin-top:22px}
+.hg{background:rgba(255,255,255,.1);border:1px solid rgba(255,255,255,.16);backdrop-filter:blur(10px);border-radius:13px;padding:12px 14px}
+.hg .k{font-size:.58rem;text-transform:uppercase;letter-spacing:.06em;color:rgba(255,255,255,.55);font-weight:600}
+.hg .v{font-size:.84rem;font-weight:700;margin-top:4px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+
+/* stat cards */
+.stats{display:grid;grid-template-columns:repeat(4,1fr);gap:16px;margin-bottom:20px}
+.scard{position:relative;overflow:hidden;border-radius:var(--radius);padding:20px;color:#fff;box-shadow:0 10px 26px rgba(49,46,129,.18)}
+.scard .ic{font-size:1.5rem;opacity:.85}
+.scard .num{font-size:2rem;font-weight:800;letter-spacing:-.02em;line-height:1;margin-top:12px}
+.scard .lbl{font-size:.74rem;opacity:.85;margin-top:5px;font-weight:500}
+.scard .spark{position:absolute;right:0;bottom:0;left:0;height:42px;opacity:.5}
+.g1{background:linear-gradient(135deg,#5e64ff,#7c3aed)}
+.g2{background:linear-gradient(135deg,#39afd1,#0d9488)}
+.g3{background:linear-gradient(135deg,#00d27a,#0d9488)}
+.g4{background:linear-gradient(135deg,#f5803e,#e63757)}
+
+.grid{display:grid;grid-template-columns:1.25fr 1fr;gap:16px}
+.glass{background:rgba(255,255,255,.82);backdrop-filter:blur(14px);border:1px solid rgba(255,255,255,.7);border-radius:var(--radius);box-shadow:0 8px 30px rgba(31,38,84,.08)}
+.gh{display:flex;align-items:center;gap:10px;padding:15px 20px;border-bottom:1px solid var(--border)}
+.gh i{color:var(--primary);font-size:1.1rem}.gh .t{font-weight:700;color:var(--dark);font-size:.92rem}
+.gh .badge{margin-left:auto;font-size:.62rem;font-weight:600;padding:3px 10px;border-radius:20px;background:#eef0ff;color:var(--primary)}
+.gb{padding:8px 20px 18px}
+
+/* event rows */
+.er{display:flex;align-items:center;gap:13px;padding:11px 0;border-bottom:1px solid var(--border)}
+.er:last-child{border-bottom:none}
+.er .rk{width:26px;height:26px;border-radius:8px;display:grid;place-items:center;font-size:.72rem;font-weight:700;color:#fff;flex-shrink:0}
+.er .nm{font-family:'SF Mono',monospace;font-size:.78rem;color:var(--dark);font-weight:500;flex-shrink:0;width:200px}
+.er .track{flex:1;height:8px;border-radius:5px;background:#eef0ff;overflow:hidden}
+.er .track i{display:block;height:100%;border-radius:5px}
+.er .ct{font-weight:700;color:var(--dark);font-variant-numeric:tabular-nums;width:90px;text-align:right;font-size:.8rem}
+
+/* runtime list */
+.rl{display:flex;justify-content:space-between;align-items:center;padding:11px 0;border-bottom:1px solid var(--border);font-size:.82rem}
+.rl:last-child{border-bottom:none}
+.rl .k{color:var(--muted);display:flex;align-items:center;gap:8px}
+.rl .k i{color:var(--primary);font-size:.95rem}
+.rl .v{color:var(--dark);font-weight:700}
+.dot{width:8px;height:8px;border-radius:50%;display:inline-block}
+
+/* fallback variant */
+.fallback{margin-top:20px;border-radius:var(--radius);overflow:hidden;border:1px solid rgba(245,128,62,.25);box-shadow:0 8px 30px rgba(31,38,84,.06)}
+.fb-h{background:linear-gradient(135deg,#fff8e1,#fff);padding:14px 20px;display:flex;align-items:center;gap:11px;border-bottom:1px solid rgba(245,128,62,.18)}
+.fb-h i{font-size:1.25rem;color:#ef6c00}.fb-h .t{font-weight:700;color:#8d6e00}.fb-h .tag{margin-left:auto;font-size:.6rem;font-weight:600;padding:3px 9px;border-radius:20px;background:#fff3e0;border:1px solid #ffb74d;color:#ef6c00}
+.fb-b{background:rgba(255,255,255,.85);padding:28px 20px;text-align:center}
+.fb-b .big{font-size:1.05rem;font-weight:700;color:var(--dark)}
+.fb-b .sm{font-size:.78rem;color:var(--muted);margin-top:6px}
+.fb-b code{background:#f5f5f5;padding:1px 7px;border-radius:5px;color:#424242;font-size:.74rem}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <!-- HERO -->
+  <div class="hero">
+    <div class="hero-top">
+      <div class="hlogo"><i class="bi bi-box-seam"></i></div>
+      <div>
+        <div class="htitle">Payments API <span style="opacity:.6;font-weight:600">(prod)</span></div>
+        <div class="hsub">Recording self-identified via <code>jeffrey.AppInformation</code></div>
+      </div>
+      <div class="hok">
+        <span class="pill ok"><i class="bi bi-patch-check-fill"></i> Handled by Jeffrey</span>
+        <span class="pill"><i class="bi bi-cpu"></i> async-profiler · 3 chunks</span>
+      </div>
+    </div>
+    <div class="hglass">
+      <div class="hg"><div class="k">Workspace</div><div class="v">$default</div></div>
+      <div class="hg"><div class="k">Project</div><div class="v">payments-api</div></div>
+      <div class="hg"><div class="k">Instance</div><div class="v">pod-7c9f4</div></div>
+      <div class="hg"><div class="k">Session</div><div class="v">#3 · aaaaaaaa…</div></div>
+      <div class="hg"><div class="k">JVM started</div><div class="v">09:14:02 UTC</div></div>
+      <div class="hg"><div class="k">Provisioned</div><div class="v">09:13:58 UTC</div></div>
+    </div>
+  </div>
+
+  <!-- STAT CARDS -->
+  <div class="stats">
+    <div class="scard g1"><i class="bi bi-stack ic"></i><div class="num">2.42M</div><div class="lbl">Total events · 42 types</div>
+      <svg class="spark" viewBox="0 0 100 42" preserveAspectRatio="none"><path d="M0,42 L0,30 C20,26 30,18 50,14 C70,10 80,22 100,18 L100,42 Z" fill="#fff"/></svg></div>
+    <div class="scard g2"><i class="bi bi-stopwatch ic"></i><div class="num">5m 32s</div><div class="lbl">Duration · 184 MB</div>
+      <svg class="spark" viewBox="0 0 100 42" preserveAspectRatio="none"><path d="M0,42 L0,24 C25,20 35,28 55,22 C75,16 85,26 100,20 L100,42 Z" fill="#fff"/></svg></div>
+    <div class="scard g3"><i class="bi bi-cpu ic"></i><div class="num">G1 · 4 GB</div><div class="lbl">OpenJDK 25.0.1 · 8 cores</div>
+      <svg class="spark" viewBox="0 0 100 42" preserveAspectRatio="none"><path d="M0,42 L0,28 C20,30 35,16 50,20 C70,24 85,12 100,16 L100,42 Z" fill="#fff"/></svg></div>
+    <div class="scard g4"><i class="bi bi-graph-up ic"></i><div class="num">47%</div><div class="lbl">Avg CPU · peak 82%</div>
+      <svg class="spark" viewBox="0 0 100 42" preserveAspectRatio="none"><path d="M0,42 L0,26 C20,14 35,30 55,18 C75,8 88,24 100,14 L100,42 Z" fill="#fff"/></svg></div>
+  </div>
+
+  <!-- GRID -->
+  <div class="grid">
+    <div class="glass">
+      <div class="gh"><i class="bi bi-bar-chart-line-fill"></i><span class="t">Top 5 Event Types</span><span class="badge">by sample count</span></div>
+      <div class="gb">
+        <div class="er"><span class="rk" style="background:#5e64ff">1</span><span class="nm">jdk.ExecutionSample</span><span class="track"><i style="width:100%;background:linear-gradient(90deg,#5e64ff,#7c3aed)"></i></span><span class="ct">1.20M</span></div>
+        <div class="er"><span class="rk" style="background:#39afd1">2</span><span class="nm">jdk.ObjectAllocationSample</span><span class="track"><i style="width:51%;background:linear-gradient(90deg,#39afd1,#0d9488)"></i></span><span class="ct">612k</span></div>
+        <div class="er"><span class="rk" style="background:#00d27a">3</span><span class="nm">jdk.JavaMonitorEnter</span><span class="track"><i style="width:8%;background:#00d27a"></i></span><span class="ct">88.2k</span></div>
+        <div class="er"><span class="rk" style="background:#f5803e">4</span><span class="nm">jdk.ThreadPark</span><span class="track"><i style="width:5%;background:#f5803e"></i></span><span class="ct">54.1k</span></div>
+        <div class="er"><span class="rk" style="background:#e63757">5</span><span class="nm">jdk.SocketRead</span><span class="track"><i style="width:3%;background:#e63757"></i></span><span class="ct">31.4k</span></div>
+      </div>
+    </div>
+
+    <div class="glass">
+      <div class="gh"><i class="bi bi-gear-wide-connected"></i><span class="t">Runtime &amp; Environment</span></div>
+      <div class="gb">
+        <div class="rl"><span class="k"><i class="bi bi-cup-hot"></i>JVM</span><span class="v">OpenJDK 25.0.1 · Corretto</span></div>
+        <div class="rl"><span class="k"><i class="bi bi-recycle"></i>Collector</span><span class="v"><span class="dot" style="background:var(--success)"></span> G1</span></div>
+        <div class="rl"><span class="k"><i class="bi bi-memory"></i>Heap max</span><span class="v">4.0 GB</span></div>
+        <div class="rl"><span class="k"><i class="bi bi-hdd-rack"></i>OS</span><span class="v">Linux 6.18 · x86_64</span></div>
+        <div class="rl"><span class="k"><i class="bi bi-diagram-2"></i>Threads</span><span class="v">318 (14 virtual)</span></div>
+        <div class="rl"><span class="k"><i class="bi bi-tags"></i>Attributes</span><span class="v">cluster=eu-west +2</span></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- FALLBACK VARIANT -->
+  <div class="fallback">
+    <div class="fb-h"><i class="bi bi-exclamation-triangle-fill"></i><span class="t">Same panel — fallback when the event is absent</span><span class="tag">no AppInformation</span></div>
+    <div class="fb-b">
+      <div class="big"><i class="bi bi-question-circle"></i> Recording not handled by Jeffrey</div>
+      <div class="sm">No <code>jeffrey.AppInformation</code> event was found in this recording, so workspace / project / session identity is unavailable. Generic recording metrics are still shown below.</div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/jeffrey-microscope/pages-microscope/src/router/index.ts
+++ b/jeffrey-microscope/pages-microscope/src/router/index.ts
@@ -14,6 +14,12 @@ const profileChildRoutes = [
     meta: { layout: 'profile' }
   },
   {
+    path: 'dashboard',
+    name: 'profile-dashboard',
+    component: () => import('@/views/profiles/detail/ProfileRecordingDashboard.vue'),
+    meta: { layout: 'profile' }
+  },
+  {
     path: 'guardian',
     name: 'profile-guardian',
     component: () => import('@/views/profiles/detail/ProfileGuardian.vue'),

--- a/jeffrey-microscope/pages-microscope/src/services/api/EventTimeseriesClient.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/EventTimeseriesClient.ts
@@ -1,0 +1,55 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import BaseProfileClient from '@/services/api/BaseProfileClient';
+import TimeseriesData from '@/services/timeseries/model/TimeseriesData';
+
+/**
+ * Thin client over the generic timeseries endpoint
+ * (POST /api/internal/profiles/{profileId}/timeseries).
+ *
+ * Used by the Recording Dashboard to render an "events over time" sparkline for
+ * a single event type. The endpoint deserializes {@code eventType} from the
+ * event-type code string (e.g. "jdk.ExecutionSample").
+ */
+export default class EventTimeseriesClient extends BaseProfileClient {
+  constructor(profileId: string) {
+    super(profileId, 'timeseries');
+  }
+
+  /**
+   * Generates a sample-count timeseries for a single event type.
+   * @param eventTypeCode the event-type code (e.g. "jdk.ExecutionSample")
+   */
+  public forEventType(eventTypeCode: string): Promise<TimeseriesData> {
+    return this.post<TimeseriesData>(
+      '',
+      {
+        eventType: eventTypeCode,
+        search: null,
+        useWeight: false,
+        excludeNonJavaSamples: false,
+        excludeIdleSamples: false,
+        onlyUnsafeAllocationSamples: false,
+        threadInfo: null,
+        markers: []
+      },
+      { suppressToast: true }
+    );
+  }
+}

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/ProfileDetail.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/ProfileDetail.vue
@@ -143,6 +143,14 @@
                   <div class="nav-section-title">ANALYSIS</div>
                   <div class="nav-items">
                     <router-link
+                      :to="`/profiles/${profileId}/dashboard`"
+                      class="nav-item"
+                      active-class="active"
+                    >
+                      <i class="bi bi-speedometer2"></i>
+                      <span>Dashboard</span>
+                    </router-link>
+                    <router-link
                       :to="`/profiles/${profileId}/ai-analysis`"
                       class="nav-item nav-item-ai"
                       :class="{ 'disabled-feature': isFeatureDisabled('ai-analysis') }"

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileRecordingDashboard.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileRecordingDashboard.vue
@@ -1,0 +1,1039 @@
+<!--
+  - Jeffrey
+  - Copyright (C) 2026 Petr Bouda
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as published by
+  - the Free Software Foundation, either version 3 of the License, or
+  - (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { useRoute } from 'vue-router';
+
+import LoadingState from '@shared/components/LoadingState.vue';
+import ErrorState from '@shared/components/ErrorState.vue';
+import EmptyState from '@shared/components/EmptyState.vue';
+import MainCard from '@shared/components/MainCard.vue';
+import MainCardHeader from '@shared/components/MainCardHeader.vue';
+import DataTable from '@shared/components/table/DataTable.vue';
+import Badge from '@shared/components/Badge.vue';
+import FormattingService from '@shared/services/FormattingService';
+
+import InformationClient from '@/services/api/InformationClient';
+import EventSummariesClient from '@/services/api/EventSummariesClient';
+import ProfileSystemClient from '@/services/api/ProfileSystemClient';
+import ProfileGCClient from '@/services/api/ProfileGCClient';
+import EventTimeseriesClient from '@/services/api/EventTimeseriesClient';
+import DirectProfileClient from '@/services/api/DirectProfileClient';
+import { profileStore } from '@/stores/profileStore';
+
+// ------------------------------------------------------------------
+// Section / field labels produced by the /information config endpoint
+// (event labels from the JFR event metadata; see event-type-fields.json).
+// ------------------------------------------------------------------
+const SECTION_APP_INFORMATION = 'Application Information';
+const SECTION_JVM = 'JVM Information';
+const SECTION_GC = 'GC Configuration';
+const SECTION_HEAP = 'GC Heap Configuration';
+const SECTION_OS = 'OS Information';
+const SECTION_CPU = 'CPU Information';
+const SECTION_CONTAINER = 'Container Configuration';
+
+const APP_PROJECT_LABEL = 'Project Label';
+const APP_PROJECT_NAME = 'Project Name';
+const APP_WORKSPACE_ID = 'Workspace ID';
+const APP_INSTANCE_ID = 'Instance ID';
+const APP_SESSION_ID = 'Session ID';
+const APP_SESSION_ORDER = 'Session Order';
+const APP_ATTRIBUTES = 'Attributes';
+const APP_PROVISIONED_AT = 'Provisioned At';
+const APP_JVM_STARTED_AT = 'JVM Started At';
+
+const TOP_EVENT_LIMIT = 5;
+const SPARK_BUCKETS = 32;
+const BASIS_POINTS_PER_PERCENT = 100;
+
+type InfoMap = Record<string, Record<string, unknown>>;
+
+interface Attribute {
+  key: string;
+  value: string;
+}
+
+interface AppIdentity {
+  projectLabel?: string;
+  projectName?: string;
+  workspaceId?: string;
+  instanceId?: string;
+  sessionId?: string;
+  sessionOrder?: string;
+  attributes: Attribute[];
+  provisionedAt?: string;
+  jvmStartedAt?: string;
+}
+
+interface TopEvent {
+  code: string;
+  label: string;
+  samples: number;
+  share: number;
+}
+
+interface InfoRow {
+  label: string;
+  value: string;
+}
+
+const route = useRoute();
+const profileId = route.params.profileId as string;
+
+const loading = ref(true);
+const error = ref<string | null>(null);
+
+const recordingName = ref<string>('');
+const eventSource = ref<string>('');
+const durationMillis = ref<number | null>(null);
+const sizeInBytes = ref<number | null>(null);
+
+const identity = ref<AppIdentity | null>(null);
+const topEvents = ref<TopEvent[]>([]);
+const totalEvents = ref(0);
+const eventTypeCount = ref(0);
+const sparkline = ref<number[]>([]);
+const sparklineLabel = ref<string>('');
+
+const avgCpuPercent = ref<number | null>(null);
+const maxCpuPercent = ref<number | null>(null);
+
+const runtimeRows = ref<InfoRow[]>([]);
+const gcRows = ref<InfoRow[]>([]);
+const hasGc = ref(false);
+
+const handledByJeffrey = computed(() => identity.value !== null);
+
+// ------------------------------------------------------------------
+// Helpers
+// ------------------------------------------------------------------
+function section(info: InfoMap | null, name: string): Record<string, unknown> | null {
+  return info?.[name] ?? null;
+}
+
+function field(sec: Record<string, unknown> | null, label: string): string | undefined {
+  const value = sec?.[label];
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+  return String(value);
+}
+
+function asNumber(value: string | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function parseAttributes(raw: string | undefined): Attribute[] {
+  if (!raw) {
+    return [];
+  }
+  const result: Attribute[] = [];
+  for (const pair of raw.split(';')) {
+    const trimmed = pair.trim();
+    if (trimmed === '') {
+      continue;
+    }
+    const eq = trimmed.indexOf('=');
+    if (eq < 0) {
+      result.push({ key: trimmed, value: '' });
+    } else {
+      result.push({ key: trimmed.slice(0, eq), value: trimmed.slice(eq + 1) });
+    }
+  }
+  return result;
+}
+
+function parseIdentity(info: InfoMap | null): AppIdentity | null {
+  const sec = section(info, SECTION_APP_INFORMATION);
+  if (sec === null) {
+    return null;
+  }
+  const provisionedAt = asNumber(field(sec, APP_PROVISIONED_AT));
+  const jvmStartedAt = asNumber(field(sec, APP_JVM_STARTED_AT));
+  return {
+    projectLabel: field(sec, APP_PROJECT_LABEL),
+    projectName: field(sec, APP_PROJECT_NAME),
+    workspaceId: field(sec, APP_WORKSPACE_ID),
+    instanceId: field(sec, APP_INSTANCE_ID),
+    sessionId: field(sec, APP_SESSION_ID),
+    sessionOrder: field(sec, APP_SESSION_ORDER),
+    attributes: parseAttributes(field(sec, APP_ATTRIBUTES)),
+    provisionedAt:
+      provisionedAt !== undefined ? FormattingService.formatTimestamp(provisionedAt) : undefined,
+    jvmStartedAt:
+      jvmStartedAt !== undefined ? FormattingService.formatTimestamp(jvmStartedAt) : undefined
+  };
+}
+
+function buildRuntimeRows(info: InfoMap | null): InfoRow[] {
+  const rows: InfoRow[] = [];
+  const push = (label: string, value: string | undefined) => {
+    rows.push({ label, value: value ?? '—' });
+  };
+
+  const jvm = section(info, SECTION_JVM);
+  push(
+    'JVM',
+    [field(jvm, 'JVM Name'), field(jvm, 'JVM Version')].filter(Boolean).join(' · ') || undefined
+  );
+
+  const gc = section(info, SECTION_GC);
+  const young = field(gc, 'Young Garbage Collector');
+  const old = field(gc, 'Old Garbage Collector');
+  push('Garbage collector', [young, old].filter(Boolean).join(' + ') || undefined);
+
+  const heap = section(info, SECTION_HEAP);
+  const maxHeap = asNumber(field(heap, 'Maximum Heap Size'));
+  const initialHeap = asNumber(field(heap, 'Initial Heap Size'));
+  if (maxHeap !== undefined || initialHeap !== undefined) {
+    const max = maxHeap !== undefined ? FormattingService.formatBytes(maxHeap) : '—';
+    const initial = initialHeap !== undefined ? FormattingService.formatBytes(initialHeap) : '—';
+    push('Heap (max / initial)', `${max} / ${initial}`);
+  } else {
+    push('Heap (max / initial)', undefined);
+  }
+
+  const os = section(info, SECTION_OS);
+  const cpu = section(info, SECTION_CPU);
+  const cores = field(cpu, 'Cores');
+  push(
+    'OS',
+    [field(os, 'OS Version'), cores ? `${cores} cores` : undefined].filter(Boolean).join(' · ') ||
+      undefined
+  );
+
+  const container = section(info, SECTION_CONTAINER);
+  const memLimit = asNumber(field(container, 'Memory Limit'));
+  const effectiveCpu = field(container, 'Effective CPU Count');
+  if (memLimit !== undefined || effectiveCpu !== undefined) {
+    const parts: string[] = [];
+    if (effectiveCpu !== undefined) {
+      parts.push(`${effectiveCpu} vCPU`);
+    }
+    if (memLimit !== undefined) {
+      parts.push(FormattingService.formatBytes(memLimit));
+    }
+    push('Container limit', parts.join(' · ') || undefined);
+  }
+
+  return rows;
+}
+
+function downsample(values: number[], buckets: number): number[] {
+  if (values.length <= buckets) {
+    return values;
+  }
+  const groupSize = Math.ceil(values.length / buckets);
+  const result: number[] = [];
+  for (let i = 0; i < values.length; i += groupSize) {
+    let sum = 0;
+    const slice = values.slice(i, i + groupSize);
+    for (const v of slice) {
+      sum += v;
+    }
+    result.push(sum / slice.length);
+  }
+  return result;
+}
+
+const sparkMax = computed(() => Math.max(1, ...sparkline.value));
+
+function barHeight(value: number): string {
+  const pct = Math.max(4, Math.round((value / sparkMax.value) * 100));
+  return `${pct}%`;
+}
+
+// ------------------------------------------------------------------
+// Data loading — each section degrades independently.
+// ------------------------------------------------------------------
+async function loadRecordingMetadata(): Promise<void> {
+  const current = profileStore.currentProfile.value;
+  if (current !== null && current.id === profileId) {
+    recordingName.value = current.name;
+    eventSource.value = String(current.eventSource ?? '');
+    durationMillis.value = current.durationInMillis ?? null;
+    sizeInBytes.value = current.sizeInBytes ?? null;
+    return;
+  }
+  try {
+    const profile = await new DirectProfileClient().getById(profileId);
+    recordingName.value = profile.name;
+    eventSource.value = String(profile.eventSource ?? '');
+    durationMillis.value = profile.durationInMillis ?? null;
+    sizeInBytes.value = profile.sizeInBytes ?? null;
+  } catch (err) {
+    console.error('Failed to load recording metadata', err);
+  }
+}
+
+async function loadDashboard(): Promise<void> {
+  loading.value = true;
+  error.value = null;
+
+  const [infoResult, eventsResult, systemResult, gcResult] = await Promise.allSettled([
+    new InformationClient(profileId).info() as Promise<InfoMap>,
+    EventSummariesClient.primary(profileId).events(),
+    new ProfileSystemClient(profileId).getOverview(),
+    new ProfileGCClient(profileId).getOverview()
+  ]);
+
+  await loadRecordingMetadata();
+
+  // Identity + runtime (from /information)
+  if (infoResult.status === 'fulfilled') {
+    const info = infoResult.value;
+    identity.value = parseIdentity(info);
+    runtimeRows.value = buildRuntimeRows(info);
+  }
+
+  // Top event types + total (from /flamegraph/events)
+  if (eventsResult.status === 'fulfilled') {
+    const summaries = eventsResult.value ?? [];
+    const sorted = [...summaries]
+      .filter(s => s.primary && s.primary.samples > 0)
+      .sort((a, b) => b.primary.samples - a.primary.samples);
+    const total = sorted.reduce((acc, s) => acc + s.primary.samples, 0);
+    totalEvents.value = total;
+    eventTypeCount.value = sorted.length;
+    topEvents.value = sorted.slice(0, TOP_EVENT_LIMIT).map(s => ({
+      code: s.code,
+      label: s.label,
+      samples: s.primary.samples,
+      share: total > 0 ? s.primary.samples / total : 0
+    }));
+  }
+
+  // System CPU (basis points -> percent)
+  if (systemResult.status === 'fulfilled') {
+    const overview = systemResult.value;
+    avgCpuPercent.value = Math.round(overview.avgMachineCpuBp / BASIS_POINTS_PER_PERCENT);
+    maxCpuPercent.value = Math.round(overview.maxMachineCpuBp / BASIS_POINTS_PER_PERCENT);
+  }
+
+  // Garbage collection summary
+  if (gcResult.status === 'fulfilled' && gcResult.value?.header) {
+    const header = gcResult.value.header;
+    hasGc.value = header.totalCollections > 0;
+    if (hasGc.value) {
+      gcRows.value = [
+        { label: 'Collections', value: FormattingService.formatNumber(header.totalCollections) },
+        { label: 'p99 pause', value: FormattingService.formatDuration(header.p99PauseTime) },
+        {
+          label: 'GC overhead',
+          value: FormattingService.formatPercentage(Number(header.gcOverhead) / 100)
+        },
+        { label: 'Memory freed', value: FormattingService.formatBytes(header.totalMemoryFreed) }
+      ];
+    }
+  }
+
+  // Events-over-time sparkline for the dominant event type (best-effort)
+  if (topEvents.value.length > 0) {
+    await loadSparkline(topEvents.value[0]);
+  }
+
+  if (
+    infoResult.status === 'rejected' &&
+    eventsResult.status === 'rejected' &&
+    systemResult.status === 'rejected' &&
+    gcResult.status === 'rejected'
+  ) {
+    error.value = 'Failed to load the recording dashboard.';
+  }
+
+  loading.value = false;
+}
+
+async function loadSparkline(top: TopEvent): Promise<void> {
+  try {
+    const data = await new EventTimeseriesClient(profileId).forEventType(top.code);
+    const serie = data.series?.[0];
+    if (serie && serie.data.length > 0) {
+      const values = serie.data.map(point => point[1] ?? 0);
+      sparkline.value = downsample(values, SPARK_BUCKETS);
+      sparklineLabel.value = top.label;
+    }
+  } catch (err) {
+    console.error('Failed to load events-over-time sparkline', err);
+  }
+}
+
+onMounted(loadDashboard);
+</script>
+
+<template>
+  <LoadingState v-if="loading" message="Loading recording dashboard..." />
+
+  <ErrorState v-else-if="error" :message="error" />
+
+  <div v-else class="dashboard">
+    <!-- ===================== Identity hero ===================== -->
+    <section v-if="handledByJeffrey && identity" class="hero">
+      <div class="hero-top">
+        <div class="hero-logo"><i class="bi bi-box-seam"></i></div>
+        <div class="hero-id">
+          <h1 class="hero-title">
+            {{ identity.projectLabel || identity.projectName || recordingName || 'Recording' }}
+          </h1>
+          <p class="hero-sub">
+            <i class="bi bi-patch-check-fill"></i>
+            Identified via <code>jeffrey.AppInformation</code> — self-describing recording
+          </p>
+        </div>
+        <div class="hero-pills">
+          <Badge
+            value="Handled by Jeffrey"
+            icon="bi-check-circle-fill"
+            variant="success"
+            size="s"
+            :uppercase="false"
+          />
+          <Badge
+            v-if="identity.sessionOrder"
+            :value="`Session #${identity.sessionOrder}`"
+            icon="bi-diagram-3"
+            variant="secondary"
+            size="s"
+            :uppercase="false"
+          />
+          <Badge
+            v-if="eventSource"
+            :value="eventSource"
+            icon="bi-cpu"
+            variant="info"
+            size="s"
+            :uppercase="false"
+          />
+        </div>
+      </div>
+      <div class="hero-meta">
+        <div class="hero-cell">
+          <span class="hero-k">Workspace</span
+          ><span class="hero-v">{{ identity.workspaceId || '—' }}</span>
+        </div>
+        <div class="hero-cell">
+          <span class="hero-k">Project</span
+          ><span class="hero-v">{{ identity.projectName || '—' }}</span>
+        </div>
+        <div class="hero-cell">
+          <span class="hero-k">Instance</span
+          ><span class="hero-v">{{ identity.instanceId || '—' }}</span>
+        </div>
+        <div class="hero-cell">
+          <span class="hero-k">Session</span
+          ><span class="hero-v">{{ identity.sessionId || '—' }}</span>
+        </div>
+        <div class="hero-cell">
+          <span class="hero-k">JVM started</span
+          ><span class="hero-v">{{ identity.jvmStartedAt || '—' }}</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- ===================== Fallback hero ===================== -->
+    <section v-else class="hero hero-fallback">
+      <div class="hero-top">
+        <div class="hero-logo hero-logo-muted"><i class="bi bi-question-circle"></i></div>
+        <div class="hero-id">
+          <h1 class="hero-title hero-title-muted">{{ recordingName || 'Recording' }}</h1>
+          <p class="hero-sub hero-sub-muted">
+            <i class="bi bi-exclamation-triangle-fill"></i>
+            Recording not handled by Jeffrey — no <code>jeffrey.AppInformation</code> event found.
+            Generic recording metrics are shown below.
+          </p>
+        </div>
+        <div class="hero-pills">
+          <Badge
+            v-if="eventSource"
+            :value="eventSource"
+            icon="bi-cpu"
+            variant="secondary"
+            size="s"
+            :uppercase="false"
+          />
+        </div>
+      </div>
+    </section>
+
+    <!-- ===================== KPI tiles ===================== -->
+    <section class="kpis">
+      <div class="kpi">
+        <div class="kpi-icon kpi-primary"><i class="bi bi-stack"></i></div>
+        <div class="kpi-body">
+          <span class="kpi-num">{{ FormattingService.formatNumber(totalEvents) }}</span>
+          <span class="kpi-label">Total events</span>
+        </div>
+        <span class="kpi-tag">{{ eventTypeCount }} types</span>
+      </div>
+      <div class="kpi">
+        <div class="kpi-icon kpi-info"><i class="bi bi-stopwatch"></i></div>
+        <div class="kpi-body">
+          <span class="kpi-num">{{
+            durationMillis !== null
+              ? FormattingService.formatDurationInMillis2Units(durationMillis)
+              : '—'
+          }}</span>
+          <span class="kpi-label">Recording duration</span>
+        </div>
+      </div>
+      <div class="kpi">
+        <div class="kpi-icon kpi-success"><i class="bi bi-hdd"></i></div>
+        <div class="kpi-body">
+          <span class="kpi-num">{{
+            sizeInBytes !== null ? FormattingService.formatBytes(sizeInBytes) : '—'
+          }}</span>
+          <span class="kpi-label">Recording size</span>
+        </div>
+      </div>
+      <div class="kpi">
+        <div class="kpi-icon kpi-warning"><i class="bi bi-cpu-fill"></i></div>
+        <div class="kpi-body">
+          <span class="kpi-num">{{ avgCpuPercent !== null ? `${avgCpuPercent}%` : '—' }}</span>
+          <span class="kpi-label">Avg machine CPU</span>
+        </div>
+        <span v-if="maxCpuPercent !== null" class="kpi-tag">peak {{ maxCpuPercent }}%</span>
+      </div>
+    </section>
+
+    <!-- ===================== Top events + sparkline ===================== -->
+    <section class="grid-2">
+      <DataTable v-if="topEvents.length > 0" table-class="top-events-table">
+        <template #toolbar>
+          <div class="table-head">
+            <span class="card-title"
+              ><i class="bi bi-bar-chart-line-fill"></i> Top {{ topEvents.length }} Event
+              Types</span
+            >
+            <Badge
+              :value="FormattingService.formatNumber(totalEvents)"
+              key-label="total"
+              variant="primary"
+              size="s"
+              borderless
+            />
+          </div>
+        </template>
+        <thead>
+          <tr>
+            <th>Event type</th>
+            <th class="share-col">Share</th>
+            <th class="text-end">Count</th>
+            <th class="text-end pct-col">%</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="event in topEvents" :key="event.code">
+            <td>
+              <span class="event-code">{{ event.label }}</span>
+            </td>
+            <td class="share-col">
+              <div class="bar-track">
+                <span
+                  class="bar-fill"
+                  :style="{ width: `${Math.max(3, Math.round(event.share * 100))}%` }"
+                ></span>
+              </div>
+            </td>
+            <td class="text-end count-cell">{{ FormattingService.formatNumber(event.samples) }}</td>
+            <td class="text-end pct-cell">{{ FormattingService.formatPercentage(event.share) }}</td>
+          </tr>
+        </tbody>
+      </DataTable>
+
+      <MainCard v-if="sparkline.length > 0" :bottom-margin="false">
+        <template #header>
+          <MainCardHeader icon="bi-activity" title="Events Over Time" />
+        </template>
+        <div class="spark-wrap">
+          <p class="spark-caption">
+            Activity for <code>{{ sparklineLabel }}</code> across the recording
+          </p>
+          <div class="spark">
+            <span
+              v-for="(value, index) in sparkline"
+              :key="index"
+              class="spark-bar"
+              :style="{ height: barHeight(value) }"
+            ></span>
+          </div>
+          <div class="spark-axis"><span>start</span><span>end</span></div>
+        </div>
+      </MainCard>
+    </section>
+
+    <!-- ===================== Runtime / GC / Attributes ===================== -->
+    <section class="grid-3">
+      <MainCard :bottom-margin="false">
+        <template #header>
+          <MainCardHeader icon="bi-gear-wide-connected" title="Runtime &amp; Environment" />
+        </template>
+        <div class="info-list">
+          <div v-for="row in runtimeRows" :key="row.label" class="info-row">
+            <span class="info-k">{{ row.label }}</span
+            ><span class="info-v">{{ row.value }}</span>
+          </div>
+          <EmptyState
+            v-if="runtimeRows.length === 0"
+            icon="bi-gear"
+            title="No configuration events"
+            description="This recording has no JVM/OS/GC configuration events."
+          />
+        </div>
+      </MainCard>
+
+      <MainCard :bottom-margin="false">
+        <template #header>
+          <MainCardHeader icon="bi-recycle" title="Garbage Collection" />
+        </template>
+        <div class="info-list">
+          <div v-for="row in gcRows" :key="row.label" class="info-row">
+            <span class="info-k">{{ row.label }}</span
+            ><span class="info-v">{{ row.value }}</span>
+          </div>
+          <EmptyState
+            v-if="!hasGc"
+            icon="bi-recycle"
+            title="No GC activity"
+            description="No garbage collection events were recorded."
+          />
+        </div>
+      </MainCard>
+
+      <MainCard :bottom-margin="false">
+        <template #header>
+          <MainCardHeader icon="bi-tags" title="Attributes" />
+        </template>
+        <div class="info-list">
+          <div v-if="identity && identity.attributes.length > 0" class="chips">
+            <Badge
+              v-for="attr in identity.attributes"
+              :key="attr.key"
+              :value="attr.value"
+              :key-label="attr.key"
+              variant="indigo"
+              size="s"
+              :uppercase="false"
+              borderless
+            />
+          </div>
+          <div v-if="identity && identity.provisionedAt" class="info-row">
+            <span class="info-k">Provisioned</span
+            ><span class="info-v">{{ identity.provisionedAt }}</span>
+          </div>
+          <EmptyState
+            v-if="!identity || (identity.attributes.length === 0 && !identity.provisionedAt)"
+            icon="bi-tags"
+            title="No attributes"
+            description="No custom attributes were attached to this recording."
+          />
+        </div>
+      </MainCard>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+/* ===================== Hero ===================== */
+.hero {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-6) var(--spacing-6);
+  background: linear-gradient(
+    135deg,
+    var(--color-indigo-dark) 0%,
+    var(--color-indigo) 45%,
+    var(--color-primary) 100%
+  );
+  box-shadow: var(--shadow-lg);
+}
+
+.hero-fallback {
+  background: linear-gradient(135deg, var(--color-light), var(--color-white));
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-base);
+}
+
+.hero-top {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-4);
+}
+
+.hero-logo {
+  width: 52px;
+  height: 52px;
+  border-radius: var(--radius-lg);
+  display: grid;
+  place-items: center;
+  font-size: 1.6rem;
+  color: var(--color-white);
+  background: rgba(255, 255, 255, 0.14);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  flex-shrink: 0;
+}
+
+.hero-logo-muted {
+  color: var(--color-warning);
+  background: var(--color-light);
+  border-color: var(--color-border);
+}
+
+.hero-id {
+  min-width: 0;
+}
+
+.hero-title {
+  color: var(--color-white);
+  font-size: 1.4rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0;
+}
+
+.hero-title-muted {
+  color: var(--color-dark);
+}
+
+.hero-sub {
+  color: rgba(255, 255, 255, 0.65);
+  font-size: var(--font-size-sm);
+  margin: 4px 0 0;
+}
+
+.hero-sub-muted {
+  color: var(--color-text-muted);
+}
+
+.hero-sub code {
+  color: var(--color-white);
+  background: rgba(255, 255, 255, 0.12);
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+}
+
+.hero-sub-muted code {
+  color: var(--color-dark);
+  background: var(--color-light);
+}
+
+.hero-pills {
+  margin-left: auto;
+  display: flex;
+  gap: var(--spacing-2);
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.hero-meta {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 1px;
+  margin-top: var(--spacing-4);
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.hero-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: var(--spacing-3) var(--spacing-3);
+  background: rgba(17, 15, 48, 0.28);
+}
+
+.hero-k {
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(255, 255, 255, 0.55);
+  font-weight: var(--font-weight-semibold);
+}
+
+.hero-v {
+  font-size: 0.82rem;
+  color: var(--color-white);
+  font-weight: var(--font-weight-semibold);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ===================== KPI tiles ===================== */
+.kpis {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--spacing-3);
+}
+
+.kpi {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-base);
+  padding: var(--spacing-4);
+}
+
+.kpi-icon {
+  width: 42px;
+  height: 42px;
+  border-radius: var(--radius-md);
+  display: grid;
+  place-items: center;
+  font-size: 1.2rem;
+  color: var(--color-white);
+  flex-shrink: 0;
+}
+
+.kpi-primary {
+  background: var(--color-primary);
+}
+
+.kpi-info {
+  background: var(--color-info);
+}
+
+.kpi-success {
+  background: var(--color-success);
+}
+
+.kpi-warning {
+  background: var(--color-warning);
+}
+
+.kpi-body {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.kpi-num {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--color-dark);
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+}
+
+.kpi-label {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.kpi-tag {
+  position: absolute;
+  top: var(--spacing-3);
+  right: var(--spacing-3);
+  font-size: 0.62rem;
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-muted);
+  background: var(--color-light);
+  padding: 2px 7px;
+  border-radius: var(--radius-sm);
+}
+
+/* ===================== Grids ===================== */
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1.3fr 1fr;
+  gap: var(--spacing-3);
+  align-items: start;
+}
+
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--spacing-3);
+  align-items: start;
+}
+
+.table-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3) var(--spacing-4);
+  background: var(--color-light);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.card-title {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text);
+  font-size: 0.84rem;
+}
+
+.card-title i {
+  color: var(--color-primary);
+}
+
+/* ===================== Top events table ===================== */
+.event-code {
+  font-family: var(--font-family-mono, monospace);
+  font-size: 0.76rem;
+  font-weight: 500;
+  color: var(--color-dark);
+}
+
+.share-col {
+  width: 34%;
+}
+
+.pct-col {
+  width: 64px;
+}
+
+.bar-track {
+  height: 6px;
+  border-radius: var(--radius-sm);
+  background: var(--color-light);
+  overflow: hidden;
+}
+
+.bar-fill {
+  display: block;
+  height: 100%;
+  border-radius: var(--radius-sm);
+  background: var(--color-primary);
+}
+
+.count-cell {
+  font-weight: var(--font-weight-semibold);
+  font-variant-numeric: tabular-nums;
+  color: var(--color-dark);
+}
+
+.pct-cell {
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ===================== Sparkline ===================== */
+.spark-wrap {
+  padding: var(--spacing-2) var(--spacing-2) 0;
+}
+
+.spark-caption {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  margin: 0 0 var(--spacing-3);
+}
+
+.spark-caption code {
+  color: var(--color-dark);
+  background: var(--color-light);
+  padding: 1px 5px;
+  border-radius: var(--radius-sm);
+}
+
+.spark {
+  display: flex;
+  align-items: flex-end;
+  gap: 3px;
+  height: 96px;
+}
+
+.spark-bar {
+  flex: 1;
+  min-height: 4px;
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+  background: linear-gradient(180deg, var(--color-primary), var(--color-info));
+}
+
+.spark-axis {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.62rem;
+  color: var(--color-text-muted);
+  margin-top: 7px;
+}
+
+/* ===================== Info lists ===================== */
+.info-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.info-row {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  padding: var(--spacing-2) 0;
+  border-bottom: 1px solid var(--color-border);
+  font-size: 0.8rem;
+}
+
+.info-row:last-child {
+  border-bottom: none;
+}
+
+.info-k {
+  color: var(--color-text-muted);
+}
+
+.info-v {
+  color: var(--color-dark);
+  font-weight: var(--font-weight-semibold);
+  text-align: right;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+  padding-bottom: var(--spacing-3);
+}
+
+@media (max-width: 992px) {
+  .kpis,
+  .grid-2,
+  .grid-3,
+  .hero-meta {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 576px) {
+  .kpis,
+  .grid-2,
+  .grid-3,
+  .hero-meta {
+    grid-template-columns: 1fr;
+  }
+}
+</style>


### PR DESCRIPTION
Adds an initial **Recording Dashboard** to the Microscope profile view. This PR contains both the design exploration (5 mockups) and the chosen design built as a real Vue view.

## Implementation (Mission Control)
New profile view at **`/profiles/{profileId}/dashboard`** (`ProfileRecordingDashboard.vue`) plus a sidebar "Dashboard" entry. Built **entirely on the frontend by composing existing profile endpoints — no backend changes**:

| Section | Source endpoint |
|---|---|
| Identity hero (`jeffrey.AppInformation`) | `/information` config sections |
| KPI tiles (events, duration, size) | `profileStore` / `EventSummaries` |
| Avg / peak machine CPU | `/system` |
| Top-5 event types + share bars | `/flamegraph/events` |
| Events-over-time sparkline | `/timeseries` (dominant event type) |
| Runtime & Environment, Garbage Collection | `/information`, `/gc` |
| Attributes chips | `jeffrey.AppInformation` attributes |

Key behaviours:
- **Graceful fallback**: when `jeffrey.AppInformation` (PR #104) is absent, the identity hero shows **"Recording not handled by Jeffrey"**. Since this branch predates #104, that's the current default — it lights up automatically once #104 merges, with zero coupling.
- **Independent degradation**: every section loads via `Promise.allSettled`; a missing GC/CPU/config section just hides or empties its card.
- Reuses shared components (`MainCard`, `DataTable`, `Badge`, `LoadingState`/`ErrorState`/`EmptyState`) and design tokens; one small new client (`EventTimeseriesClient`).

Verified: `vite build` succeeds (emits the `ProfileRecordingDashboard` chunk), ESLint passes with 0 errors.

## Mockups
Five HTML mockups remain in `dashboard-mockups/` for reference (option 1, *Mission Control*, is the one implemented). Open any in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)