### PR TITLE
Add Recording Overview landing page with shared time-window navigator

### DIFF
--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/DifferentialTimeseriesController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/DifferentialTimeseriesController.java
@@ -70,6 +70,7 @@ public class DifferentialTimeseriesController {
                 request.eventType(),
                 graphParameters,
                 request.threadInfo(),
-                request.targetBuckets()));
+                request.targetBuckets(),
+                request.allEventTypes()));
     }
 }

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/DifferentialTimeseriesController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/DifferentialTimeseriesController.java
@@ -69,6 +69,7 @@ public class DifferentialTimeseriesController {
         return diffMgr.timeseries(new TimeseriesManager.Generate(
                 request.eventType(),
                 graphParameters,
-                request.threadInfo()));
+                request.threadInfo(),
+                request.targetBuckets()));
     }
 }

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/TimeseriesController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/TimeseriesController.java
@@ -72,6 +72,7 @@ public class TimeseriesController {
                 request.eventType(),
                 builder.build(),
                 request.threadInfo(),
-                request.targetBuckets());
+                request.targetBuckets(),
+                request.allEventTypes());
     }
 }

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/TimeseriesController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/TimeseriesController.java
@@ -26,9 +26,12 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
+import cafe.jeffrey.profile.TimeRangeRequest;
 import cafe.jeffrey.profile.common.config.GraphParameters;
+import cafe.jeffrey.profile.common.config.GraphParametersBuilder;
 import cafe.jeffrey.profile.manager.TimeseriesManager;
 import cafe.jeffrey.profile.resources.request.GenerateTimeseriesRequest;
+import cafe.jeffrey.shared.common.model.time.RelativeTimeRange;
 import cafe.jeffrey.timeseries.TimeseriesData;
 
 @RestController
@@ -52,18 +55,23 @@ public class TimeseriesController {
     }
 
     private static TimeseriesManager.Generate mapToGenerateRequest(GenerateTimeseriesRequest request) {
-        GraphParameters graphParameters = GraphParameters.builder()
+        GraphParametersBuilder builder = GraphParameters.builder()
                 .withSearchPattern(request.search())
                 .withUseWeight(request.useWeight())
                 .withExcludeNonJavaSamples(request.excludeNonJavaSamples())
                 .withExcludeIdleSamples(request.excludeIdleSamples())
                 .withOnlyUnsafeAllocationSamples(request.onlyUnsafeAllocationSamples())
-                .withMarkers(request.markers())
-                .build();
+                .withMarkers(request.markers());
+
+        TimeRangeRequest timeRange = request.timeRange();
+        if (timeRange != null) {
+            builder.withTimeRange(new RelativeTimeRange(timeRange.start(), timeRange.end()));
+        }
 
         return new TimeseriesManager.Generate(
                 request.eventType(),
-                graphParameters,
-                request.threadInfo());
+                builder.build(),
+                request.threadInfo(),
+                request.targetBuckets());
     }
 }

--- a/jeffrey-microscope/pages-microscope/src/composables/useProfileTimeWindow.ts
+++ b/jeffrey-microscope/pages-microscope/src/composables/useProfileTimeWindow.ts
@@ -1,0 +1,159 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { computed, type ComputedRef, type Ref, ref } from 'vue';
+import type { LocationQuery, Router } from 'vue-router';
+import { profileStore } from '@/stores/profileStore';
+
+/**
+ * A selected slice of the recording, expressed in milliseconds elapsed from the
+ * beginning of the recording (the same zero point the backend uses for relative
+ * time ranges). `null` anywhere a TimeWindow is expected means "the whole recording".
+ */
+export interface TimeWindow {
+  from: number;
+  to: number;
+}
+
+const QUERY_PARAM_FROM = 'from';
+const QUERY_PARAM_TO = 'to';
+
+/**
+ * Shared, app-level selected window. A single window is the source of truth for
+ * the whole profile: the Recording Overview navigator writes it, every other
+ * profile view reads it. Module-level state so it survives feature navigation.
+ */
+const activeWindow = ref<TimeWindow | null>(null);
+
+/**
+ * The profile the current window belongs to. When the user opens a different
+ * profile, a leftover window from the previous one is meaningless, so it is
+ * dropped (see {@link useProfileTimeWindow}).
+ */
+const windowProfileId = ref<string | null>(null);
+
+const recordingDurationMillis: ComputedRef<number> = computed(
+  () => profileStore.currentProfile.value?.durationInMillis ?? 0
+);
+
+const isWindowed: ComputedRef<boolean> = computed(() => activeWindow.value !== null);
+
+/**
+ * Fraction of the whole recording covered by the active window (1 when the whole
+ * recording is selected). Used by the header to show "X% of recording".
+ */
+const windowFraction: ComputedRef<number> = computed(() => {
+  const duration = recordingDurationMillis.value;
+  if (duration <= 0 || activeWindow.value === null) {
+    return 1;
+  }
+  return (activeWindow.value.to - activeWindow.value.from) / duration;
+});
+
+/**
+ * The effective range to query: the active window when one is selected, otherwise
+ * the whole recording [0, duration].
+ */
+const resolvedWindow: ComputedRef<TimeWindow> = computed(() => {
+  if (activeWindow.value !== null) {
+    return activeWindow.value;
+  }
+  return { from: 0, to: recordingDurationMillis.value };
+});
+
+function clamp(from: number, to: number): TimeWindow {
+  const duration = recordingDurationMillis.value;
+  const upperBound = duration > 0 ? duration : Math.max(from, to);
+  const start = Math.max(0, Math.min(from, to));
+  const end = Math.min(upperBound, Math.max(from, to));
+  return { from: start, to: end > start ? end : upperBound };
+}
+
+function setWindow(from: number, to: number): void {
+  activeWindow.value = clamp(from, to);
+}
+
+function clearWindow(): void {
+  activeWindow.value = null;
+}
+
+/**
+ * Seeds the window from the route query (`?from=&to=`) so a windowed view can be
+ * reloaded or shared by URL. Invalid or missing params clear the window.
+ */
+function initFromQuery(query: LocationQuery): void {
+  const from = Number(query[QUERY_PARAM_FROM]);
+  const to = Number(query[QUERY_PARAM_TO]);
+  if (Number.isFinite(from) && Number.isFinite(to) && to > from) {
+    activeWindow.value = clamp(from, to);
+  } else {
+    activeWindow.value = null;
+  }
+}
+
+/**
+ * Mirrors the active window into the URL without polluting browser history
+ * (uses `replace`). Removes the params when the whole recording is selected.
+ */
+function syncToRouter(router: Router): void {
+  const query = { ...router.currentRoute.value.query };
+  if (activeWindow.value !== null) {
+    query[QUERY_PARAM_FROM] = String(Math.round(activeWindow.value.from));
+    query[QUERY_PARAM_TO] = String(Math.round(activeWindow.value.to));
+  } else {
+    delete query[QUERY_PARAM_FROM];
+    delete query[QUERY_PARAM_TO];
+  }
+  router.replace({ query });
+}
+
+/**
+ * Shared time-window context for a profile. Reading views call this to obtain the
+ * resolved range; the Recording Overview navigator calls `setWindow`/`clearWindow`
+ * and the URL sync helpers.
+ */
+export function useProfileTimeWindow(): {
+  activeWindow: Ref<TimeWindow | null>;
+  resolvedWindow: ComputedRef<TimeWindow>;
+  recordingDurationMillis: ComputedRef<number>;
+  isWindowed: ComputedRef<boolean>;
+  windowFraction: ComputedRef<number>;
+  setWindow: (from: number, to: number) => void;
+  clearWindow: () => void;
+  initFromQuery: (query: LocationQuery) => void;
+  syncToRouter: (router: Router) => void;
+} {
+  // Drop a stale window when the active profile changes.
+  const currentProfileId = profileStore.profileId.value;
+  if (windowProfileId.value !== currentProfileId) {
+    windowProfileId.value = currentProfileId;
+    activeWindow.value = null;
+  }
+
+  return {
+    activeWindow,
+    resolvedWindow,
+    recordingDurationMillis,
+    isWindowed,
+    windowFraction,
+    setWindow,
+    clearWindow,
+    initFromQuery,
+    syncToRouter
+  };
+}

--- a/jeffrey-microscope/pages-microscope/src/router/index.ts
+++ b/jeffrey-microscope/pages-microscope/src/router/index.ts
@@ -5,7 +5,14 @@ import AppLayout from '@/layout/AppLayout.vue';
 const profileChildRoutes = [
   {
     path: '',
-    redirect: (to: { params: { profileId: string } }) => `/profiles/${to.params.profileId}/overview`
+    redirect: (to: { params: { profileId: string } }) =>
+      `/profiles/${to.params.profileId}/recording-overview`
+  },
+  {
+    path: 'recording-overview',
+    name: 'profile-recording-overview',
+    component: () => import('@/views/profiles/detail/ProfileRecordingOverview.vue'),
+    meta: { layout: 'profile' }
   },
   {
     path: 'overview',

--- a/jeffrey-microscope/pages-microscope/src/services/api/ProfileTimeseriesClient.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/ProfileTimeseriesClient.ts
@@ -1,0 +1,57 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import BaseProfileClient from '@/services/api/BaseProfileClient';
+import TimeseriesData from '@/services/timeseries/model/TimeseriesData';
+import TimeRange from '@/services/api/model/TimeRange';
+
+/**
+ * Generic per-event timeseries endpoint (`POST /profiles/{id}/timeseries`). Unlike the feature
+ * clients it accepts a `timeRange` (relative millis window) and a `targetBuckets` cap, so the
+ * backend aggregates server-side into a bounded number of points (plus a peak series) — keeping
+ * long recordings readable instead of shipping one point per second.
+ */
+export default class ProfileTimeseriesClient extends BaseProfileClient {
+  constructor(profileId: string) {
+    super(profileId, 'timeseries');
+  }
+
+  /**
+   * @param eventType     event type code (e.g. `jdk.ExecutionSample`)
+   * @param timeRange     window to restrict to, or null for the whole recording
+   * @param targetBuckets maximum number of points to return
+   */
+  getTimeseries(
+    eventType: string,
+    timeRange: TimeRange | null,
+    targetBuckets: number
+  ): Promise<TimeseriesData> {
+    return this.post<TimeseriesData>('', {
+      eventType: eventType,
+      search: null,
+      useWeight: false,
+      excludeNonJavaSamples: false,
+      excludeIdleSamples: false,
+      onlyUnsafeAllocationSamples: false,
+      threadInfo: null,
+      markers: [],
+      timeRange: timeRange,
+      targetBuckets: targetBuckets
+    });
+  }
+}

--- a/jeffrey-microscope/pages-microscope/src/services/api/ProfileTimeseriesClient.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/ProfileTimeseriesClient.ts
@@ -32,14 +32,16 @@ export default class ProfileTimeseriesClient extends BaseProfileClient {
   }
 
   /**
-   * @param eventType     event type code (e.g. `jdk.ExecutionSample`)
+   * @param eventType     event type code (e.g. `jdk.ExecutionSample`); ignored when allEventTypes
    * @param timeRange     window to restrict to, or null for the whole recording
    * @param targetBuckets maximum number of points to return
+   * @param allEventTypes when true, aggregate across every event type (total activity)
    */
   getTimeseries(
     eventType: string,
     timeRange: TimeRange | null,
-    targetBuckets: number
+    targetBuckets: number,
+    allEventTypes: boolean
   ): Promise<TimeseriesData> {
     return this.post<TimeseriesData>('', {
       eventType: eventType,
@@ -51,7 +53,8 @@ export default class ProfileTimeseriesClient extends BaseProfileClient {
       threadInfo: null,
       markers: [],
       timeRange: timeRange,
-      targetBuckets: targetBuckets
+      targetBuckets: targetBuckets,
+      allEventTypes: allEventTypes
     });
   }
 }

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/ProfileDetail.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/ProfileDetail.vue
@@ -143,6 +143,14 @@
                   <div class="nav-section-title">ANALYSIS</div>
                   <div class="nav-items">
                     <router-link
+                      :to="`/profiles/${profileId}/recording-overview`"
+                      class="nav-item"
+                      active-class="active"
+                    >
+                      <i class="bi bi-clock-history"></i>
+                      <span>Recording Overview</span>
+                    </router-link>
+                    <router-link
                       :to="`/profiles/${profileId}/ai-analysis`"
                       class="nav-item nav-item-ai"
                       :class="{ 'disabled-feature': isFeatureDisabled('ai-analysis') }"
@@ -1566,7 +1574,7 @@ const selectMode = (mode: 'JVM' | 'Technologies' | 'Visualization' | 'HeapDump' 
 
   // Navigate to the first item in the selected mode's menu (simplified URLs)
   const firstRoutes: Record<string, string> = {
-    JVM: `/profiles/${profileId}/overview`,
+    JVM: `/profiles/${profileId}/recording-overview`,
     Technologies: `/profiles/${profileId}/technologies/hub`,
     Visualization: `/profiles/${profileId}/flamegraphs/primary`,
     HeapDump: `/profiles/${profileId}/heap-dump/settings`,

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileRecordingOverview.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileRecordingOverview.vue
@@ -61,25 +61,23 @@
     </div>
 
     <EmptyState
-      v-if="activityData.length === 0"
+      v-if="!hasEvents"
       icon="bi-clock-history"
       title="No time-based events in this recording"
       description="This profile has no sampled events to plot over time (for example a heap-dump-only profile). The recording window selector is unavailable."
     />
 
     <template v-else>
+      <TabBar v-model="activeTab" :tabs="tabs" class="overview-tabs" />
       <ChartDescription
-        :shows="`${activityLabel} activity over the whole recording`"
-        use-case="Drag on the lower navigator to select a window; the selection drives every other view."
+        :shows="`${activeLabel} over the whole recording (events per second)`"
+        use-case="Pick an event type above; drag on the lower navigator to select a window that drives every other view."
       />
       <TimeSeriesChart
-        :key="chartResetKey"
+        :key="`${activeTab}-${chartResetKey}`"
         :primary-data="activityData"
-        :secondary-data="peakData"
-        :primary-title="activityLabel"
-        secondary-title="Peak"
+        :primary-title="activeLabel"
         :primary-axis-type="AxisFormatType.NUMBER"
-        :secondary-axis-type="AxisFormatType.NUMBER"
         :visible-minutes="overviewVisibleMinutes"
         :zoom-enabled="true"
         @update:time-range="onTimeRangeChange"
@@ -105,10 +103,11 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import { useRoute, useRouter, type LocationQueryRaw } from 'vue-router';
 
 import TimeSeriesChart from '@/components/TimeSeriesChart.vue';
+import TabBar from '@shared/components/TabBar.vue';
 import ChartDescription from '@shared/components/ChartDescription.vue';
 import PageHeader from '@shared/components/layout/PageHeader.vue';
 import LoadingState from '@shared/components/LoadingState.vue';
@@ -118,9 +117,8 @@ import AxisFormatType from '@/services/timeseries/AxisFormatType.ts';
 import TimeConverter from '@/services/timeseries/TimeConverter.ts';
 import FormattingService from '@shared/services/FormattingService';
 
-import EventSummariesClient from '@/services/api/EventSummariesClient';
-import EventSummary from '@/services/api/model/EventSummary';
 import EventTypes from '@/services/EventTypes';
+import EventViewerClient from '@/services/api/EventViewerClient';
 import ProfileTimeseriesClient from '@/services/api/ProfileTimeseriesClient';
 import { useProfileTimeWindow } from '@/composables/useProfileTimeWindow';
 
@@ -128,12 +126,22 @@ import { useProfileTimeWindow } from '@/composables/useProfileTimeWindow';
 // "the whole recording" — so dragging to the edges clears the window cleanly.
 const WHOLE_RECORDING_FRACTION = 0.99;
 const MILLIS_PER_SECOND = 1000;
-const MILLIS_PER_MINUTE = 60_000;
+const SECONDS_PER_MINUTE = 60;
 
 // Upper bound on points the overview navigator requests. The backend aggregates
-// the recording into at most this many buckets (plus a peak series), so even a
-// multi-hour recording stays light instead of returning one point per second.
+// the recording into at most this many buckets, so even a multi-hour recording
+// stays light instead of returning one point per second.
 const OVERVIEW_TARGET_BUCKETS = 1500;
+
+// GC events are stackless; classify them locally since EventTypes has no GC helper.
+const GC_EVENT_CODES = [
+  'jdk.GarbageCollection',
+  'jdk.YoungGarbageCollection',
+  'jdk.OldGarbageCollection',
+  'jdk.G1GarbageCollection',
+  'jdk.ZYoungGarbageCollection',
+  'jdk.ZOldGarbageCollection'
+];
 
 const route = useRoute();
 const router = useRouter();
@@ -153,8 +161,8 @@ const loading = ref(true);
 const error = ref<string | null>(null);
 
 const activityData = ref<number[][]>([]);
-const peakData = ref<number[][]>([]);
-const activityLabel = ref('');
+const presentTypes = ref<{ code: string; count: number }[]>([]);
+const activeTab = ref('all');
 
 // Bumping this key remounts the chart, resetting its visible range to the full
 // recording when the user clears the window from the header.
@@ -162,11 +170,17 @@ const chartResetKey = ref(0);
 
 const profileId = computed(() => route.params.profileId as string);
 
-// The navigator (and ApexCharts) work in seconds-from-start; the chart's initial
-// visible window is expressed in minutes, so show the whole recording by default.
-const overviewVisibleMinutes = computed(() =>
-  Math.max(1, Math.ceil(recordingDurationMillis.value / MILLIS_PER_MINUTE))
-);
+// Default the visible window (and thus the brush selection) to the whole interval by
+// sizing it from the loaded data span — not from profileStore, which is still 0 when
+// this child view mounts. The chart re-runs its range init when the data arrives.
+const overviewVisibleMinutes = computed(() => {
+  const data = activityData.value;
+  if (data.length === 0) {
+    return 1;
+  }
+  const maxSecond = data[data.length - 1][0];
+  return Math.max(1, Math.ceil(maxSecond / SECONDS_PER_MINUTE) + 1);
+});
 
 // Formats a relative offset (millis from recording start) as HH:MM:SS, matching
 // the chart's own axis labels.
@@ -214,35 +228,71 @@ const jumpTiles: JumpTile[] = [
   { name: 'profile-threads-timeline', label: 'Threads', icon: 'bi-diagram-3' }
 ];
 
-// Priority order for the representative "activity" series: CPU first, then
-// allocation/blocking, finally whatever has the most samples.
-const ACTIVITY_PRIORITIES: Array<(code: string) => boolean> = [
-  code => EventTypes.isExecutionEventType(code),
-  code => EventTypes.isCpuTimeSample(code),
-  code => EventTypes.isWallClock(code),
-  code => EventTypes.isAllocationEventType(code),
-  code => EventTypes.isBlockingEventType(code)
-];
-
-function maxBySamples(events: EventSummary[]): EventSummary {
-  return events.reduce((best, candidate) =>
-    (candidate.primary?.samples ?? 0) > (best.primary?.samples ?? 0) ? candidate : best
-  );
+interface OverviewCategory {
+  id: string;
+  label: string;
+  matches: (code: string) => boolean;
 }
 
-function pickActivityEvent(events: EventSummary[]): EventSummary | null {
-  if (!events || events.length === 0) {
+// Rendered after the always-present "All events" tab, in this order; a category only
+// appears when the profile actually contains a matching event type.
+const CATEGORIES: OverviewCategory[] = [
+  {
+    id: 'execution',
+    label: 'Execution Samples',
+    matches: code => EventTypes.isExecutionEventType(code) || EventTypes.isCpuTimeSample(code)
+  },
+  {
+    id: 'allocation',
+    label: 'Allocation',
+    matches: code => EventTypes.isAllocationEventType(code)
+  },
+  { id: 'wallclock', label: 'Wall Clock', matches: code => EventTypes.isWallClock(code) },
+  { id: 'locks', label: 'Locks / Monitor', matches: code => EventTypes.isBlockingEventType(code) },
+  { id: 'gc', label: 'Garbage Collection', matches: code => GC_EVENT_CODES.includes(code) }
+];
+
+const ALL_EVENTS_TAB_ID = 'all';
+
+const hasEvents = computed(() => presentTypes.value.length > 0);
+
+// Most frequent present event type. Used as the (filter-ignored) event-type param for
+// the all-events request, which still needs a concrete code for parameter binding.
+const fallbackCode = computed(() => {
+  if (presentTypes.value.length === 0) {
+    return '';
+  }
+  return presentTypes.value.reduce((best, type) => (type.count > best.count ? type : best)).code;
+});
+
+// The representative (most frequent present) code for a category, or null if absent.
+function dominantCode(matches: (code: string) => boolean): string | null {
+  const candidates = presentTypes.value.filter(type => matches(type.code));
+  if (candidates.length === 0) {
     return null;
   }
-  const withSamples = events.filter(event => (event.primary?.samples ?? 0) > 0);
-  const pool = withSamples.length > 0 ? withSamples : events;
-  for (const matches of ACTIVITY_PRIORITIES) {
-    const candidates = pool.filter(event => matches(event.code));
-    if (candidates.length > 0) {
-      return maxBySamples(candidates);
+  return candidates.reduce((best, type) => (type.count > best.count ? type : best)).code;
+}
+
+const tabs = computed(() => {
+  const items: { id: string; label: string }[] = [{ id: ALL_EVENTS_TAB_ID, label: 'All events' }];
+  for (const category of CATEGORIES) {
+    if (dominantCode(category.matches) !== null) {
+      items.push({ id: category.id, label: category.label });
     }
   }
-  return maxBySamples(pool);
+  return items;
+});
+
+const activeLabel = computed(() => tabs.value.find(tab => tab.id === activeTab.value)?.label ?? '');
+
+// Resolves the request parameters (event code + all-events flag) for a tab.
+function requestForTab(tabId: string): { code: string; allEventTypes: boolean } {
+  if (tabId === ALL_EVENTS_TAB_ID) {
+    return { code: fallbackCode.value, allEventTypes: true };
+  }
+  const category = CATEGORIES.find(item => item.id === tabId);
+  return { code: category ? (dominantCode(category.matches) ?? '') : '', allEventTypes: false };
 }
 
 function onTimeRangeChange(payload: { start: number; end: number; isZoomed: boolean }): void {
@@ -268,30 +318,37 @@ function resetWindow(): void {
   chartResetKey.value += 1;
 }
 
+async function loadSeries(tabId: string): Promise<void> {
+  const { code, allEventTypes } = requestForTab(tabId);
+  if (!code) {
+    activityData.value = [];
+    return;
+  }
+  // Whole recording, bounded server-side (≈ recording / targetBuckets per point).
+  const timeseries = await new ProfileTimeseriesClient(profileId.value).getTimeseries(
+    code,
+    null,
+    OVERVIEW_TARGET_BUCKETS,
+    allEventTypes
+  );
+  activityData.value = timeseries.series?.[0]?.data ?? [];
+}
+
 async function load(): Promise<void> {
   try {
     loading.value = true;
     error.value = null;
 
-    const summaries = await EventSummariesClient.primary(profileId.value).events();
-    const chosen = pickActivityEvent(summaries);
-    if (chosen === null) {
+    presentTypes.value = (await new EventViewerClient(profileId.value).eventTypes())
+      .filter(type => type.count > 0)
+      .map(type => ({ code: type.code, count: type.count }));
+
+    if (presentTypes.value.length === 0) {
       activityData.value = [];
-      peakData.value = [];
-      activityLabel.value = '';
       return;
     }
-
-    activityLabel.value = chosen.label;
-    // Whole recording, bounded server-side. The endpoint returns a SUM series plus a
-    // peak (MAX) series so transient spikes survive the aggregation.
-    const timeseries = await new ProfileTimeseriesClient(profileId.value).getTimeseries(
-      chosen.code,
-      null,
-      OVERVIEW_TARGET_BUCKETS
-    );
-    activityData.value = timeseries.series?.[0]?.data ?? [];
-    peakData.value = timeseries.series?.[1]?.data ?? [];
+    activeTab.value = ALL_EVENTS_TAB_ID;
+    await loadSeries(ALL_EVENTS_TAB_ID);
   } catch (err) {
     error.value = err instanceof Error ? err.message : 'Unknown error occurred';
     console.error('Error loading recording overview:', err);
@@ -299,6 +356,14 @@ async function load(): Promise<void> {
     loading.value = false;
   }
 }
+
+// User switches event type → reload that series (the initial 'all' load runs in load()).
+watch(activeTab, tabId => {
+  loadSeries(tabId).catch(err => {
+    error.value = err instanceof Error ? err.message : 'Unknown error occurred';
+    console.error('Error loading recording overview series:', err);
+  });
+});
 
 onMounted(() => {
   initFromQuery(route.query);
@@ -398,6 +463,11 @@ onMounted(() => {
   font-size: 11.5px;
   color: var(--color-text-muted);
   white-space: nowrap;
+}
+
+/* ----- Event-type selector ----- */
+.overview-tabs {
+  margin-bottom: 12px;
 }
 
 /* ----- Jump tiles ----- */

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileRecordingOverview.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileRecordingOverview.vue
@@ -75,8 +75,11 @@
       <TimeSeriesChart
         :key="chartResetKey"
         :primary-data="activityData"
+        :secondary-data="peakData"
         :primary-title="activityLabel"
+        secondary-title="Peak"
         :primary-axis-type="AxisFormatType.NUMBER"
+        :secondary-axis-type="AxisFormatType.NUMBER"
         :visible-minutes="overviewVisibleMinutes"
         :zoom-enabled="true"
         @update:time-range="onTimeRangeChange"
@@ -118,7 +121,7 @@ import FormattingService from '@shared/services/FormattingService';
 import EventSummariesClient from '@/services/api/EventSummariesClient';
 import EventSummary from '@/services/api/model/EventSummary';
 import EventTypes from '@/services/EventTypes';
-import PrimaryFlamegraphClient from '@/services/api/PrimaryFlamegraphClient';
+import ProfileTimeseriesClient from '@/services/api/ProfileTimeseriesClient';
 import { useProfileTimeWindow } from '@/composables/useProfileTimeWindow';
 
 // A selection covering at least this fraction of the recording is treated as
@@ -126,6 +129,11 @@ import { useProfileTimeWindow } from '@/composables/useProfileTimeWindow';
 const WHOLE_RECORDING_FRACTION = 0.99;
 const MILLIS_PER_SECOND = 1000;
 const MILLIS_PER_MINUTE = 60_000;
+
+// Upper bound on points the overview navigator requests. The backend aggregates
+// the recording into at most this many buckets (plus a peak series), so even a
+// multi-hour recording stays light instead of returning one point per second.
+const OVERVIEW_TARGET_BUCKETS = 1500;
 
 const route = useRoute();
 const router = useRouter();
@@ -145,6 +153,7 @@ const loading = ref(true);
 const error = ref<string | null>(null);
 
 const activityData = ref<number[][]>([]);
+const peakData = ref<number[][]>([]);
 const activityLabel = ref('');
 
 // Bumping this key remounts the chart, resetting its visible range to the full
@@ -268,23 +277,21 @@ async function load(): Promise<void> {
     const chosen = pickActivityEvent(summaries);
     if (chosen === null) {
       activityData.value = [];
+      peakData.value = [];
       activityLabel.value = '';
       return;
     }
 
     activityLabel.value = chosen.label;
-    const client = new PrimaryFlamegraphClient(
-      profileId.value,
+    // Whole recording, bounded server-side. The endpoint returns a SUM series plus a
+    // peak (MAX) series so transient spikes survive the aggregation.
+    const timeseries = await new ProfileTimeseriesClient(profileId.value).getTimeseries(
       chosen.code,
-      false,
-      false,
-      false,
-      false,
-      false,
-      null
+      null,
+      OVERVIEW_TARGET_BUCKETS
     );
-    const timeseries = await client.provideTimeseries(null);
     activityData.value = timeseries.series?.[0]?.data ?? [];
+    peakData.value = timeseries.series?.[1]?.data ?? [];
   } catch (err) {
     error.value = err instanceof Error ? err.message : 'Unknown error occurred';
     console.error('Error loading recording overview:', err);

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileRecordingOverview.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileRecordingOverview.vue
@@ -1,0 +1,444 @@
+<!--
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ -->
+
+<template>
+  <LoadingState v-if="loading" message="Loading recording overview..." />
+
+  <ErrorState v-else-if="error" message="Failed to load recording overview" />
+
+  <div v-else>
+    <PageHeader
+      title="Recording Overview"
+      description="Pick a window on the timeline below — every view in this profile follows it."
+      icon="bi-clock-history"
+    >
+      <template #actions>
+        <!-- The active analysis window. Stays neutral for the whole recording and
+             turns amber (with a reset) the moment a sub-range is selected, so it is
+             always clear that the rest of the app is scoped to a slice. -->
+        <div class="scope-chip" :class="{ windowed: isWindowed }">
+          <span class="scope-label">Analyzing</span>
+          <template v-if="isWindowed">
+            <span class="scope-range">{{ windowFromLabel }} – {{ windowToLabel }}</span>
+            <span class="scope-meta">{{ windowDurationLabel }} · {{ windowPercentLabel }}</span>
+            <button class="scope-reset" type="button" @click="resetWindow">
+              <i class="bi bi-arrow-counterclockwise"></i> Full recording
+            </button>
+          </template>
+          <template v-else>
+            <span class="scope-range">Whole recording</span>
+            <span class="scope-meta">{{ recordingDurationLabel }}</span>
+          </template>
+        </div>
+      </template>
+    </PageHeader>
+
+    <!-- Extra clarity strip: only shown while a sub-range is active. -->
+    <div v-if="isWindowed" class="scope-banner">
+      <i class="bi bi-exclamation-triangle"></i>
+      <span>
+        Showing a <b>{{ windowDurationLabel }}</b> slice (<b
+          >{{ windowFromLabel }} → {{ windowToLabel }}</b
+        >) of the <b>{{ recordingDurationLabel }}</b> recording. Open any view to analyze just this
+        window.
+      </span>
+      <span class="scope-banner-pct">{{ windowPercentLabel }} of recording</span>
+    </div>
+
+    <EmptyState
+      v-if="activityData.length === 0"
+      icon="bi-clock-history"
+      title="No time-based events in this recording"
+      description="This profile has no sampled events to plot over time (for example a heap-dump-only profile). The recording window selector is unavailable."
+    />
+
+    <template v-else>
+      <ChartDescription
+        :shows="`${activityLabel} activity over the whole recording`"
+        use-case="Drag on the lower navigator to select a window; the selection drives every other view."
+      />
+      <TimeSeriesChart
+        :key="chartResetKey"
+        :primary-data="activityData"
+        :primary-title="activityLabel"
+        :primary-axis-type="AxisFormatType.NUMBER"
+        :visible-minutes="overviewVisibleMinutes"
+        :zoom-enabled="true"
+        @update:time-range="onTimeRangeChange"
+      />
+
+      <!-- Jump into a view; the selected window rides along in the URL. -->
+      <div class="jump-row">
+        <span class="jump-row-title">Open a view scoped to this window</span>
+        <div class="jump-tiles">
+          <router-link
+            v-for="tile in jumpTiles"
+            :key="tile.name"
+            class="jump-tile"
+            :to="{ name: tile.name, params: { profileId }, query: windowQuery }"
+          >
+            <i class="bi" :class="tile.icon"></i>
+            <span>{{ tile.label }}</span>
+          </router-link>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { useRoute, useRouter, type LocationQueryRaw } from 'vue-router';
+
+import TimeSeriesChart from '@/components/TimeSeriesChart.vue';
+import ChartDescription from '@shared/components/ChartDescription.vue';
+import PageHeader from '@shared/components/layout/PageHeader.vue';
+import LoadingState from '@shared/components/LoadingState.vue';
+import ErrorState from '@shared/components/ErrorState.vue';
+import EmptyState from '@shared/components/EmptyState.vue';
+import AxisFormatType from '@/services/timeseries/AxisFormatType.ts';
+import TimeConverter from '@/services/timeseries/TimeConverter.ts';
+import FormattingService from '@shared/services/FormattingService';
+
+import EventSummariesClient from '@/services/api/EventSummariesClient';
+import EventSummary from '@/services/api/model/EventSummary';
+import EventTypes from '@/services/EventTypes';
+import PrimaryFlamegraphClient from '@/services/api/PrimaryFlamegraphClient';
+import { useProfileTimeWindow } from '@/composables/useProfileTimeWindow';
+
+// A selection covering at least this fraction of the recording is treated as
+// "the whole recording" — so dragging to the edges clears the window cleanly.
+const WHOLE_RECORDING_FRACTION = 0.99;
+const MILLIS_PER_SECOND = 1000;
+const MILLIS_PER_MINUTE = 60_000;
+
+const route = useRoute();
+const router = useRouter();
+
+const {
+  activeWindow,
+  recordingDurationMillis,
+  isWindowed,
+  windowFraction,
+  setWindow,
+  clearWindow,
+  initFromQuery,
+  syncToRouter
+} = useProfileTimeWindow();
+
+const loading = ref(true);
+const error = ref<string | null>(null);
+
+const activityData = ref<number[][]>([]);
+const activityLabel = ref('');
+
+// Bumping this key remounts the chart, resetting its visible range to the full
+// recording when the user clears the window from the header.
+const chartResetKey = ref(0);
+
+const profileId = computed(() => route.params.profileId as string);
+
+// The navigator (and ApexCharts) work in seconds-from-start; the chart's initial
+// visible window is expressed in minutes, so show the whole recording by default.
+const overviewVisibleMinutes = computed(() =>
+  Math.max(1, Math.ceil(recordingDurationMillis.value / MILLIS_PER_MINUTE))
+);
+
+// Formats a relative offset (millis from recording start) as HH:MM:SS, matching
+// the chart's own axis labels.
+const offsetFormatter = new TimeConverter('milliseconds');
+
+const windowFromLabel = computed(() =>
+  activeWindow.value ? offsetFormatter.formatTime(activeWindow.value.from) : ''
+);
+const windowToLabel = computed(() =>
+  activeWindow.value ? offsetFormatter.formatTime(activeWindow.value.to) : ''
+);
+const windowDurationLabel = computed(() => {
+  if (!activeWindow.value) {
+    return '';
+  }
+  return FormattingService.formatDurationInMillis2Units(
+    activeWindow.value.to - activeWindow.value.from
+  );
+});
+const windowPercentLabel = computed(() => FormattingService.formatPercentage(windowFraction.value));
+const recordingDurationLabel = computed(() =>
+  FormattingService.formatDurationInMillis2Units(recordingDurationMillis.value)
+);
+
+const windowQuery = computed<LocationQueryRaw>(() => {
+  if (!activeWindow.value) {
+    return {};
+  }
+  return {
+    from: String(Math.round(activeWindow.value.from)),
+    to: String(Math.round(activeWindow.value.to))
+  };
+});
+
+interface JumpTile {
+  name: string;
+  label: string;
+  icon: string;
+}
+
+const jumpTiles: JumpTile[] = [
+  { name: 'profile-flamegraphs-primary', label: 'Flamegraphs', icon: 'bi-fire' },
+  { name: 'subsecond', label: 'Sub-second', icon: 'bi-grid-3x3' },
+  { name: 'profile-garbage-collection', label: 'Garbage Collection', icon: 'bi-recycle' },
+  { name: 'profile-threads-timeline', label: 'Threads', icon: 'bi-diagram-3' }
+];
+
+// Priority order for the representative "activity" series: CPU first, then
+// allocation/blocking, finally whatever has the most samples.
+const ACTIVITY_PRIORITIES: Array<(code: string) => boolean> = [
+  code => EventTypes.isExecutionEventType(code),
+  code => EventTypes.isCpuTimeSample(code),
+  code => EventTypes.isWallClock(code),
+  code => EventTypes.isAllocationEventType(code),
+  code => EventTypes.isBlockingEventType(code)
+];
+
+function maxBySamples(events: EventSummary[]): EventSummary {
+  return events.reduce((best, candidate) =>
+    (candidate.primary?.samples ?? 0) > (best.primary?.samples ?? 0) ? candidate : best
+  );
+}
+
+function pickActivityEvent(events: EventSummary[]): EventSummary | null {
+  if (!events || events.length === 0) {
+    return null;
+  }
+  const withSamples = events.filter(event => (event.primary?.samples ?? 0) > 0);
+  const pool = withSamples.length > 0 ? withSamples : events;
+  for (const matches of ACTIVITY_PRIORITIES) {
+    const candidates = pool.filter(event => matches(event.code));
+    if (candidates.length > 0) {
+      return maxBySamples(candidates);
+    }
+  }
+  return maxBySamples(pool);
+}
+
+function onTimeRangeChange(payload: { start: number; end: number; isZoomed: boolean }): void {
+  if (!payload.isZoomed) {
+    clearWindow();
+    syncToRouter(router);
+    return;
+  }
+  const fromMs = Math.max(0, Math.floor(payload.start * MILLIS_PER_SECOND));
+  const toMs = Math.ceil(payload.end * MILLIS_PER_SECOND);
+  const duration = recordingDurationMillis.value;
+  if (duration > 0 && toMs - fromMs >= duration * WHOLE_RECORDING_FRACTION) {
+    clearWindow();
+  } else {
+    setWindow(fromMs, toMs);
+  }
+  syncToRouter(router);
+}
+
+function resetWindow(): void {
+  clearWindow();
+  syncToRouter(router);
+  chartResetKey.value += 1;
+}
+
+async function load(): Promise<void> {
+  try {
+    loading.value = true;
+    error.value = null;
+
+    const summaries = await EventSummariesClient.primary(profileId.value).events();
+    const chosen = pickActivityEvent(summaries);
+    if (chosen === null) {
+      activityData.value = [];
+      activityLabel.value = '';
+      return;
+    }
+
+    activityLabel.value = chosen.label;
+    const client = new PrimaryFlamegraphClient(
+      profileId.value,
+      chosen.code,
+      false,
+      false,
+      false,
+      false,
+      false,
+      null
+    );
+    const timeseries = await client.provideTimeseries(null);
+    activityData.value = timeseries.series?.[0]?.data ?? [];
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Unknown error occurred';
+    console.error('Error loading recording overview:', err);
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(() => {
+  initFromQuery(route.query);
+  load();
+});
+</script>
+
+<style scoped>
+/* ----- Header scope indicator ----- */
+.scope-chip {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 8px 6px 12px;
+  border-radius: var(--radius-pill, 999px);
+  background: var(--color-neutral-light);
+  border: 1px solid var(--color-border);
+}
+
+.scope-chip.windowed {
+  background: var(--color-warning-bg);
+  border-color: var(--color-warning-border);
+}
+
+.scope-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.scope-chip.windowed .scope-label {
+  color: var(--color-warning-text);
+}
+
+.scope-range {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--color-dark);
+  font-variant-numeric: tabular-nums;
+}
+
+.scope-meta {
+  font-size: 11.5px;
+  color: var(--color-text-muted);
+}
+
+.scope-chip.windowed .scope-meta {
+  color: var(--color-warning-text);
+}
+
+.scope-reset {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: 1px solid var(--color-warning-border);
+  background: var(--color-white);
+  color: var(--color-warning-text);
+  font-size: 11.5px;
+  font-weight: 600;
+  border-radius: var(--radius-pill, 999px);
+  padding: 4px 10px;
+  cursor: pointer;
+}
+
+.scope-reset:hover {
+  background: var(--color-warning-light);
+}
+
+/* ----- Clarity banner ----- */
+.scope-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 14px;
+  padding: 9px 14px;
+  font-size: 12.5px;
+  color: var(--color-text);
+  background: var(--color-primary-lighter);
+  border: 1px solid var(--color-primary-light);
+  border-left: 3px solid var(--color-primary);
+  border-radius: var(--radius-md, 8px);
+}
+
+.scope-banner i {
+  color: var(--color-primary);
+}
+
+.scope-banner b {
+  color: var(--color-dark);
+  font-variant-numeric: tabular-nums;
+}
+
+.scope-banner-pct {
+  margin-left: auto;
+  font-size: 11.5px;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+/* ----- Jump tiles ----- */
+.jump-row {
+  margin-top: 18px;
+}
+
+.jump-row-title {
+  display: block;
+  font-size: 12.5px;
+  font-weight: 700;
+  color: var(--color-dark);
+  margin-bottom: 10px;
+}
+
+.jump-tiles {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+}
+
+.jump-tile {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 11px 13px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md, 8px);
+  background: var(--color-white);
+  color: var(--color-dark);
+  text-decoration: none;
+  font-size: 12.5px;
+  font-weight: 600;
+  transition: border-color 0.15s ease;
+}
+
+.jump-tile:hover {
+  border-color: var(--color-primary);
+}
+
+.jump-tile i {
+  color: var(--color-primary);
+  font-size: 1rem;
+}
+
+@media (max-width: 768px) {
+  .jump-tiles {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+</style>

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/PrimaryTimeseriesManager.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/PrimaryTimeseriesManager.java
@@ -23,6 +23,7 @@ import cafe.jeffrey.shared.common.model.ProfilingStartEnd;
 import cafe.jeffrey.shared.common.model.time.RelativeTimeRange;
 import cafe.jeffrey.provider.profile.api.EventQueryConfigurer;
 import cafe.jeffrey.provider.profile.api.ProfileEventStreamRepository;
+import cafe.jeffrey.timeseries.SimpleTimeseriesBuilder;
 import cafe.jeffrey.timeseries.TimeseriesData;
 import cafe.jeffrey.timeseries.TimeseriesDownsampler;
 import cafe.jeffrey.timeseries.TimeseriesResolver;
@@ -45,24 +46,34 @@ public class PrimaryTimeseriesManager implements TimeseriesManager {
         GraphParameters params = generate.graphParameters();
 
         // The request may restrict the query to a window; otherwise the whole recording is used.
-        // The effective range must also reach the builder (via params) so its bucket pre-fill spans
-        // exactly the queried range.
         RelativeTimeRange effectiveRange = params.timeRange() != null ? params.timeRange() : timeRange;
-        GraphParameters effectiveParams = params.toBuilder().withTimeRange(effectiveRange).build();
 
+        // The recording-overview navigator always sends targetBuckets. It uses the overview activity
+        // query (no stacktrace join, so stackless event types like GC are included) and may aggregate
+        // across all event types. The result is then bounded to the requested number of buckets.
+        Integer targetBuckets = generate.targetBuckets();
+        if (targetBuckets != null) {
+            EventQueryConfigurer overviewConfigurer = new EventQueryConfigurer()
+                    .withEventType(generate.eventType())
+                    .withTimeRange(effectiveRange)
+                    .withWeight(params.useWeight())
+                    .withAllEventTypes(generate.allEventTypes());
+
+            TimeseriesData data = eventStreamRepository.overviewTimeseriesStreamer(
+                    overviewConfigurer, new SimpleTimeseriesBuilder(effectiveRange));
+            return TimeseriesDownsampler.downsample(data, targetBuckets);
+        }
+
+        // Legacy per-event-type series (full per-second resolution). The effective range must also
+        // reach the builder (via params) so its bucket pre-fill spans exactly the queried range.
+        GraphParameters effectiveParams = params.toBuilder().withTimeRange(effectiveRange).build();
         EventQueryConfigurer configurer = new EventQueryConfigurer()
                 .withEventType(generate.eventType())
                 .withTimeRange(effectiveRange)
                 .withWeight(params.useWeight())
                 .withThreads(params.threadMode());
 
-        TimeseriesData data = eventStreamRepository.timeseriesStreamer(
+        return eventStreamRepository.timeseriesStreamer(
                 configurer, TimeseriesResolver.resolve(effectiveParams));
-
-        Integer targetBuckets = generate.targetBuckets();
-        if (targetBuckets == null) {
-            return data;
-        }
-        return TimeseriesDownsampler.downsample(data, targetBuckets);
     }
 }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/PrimaryTimeseriesManager.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/PrimaryTimeseriesManager.java
@@ -24,6 +24,7 @@ import cafe.jeffrey.shared.common.model.time.RelativeTimeRange;
 import cafe.jeffrey.provider.profile.api.EventQueryConfigurer;
 import cafe.jeffrey.provider.profile.api.ProfileEventStreamRepository;
 import cafe.jeffrey.timeseries.TimeseriesData;
+import cafe.jeffrey.timeseries.TimeseriesDownsampler;
 import cafe.jeffrey.timeseries.TimeseriesResolver;
 
 public class PrimaryTimeseriesManager implements TimeseriesManager {
@@ -43,12 +44,25 @@ public class PrimaryTimeseriesManager implements TimeseriesManager {
     public TimeseriesData timeseries(Generate generate) {
         GraphParameters params = generate.graphParameters();
 
+        // The request may restrict the query to a window; otherwise the whole recording is used.
+        // The effective range must also reach the builder (via params) so its bucket pre-fill spans
+        // exactly the queried range.
+        RelativeTimeRange effectiveRange = params.timeRange() != null ? params.timeRange() : timeRange;
+        GraphParameters effectiveParams = params.toBuilder().withTimeRange(effectiveRange).build();
+
         EventQueryConfigurer configurer = new EventQueryConfigurer()
                 .withEventType(generate.eventType())
-                .withTimeRange(timeRange)
+                .withTimeRange(effectiveRange)
                 .withWeight(params.useWeight())
                 .withThreads(params.threadMode());
 
-        return eventStreamRepository.timeseriesStreamer(configurer, TimeseriesResolver.resolve(params));
+        TimeseriesData data = eventStreamRepository.timeseriesStreamer(
+                configurer, TimeseriesResolver.resolve(effectiveParams));
+
+        Integer targetBuckets = generate.targetBuckets();
+        if (targetBuckets == null) {
+            return data;
+        }
+        return TimeseriesDownsampler.downsample(data, targetBuckets);
     }
 }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/TimeseriesManager.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/TimeseriesManager.java
@@ -32,7 +32,8 @@ public interface TimeseriesManager {
     record Generate(
             Type eventType,
             GraphParameters graphParameters,
-            ThreadInfo threadInfo) {
+            ThreadInfo threadInfo,
+            Integer targetBuckets) {
     }
 
     @FunctionalInterface

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/TimeseriesManager.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/TimeseriesManager.java
@@ -33,7 +33,8 @@ public interface TimeseriesManager {
             Type eventType,
             GraphParameters graphParameters,
             ThreadInfo threadInfo,
-            Integer targetBuckets) {
+            Integer targetBuckets,
+            boolean allEventTypes) {
     }
 
     @FunctionalInterface

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/resources/request/GenerateTimeseriesRequest.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/resources/request/GenerateTimeseriesRequest.java
@@ -18,12 +18,21 @@
 
 package cafe.jeffrey.profile.resources.request;
 
+import cafe.jeffrey.profile.TimeRangeRequest;
 import cafe.jeffrey.shared.common.model.ThreadInfo;
 import cafe.jeffrey.shared.common.model.Type;
 import cafe.jeffrey.profile.common.analysis.marker.Marker;
 
 import java.util.List;
 
+/**
+ * @param timeRange     optional window (relative millis from recording start) to restrict the
+ *                      query to; {@code null} means the whole recording.
+ * @param targetBuckets optional cap on the number of returned points. When set, the series is
+ *                      aggregated server-side into at most this many buckets (SUM plus a MAX peak
+ *                      series), so long recordings stay readable; {@code null} keeps the full
+ *                      per-second resolution (backward compatible).
+ */
 public record GenerateTimeseriesRequest(
         Type eventType,
         String search,
@@ -32,5 +41,7 @@ public record GenerateTimeseriesRequest(
         boolean excludeIdleSamples,
         boolean onlyUnsafeAllocationSamples,
         ThreadInfo threadInfo,
-        List<Marker> markers) {
+        List<Marker> markers,
+        TimeRangeRequest timeRange,
+        Integer targetBuckets) {
 }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/resources/request/GenerateTimeseriesRequest.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/resources/request/GenerateTimeseriesRequest.java
@@ -29,9 +29,12 @@ import java.util.List;
  * @param timeRange     optional window (relative millis from recording start) to restrict the
  *                      query to; {@code null} means the whole recording.
  * @param targetBuckets optional cap on the number of returned points. When set, the series is
- *                      aggregated server-side into at most this many buckets (SUM plus a MAX peak
- *                      series), so long recordings stay readable; {@code null} keeps the full
- *                      per-second resolution (backward compatible).
+ *                      aggregated server-side into at most this many buckets, so long recordings
+ *                      stay readable; {@code null} keeps the full per-second resolution (backward
+ *                      compatible). Presence of {@code targetBuckets} also selects the overview
+ *                      activity query (no stacktrace join).
+ * @param allEventTypes when {@code true}, aggregate across every event type (total activity) and
+ *                      ignore {@code eventType}. Only honoured by the overview query.
  */
 public record GenerateTimeseriesRequest(
         Type eventType,
@@ -43,5 +46,6 @@ public record GenerateTimeseriesRequest(
         ThreadInfo threadInfo,
         List<Marker> markers,
         TimeRangeRequest timeRange,
-        Integer targetBuckets) {
+        Integer targetBuckets,
+        boolean allEventTypes) {
 }

--- a/jeffrey-microscope/profiles/profile-persistence-api/src/main/java/cafe/jeffrey/provider/profile/api/EventQueryConfigurer.java
+++ b/jeffrey-microscope/profiles/profile-persistence-api/src/main/java/cafe/jeffrey/provider/profile/api/EventQueryConfigurer.java
@@ -61,6 +61,7 @@ public class EventQueryConfigurer {
     private String searchPattern;
     private List<SpanInterval> spanIntervals;
     private boolean orderedByTime;
+    private boolean allEventTypes;
 
     /**
      * Include all types of events in the event-stream.
@@ -69,6 +70,17 @@ public class EventQueryConfigurer {
      */
     public EventQueryConfigurer withEventTypes(List<Type> eventTypes) {
         this.eventTypes = eventTypes;
+        return this;
+    }
+
+    /**
+     * Aggregate across every event type, ignoring the configured event type filter. Used by the
+     * recording-overview activity query to produce a total-activity timeseries.
+     *
+     * @return instance of the event-stream configurer
+     */
+    public EventQueryConfigurer withAllEventTypes(boolean allEventTypes) {
+        this.allEventTypes = allEventTypes;
         return this;
     }
 
@@ -235,6 +247,10 @@ public class EventQueryConfigurer {
 
     public List<Type> eventTypes() {
         return eventTypes;
+    }
+
+    public boolean allEventTypes() {
+        return allEventTypes;
     }
 
     public RelativeTimeRange timeRange() {

--- a/jeffrey-microscope/profiles/profile-persistence-api/src/main/java/cafe/jeffrey/provider/profile/api/ProfileEventStreamRepository.java
+++ b/jeffrey-microscope/profiles/profile-persistence-api/src/main/java/cafe/jeffrey/provider/profile/api/ProfileEventStreamRepository.java
@@ -28,6 +28,13 @@ public interface ProfileEventStreamRepository {
 
     <T> T timeseriesStreamer(EventQueryConfigurer configurer, RecordBuilder<TimeseriesRecord, T> builder);
 
+    /**
+     * Total-activity timeseries for the recording overview. Unlike {@link #timeseriesStreamer} it
+     * runs the overview query (no stacktrace join, so stackless event types are included) and
+     * honours {@link EventQueryConfigurer#allEventTypes()} to aggregate across all event types.
+     */
+    <T> T overviewTimeseriesStreamer(EventQueryConfigurer configurer, RecordBuilder<TimeseriesRecord, T> builder);
+
     <T> T timeseriesSearchingStreamer(EventQueryConfigurer configurer, RecordBuilder<TimeseriesSearchRecord, T> builder);
 
     <T> T filterableTimeseriesStreamer(EventQueryConfigurer configurer, RecordBuilder<SecondValue, T> builder);

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/ComplexQueries.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/ComplexQueries.java
@@ -47,6 +47,13 @@ public interface ComplexQueries {
         String filterable(EventQueryConfigurer configurer);
 
         String frameBased(EventQueryConfigurer configurer);
+
+        /**
+         * Total-activity timeseries for the recording overview: bucketed {@code SUM} of the value,
+         * with no stacktrace join (so stackless event types such as GC are included) and an
+         * event-type filter that is omitted when {@link EventQueryConfigurer#allEventTypes()}.
+         */
+        String overview(EventQueryConfigurer configurer);
     }
 
     interface SubSecond {

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/DuckDBNativeTimeseriesQueries.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/DuckDBNativeTimeseriesQueries.java
@@ -45,4 +45,9 @@ public class DuckDBNativeTimeseriesQueries implements ComplexQueries.Timeseries 
     public String frameBased(EventQueryConfigurer configurer) {
         return QUERIES.frameBased(configurer);
     }
+
+    @Override
+    public String overview(EventQueryConfigurer configurer) {
+        return QUERIES.overview(configurer);
+    }
 }

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/DuckDBTimeseriesQueries.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/DuckDBTimeseriesQueries.java
@@ -36,8 +36,12 @@ public class DuckDBTimeseriesQueries implements ComplexQueries.Timeseries {
     private static final String PLACEHOLDER_EVENT_TYPE = "<<event_type>>";
     private static final String PLACEHOLDER_TARGET_VALUE = "<<target_value>>";
     private static final String PLACEHOLDER_THREAD_JOIN = "<<thread_join>>";
+    private static final String PLACEHOLDER_EVENT_TYPE_FILTER = "<<event_type_filter>>";
 
     private static final String THREAD_JOIN = "LEFT JOIN threads t ON e.thread_hash = t.thread_hash";
+
+    /** Single-event-type predicate for the overview query; omitted when querying all events. */
+    private static final String EVENT_TYPE_FILTER_CLAUSE = "AND e.event_type = :event_type\n";
 
     /** Width of a single timeseries bucket in milliseconds (one bucket per second). */
     private static final int BUCKET_SIZE_MS = 1000;
@@ -178,16 +182,30 @@ public class DuckDBTimeseriesQueries implements ComplexQueries.Timeseries {
             CROSS JOIN frame_lookup fl;
             """;
 
+    //language=SQL
+    private static final String OVERVIEW = """
+            SELECT (e.start_timestamp_from_beginning // <<bucket_size_ms>>) AS seconds,
+                   SUM(<<target_value>>) AS value
+            FROM events e
+            WHERE 1 = 1
+                <<event_type_filter>>
+                <<time_filters>>
+            GROUP BY seconds
+            ORDER BY seconds
+            """;
+
     private final String simple;
     private final String simpleSearch;
     private final String filterable;
     private final String frameBased;
+    private final String overview;
 
     private DuckDBTimeseriesQueries(String eventType, String additionalFilters) {
         this.simple = prepare(SIMPLE, eventType, additionalFilters);
         this.simpleSearch = prepare(SIMPLE_SEARCH, eventType, additionalFilters);
         this.filterable = prepare(FILTERABLE, eventType, additionalFilters);
         this.frameBased = prepare(FRAME_BASED, eventType, additionalFilters);
+        this.overview = prepare(OVERVIEW, eventType, additionalFilters);
     }
 
     private static String prepare(String template, String eventType, String additionalFilters) {
@@ -208,10 +226,12 @@ public class DuckDBTimeseriesQueries implements ComplexQueries.Timeseries {
     private static String render(String sql, EventQueryConfigurer configurer) {
         String valueField = configurer.useWeight() ? "e.weight" : "e.samples";
         String threadJoin = configurer.specifiedThread() != null ? THREAD_JOIN : "";
+        String eventTypeFilter = configurer.allEventTypes() ? "" : EVENT_TYPE_FILTER_CLAUSE;
 
         String result = sql
                 .replace(PLACEHOLDER_TARGET_VALUE, valueField)
-                .replace(PLACEHOLDER_THREAD_JOIN, threadJoin);
+                .replace(PLACEHOLDER_THREAD_JOIN, threadJoin)
+                .replace(PLACEHOLDER_EVENT_TYPE_FILTER, eventTypeFilter);
 
         return EventQueryFilters.splice(result, configurer);
     }
@@ -234,5 +254,10 @@ public class DuckDBTimeseriesQueries implements ComplexQueries.Timeseries {
     @Override
     public String frameBased(EventQueryConfigurer configurer) {
         return render(frameBased, configurer);
+    }
+
+    @Override
+    public String overview(EventQueryConfigurer configurer) {
+        return render(overview, configurer);
     }
 }

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/JdbcProfileEventStreamRepository.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/JdbcProfileEventStreamRepository.java
@@ -106,6 +106,23 @@ public class JdbcProfileEventStreamRepository implements ProfileEventStreamRepos
     }
 
     @Override
+    public <T> T overviewTimeseriesStreamer(EventQueryConfigurer configurer, RecordBuilder<TimeseriesRecord, T> builder) {
+        QueryBuilderFactory factory = queryBuilderFactoryResolver.resolve(configurer.eventTypes());
+
+        MapSqlParameterSource baseParams = createBaseParams(configurer);
+
+        ComplexQueries.Timeseries timeseries = factory.complexQueries().timeseries();
+        databaseClient.queryStream(
+                StatementLabel.STREAM_EVENTS,
+                timeseries.overview(configurer),
+                baseParams,
+                (r, _) -> TimeseriesRecord.secondsAndValues(r.getLong("seconds"), r.getLong("value")),
+                builder::onRecord);
+
+        return builder.build();
+    }
+
+    @Override
     public <T> T timeseriesSearchingStreamer(EventQueryConfigurer configurer, RecordBuilder<TimeseriesSearchRecord, T> builder) {
         QueryBuilderFactory factory = queryBuilderFactoryResolver.resolve(configurer.eventTypes());
 

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/test/java/cafe/jeffrey/provider/profile/jdbc/DuckDBOverviewTimeseriesTest.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/test/java/cafe/jeffrey/provider/profile/jdbc/DuckDBOverviewTimeseriesTest.java
@@ -1,0 +1,125 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.provider.profile.jdbc;
+
+import cafe.jeffrey.provider.profile.api.EventQueryConfigurer;
+import cafe.jeffrey.shared.common.model.Type;
+import cafe.jeffrey.shared.persistence.GroupLabel;
+import cafe.jeffrey.shared.persistence.StatementLabel;
+import cafe.jeffrey.shared.persistence.client.DatabaseClient;
+import cafe.jeffrey.shared.persistence.client.DatabaseClientProvider;
+import cafe.jeffrey.test.DuckDBTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Exercises the real overview activity query against DuckDB. It proves the query (a) totals every
+ * event type when {@code allEventTypes} is set, (b) restricts to a single type otherwise, and
+ * (c) includes stackless event types such as {@code jdk.GarbageCollection} — which the stacktrace-
+ * joined SIMPLE query excludes.
+ */
+@DuckDBTest(migration = "classpath:db/migration/profile")
+class DuckDBOverviewTimeseriesTest {
+
+    private static final String EXECUTION_SAMPLE = "jdk.ExecutionSample";
+    private static final String ALLOCATION_SAMPLE = "jdk.ObjectAllocationSample";
+    private static final String GARBAGE_COLLECTION = "jdk.GarbageCollection";
+
+    // 3 execution samples + 2 allocation samples (all stackful) + 2 GC events (stackless) = 7.
+    //language=SQL
+    private static final String INSERT_EVENTS = """
+            INSERT INTO events
+                (event_type, start_timestamp, start_timestamp_from_beginning, duration,
+                 samples, weight, weight_entity, stacktrace_hash, thread_hash, fields)
+            VALUES
+                ('jdk.ExecutionSample',        TIMESTAMPTZ '2025-01-01 00:00:00+00',    0, NULL, 1, NULL, NULL,  111, NULL, NULL),
+                ('jdk.ExecutionSample',        TIMESTAMPTZ '2025-01-01 00:00:01+00', 1500, NULL, 1, NULL, NULL,  111, NULL, NULL),
+                ('jdk.ExecutionSample',        TIMESTAMPTZ '2025-01-01 00:00:03+00', 3000, NULL, 1, NULL, NULL,  112, NULL, NULL),
+                ('jdk.ObjectAllocationSample', TIMESTAMPTZ '2025-01-01 00:00:00+00',  500, NULL, 1, NULL, NULL,  222, NULL, NULL),
+                ('jdk.ObjectAllocationSample', TIMESTAMPTZ '2025-01-01 00:00:02+00', 2500, NULL, 1, NULL, NULL,  222, NULL, NULL),
+                ('jdk.GarbageCollection',      TIMESTAMPTZ '2025-01-01 00:00:01+00', 1000, NULL, 1, NULL, NULL, NULL, NULL, NULL),
+                ('jdk.GarbageCollection',      TIMESTAMPTZ '2025-01-01 00:00:04+00', 4000, NULL, 1, NULL, NULL, NULL, NULL, NULL)
+            """;
+
+    private static void insertEvents(DataSource dataSource) throws SQLException {
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement()) {
+            statement.execute(INSERT_EVENTS);
+        }
+    }
+
+    private static long sumValues(DatabaseClient client, String sql, MapSqlParameterSource params) {
+        return client.query(StatementLabel.STREAM_EVENTS, sql, params, (rs, _) -> rs.getLong("value"))
+                .stream()
+                .mapToLong(Long::longValue)
+                .sum();
+    }
+
+    @Test
+    void allEventTypesTotalsEverythingIncludingStacklessEvents(DataSource dataSource) throws SQLException {
+        insertEvents(dataSource);
+        DatabaseClient client = new DatabaseClientProvider(dataSource).provide(GroupLabel.PROFILE_EVENTS);
+
+        EventQueryConfigurer configurer = new EventQueryConfigurer().withAllEventTypes(true);
+        String sql = DuckDBTimeseriesQueries.of().overview(configurer);
+        assertFalse(sql.contains("event_type ="), "all-events query must omit the event-type filter");
+
+        // 3 execution + 2 allocation + 2 GC = 7.
+        assertEquals(7L, sumValues(client, sql, new MapSqlParameterSource()));
+    }
+
+    @Test
+    void singleEventTypeRestrictsToThatType(DataSource dataSource) throws SQLException {
+        insertEvents(dataSource);
+        DatabaseClient client = new DatabaseClientProvider(dataSource).provide(GroupLabel.PROFILE_EVENTS);
+
+        EventQueryConfigurer configurer = new EventQueryConfigurer().withEventType(Type.EXECUTION_SAMPLE);
+        String sql = DuckDBTimeseriesQueries.of().overview(configurer);
+        assertTrue(sql.contains("e.event_type = :event_type"), "per-type query must include the event-type filter");
+
+        assertEquals(3L, sumValues(client, sql, new MapSqlParameterSource().addValue("event_type", EXECUTION_SAMPLE)));
+        assertEquals(2L, sumValues(client,
+                DuckDBTimeseriesQueries.of().overview(new EventQueryConfigurer().withEventType(Type.fromCode(ALLOCATION_SAMPLE))),
+                new MapSqlParameterSource().addValue("event_type", ALLOCATION_SAMPLE)));
+    }
+
+    @Test
+    void stacklessEventTypeIsIncludedUnlikeSimpleQuery(DataSource dataSource) throws SQLException {
+        insertEvents(dataSource);
+        DatabaseClient client = new DatabaseClientProvider(dataSource).provide(GroupLabel.PROFILE_EVENTS);
+
+        EventQueryConfigurer configurer = new EventQueryConfigurer().withEventType(Type.fromCode(GARBAGE_COLLECTION));
+        MapSqlParameterSource params = new MapSqlParameterSource().addValue("event_type", GARBAGE_COLLECTION);
+
+        // The overview query has no stacktrace join, so both stackless GC events are counted.
+        assertEquals(2L, sumValues(client, DuckDBTimeseriesQueries.of().overview(configurer), params));
+
+        // The stacktrace-joined SIMPLE query would have excluded them.
+        assertEquals(0L, sumValues(client, DuckDBTimeseriesQueries.of().simple(configurer), params));
+    }
+}

--- a/jeffrey-microscope/profiles/timeseries/src/main/java/cafe/jeffrey/timeseries/TimeseriesDownsampler.java
+++ b/jeffrey-microscope/profiles/timeseries/src/main/java/cafe/jeffrey/timeseries/TimeseriesDownsampler.java
@@ -25,16 +25,11 @@ import java.util.List;
  * Reduces a per-second timeseries to at most a target number of points so long recordings stay
  * readable, instead of shipping tens of thousands of points and decimating (and losing spikes) on
  * the client. Consecutive points are grouped into equal-width buckets; each bucket's value is the
- * SUM of the grouped values, so no sample mass is lost.
- *
- * <p>When the input has a single series an additional {@code Peak} series (the MAX value within each
- * bucket) is appended, so a transient spike that a coarse SUM would blend into its neighbours stays
- * visible as a peak. Multi-series inputs (e.g. differential or matched/total splits) are reduced
- * with SUM only, preserving their series count and pairing.
+ * SUM of the grouped values, so no sample mass is lost. Multi-series inputs (e.g. differential or
+ * matched/total splits) keep their series count and pairing.
  */
 public final class TimeseriesDownsampler {
 
-    private static final String PEAK_SERIE_NAME = "Peak";
     private static final int TIME_INDEX = 0;
     private static final int VALUE_INDEX = 1;
 
@@ -46,21 +41,17 @@ public final class TimeseriesDownsampler {
             return data;
         }
 
-        boolean singleSerie = data.series().size() == 1;
         List<SingleSerie> result = new ArrayList<>();
         for (SingleSerie serie : data.series()) {
-            result.add(reduce(serie.name(), serie.data(), targetBuckets, false));
-            if (singleSerie) {
-                result.add(reduce(PEAK_SERIE_NAME, serie.data(), targetBuckets, true));
-            }
+            result.add(reduce(serie.name(), serie.data(), targetBuckets));
         }
         return new TimeseriesData(result);
     }
 
-    private static SingleSerie reduce(String name, List<List<Long>> points, int targetBuckets, boolean peak) {
+    private static SingleSerie reduce(String name, List<List<Long>> points, int targetBuckets) {
         int size = points.size();
         if (size <= targetBuckets) {
-            // Already within budget: every bucket holds a single point, so SUM and MAX both equal it.
+            // Already within budget: every bucket holds a single point.
             List<List<Long>> copy = new ArrayList<>(size);
             for (List<Long> point : points) {
                 copy.add(point(point.get(TIME_INDEX), point.get(VALUE_INDEX)));
@@ -73,16 +64,11 @@ public final class TimeseriesDownsampler {
         for (int start = 0; start < size; start += groupSize) {
             int end = Math.min(start + groupSize, size);
             long bucketTime = points.get(start).get(TIME_INDEX);
-            long aggregate = peak ? Long.MIN_VALUE : 0L;
+            long sum = 0L;
             for (int i = start; i < end; i++) {
-                long value = points.get(i).get(VALUE_INDEX);
-                if (peak) {
-                    aggregate = Math.max(aggregate, value);
-                } else {
-                    aggregate += value;
-                }
+                sum += points.get(i).get(VALUE_INDEX);
             }
-            reduced.add(point(bucketTime, aggregate));
+            reduced.add(point(bucketTime, sum));
         }
         return new SingleSerie(name, reduced);
     }

--- a/jeffrey-microscope/profiles/timeseries/src/main/java/cafe/jeffrey/timeseries/TimeseriesDownsampler.java
+++ b/jeffrey-microscope/profiles/timeseries/src/main/java/cafe/jeffrey/timeseries/TimeseriesDownsampler.java
@@ -1,0 +1,96 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.timeseries;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Reduces a per-second timeseries to at most a target number of points so long recordings stay
+ * readable, instead of shipping tens of thousands of points and decimating (and losing spikes) on
+ * the client. Consecutive points are grouped into equal-width buckets; each bucket's value is the
+ * SUM of the grouped values, so no sample mass is lost.
+ *
+ * <p>When the input has a single series an additional {@code Peak} series (the MAX value within each
+ * bucket) is appended, so a transient spike that a coarse SUM would blend into its neighbours stays
+ * visible as a peak. Multi-series inputs (e.g. differential or matched/total splits) are reduced
+ * with SUM only, preserving their series count and pairing.
+ */
+public final class TimeseriesDownsampler {
+
+    private static final String PEAK_SERIE_NAME = "Peak";
+    private static final int TIME_INDEX = 0;
+    private static final int VALUE_INDEX = 1;
+
+    private TimeseriesDownsampler() {
+    }
+
+    public static TimeseriesData downsample(TimeseriesData data, int targetBuckets) {
+        if (targetBuckets <= 0) {
+            return data;
+        }
+
+        boolean singleSerie = data.series().size() == 1;
+        List<SingleSerie> result = new ArrayList<>();
+        for (SingleSerie serie : data.series()) {
+            result.add(reduce(serie.name(), serie.data(), targetBuckets, false));
+            if (singleSerie) {
+                result.add(reduce(PEAK_SERIE_NAME, serie.data(), targetBuckets, true));
+            }
+        }
+        return new TimeseriesData(result);
+    }
+
+    private static SingleSerie reduce(String name, List<List<Long>> points, int targetBuckets, boolean peak) {
+        int size = points.size();
+        if (size <= targetBuckets) {
+            // Already within budget: every bucket holds a single point, so SUM and MAX both equal it.
+            List<List<Long>> copy = new ArrayList<>(size);
+            for (List<Long> point : points) {
+                copy.add(point(point.get(TIME_INDEX), point.get(VALUE_INDEX)));
+            }
+            return new SingleSerie(name, copy);
+        }
+
+        int groupSize = (int) Math.ceil((double) size / targetBuckets);
+        List<List<Long>> reduced = new ArrayList<>();
+        for (int start = 0; start < size; start += groupSize) {
+            int end = Math.min(start + groupSize, size);
+            long bucketTime = points.get(start).get(TIME_INDEX);
+            long aggregate = peak ? Long.MIN_VALUE : 0L;
+            for (int i = start; i < end; i++) {
+                long value = points.get(i).get(VALUE_INDEX);
+                if (peak) {
+                    aggregate = Math.max(aggregate, value);
+                } else {
+                    aggregate += value;
+                }
+            }
+            reduced.add(point(bucketTime, aggregate));
+        }
+        return new SingleSerie(name, reduced);
+    }
+
+    private static List<Long> point(long time, long value) {
+        List<Long> point = new ArrayList<>(2);
+        point.add(time);
+        point.add(value);
+        return point;
+    }
+}

--- a/jeffrey-microscope/profiles/timeseries/src/test/java/cafe/jeffrey/timeseries/TimeseriesDownsamplerTest.java
+++ b/jeffrey-microscope/profiles/timeseries/src/test/java/cafe/jeffrey/timeseries/TimeseriesDownsamplerTest.java
@@ -55,16 +55,13 @@ class TimeseriesDownsamplerTest {
     class SingleSerieInput {
 
         @Test
-        void boundsThePointCountAndAppendsPeak() {
+        void boundsThePointCount() {
             TimeseriesData input = new TimeseriesData(serie("Samples", 10_000));
 
             TimeseriesData result = TimeseriesDownsampler.downsample(input, 1_000);
 
-            assertEquals(2, result.series().size());
-            SingleSerie samples = byName(result, "Samples");
-            SingleSerie peak = byName(result, "Peak");
-            assertTrue(samples.data().size() <= 1_000);
-            assertEquals(samples.data().size(), peak.data().size());
+            assertEquals(1, result.series().size());
+            assertTrue(byName(result, "Samples").data().size() <= 1_000);
         }
 
         @Test
@@ -77,7 +74,7 @@ class TimeseriesDownsamplerTest {
         }
 
         @Test
-        void peakKeepsTransientSpikeThatSumWouldBlend() {
+        void aggregatesSpikeMassIntoItsBucket() {
             List<List<Long>> data = new ArrayList<>();
             for (long second = 0; second < 1_000; second++) {
                 List<Long> point = new ArrayList<>(2);
@@ -89,22 +86,18 @@ class TimeseriesDownsamplerTest {
 
             TimeseriesData result = TimeseriesDownsampler.downsample(input, 100);
 
-            long maxPeak = byName(result, "Peak").data().stream()
-                    .mapToLong(point -> point.get(1))
-                    .max()
-                    .orElseThrow();
-            assertEquals(400L, maxPeak);
+            // Total mass (999 ones + one 400) is preserved by SUM.
+            assertEquals(999L + 400L, totalValue(byName(result, "Samples")));
         }
 
         @Test
-        void smallInputIsReturnedWithinBudgetWithPeak() {
+        void smallInputIsReturnedUnchanged() {
             TimeseriesData input = new TimeseriesData(serie("Samples", 50));
 
             TimeseriesData result = TimeseriesDownsampler.downsample(input, 1_000);
 
-            assertEquals(2, result.series().size());
+            assertEquals(1, result.series().size());
             assertEquals(50, byName(result, "Samples").data().size());
-            assertEquals(50, byName(result, "Peak").data().size());
         }
     }
 
@@ -112,7 +105,7 @@ class TimeseriesDownsamplerTest {
     class MultiSerieInput {
 
         @Test
-        void reducesEachSerieWithoutAddingPeak() {
+        void reducesEachSerieKeepingSeriesCount() {
             TimeseriesData input = new TimeseriesData(
                     serie("Samples", 5_000),
                     serie("Matched Samples", 5_000));

--- a/jeffrey-microscope/profiles/timeseries/src/test/java/cafe/jeffrey/timeseries/TimeseriesDownsamplerTest.java
+++ b/jeffrey-microscope/profiles/timeseries/src/test/java/cafe/jeffrey/timeseries/TimeseriesDownsamplerTest.java
@@ -1,0 +1,127 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.timeseries;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TimeseriesDownsamplerTest {
+
+    private static SingleSerie serie(String name, int seconds) {
+        List<List<Long>> data = new ArrayList<>();
+        for (long second = 0; second < seconds; second++) {
+            List<Long> point = new ArrayList<>(2);
+            point.add(second);
+            point.add(1L);
+            data.add(point);
+        }
+        return new SingleSerie(name, data);
+    }
+
+    private static long totalValue(SingleSerie serie) {
+        return serie.data().stream().mapToLong(point -> point.get(1)).sum();
+    }
+
+    private static SingleSerie byName(TimeseriesData data, String name) {
+        return data.series().stream()
+                .filter(serie -> serie.name().equals(name))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    @Nested
+    class SingleSerieInput {
+
+        @Test
+        void boundsThePointCountAndAppendsPeak() {
+            TimeseriesData input = new TimeseriesData(serie("Samples", 10_000));
+
+            TimeseriesData result = TimeseriesDownsampler.downsample(input, 1_000);
+
+            assertEquals(2, result.series().size());
+            SingleSerie samples = byName(result, "Samples");
+            SingleSerie peak = byName(result, "Peak");
+            assertTrue(samples.data().size() <= 1_000);
+            assertEquals(samples.data().size(), peak.data().size());
+        }
+
+        @Test
+        void sumPreservesTotalValue() {
+            TimeseriesData input = new TimeseriesData(serie("Samples", 10_000));
+
+            TimeseriesData result = TimeseriesDownsampler.downsample(input, 1_000);
+
+            assertEquals(10_000L, totalValue(byName(result, "Samples")));
+        }
+
+        @Test
+        void peakKeepsTransientSpikeThatSumWouldBlend() {
+            List<List<Long>> data = new ArrayList<>();
+            for (long second = 0; second < 1_000; second++) {
+                List<Long> point = new ArrayList<>(2);
+                point.add(second);
+                point.add(second == 500 ? 400L : 1L);
+                data.add(point);
+            }
+            TimeseriesData input = new TimeseriesData(new SingleSerie("Samples", data));
+
+            TimeseriesData result = TimeseriesDownsampler.downsample(input, 100);
+
+            long maxPeak = byName(result, "Peak").data().stream()
+                    .mapToLong(point -> point.get(1))
+                    .max()
+                    .orElseThrow();
+            assertEquals(400L, maxPeak);
+        }
+
+        @Test
+        void smallInputIsReturnedWithinBudgetWithPeak() {
+            TimeseriesData input = new TimeseriesData(serie("Samples", 50));
+
+            TimeseriesData result = TimeseriesDownsampler.downsample(input, 1_000);
+
+            assertEquals(2, result.series().size());
+            assertEquals(50, byName(result, "Samples").data().size());
+            assertEquals(50, byName(result, "Peak").data().size());
+        }
+    }
+
+    @Nested
+    class MultiSerieInput {
+
+        @Test
+        void reducesEachSerieWithoutAddingPeak() {
+            TimeseriesData input = new TimeseriesData(
+                    serie("Samples", 5_000),
+                    serie("Matched Samples", 5_000));
+
+            TimeseriesData result = TimeseriesDownsampler.downsample(input, 500);
+
+            assertEquals(2, result.series().size());
+            assertTrue(byName(result, "Samples").data().size() <= 500);
+            assertTrue(byName(result, "Matched Samples").data().size() <= 500);
+        }
+    }
+}


### PR DESCRIPTION
Long recordings are hard to follow because every profile view renders the
whole recording at once. This introduces a Recording Overview as the profile
landing page: an activity timeline (reusing TimeSeriesChart) whose brush
selection picks a single analysis window shared across the profile.

- useProfileTimeWindow composable: module-level shared window (millis from
  recording start, null = whole recording) with URL (?from=&to=) sync, so the
  selection survives feature navigation and is shareable. Drops a stale window
  when the active profile changes.
- ProfileRecordingOverview view: reuses TimeSeriesChart for the navigator;
  sources its activity series from the existing event summaries + primary
  flamegraph timeseries path (prefers CPU execution samples, else the most
  sampled event). Header scope indicator stays neutral for the whole recording
  and turns amber with a reset once a sub-range is active, so it is always clear
  that the rest of the app is scoped to a slice. Three-state + EmptyState for
  heap-dump-only profiles. Jump tiles carry the window into other views.
- Routing/nav: new recording-overview route is now the profile landing page and
  the first item in the JVM Internals sidebar; Configuration stays reachable.