### PR TITLE
Trace/span-scoped flamegraphs and timeseries for OTLP profiles

### DIFF
--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/FlamegraphController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/FlamegraphController.java
@@ -107,6 +107,7 @@ public class FlamegraphController {
                 .withGraphComponents(request.components())
                 .withSearchPattern(request.search())
                 .withMarkers(request.markers())
+                .withJsonFieldFilter(request.toJsonFieldFilter())
                 .build();
     }
 

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/TimeseriesController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/TimeseriesController.java
@@ -59,6 +59,7 @@ public class TimeseriesController {
                 .withExcludeIdleSamples(request.excludeIdleSamples())
                 .withOnlyUnsafeAllocationSamples(request.onlyUnsafeAllocationSamples())
                 .withMarkers(request.markers())
+                .withJsonFieldFilter(request.toJsonFieldFilter())
                 .build();
 
         return new TimeseriesManager.Generate(

--- a/jeffrey-microscope/pages-microscope/src/services/api/FlamegraphClients.test.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/FlamegraphClients.test.ts
@@ -192,6 +192,40 @@ describe('PrimaryFlamegraphClient payloads', () => {
       })
     );
   });
+
+  it('sends trace and span correlation keys only when set', async () => {
+    const scoped = new PrimaryFlamegraphClient(
+      'p1',
+      'otel.cpu',
+      true,
+      false,
+      true,
+      false,
+      true,
+      null,
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      '1111111111111111'
+    );
+
+    await scoped.provideBoth(GraphComponents.BOTH, timeRange, null);
+
+    expect(lastPost().bodyJson).toBe(
+      expectJson({
+        eventType: 'otel.cpu',
+        useWeight: false,
+        useThreadMode: true,
+        timeRange: { start: 1000, end: 2000, absoluteTime: true },
+        search: null,
+        excludeNonJavaSamples: true,
+        excludeIdleSamples: false,
+        onlyUnsafeAllocationSamples: true,
+        threadInfo: null,
+        components: 'BOTH',
+        traceId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        spanId: '1111111111111111'
+      })
+    );
+  });
 });
 
 describe('SingleSpanFlamegraphClient payloads', () => {

--- a/jeffrey-microscope/pages-microscope/src/services/api/PrimaryFlamegraphClient.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/PrimaryFlamegraphClient.ts
@@ -30,6 +30,8 @@ export default class PrimaryFlamegraphClient extends RemoteFlamegraphClient {
   private readonly excludeIdleSamples: boolean;
   private readonly onlyUnsafeAllocationSamples: boolean;
   private readonly threadInfo: ThreadInfo | null;
+  private readonly traceId: string | null;
+  private readonly spanId: string | null;
 
   constructor(
     profileId: string,
@@ -39,7 +41,9 @@ export default class PrimaryFlamegraphClient extends RemoteFlamegraphClient {
     excludeNonJavaSamples: boolean,
     excludeIdleSamples: boolean,
     onlyUnsafeAllocationSamples: boolean,
-    threadInfo: ThreadInfo | null
+    threadInfo: ThreadInfo | null,
+    traceId: string | null = null,
+    spanId: string | null = null
   ) {
     super(GlobalVars.internalUrl + '/profiles/' + profileId + '/flamegraph');
     this.eventType = eventType;
@@ -49,6 +53,8 @@ export default class PrimaryFlamegraphClient extends RemoteFlamegraphClient {
     this.excludeIdleSamples = excludeIdleSamples;
     this.onlyUnsafeAllocationSamples = onlyUnsafeAllocationSamples;
     this.threadInfo = threadInfo;
+    this.traceId = traceId;
+    this.spanId = spanId;
   }
 
   protected bothContent(
@@ -56,7 +62,7 @@ export default class PrimaryFlamegraphClient extends RemoteFlamegraphClient {
     timeRange: TimeRange | null | undefined,
     search: string | null | undefined
   ): Record<string, unknown> {
-    return {
+    const content: Record<string, unknown> = {
       eventType: this.eventType,
       useWeight: this.useWeight,
       useThreadMode: this.useThreadMode,
@@ -68,6 +74,13 @@ export default class PrimaryFlamegraphClient extends RemoteFlamegraphClient {
       threadInfo: this.threadInfo,
       components: components
     };
+    if (this.traceId !== null) {
+      content.traceId = this.traceId;
+    }
+    if (this.spanId !== null) {
+      content.spanId = this.spanId;
+    }
+    return content;
   }
 
   save(

--- a/jeffrey-microscope/profiles/common-profile/src/main/java/cafe/jeffrey/profile/common/config/GraphParameters.java
+++ b/jeffrey-microscope/profiles/common-profile/src/main/java/cafe/jeffrey/profile/common/config/GraphParameters.java
@@ -19,6 +19,7 @@
 package cafe.jeffrey.profile.common.config;
 
 import cafe.jeffrey.shared.common.GraphType;
+import cafe.jeffrey.shared.common.model.JsonFieldFilter;
 import cafe.jeffrey.shared.common.model.SpanInterval;
 import cafe.jeffrey.shared.common.model.ThreadInfo;
 import cafe.jeffrey.shared.common.model.Type;
@@ -44,7 +45,8 @@ public record GraphParameters(
         List<Marker> markers,
         GraphType graphType,
         GraphComponents graphComponents,
-        List<SpanInterval> spanIntervals) {
+        List<SpanInterval> spanIntervals,
+        JsonFieldFilter jsonFieldFilter) {
 
     public List<StacktraceTag> stacktraceTags() {
         List<StacktraceTag> tags = new ArrayList<>();
@@ -88,7 +90,8 @@ public record GraphParameters(
                 .withMarkers(markers)
                 .withGraphType(graphType)
                 .withGraphComponents(graphComponents)
-                .withSpanIntervals(spanIntervals);
+                .withSpanIntervals(spanIntervals)
+                .withJsonFieldFilter(jsonFieldFilter);
     }
 
     public static GraphParametersBuilder builder() {

--- a/jeffrey-microscope/profiles/common-profile/src/main/java/cafe/jeffrey/profile/common/config/GraphParametersBuilder.java
+++ b/jeffrey-microscope/profiles/common-profile/src/main/java/cafe/jeffrey/profile/common/config/GraphParametersBuilder.java
@@ -19,6 +19,7 @@
 package cafe.jeffrey.profile.common.config;
 
 import cafe.jeffrey.shared.common.GraphType;
+import cafe.jeffrey.shared.common.model.JsonFieldFilter;
 import cafe.jeffrey.shared.common.model.SpanInterval;
 import cafe.jeffrey.shared.common.model.ThreadInfo;
 import cafe.jeffrey.shared.common.model.Type;
@@ -43,6 +44,7 @@ public class GraphParametersBuilder {
     private GraphType graphType;
     private GraphComponents graphComponents;
     private List<SpanInterval> spanIntervals;
+    private JsonFieldFilter jsonFieldFilter;
 
     public GraphParametersBuilder withEventType(Type eventType) {
         this.eventType = eventType;
@@ -114,6 +116,11 @@ public class GraphParametersBuilder {
         return this;
     }
 
+    public GraphParametersBuilder withJsonFieldFilter(JsonFieldFilter jsonFieldFilter) {
+        this.jsonFieldFilter = jsonFieldFilter;
+        return this;
+    }
+
     public GraphParameters build() {
         return new GraphParameters(
                 eventType,
@@ -129,6 +136,7 @@ public class GraphParametersBuilder {
                 markers,
                 graphType,
                 graphComponents,
-                spanIntervals);
+                spanIntervals,
+                jsonFieldFilter);
     }
 }

--- a/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/provider/FlamegraphDataProvider.java
+++ b/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/provider/FlamegraphDataProvider.java
@@ -117,6 +117,12 @@ public class FlamegraphDataProvider {
                 .withWeight(graphParameters.useWeight())
                 .withSpanIntervals(graphParameters.spanIntervals());
 
+        if (graphParameters.jsonFieldFilter() != null) {
+            configurer.withJsonFieldEquals(
+                    graphParameters.jsonFieldFilter().field(),
+                    graphParameters.jsonFieldFilter().value());
+        }
+
         Frame frame = eventStreamRepository.flamegraphStreamer(configurer, frameBuilder);
 
         if (graphParameters.markers() != null) {

--- a/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/provider/TimeseriesDataProvider.java
+++ b/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/provider/TimeseriesDataProvider.java
@@ -53,6 +53,12 @@ public class TimeseriesDataProvider {
                     .withSpecifiedThread(graphParameters.threadInfo())
                     .withSpanIntervals(graphParameters.spanIntervals());
 
+            if (graphParameters.jsonFieldFilter() != null) {
+                configurer.withJsonFieldEquals(
+                        graphParameters.jsonFieldFilter().field(),
+                        graphParameters.jsonFieldFilter().value());
+            }
+
             if (timeseriesType == TimeseriesType.SIMPLE) {
                 return eventStreamRepository.timeseriesStreamer(configurer, TimeseriesResolver.resolve(graphParameters));
             } else if (timeseriesType == TimeseriesType.SEARCHING) {

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/resources/request/GenerateFlamegraphRequest.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/resources/request/GenerateFlamegraphRequest.java
@@ -19,6 +19,7 @@
 package cafe.jeffrey.profile.resources.request;
 
 import cafe.jeffrey.profile.TimeRangeRequest;
+import cafe.jeffrey.shared.common.model.JsonFieldFilter;
 import cafe.jeffrey.shared.common.model.ThreadInfo;
 import cafe.jeffrey.shared.common.model.Type;
 import cafe.jeffrey.profile.common.analysis.marker.Marker;
@@ -38,5 +39,21 @@ public record GenerateFlamegraphRequest(
         boolean onlyUnsafeAllocationSamples,
         ThreadInfo threadInfo,
         GraphComponents components,
-        List<Marker> markers) {
+        List<Marker> markers,
+        String traceId,
+        String spanId) {
+
+    /**
+     * OpenTelemetry trace-correlation scope of the graph: the more specific span id wins over the
+     * trace id, {@code null} when the request carries neither.
+     */
+    public JsonFieldFilter toJsonFieldFilter() {
+        if (spanId != null && !spanId.isBlank()) {
+            return JsonFieldFilter.bySpanId(spanId);
+        }
+        if (traceId != null && !traceId.isBlank()) {
+            return JsonFieldFilter.byTraceId(traceId);
+        }
+        return null;
+    }
 }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/resources/request/GenerateTimeseriesRequest.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/resources/request/GenerateTimeseriesRequest.java
@@ -18,6 +18,7 @@
 
 package cafe.jeffrey.profile.resources.request;
 
+import cafe.jeffrey.shared.common.model.JsonFieldFilter;
 import cafe.jeffrey.shared.common.model.ThreadInfo;
 import cafe.jeffrey.shared.common.model.Type;
 import cafe.jeffrey.profile.common.analysis.marker.Marker;
@@ -32,5 +33,21 @@ public record GenerateTimeseriesRequest(
         boolean excludeIdleSamples,
         boolean onlyUnsafeAllocationSamples,
         ThreadInfo threadInfo,
-        List<Marker> markers) {
+        List<Marker> markers,
+        String traceId,
+        String spanId) {
+
+    /**
+     * OpenTelemetry trace-correlation scope of the graph: the more specific span id wins over the
+     * trace id, {@code null} when the request carries neither.
+     */
+    public JsonFieldFilter toJsonFieldFilter() {
+        if (spanId != null && !spanId.isBlank()) {
+            return JsonFieldFilter.bySpanId(spanId);
+        }
+        if (traceId != null && !traceId.isBlank()) {
+            return JsonFieldFilter.byTraceId(traceId);
+        }
+        return null;
+    }
 }

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/DuckDBFlamegraphQueries.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/DuckDBFlamegraphQueries.java
@@ -96,6 +96,7 @@ public class DuckDBFlamegraphQueries implements ComplexQueries.Flamegraph {
                 WHERE e.event_type = <<event_type>>
                     <<time_filters>>
                     <<span_filter>>
+                    <<json_field_filter>>
                     <<stacktrace_filters>>
                 <<additional_filters>>
                 GROUP BY s.stacktrace_hash, s.frame_hashes
@@ -142,6 +143,7 @@ public class DuckDBFlamegraphQueries implements ComplexQueries.Flamegraph {
             WHERE e.event_type = <<event_type>>
                 <<time_filters>>
                 <<span_filter>>
+                <<json_field_filter>>
                 <<stacktrace_filters>>
                 <<additional_filters>>
             GROUP BY s.stacktrace_hash, s.frame_hashes;
@@ -165,6 +167,7 @@ public class DuckDBFlamegraphQueries implements ComplexQueries.Flamegraph {
                 WHERE e.event_type = <<event_type>>
                     <<time_filters>>
                     <<span_filter>>
+                    <<json_field_filter>>
                     <<stacktrace_filters>>
                     <<additional_filters>>
                 GROUP BY s.stacktrace_hash, s.frame_hashes, e.weight_entity
@@ -213,6 +216,7 @@ public class DuckDBFlamegraphQueries implements ComplexQueries.Flamegraph {
             WHERE e.event_type = <<event_type>>
                 <<time_filters>>
                 <<span_filter>>
+                <<json_field_filter>>
                 <<stacktrace_filters>>
                 <<additional_filters>>
             GROUP BY s.stacktrace_hash, s.frame_hashes, e.weight_entity;
@@ -250,6 +254,7 @@ public class DuckDBFlamegraphQueries implements ComplexQueries.Flamegraph {
                 WHERE e.event_type = <<event_type>>
                     <<time_filters>>
                     <<span_filter>>
+                    <<json_field_filter>>
                     <<thread_filters>>
                     <<stacktrace_filters>>
                     <<additional_filters>>
@@ -307,6 +312,7 @@ public class DuckDBFlamegraphQueries implements ComplexQueries.Flamegraph {
                 WHERE e.event_type = <<event_type>>
                     <<time_filters>>
                     <<span_filter>>
+                    <<json_field_filter>>
                     <<thread_filters>>
                     <<stacktrace_filters>>
                     <<additional_filters>>
@@ -363,6 +369,7 @@ public class DuckDBFlamegraphQueries implements ComplexQueries.Flamegraph {
             WHERE e.event_type = <<event_type>>
                 <<time_filters>>
                 <<span_filter>>
+                <<json_field_filter>>
                 <<thread_filters>>
                 <<stacktrace_filters>>
                 <<additional_filters>>
@@ -393,6 +400,7 @@ public class DuckDBFlamegraphQueries implements ComplexQueries.Flamegraph {
             WHERE e.event_type = <<event_type>>
                 <<time_filters>>
                 <<span_filter>>
+                <<json_field_filter>>
                 <<thread_filters>>
                 <<stacktrace_filters>>
                 <<additional_filters>>

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/DuckDBTimeseriesQueries.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/DuckDBTimeseriesQueries.java
@@ -50,6 +50,7 @@ public class DuckDBTimeseriesQueries implements ComplexQueries.Timeseries {
             WHERE e.event_type = <<event_type>>
                 <<time_filters>>
                 <<span_filter>>
+                <<json_field_filter>>
                 <<thread_filters>>
                 AND EXISTS (
                     SELECT 1
@@ -74,6 +75,7 @@ public class DuckDBTimeseriesQueries implements ComplexQueries.Timeseries {
                 WHERE e.event_type = <<event_type>>
                     <<time_filters>>
                     <<span_filter>>
+                    <<json_field_filter>>
                     <<thread_filters>>
             ),
             relevant_stacktraces AS (
@@ -146,6 +148,7 @@ public class DuckDBTimeseriesQueries implements ComplexQueries.Timeseries {
                 WHERE e.event_type = <<event_type>>
                     <<time_filters>>
                     <<span_filter>>
+                    <<json_field_filter>>
                     <<stacktrace_filters>>
                     <<additional_filters>>
                 GROUP BY seconds, s.stacktrace_hash, s.frame_hashes

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/JdbcProfileEventStreamRepository.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/JdbcProfileEventStreamRepository.java
@@ -127,7 +127,6 @@ public class JdbcProfileEventStreamRepository implements ProfileEventStreamRepos
         QueryBuilderFactory factory = queryBuilderFactoryResolver.resolve(configurer.eventTypes());
 
         MapSqlParameterSource baseParams = createBaseParams(configurer);
-        applyJsonFieldFilter(baseParams, configurer.jsonFieldFilter());
 
         databaseClient.queryStream(
                 StatementLabel.STREAM_EVENTS,
@@ -295,6 +294,7 @@ public class JdbcProfileEventStreamRepository implements ProfileEventStreamRepos
         }
 
         SpanIntervalParams.apply(baseParams, configurer.spanIntervals());
+        applyJsonFieldFilter(baseParams, configurer.jsonFieldFilter());
 
         return baseParams;
     }

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/test/java/cafe/jeffrey/provider/profile/jdbc/DuckDBFlamegraphJsonFieldFilterTest.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/test/java/cafe/jeffrey/provider/profile/jdbc/DuckDBFlamegraphJsonFieldFilterTest.java
@@ -1,0 +1,109 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.provider.profile.jdbc;
+
+import cafe.jeffrey.provider.profile.api.EventQueryConfigurer;
+import cafe.jeffrey.shared.common.model.JsonFieldFilter;
+import cafe.jeffrey.shared.persistence.GroupLabel;
+import cafe.jeffrey.shared.persistence.StatementLabel;
+import cafe.jeffrey.shared.persistence.client.DatabaseClient;
+import cafe.jeffrey.shared.persistence.client.DatabaseClientProvider;
+import cafe.jeffrey.test.DuckDBTest;
+import cafe.jeffrey.test.TestUtils;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+
+import javax.sql.DataSource;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Exercises the real flamegraph SIMPLE query (resolved from {@link DuckDBFlamegraphQueries}) against
+ * DuckDB to prove the JSON-field equality predicate keeps only the samples linked to the requested
+ * OpenTelemetry trace/span (persisted in the {@code events.fields} JSON column by the OTLP parser).
+ */
+@DuckDBTest(migration = "classpath:db/migration/profile")
+class DuckDBFlamegraphJsonFieldFilterTest {
+
+    private static final String EVENT_TYPE = "otel.cpu";
+    private static final String TRACE_A = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    private static final String SPAN_OF_TRACE_B = "3333333333333333";
+    private static final String UNKNOWN_TRACE = "cccccccccccccccccccccccccccccccc";
+
+    private static final String JSON_ROOT_PATH_PREFIX = "$.";
+
+    private static long totalSamples(DatabaseClient client, JsonFieldFilter filter) {
+        EventQueryConfigurer configurer = new EventQueryConfigurer();
+        if (filter != null) {
+            configurer.withJsonFieldEquals(filter.field(), filter.value());
+        }
+        String sql = DuckDBFlamegraphQueries.of(EVENT_TYPE, "").simple(configurer);
+
+        MapSqlParameterSource params = new MapSqlParameterSource();
+        if (filter != null) {
+            params.addValue("json_field_path", JSON_ROOT_PATH_PREFIX + filter.field());
+            params.addValue("json_field_value", filter.value());
+        }
+
+        return client.query(StatementLabel.STREAM_EVENTS, sql, params, (rs, _) -> rs.getLong("total_samples"))
+                .stream()
+                .mapToLong(Long::longValue)
+                .sum();
+    }
+
+    @Test
+    void traceIdFilterKeepsOnlyLinkedSamples(DataSource dataSource) throws SQLException {
+        TestUtils.executeSql(dataSource, "sql/events/insert-trace-flamegraph.sql");
+        DatabaseClient client = new DatabaseClientProvider(dataSource).provide(GroupLabel.PROFILE_EVENTS);
+
+        // Two of the four samples belong to trace A.
+        assertEquals(2, totalSamples(client, JsonFieldFilter.byTraceId(TRACE_A)));
+    }
+
+    @Test
+    void spanIdFilterKeepsOnlyThatSpan(DataSource dataSource) throws SQLException {
+        TestUtils.executeSql(dataSource, "sql/events/insert-trace-flamegraph.sql");
+        DatabaseClient client = new DatabaseClientProvider(dataSource).provide(GroupLabel.PROFILE_EVENTS);
+
+        assertEquals(1, totalSamples(client, JsonFieldFilter.bySpanId(SPAN_OF_TRACE_B)));
+    }
+
+    @Test
+    void unknownTraceMatchesNothing(DataSource dataSource) throws SQLException {
+        TestUtils.executeSql(dataSource, "sql/events/insert-trace-flamegraph.sql");
+        DatabaseClient client = new DatabaseClientProvider(dataSource).provide(GroupLabel.PROFILE_EVENTS);
+
+        // Includes the sample without any trace link — json_extract_string returns NULL and never matches.
+        assertEquals(0, totalSamples(client, JsonFieldFilter.byTraceId(UNKNOWN_TRACE)));
+    }
+
+    @Test
+    void disabledFilterCountsEverySample(DataSource dataSource) throws SQLException {
+        TestUtils.executeSql(dataSource, "sql/events/insert-trace-flamegraph.sql");
+        DatabaseClient client = new DatabaseClientProvider(dataSource).provide(GroupLabel.PROFILE_EVENTS);
+
+        // Without the filter the predicate is spliced out entirely and all four samples count.
+        String sql = DuckDBFlamegraphQueries.of(EVENT_TYPE, "").simple(new EventQueryConfigurer());
+        assertFalse(sql.contains("json_extract_string"));
+
+        assertEquals(4, totalSamples(client, null));
+    }
+}

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/test/resources/sql/events/insert-trace-flamegraph.sql
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/test/resources/sql/events/insert-trace-flamegraph.sql
@@ -1,0 +1,34 @@
+-- Fixture for DuckDBFlamegraphJsonFieldFilterTest.
+-- otel.cpu events carrying OpenTelemetry trace correlation in the JSON fields column, to prove the
+-- JSON-field equality predicate keeps only the samples linked to the requested trace/span.
+--
+--   trace aaaa..: two samples (spans 1111.. and 2222..)
+--   trace bbbb..: one sample (span 3333..)
+--   one sample without any trace link (fields without trace keys)
+
+INSERT INTO event_types (name, label, type_id, description, categories, source, subtype, has_stacktrace, extras, settings, columns)
+VALUES
+    ('otel.cpu', 'CPU (OTel)', 1, 'OpenTelemetry cpu samples', '["OpenTelemetry","CPU"]', '4', NULL, true, NULL, NULL, NULL);
+
+INSERT INTO threads (thread_hash, name, os_id, java_id, is_virtual)
+VALUES
+    (2001, 'worker-1', 41, 12, false);
+
+INSERT INTO frames (frame_hash, class_name, method_name, frame_type, line_number, bytecode_index)
+VALUES
+    (9001, 'com.example.Service', 'handle', 'JIT compiled', 10, -1);
+
+INSERT INTO stacktraces (stacktrace_hash, type_id, frame_hashes, tag_ids)
+VALUES
+    (5001, 100, [9001], []);
+
+INSERT INTO events (event_type, start_timestamp, start_timestamp_from_beginning, duration, samples, weight, weight_entity, stacktrace_hash, thread_hash, fields)
+VALUES
+    ('otel.cpu', '2025-01-15T10:00:00.000Z', 0, NULL, 1, 10000000, NULL, 5001, 2001,
+     '{"trace_id":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","span_id":"1111111111111111"}'),
+    ('otel.cpu', '2025-01-15T10:00:00.010Z', 10, NULL, 1, 10000000, NULL, 5001, 2001,
+     '{"trace_id":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","span_id":"2222222222222222"}'),
+    ('otel.cpu', '2025-01-15T10:00:00.020Z', 20, NULL, 1, 10000000, NULL, 5001, 2001,
+     '{"trace_id":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","span_id":"3333333333333333"}'),
+    ('otel.cpu', '2025-01-15T10:00:00.030Z', 30, NULL, 1, 10000000, NULL, 5001, 2001,
+     '{"thread.state":"RUNNABLE"}');

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/OtlpProfileReader.java
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/OtlpProfileReader.java
@@ -45,6 +45,7 @@ import cafe.jeffrey.provider.profile.api.EventThread;
 import cafe.jeffrey.provider.profile.api.EventType;
 import cafe.jeffrey.provider.profile.api.SingleThreadedEventWriter;
 import cafe.jeffrey.shared.common.Json;
+import cafe.jeffrey.shared.common.model.JsonFieldFilter;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ObjectNode;
 
@@ -70,8 +71,8 @@ public class OtlpProfileReader {
 
     private static final Logger LOG = LoggerFactory.getLogger(OtlpProfileReader.class);
 
-    private static final String FIELD_TRACE_ID = "trace_id";
-    private static final String FIELD_SPAN_ID = "span_id";
+    private static final String FIELD_TRACE_ID = JsonFieldFilter.TRACE_ID_FIELD;
+    private static final String FIELD_SPAN_ID = JsonFieldFilter.SPAN_ID_FIELD;
 
     private static final String SETTING_PERIOD = "otel.period";
 

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/JsonFieldFilter.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/JsonFieldFilter.java
@@ -1,0 +1,57 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.shared.common.model;
+
+/**
+ * Equality filter on a single top-level JSON field of an event ({@code events.fields} column).
+ * Carried on graph parameters and pushed down into SQL by the persistence layer.
+ * <p>
+ * The canonical field names for the OpenTelemetry trace correlation ({@link #TRACE_ID_FIELD},
+ * {@link #SPAN_ID_FIELD}) are defined here as the single source of truth — the OTLP parser writes
+ * them and the flamegraph/timeseries filters read them.
+ */
+public record JsonFieldFilter(String field, String value) {
+
+    /**
+     * Per-event JSON field carrying the OpenTelemetry trace id (lowercase hex) of the sample's link.
+     */
+    public static final String TRACE_ID_FIELD = "trace_id";
+
+    /**
+     * Per-event JSON field carrying the OpenTelemetry span id (lowercase hex) of the sample's link.
+     */
+    public static final String SPAN_ID_FIELD = "span_id";
+
+    public JsonFieldFilter {
+        if (field == null || field.isBlank()) {
+            throw new IllegalArgumentException("JSON field name must not be blank");
+        }
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("JSON field value must not be blank");
+        }
+    }
+
+    public static JsonFieldFilter byTraceId(String traceId) {
+        return new JsonFieldFilter(TRACE_ID_FIELD, traceId);
+    }
+
+    public static JsonFieldFilter bySpanId(String spanId) {
+        return new JsonFieldFilter(SPAN_ID_FIELD, spanId);
+    }
+}


### PR DESCRIPTION
Builds on the OTLP profiles integration (base branch): OpenTelemetry profile samples carry their trace correlation (`Link` trace_id/span_id) in the per-event JSON `fields` written by the OTLP parser. This PR makes flamegraphs and timeseries filterable by a single trace or span.

## Changes

- **`JsonFieldFilter`** (shared model) — single source of truth for the `trace_id`/`span_id` field names; used by both the OTLP parser (writer side) and the graph filters (reader side), with `byTraceId(...)`/`bySpanId(...)` factories.
- **`GraphParameters`/`GraphParametersBuilder`** carry an optional `JsonFieldFilter`; `FlamegraphDataProvider` and `TimeseriesDataProvider` push it into `EventQueryConfigurer.withJsonFieldEquals(...)`.
- **SQL templates** — the existing JSON-field equality predicate (`json_extract_string(e.fields, :json_field_path) = :json_field_value`) is now spliced into all eight flamegraph aggregation templates and the remaining timeseries templates; previously only the filterable-timeseries template carried the `<<json_field_filter>>` placeholder, so the filter silently no-op'd on those paths. Its parameters are bound in the shared base params.
- **REST** — `GenerateFlamegraphRequest`/`GenerateTimeseriesRequest` accept optional `traceId`/`spanId`; the more specific span id wins when both are present.
- **Frontend** — `PrimaryFlamegraphClient` can send the correlation keys; they are omitted from the payload when unset, keeping the wire format pinned by the existing payload tests byte-identical.

## Tests

- `DuckDBFlamegraphJsonFieldFilterTest` (`@DuckDBTest`) proves the predicate against the real flamegraph SQL: trace-scoped, span-scoped, unknown-trace (matches nothing, including events without a link), and filter-disabled (predicate spliced out) cases.
- New frontend payload test for the correlation keys; all 190 vitest tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnFTty9iKzjNUyswHDGF1S

---
_Generated by [Claude Code](https://claude.ai/code/session_01WnFTty9iKzjNUyswHDGF1S)_