### PR TITLE
Add OpenTelemetry profiles (OTLP) as a new recording type in Microscope

### DIFF
--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/configuration/AppConfiguration.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/configuration/AppConfiguration.java
@@ -35,6 +35,8 @@ import cafe.jeffrey.profile.ProfileInitializer;
 import cafe.jeffrey.profile.configuration.ProfileFactoriesConfiguration;
 import cafe.jeffrey.profile.configuration.ProfilesConfiguration;
 import cafe.jeffrey.profile.manager.ProfileManager;
+import cafe.jeffrey.otlpparser.OtlpRecordingInformationParser;
+import cafe.jeffrey.profile.parser.FileTypeDispatchingRecordingInformationParser;
 import cafe.jeffrey.profile.parser.JfrRecordingInformationParser;
 import cafe.jeffrey.provider.profile.api.DatabaseManagerResolver;
 import cafe.jeffrey.provider.profile.jdbc.DatabaseManagerResolverImpl;
@@ -193,7 +195,8 @@ public class AppConfiguration {
     @Bean
     public RecordingStorage projectRecordingStorage(MicroscopeJeffreyDirs jeffreyDirs) {
         return new FilesystemRecordingStorage(
-                jeffreyDirs.recordings(), List.of(SupportedRecordingFile.JFR_LZ4, SupportedRecordingFile.JFR));
+                jeffreyDirs.recordings(),
+                List.of(SupportedRecordingFile.JFR_LZ4, SupportedRecordingFile.JFR, SupportedRecordingFile.OTLP_PROFILE));
     }
 
     @Bean
@@ -209,6 +212,8 @@ public class AppConfiguration {
                 projectInfo,
                 recordingStorage.projectRecordingStorage(projectInfo.id()),
                 localCoreRepositories.newRecordingRepository(projectInfo.id()),
-                new JfrRecordingInformationParser(jeffreyDirs));
+                new FileTypeDispatchingRecordingInformationParser(
+                        new JfrRecordingInformationParser(jeffreyDirs),
+                        new OtlpRecordingInformationParser()));
     }
 }

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/configuration/MicroscopeAppConfiguration.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/configuration/MicroscopeAppConfiguration.java
@@ -25,8 +25,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import cafe.jeffrey.microscope.core.initializer.RecordingSeedInitializer;
-import cafe.jeffrey.microscope.core.manager.recordings.JfrRecordingMetadataParserAdapter;
 import cafe.jeffrey.microscope.core.manager.recordings.MicroscopeProfileCleanup;
+import cafe.jeffrey.microscope.core.manager.recordings.RecordingMetadataParserAdapter;
 import cafe.jeffrey.microscope.core.manager.recordings.ProfileRecordingsManager;
 import cafe.jeffrey.microscope.core.manager.recordings.RecordingsManager;
 import cafe.jeffrey.microscope.core.manager.server.HubsManager;
@@ -52,8 +52,13 @@ import cafe.jeffrey.profile.ProfileInitializerImpl;
 import cafe.jeffrey.profile.configuration.ProfileFactoriesConfiguration;
 import cafe.jeffrey.profile.manager.ProfileManager;
 import cafe.jeffrey.profile.manager.action.ProfileDataInitializer;
+import cafe.jeffrey.otlpparser.OtlpRecordingEventParser;
+import cafe.jeffrey.otlpparser.OtlpRecordingInformationParser;
+import cafe.jeffrey.profile.parser.FileTypeDispatchingRecordingInformationParser;
 import cafe.jeffrey.profile.parser.JfrRecordingEventParser;
 import cafe.jeffrey.profile.parser.JfrRecordingInformationParser;
+import cafe.jeffrey.provider.profile.api.RecordingEventParserResolver;
+import cafe.jeffrey.shared.common.model.RecordingEventSource;
 import cafe.jeffrey.microscope.persistence.api.MicroscopeCorePersistenceProvider;
 import cafe.jeffrey.provider.profile.jdbc.DuckDBProfilePersistenceProvider;
 import cafe.jeffrey.provider.profile.api.ProfilePersistenceProvider;
@@ -61,6 +66,7 @@ import cafe.jeffrey.shared.common.FrameResolutionMode;
 import cafe.jeffrey.shared.common.compression.Lz4Compressor;
 import cafe.jeffrey.microscope.core.MicroscopeJeffreyDirs;
 
+import java.util.Map;
 import java.util.Optional;
 
 import java.nio.file.Path;
@@ -86,17 +92,23 @@ public class MicroscopeAppConfiguration {
         ProfilePersistenceProvider quickProvider =
                 new DuckDBProfilePersistenceProvider(jeffreyDirs.profiles(), frameResolutionMode, clock);
 
+        RecordingEventParserResolver parserResolver = RecordingEventParserResolver.of(
+                Map.of(RecordingEventSource.OPEN_TELEMETRY, new OtlpRecordingEventParser()),
+                new JfrRecordingEventParser(jeffreyDirs, new Lz4Compressor(jeffreyDirs)));
+
         ProfileInitializer recordingsProfileInitializer = new ProfileInitializerImpl(
                 quickProvider.repositories(),
                 quickProvider.databaseManager(),
-                new JfrRecordingEventParser(jeffreyDirs, new Lz4Compressor(jeffreyDirs)),
+                parserResolver,
                 quickProvider.eventWriterFactory(),
                 profileManagerFactory,
                 profileDataInitializer,
                 clock);
 
         MicroscopeCoreRepositories repos = localCorePersistenceProvider.localCoreRepositories();
-        RecordingInformationParser recordingInformationParser = new JfrRecordingInformationParser(jeffreyDirs);
+        RecordingInformationParser recordingInformationParser = new FileTypeDispatchingRecordingInformationParser(
+                new JfrRecordingInformationParser(jeffreyDirs),
+                new OtlpRecordingInformationParser());
         MicroscopeProfileCleanup profileCleanup = new MicroscopeProfileCleanup(jeffreyDirs, repos);
 
         RecordingsCoreManager core = new RecordingsCoreManagerImpl(
@@ -104,7 +116,7 @@ public class MicroscopeAppConfiguration {
                 recordingsPath,
                 repos.newRecordingRepository(null),
                 repos.recordingTagsRepository(),
-                new JfrRecordingMetadataParserAdapter(recordingInformationParser),
+                new RecordingMetadataParserAdapter(recordingInformationParser),
                 profileCleanup);
 
         return new ProfileRecordingsManager(

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/manager/recordings/ProfileRecordingsManager.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/manager/recordings/ProfileRecordingsManager.java
@@ -176,14 +176,19 @@ public class ProfileRecordingsManager implements RecordingsManager {
         if (recording.eventSource() == RecordingEventSource.HEAP_DUMP) {
             profileId = analyzeHeapDump(recording, file);
         } else {
-            profileId = analyzeJfr(recording, file);
+            profileId = analyzeEvents(recording, file);
         }
 
         LOG.info("Quick analysis recording analyzed: recordingId={} profileId={}", recordingId, profileId);
         return profileId;
     }
 
-    private String analyzeJfr(Recording recording, RecordingFile file) {
+    /**
+     * Analysis path for every event-based recording (JFR, async-profiler, OpenTelemetry profiles):
+     * the concrete parser is resolved from the recording's event source inside the profile
+     * initializer.
+     */
+    private String analyzeEvents(Recording recording, RecordingFile file) {
         Path filePath = resolveRecordingFilePath(file);
         if (!Files.exists(filePath)) {
             throw new IllegalArgumentException("Recording file does not exist: " + filePath);
@@ -217,8 +222,8 @@ public class ProfileRecordingsManager implements RecordingsManager {
 
     /**
      * Prefers the recording metadata persisted at upload time (event source + profiling start/end)
-     * and re-parses the JFR file only when any of them is missing — e.g. when the metadata parse
-     * failed during the upload.
+     * and re-parses the recording file only when any of them is missing — e.g. when the metadata
+     * parse failed during the upload.
      */
     private RecordingInformation resolveRecordingInformation(Recording recording, Path filePath) {
         boolean persistedInfoComplete = recording.eventSource() != null

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/manager/recordings/RecordingMetadataParserAdapter.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/manager/recordings/RecordingMetadataParserAdapter.java
@@ -32,13 +32,13 @@ import java.util.Optional;
  * {@code recordings-core} {@link RecordingMetadataParser} SPI, swallowing parse failures
  * (so ingestion falls back to filename-based event-source detection, matching prior behavior).
  */
-public class JfrRecordingMetadataParserAdapter implements RecordingMetadataParser {
+public class RecordingMetadataParserAdapter implements RecordingMetadataParser {
 
-    private static final Logger LOG = LoggerFactory.getLogger(JfrRecordingMetadataParserAdapter.class);
+    private static final Logger LOG = LoggerFactory.getLogger(RecordingMetadataParserAdapter.class);
 
     private final RecordingInformationParser delegate;
 
-    public JfrRecordingMetadataParserAdapter(RecordingInformationParser delegate) {
+    public RecordingMetadataParserAdapter(RecordingInformationParser delegate) {
         this.delegate = delegate;
     }
 

--- a/jeffrey-microscope/pages-microscope/src/components/assistants/global/RecordingsAssistant.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/assistants/global/RecordingsAssistant.vue
@@ -67,7 +67,7 @@
           <input
             ref="fileInputRef"
             type="file"
-            accept=".jfr,.lz4,.hprof,.gz"
+            accept=".jfr,.lz4,.hprof,.gz,.otlp"
             class="file-input-hidden"
             @change="handleFileSelect"
           />
@@ -75,9 +75,9 @@
           <!-- Default state -->
           <template v-if="!isProcessing && !selectedFile">
             <i class="bi bi-cloud-upload dropzone-icon"></i>
-            <span class="dropzone-text">Drop your JFR or Heap Dump file here</span>
+            <span class="dropzone-text">Drop your JFR, OpenTelemetry, or Heap Dump file here</span>
             <span class="dropzone-subtext"
-              >or click to select (.jfr, .jfr.lz4, .hprof, .hprof.gz)</span
+              >or click to select (.jfr, .jfr.lz4, .otlp, .hprof, .hprof.gz)</span
             >
           </template>
 

--- a/jeffrey-microscope/pages-microscope/src/components/streaming/EventTypeSelector.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/streaming/EventTypeSelector.vue
@@ -284,6 +284,10 @@ onBeforeUnmount(() => {
   background: var(--color-teal-light);
   color: var(--color-teal);
 }
+.ets-tag--otel {
+  background: var(--color-orange-bg);
+  color: var(--color-orange);
+}
 .ets-tag--custom {
   background: var(--color-amber-light);
   color: var(--color-amber-text);

--- a/jeffrey-microscope/pages-microscope/src/services/EventTypeCatalog.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/EventTypeCatalog.ts
@@ -9,10 +9,19 @@ export interface EventTypeCategory {
   events: EventTypeEntry[];
 }
 
-export function getEventTypePrefix(name: string): 'jdk' | 'jeffrey' | 'profiler' | 'custom' {
-  if (name.startsWith('jdk.')) return 'jdk';
-  if (name.startsWith('jeffrey.')) return 'jeffrey';
-  if (name.startsWith('profiler.')) return 'profiler';
+export function getEventTypePrefix(name: string): 'jdk' | 'jeffrey' | 'profiler' | 'otel' | 'custom' {
+  if (name.startsWith('jdk.')) {
+    return 'jdk';
+  }
+  if (name.startsWith('jeffrey.')) {
+    return 'jeffrey';
+  }
+  if (name.startsWith('profiler.')) {
+    return 'profiler';
+  }
+  if (name.startsWith('otel.')) {
+    return 'otel';
+  }
   return 'custom';
 }
 

--- a/jeffrey-microscope/pages-microscope/src/services/EventTypes.test.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/EventTypes.test.ts
@@ -97,6 +97,25 @@ describe('EventTypes', () => {
     });
   });
 
+  describe('OpenTelemetry event types', () => {
+    it('otel execution samples bucket with execution events', () => {
+      expect(EventTypes.isExecutionEventType('otel.cpu')).toBe(true);
+      expect(EventTypes.isExecutionEventType('otel.samples')).toBe(true);
+    });
+
+    it('otel wall clock buckets with wall-clock events', () => {
+      expect(EventTypes.isWallClock('otel.wall')).toBe(true);
+    });
+
+    it('otel allocations bucket with allocation events', () => {
+      expect(EventTypes.isAllocationEventType('otel.alloc')).toBe(true);
+    });
+
+    it('otel lock contention buckets with blocking events', () => {
+      expect(EventTypes.isBlockingEventType('otel.lock')).toBe(true);
+    });
+  });
+
   describe('getSapDocumentationUrl', () => {
     it('returns URL for jdk-prefixed event', () => {
       const url = EventTypes.getSapDocumentationUrl('jdk.ExecutionSample');

--- a/jeffrey-microscope/pages-microscope/src/services/EventTypes.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/EventTypes.ts
@@ -33,6 +33,13 @@ export default class EventTypes {
   static NATIVE_MALLOC_ALLOCATION = 'profiler.Malloc';
   static NATIVE_LEAK = 'jeffrey.NativeLeak';
 
+  // OpenTelemetry profiles (synthesized from OTLP sample types)
+  static OTEL_CPU = 'otel.cpu';
+  static OTEL_SAMPLES = 'otel.samples';
+  static OTEL_WALL = 'otel.wall';
+  static OTEL_ALLOC = 'otel.alloc';
+  static OTEL_LOCK = 'otel.lock';
+
   static isObjectAllocationInNewTLAB(code: string) {
     return code === this.OBJECT_ALLOCATION_IN_NEW_TLAB;
   }
@@ -62,14 +69,15 @@ export default class EventTypes {
   }
 
   static isWallClock(code: string) {
-    return code === this.WALL_CLOCK;
+    return code === this.WALL_CLOCK || code === this.OTEL_WALL;
   }
 
   static isAllocationEventType(code: string) {
     return (
       this.isObjectAllocationInNewTLAB(code) ||
       this.isObjectAllocationOutsideTLAB(code) ||
-      this.isObjectAllocationSample(code)
+      this.isObjectAllocationSample(code) ||
+      code === this.OTEL_ALLOC
     );
   }
 
@@ -78,7 +86,8 @@ export default class EventTypes {
       this.isJavaMonitorEnter(code) ||
       this.isJavaMonitorWait(code) ||
       this.isThreadPark(code) ||
-      this.isVirtualThreadPinned(code)
+      this.isVirtualThreadPinned(code) ||
+      code === this.OTEL_LOCK
     );
   }
 
@@ -92,7 +101,7 @@ export default class EventTypes {
   }
 
   static isExecutionEventType(code: string) {
-    return code === this.EXECUTION_SAMPLE;
+    return code === this.EXECUTION_SAMPLE || code === this.OTEL_CPU || code === this.OTEL_SAMPLES;
   }
 
   static isCpuTimeSample(code: string) {

--- a/jeffrey-microscope/pages-microscope/src/views/global/RecordingsView.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/global/RecordingsView.vue
@@ -42,7 +42,7 @@
           <input
             ref="fileInputRef"
             type="file"
-            accept=".jfr,.lz4,.hprof,.gz"
+            accept=".jfr,.lz4,.hprof,.gz,.otlp"
             multiple
             class="file-input-hidden"
             @change="handleFileInput"
@@ -62,6 +62,8 @@
                 <Badge value=".jfr" variant="indigo" size="s" :uppercase="false" borderless />
                 <Badge value=".jfr.lz4" variant="indigo" size="s" :uppercase="false" borderless />
                 JFR recordings ·
+                <Badge value=".otlp" variant="orange" size="s" :uppercase="false" borderless />
+                OpenTelemetry profiles ·
                 <Badge value=".hprof" variant="purple" size="s" :uppercase="false" borderless />
                 <Badge value=".hprof.gz" variant="purple" size="s" :uppercase="false" borderless />
                 heap dumps
@@ -369,7 +371,7 @@ import type Recording from '@workspaces/services/api/model/Recording';
 
 const HEAP_DUMP_SOURCE = 'HEAP_DUMP';
 const UNGROUPED_KEY = '__ungrouped__';
-const ALLOWED_FILE_SUFFIXES = ['.jfr', '.jfr.lz4', '.hprof', '.hprof.gz'];
+const ALLOWED_FILE_SUFFIXES = ['.jfr', '.jfr.lz4', '.hprof', '.hprof.gz', '.otlp'];
 
 type ViewFilter = 'all' | typeof UNGROUPED_KEY | string;
 

--- a/jeffrey-microscope/profiles/common-profile/src/main/java/cafe/jeffrey/profile/common/model/FrameType.java
+++ b/jeffrey-microscope/profiles/common-profile/src/main/java/cafe/jeffrey/profile/common/model/FrameType.java
@@ -114,6 +114,14 @@ public enum FrameType {
         throw new RuntimeException("Frame type does not exists: " + code);
     }
 
+    /**
+     * @return the persisted string code of the frame type (e.g. {@code "JIT compiled"}), or {@code null}
+     * for synthetic frame types that are never emitted by a parser
+     */
+    public String code() {
+        return code;
+    }
+
     public boolean isSynthetic() {
         return synthetic;
     }

--- a/jeffrey-microscope/profiles/profile-management/pom.xml
+++ b/jeffrey-microscope/profiles/profile-management/pom.xml
@@ -100,6 +100,10 @@
             <artifactId>jfr-parser-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>otlp-parser</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.openjdk.jmc</groupId>
             <artifactId>flightrecorder.rules.jdk</artifactId>
         </dependency>

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/ProfileInitializerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/ProfileInitializerImpl.java
@@ -25,6 +25,7 @@ import cafe.jeffrey.profile.manager.ProfileManager;
 import cafe.jeffrey.profile.manager.action.ProfileDataInitializer;
 import cafe.jeffrey.provider.profile.api.EventWriter;
 import cafe.jeffrey.provider.profile.api.RecordingEventParser;
+import cafe.jeffrey.provider.profile.api.RecordingEventParserResolver;
 import cafe.jeffrey.provider.profile.api.ProfileInfoRepository;
 import cafe.jeffrey.provider.profile.api.ProfileRepositories;
 import cafe.jeffrey.shared.common.model.ProfileInfo;
@@ -58,7 +59,7 @@ public class ProfileInitializerImpl implements ProfileInitializer {
 
     private final ProfileRepositories profileRepositories;
     private final DatabaseManager databaseManager;
-    private final RecordingEventParser recordingEventParser;
+    private final RecordingEventParserResolver recordingEventParserResolver;
     private final EventWriter.Factory eventWriterFactory;
     private final ProfileManager.Factory profileManagerFactory;
     private final ProfileDataInitializer profileDataInitializer;
@@ -67,7 +68,7 @@ public class ProfileInitializerImpl implements ProfileInitializer {
     public ProfileInitializerImpl(
             ProfileRepositories profileRepositories,
             DatabaseManager databaseManager,
-            RecordingEventParser recordingEventParser,
+            RecordingEventParserResolver recordingEventParserResolver,
             EventWriter.Factory eventWriterFactory,
             ProfileManager.Factory profileManagerFactory,
             ProfileDataInitializer profileDataInitializer,
@@ -75,7 +76,7 @@ public class ProfileInitializerImpl implements ProfileInitializer {
 
         this.profileRepositories = profileRepositories;
         this.databaseManager = databaseManager;
-        this.recordingEventParser = recordingEventParser;
+        this.recordingEventParserResolver = recordingEventParserResolver;
         this.eventWriterFactory = eventWriterFactory;
         this.profileManagerFactory = profileManagerFactory;
         this.profileDataInitializer = profileDataInitializer;
@@ -107,6 +108,7 @@ public class ProfileInitializerImpl implements ProfileInitializer {
             // Parse recording and store events into the database
             // The profiling start is the zero point of the relative event timeline persisted with every event
             EventWriter eventWriter = eventWriterFactory.create(dataSource, profileInfo.profilingStartedAt());
+            RecordingEventParser recordingEventParser = recordingEventParserResolver.resolve(profileInfo.eventSource());
             recordingEventParser.start(eventWriter, recordingPath);
             eventWriter.onComplete();
 

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/configuration/ProfileFactoriesConfiguration.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/configuration/ProfileFactoriesConfiguration.java
@@ -50,6 +50,7 @@ import cafe.jeffrey.profile.manager.registry.AnalysisFactories;
 import cafe.jeffrey.profile.manager.registry.JvmInsightFactories;
 import cafe.jeffrey.profile.manager.registry.ProfileManagerFactoryRegistry;
 import cafe.jeffrey.profile.manager.registry.VisualizationFactories;
+import cafe.jeffrey.otlpparser.OtlpRecordingEventParser;
 import cafe.jeffrey.profile.parser.JfrRecordingEventParser;
 import cafe.jeffrey.profile.settings.ActiveSettingsProvider;
 import cafe.jeffrey.profile.settings.CachedActiveSettingsProvider;
@@ -63,6 +64,7 @@ import cafe.jeffrey.provider.profile.api.*;
 import cafe.jeffrey.shared.common.compression.Lz4Compressor;
 import cafe.jeffrey.shared.common.filesystem.TempDirFactory;
 import cafe.jeffrey.shared.common.model.ProfileInfo;
+import cafe.jeffrey.shared.common.model.RecordingEventSource;
 import cafe.jeffrey.shared.persistence.DatabaseManager;
 import cafe.jeffrey.storage.recording.api.RecordingStorage;
 
@@ -71,6 +73,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Clock;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -455,11 +458,24 @@ public class ProfileFactoriesConfiguration {
         return new ProfileInitializerImpl(
                 profileRepositories,
                 profileDatabaseProvider,
-                new JfrRecordingEventParser(tempDirFactory, new Lz4Compressor(tempDirFactory)),
+                recordingEventParserResolver(tempDirFactory),
                 eventWriterFactory,
                 profileManagerFactory,
                 profileDataInitializer,
                 clock);
+    }
+
+    /**
+     * JFR-based sources (JDK, async-profiler) parse with the JFR parser — including {@code UNKNOWN},
+     * which preserves the previous behavior for recordings whose metadata parse failed at upload time.
+     * OpenTelemetry recordings parse with the OTLP parser.
+     */
+    private static RecordingEventParserResolver recordingEventParserResolver(TempDirFactory tempDirFactory) {
+        JfrRecordingEventParser jfrParser =
+                new JfrRecordingEventParser(tempDirFactory, new Lz4Compressor(tempDirFactory));
+        return RecordingEventParserResolver.of(
+                Map.of(RecordingEventSource.OPEN_TELEMETRY, new OtlpRecordingEventParser()),
+                jfrParser);
     }
 
     @Bean

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/parser/FileTypeDispatchingRecordingInformationParser.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/parser/FileTypeDispatchingRecordingInformationParser.java
@@ -1,0 +1,52 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.parser;
+
+import cafe.jeffrey.provider.profile.api.RecordingInformation;
+import cafe.jeffrey.provider.profile.api.RecordingInformationParser;
+import cafe.jeffrey.shared.common.model.repository.SupportedRecordingFile;
+
+import java.nio.file.Path;
+
+/**
+ * Routes recording-metadata parsing by the recording's file type: OpenTelemetry profiles
+ * ({@code .otlp}) are parsed by the OTLP parser, everything else falls through to the JFR parser
+ * (matching the previous behavior for JFR and unrecognized files).
+ */
+public class FileTypeDispatchingRecordingInformationParser implements RecordingInformationParser {
+
+    private final RecordingInformationParser jfrParser;
+    private final RecordingInformationParser otlpParser;
+
+    public FileTypeDispatchingRecordingInformationParser(
+            RecordingInformationParser jfrParser,
+            RecordingInformationParser otlpParser) {
+
+        this.jfrParser = jfrParser;
+        this.otlpParser = otlpParser;
+    }
+
+    @Override
+    public RecordingInformation provide(Path recordingPath) {
+        if (SupportedRecordingFile.of(recordingPath) == SupportedRecordingFile.OTLP_PROFILE) {
+            return otlpParser.provide(recordingPath);
+        }
+        return jfrParser.provide(recordingPath);
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/module-info.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/module-info.java
@@ -36,6 +36,7 @@ module cafe.jeffrey.microscope.profile.management {
     requires cafe.jeffrey.microscope.profile.timeseries;
     requires cafe.jeffrey.microscope.profile.frame.ir;
     requires cafe.jeffrey.microscope.profile.parser.jdk;
+    requires cafe.jeffrey.microscope.profile.parser.otlp;
     requires cafe.jeffrey.microscope.profile.parser.api;
     requires cafe.jeffrey.shared.common;
     requires cafe.jeffrey.shared.persistence;

--- a/jeffrey-microscope/profiles/profile-persistence-api/src/main/java/cafe/jeffrey/provider/profile/api/RecordingEventParserResolver.java
+++ b/jeffrey-microscope/profiles/profile-persistence-api/src/main/java/cafe/jeffrey/provider/profile/api/RecordingEventParserResolver.java
@@ -1,0 +1,45 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.provider.profile.api;
+
+import cafe.jeffrey.shared.common.model.RecordingEventSource;
+
+import java.util.Map;
+
+/**
+ * Resolves the {@link RecordingEventParser} for the event source of the recording being analyzed —
+ * JFR-based sources (JDK, async-profiler) and OpenTelemetry profiles use different parsers over the
+ * same event-writing pipeline.
+ */
+@FunctionalInterface
+public interface RecordingEventParserResolver {
+
+    RecordingEventParser resolve(RecordingEventSource eventSource);
+
+    /**
+     * @param parsersBySource parsers keyed by event source
+     * @param defaultParser   parser used for sources without a dedicated entry (including {@code null})
+     */
+    static RecordingEventParserResolver of(
+            Map<RecordingEventSource, RecordingEventParser> parsersBySource,
+            RecordingEventParser defaultParser) {
+
+        return eventSource -> parsersBySource.getOrDefault(eventSource, defaultParser);
+    }
+}

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/pom.xml
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/pom.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Jeffrey
+  ~ Copyright (C) 2026 Petr Bouda
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>cafe.jeffrey</groupId>
+        <artifactId>recording-parser</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>otlp-parser</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${protobuf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>common-profile</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>profile-persistence-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>profile-sql-persistence</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.7.1</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.6.1</version>
+                <configuration>
+                    <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/OtlpFileFormat.java
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/OtlpFileFormat.java
@@ -1,0 +1,80 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.otlpparser;
+
+/**
+ * Jeffrey's on-disk convention for OpenTelemetry profiles ({@code .otlp} files).
+ * <p>
+ * There is no standardized file format for OTLP profiles (the signal is network-first), so Jeffrey
+ * defines one: an optional header ({@link #MAGIC} followed by a little-endian {@code u32} format
+ * version) and then a sequence of <em>length-delimited</em> {@code ProfilesData} protobuf messages
+ * (each frame is one export batch carrying its own dictionary). Because every frame is
+ * self-contained, merging rotated files is plain byte concatenation of their frame sequences.
+ * <p>
+ * Files without the header are treated as a single raw serialized {@code ProfilesData} /
+ * {@code ExportProfilesServiceRequest} message (the two are wire-compatible: both have
+ * {@code resource_profiles = 1} and {@code dictionary = 2}), so payload dumps produced by an
+ * OpenTelemetry Collector debug exporter or async-profiler's OTLP output can be uploaded as-is.
+ */
+public final class OtlpFileFormat {
+
+    /**
+     * Header magic of Jeffrey's framed {@code .otlp} files.
+     */
+    public static final byte[] MAGIC = {'O', 'T', 'L', 'P'};
+
+    /**
+     * Current version of the framed file format, written as little-endian {@code u32} after the magic.
+     */
+    public static final int VERSION = 1;
+
+    /**
+     * Total header size in bytes: 4 magic bytes + 4 version bytes.
+     */
+    public static final int HEADER_SIZE = MAGIC.length + Integer.BYTES;
+
+    private OtlpFileFormat() {
+    }
+
+    /**
+     * @return {@code true} if the given buffer starts with the {@link #MAGIC} bytes
+     */
+    public static boolean startsWithMagic(byte[] header, int length) {
+        if (length < MAGIC.length) {
+            return false;
+        }
+        for (int i = 0; i < MAGIC.length; i++) {
+            if (header[i] != MAGIC[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Reads the little-endian {@code u32} version that follows the magic bytes.
+     */
+    public static int readVersion(byte[] header) {
+        int offset = MAGIC.length;
+        return (header[offset] & 0xFF)
+                | ((header[offset + 1] & 0xFF) << 8)
+                | ((header[offset + 2] & 0xFF) << 16)
+                | ((header[offset + 3] & 0xFF) << 24);
+    }
+}

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/OtlpProfileReader.java
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/OtlpProfileReader.java
@@ -1,0 +1,460 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.otlpparser;
+
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.profiles.v1development.Link;
+import io.opentelemetry.proto.profiles.v1development.Profile;
+import io.opentelemetry.proto.profiles.v1development.ProfilesData;
+import io.opentelemetry.proto.profiles.v1development.ResourceProfiles;
+import io.opentelemetry.proto.profiles.v1development.Sample;
+import io.opentelemetry.proto.profiles.v1development.ScopeProfiles;
+import io.opentelemetry.proto.profiles.v1development.Stack;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import cafe.jeffrey.otlpparser.dictionary.OtlpDictionary;
+import cafe.jeffrey.otlpparser.mapping.OtelEventTypeNaming;
+import cafe.jeffrey.otlpparser.mapping.OtelEventTypeNaming.OtelEventType;
+import cafe.jeffrey.otlpparser.mapping.OtelFrameMapper;
+import cafe.jeffrey.otlpparser.mapping.OtelFrameMapper.MappedStack;
+import cafe.jeffrey.otlpparser.mapping.OtelSampleUnit;
+import cafe.jeffrey.otlpparser.mapping.OtelSemconv;
+import cafe.jeffrey.otlpparser.mapping.OtelThreadResolver;
+import cafe.jeffrey.otlpparser.mapping.OtlpAttributes;
+import cafe.jeffrey.provider.profile.api.Event;
+import cafe.jeffrey.provider.profile.api.EventSetting;
+import cafe.jeffrey.provider.profile.api.EventStacktrace;
+import cafe.jeffrey.provider.profile.api.EventThread;
+import cafe.jeffrey.provider.profile.api.EventType;
+import cafe.jeffrey.provider.profile.api.SingleThreadedEventWriter;
+import cafe.jeffrey.shared.common.Json;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ObjectNode;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Streams OTLP profiles out of a {@code .otlp} recording and emits them into a
+ * {@link SingleThreadedEventWriter}, following the writer's announce-once protocol for threads and
+ * stacktraces. This is the OTLP analogue of the JFR {@code JfrEventReader}.
+ * <p>
+ * Every OTLP {@code Profile} (one {@code sample_type}) maps onto one Jeffrey {@code otel.*} event
+ * type; all profiles of all frames in the file are folded into the same target profile database.
+ */
+public class OtlpProfileReader {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OtlpProfileReader.class);
+
+    private static final String FIELD_TRACE_ID = "trace_id";
+    private static final String FIELD_SPAN_ID = "span_id";
+
+    private static final String SETTING_PERIOD = "otel.period";
+
+    private static final String FALLBACK_THREAD_NAME = "otel-samples";
+
+    /**
+     * Per-event-type accumulation used to synthesize the {@code EventType} rows at the end of parsing.
+     */
+    private static class EventTypeState {
+        private final OtelEventType otelEventType;
+        private final String sampleType;
+        private final String sampleUnit;
+        private final long typeId;
+        private final Set<String> fieldKeys = new TreeSet<>();
+
+        private EventTypeState(OtelEventType otelEventType, String sampleType, String sampleUnit, long typeId) {
+            this.otelEventType = otelEventType;
+            this.sampleType = sampleType;
+            this.sampleUnit = sampleUnit;
+            this.typeId = typeId;
+        }
+    }
+
+    private final SingleThreadedEventWriter writer;
+    private final OtlpStreamReader streamReader;
+
+    private final Map<String, EventTypeState> eventTypesByName = new LinkedHashMap<>();
+    private final Map<EventThread, Long> threadIdsByThread = new HashMap<>();
+    private final Set<String> emittedSettingKeys = new HashSet<>();
+
+    public OtlpProfileReader(SingleThreadedEventWriter writer) {
+        this(writer, new OtlpStreamReader());
+    }
+
+    public OtlpProfileReader(SingleThreadedEventWriter writer, OtlpStreamReader streamReader) {
+        this.writer = writer;
+        this.streamReader = streamReader;
+    }
+
+    public void read(Path recording) {
+        writer.onThreadStart();
+        streamReader.read(recording, this::onFrame);
+        emitEventTypes();
+        writer.onThreadComplete();
+    }
+
+    private void onFrame(ProfilesData frame) {
+        OtlpDictionary dictionary = new OtlpDictionary(frame.getDictionary());
+        // Stack dedup is index-based and dictionary indices are only valid within a single frame.
+        // Cross-frame duplicates are collapsed by the writer's content-hash deduplication.
+        Map<Integer, StacktraceRef> stacktracesByStackIndex = new HashMap<>();
+
+        for (ResourceProfiles resourceProfiles : frame.getResourceProfilesList()) {
+            String fallbackThreadName = resolveFallbackThreadName(resourceProfiles);
+            for (ScopeProfiles scopeProfiles : resourceProfiles.getScopeProfilesList()) {
+                for (Profile profile : scopeProfiles.getProfilesList()) {
+                    readProfile(profile, resourceProfiles, scopeProfiles, dictionary, fallbackThreadName,
+                            stacktracesByStackIndex);
+                }
+            }
+        }
+    }
+
+    private void readProfile(
+            Profile profile,
+            ResourceProfiles resourceProfiles,
+            ScopeProfiles scopeProfiles,
+            OtlpDictionary dictionary,
+            String fallbackThreadName,
+            Map<Integer, StacktraceRef> stacktracesByStackIndex) {
+
+        String sampleType = dictionary.string(profile.getSampleType().getTypeStrindex());
+        String sampleUnitName = dictionary.string(profile.getSampleType().getUnitStrindex());
+
+        OtelEventType otelEventType = OtelEventTypeNaming.resolve(sampleType, sampleUnitName);
+        OtelSampleUnit sampleUnit = OtelSampleUnit.fromUnitString(sampleUnitName);
+
+        EventTypeState state = eventTypesByName.computeIfAbsent(
+                otelEventType.name(),
+                name -> new EventTypeState(otelEventType, sampleType, sampleUnitName, eventTypesByName.size() + 1));
+
+        emitProvenanceSettings(otelEventType.name(), profile, resourceProfiles, scopeProfiles, dictionary);
+
+        boolean cardinalityMismatchLogged = false;
+        for (Sample sample : profile.getSamplesList()) {
+            cardinalityMismatchLogged = readSample(
+                    sample, profile, dictionary, state, sampleUnit, fallbackThreadName,
+                    stacktracesByStackIndex, cardinalityMismatchLogged);
+        }
+    }
+
+    /**
+     * @return the updated "cardinality mismatch already logged" flag for the current profile
+     */
+    private boolean readSample(
+            Sample sample,
+            Profile profile,
+            OtlpDictionary dictionary,
+            EventTypeState state,
+            OtelSampleUnit sampleUnit,
+            String fallbackThreadName,
+            Map<Integer, StacktraceRef> stacktracesByStackIndex,
+            boolean cardinalityMismatchLogged) {
+
+        Map<String, AnyValue> sampleAttributes = OtlpAttributes.resolve(sample.getAttributeIndicesList(), dictionary);
+
+        Long threadId = resolveThreadId(sampleAttributes, fallbackThreadName);
+        Long stacktraceId = resolveStacktraceId(sample, dictionary, stacktracesByStackIndex);
+        String weightEntity = resolveWeightEntity(sampleUnit, sampleAttributes);
+        ObjectNode fields = buildFields(sample, sampleAttributes, dictionary, state);
+
+        List<Long> timestamps = sample.getTimestampsUnixNanoList();
+        List<Long> values = sample.getValuesList();
+
+        if (timestamps.isEmpty()) {
+            long totalValue = values.isEmpty() ? 1 : sum(values);
+            Instant timestamp = Instant.ofEpochSecond(0, profile.getTimeUnixNano());
+            emitEvent(state, sampleUnit, timestamp, totalValue, weightEntity, stacktraceId, threadId, fields);
+            return cardinalityMismatchLogged;
+        }
+
+        if (values.isEmpty()) {
+            // Timestamps-only shape: the value of each observation is 1 (per the OTLP profiles spec)
+            for (Long timestampNanos : timestamps) {
+                Instant timestamp = Instant.ofEpochSecond(0, timestampNanos);
+                emitEvent(state, sampleUnit, timestamp, 1, weightEntity, stacktraceId, threadId, fields);
+            }
+            return cardinalityMismatchLogged;
+        }
+
+        if (values.size() == timestamps.size()) {
+            for (int i = 0; i < timestamps.size(); i++) {
+                Instant timestamp = Instant.ofEpochSecond(0, timestamps.get(i));
+                emitEvent(state, sampleUnit, timestamp, values.get(i), weightEntity, stacktraceId, threadId, fields);
+            }
+            return cardinalityMismatchLogged;
+        }
+
+        // Off-spec shape: values/timestamps cardinality mismatch. Spread the total value evenly over
+        // the timestamps (remainder on the last one) so per-event granularity survives and the total
+        // stays exact.
+        if (!cardinalityMismatchLogged) {
+            LOG.warn("OTLP sample values/timestamps cardinality mismatch, spreading total evenly: "
+                            + "event_type={} values_count={} timestamps_count={}",
+                    state.otelEventType.name(), values.size(), timestamps.size());
+        }
+        long total = sum(values);
+        long base = total / timestamps.size();
+        long remainder = total - base * timestamps.size();
+        for (int i = 0; i < timestamps.size(); i++) {
+            long value = base + (i == timestamps.size() - 1 ? remainder : 0);
+            Instant timestamp = Instant.ofEpochSecond(0, timestamps.get(i));
+            emitEvent(state, sampleUnit, timestamp, value, weightEntity, stacktraceId, threadId, fields);
+        }
+        return true;
+    }
+
+    private void emitEvent(
+            EventTypeState state,
+            OtelSampleUnit sampleUnit,
+            Instant timestamp,
+            long value,
+            String weightEntity,
+            Long stacktraceId,
+            Long threadId,
+            ObjectNode fields) {
+
+        long samples;
+        Long weight;
+        switch (sampleUnit) {
+            case OtelSampleUnit.CountUnit _ -> {
+                samples = value;
+                weight = null;
+            }
+            case OtelSampleUnit.DurationUnit durationUnit -> {
+                samples = 1;
+                weight = durationUnit.toNanos(value);
+            }
+            case OtelSampleUnit.BytesUnit _ -> {
+                samples = 1;
+                weight = value;
+            }
+        }
+
+        Event event = new Event(
+                state.otelEventType.name(),
+                timestamp,
+                null,
+                samples,
+                weight,
+                weight != null ? weightEntity : null,
+                stacktraceId,
+                threadId,
+                fields);
+        writer.onEvent(event);
+    }
+
+    private Long resolveThreadId(Map<String, AnyValue> sampleAttributes, String fallbackThreadName) {
+        EventThread thread = OtelThreadResolver.resolve(sampleAttributes, fallbackThreadName);
+        return threadIdsByThread.computeIfAbsent(thread, writer::onEventThread);
+    }
+
+    /**
+     * Announced stacktrace reference; {@code id} is {@code null} for empty/unresolvable stacks.
+     */
+    private record StacktraceRef(Long id) {
+    }
+
+    private Long resolveStacktraceId(
+            Sample sample,
+            OtlpDictionary dictionary,
+            Map<Integer, StacktraceRef> stacktracesByStackIndex) {
+
+        int stackIndex = sample.getStackIndex();
+        Stack stack = dictionary.stack(stackIndex);
+        if (stack == null) {
+            return null;
+        }
+
+        StacktraceRef ref = stacktracesByStackIndex.computeIfAbsent(stackIndex, _ -> {
+            MappedStack mappedStack = OtelFrameMapper.mapStack(stack, dictionary);
+            if (mappedStack.frames().isEmpty()) {
+                return new StacktraceRef(null);
+            }
+            EventStacktrace stacktrace = new EventStacktrace(mappedStack.type(), mappedStack.frames());
+            return new StacktraceRef(writer.onEventStacktrace(stacktrace));
+        });
+        return ref.id();
+    }
+
+    private String resolveWeightEntity(OtelSampleUnit sampleUnit, Map<String, AnyValue> sampleAttributes) {
+        if (!(sampleUnit instanceof OtelSampleUnit.BytesUnit)) {
+            return null;
+        }
+        for (String key : OtelSemconv.WEIGHT_ENTITY_KEYS) {
+            String entity = OtlpAttributes.stringValue(sampleAttributes.get(key));
+            if (entity != null && !entity.isBlank()) {
+                return entity;
+            }
+        }
+        return null;
+    }
+
+    private ObjectNode buildFields(
+            Sample sample,
+            Map<String, AnyValue> sampleAttributes,
+            OtlpDictionary dictionary,
+            EventTypeState state) {
+
+        ObjectNode fields = Json.createObject();
+
+        Link link = dictionary.link(sample.getLinkIndex());
+        if (link != null) {
+            String traceId = toHex(link.getTraceId().toByteArray());
+            String spanId = toHex(link.getSpanId().toByteArray());
+            if (traceId != null) {
+                fields.put(FIELD_TRACE_ID, traceId);
+                state.fieldKeys.add(FIELD_TRACE_ID);
+            }
+            if (spanId != null) {
+                fields.put(FIELD_SPAN_ID, spanId);
+                state.fieldKeys.add(FIELD_SPAN_ID);
+            }
+        }
+
+        for (Map.Entry<String, AnyValue> attribute : sampleAttributes.entrySet()) {
+            if (OtelSemconv.STRUCTURAL_SAMPLE_KEYS.contains(attribute.getKey())) {
+                continue;
+            }
+            OtlpAttributes.putJsonField(fields, attribute.getKey(), attribute.getValue());
+            state.fieldKeys.add(attribute.getKey());
+        }
+        return fields;
+    }
+
+    private void emitProvenanceSettings(
+            String eventTypeName,
+            Profile profile,
+            ResourceProfiles resourceProfiles,
+            ScopeProfiles scopeProfiles,
+            OtlpDictionary dictionary) {
+
+        for (KeyValue attribute : resourceProfiles.getResource().getAttributesList()) {
+            emitSetting(eventTypeName, attribute.getKey(), OtlpAttributes.stringValue(attribute.getValue()));
+        }
+
+        if (scopeProfiles.hasScope()) {
+            emitSetting(eventTypeName, OtelSemconv.SCOPE_NAME_SETTING, scopeProfiles.getScope().getName());
+            emitSetting(eventTypeName, OtelSemconv.SCOPE_VERSION_SETTING, scopeProfiles.getScope().getVersion());
+        }
+
+        if (profile.getPeriod() > 0) {
+            String periodType = dictionary.string(profile.getPeriodType().getTypeStrindex());
+            String periodUnit = dictionary.string(profile.getPeriodType().getUnitStrindex());
+            emitSetting(eventTypeName, SETTING_PERIOD,
+                    profile.getPeriod() + " " + periodUnit + " (" + periodType + ")");
+        }
+    }
+
+    private void emitSetting(String eventTypeName, String name, String value) {
+        if (name == null || name.isBlank() || value == null || value.isBlank()) {
+            return;
+        }
+        if (emittedSettingKeys.add(eventTypeName + "|" + name)) {
+            writer.onEventSetting(new EventSetting(eventTypeName, name, value));
+        }
+    }
+
+    private void emitEventTypes() {
+        for (EventTypeState state : eventTypesByName.values()) {
+            writer.onEventType(new EventType(
+                    state.otelEventType.name(),
+                    state.otelEventType.label(),
+                    state.typeId,
+                    describe(state),
+                    state.otelEventType.categories(),
+                    buildColumns(state)));
+        }
+    }
+
+    private static String describe(EventTypeState state) {
+        return "Synthesized from the OpenTelemetry profile sample type '"
+                + state.sampleType + "/" + state.sampleUnit + "'";
+    }
+
+    private static JsonNode buildColumns(EventTypeState state) {
+        List<ObjectNode> columns = state.fieldKeys.stream()
+                .map(key -> {
+                    ObjectNode column = Json.createObject()
+                            .put("field", key)
+                            .put("header", key);
+                    column.putNull("type");
+                    column.putNull("description");
+                    return column;
+                })
+                .toList();
+        return Json.mapper().valueToTree(columns);
+    }
+
+    private String resolveFallbackThreadName(ResourceProfiles resourceProfiles) {
+        String executable = null;
+        String pid = null;
+        String serviceName = null;
+        for (KeyValue attribute : resourceProfiles.getResource().getAttributesList()) {
+            switch (attribute.getKey()) {
+                case OtelSemconv.PROCESS_EXECUTABLE_NAME -> executable = OtlpAttributes.stringValue(attribute.getValue());
+                case OtelSemconv.PROCESS_PID -> pid = OtlpAttributes.stringValue(attribute.getValue());
+                case OtelSemconv.SERVICE_NAME -> serviceName = OtlpAttributes.stringValue(attribute.getValue());
+                default -> {
+                }
+            }
+        }
+
+        if (executable != null && !executable.isBlank()) {
+            return pid != null && !pid.isBlank() ? executable + " (pid=" + pid + ")" : executable;
+        }
+        if (serviceName != null && !serviceName.isBlank()) {
+            return serviceName;
+        }
+        return FALLBACK_THREAD_NAME;
+    }
+
+    private static long sum(List<Long> values) {
+        long total = 0;
+        for (Long value : values) {
+            total += value;
+        }
+        return total;
+    }
+
+    private static String toHex(byte[] bytes) {
+        if (bytes == null || bytes.length == 0) {
+            return null;
+        }
+        boolean allZero = true;
+        StringBuilder hex = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            if (b != 0) {
+                allZero = false;
+            }
+            hex.append(Character.forDigit((b >> 4) & 0xF, 16));
+            hex.append(Character.forDigit(b & 0xF, 16));
+        }
+        return allZero ? null : hex.toString();
+    }
+}

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/OtlpRecordingEventParser.java
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/OtlpRecordingEventParser.java
@@ -1,0 +1,46 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.otlpparser;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import cafe.jeffrey.provider.profile.api.EventWriter;
+import cafe.jeffrey.provider.profile.api.RecordingEventParser;
+import cafe.jeffrey.shared.common.measure.Measuring;
+
+import java.nio.file.Path;
+import java.time.Duration;
+
+/**
+ * {@link RecordingEventParser} for OpenTelemetry profiles recordings ({@code .otlp} files, see
+ * {@link OtlpFileFormat}). Parsing is single-threaded: every frame carries its own dictionary, and
+ * OTLP recordings are typically much smaller than JFR ones, so chunk-parallelism is not worth the
+ * coordination overhead yet.
+ */
+public class OtlpRecordingEventParser implements RecordingEventParser {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OtlpRecordingEventParser.class);
+
+    @Override
+    public void start(EventWriter eventWriter, Path recording) {
+        OtlpProfileReader reader = new OtlpProfileReader(eventWriter.newSingleThreadedWriter());
+        Duration elapsed = Measuring.r(() -> reader.read(recording));
+        LOG.info("OTLP recording parsed: recording={} duration_in_ms={}", recording, elapsed.toMillis());
+    }
+}

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/OtlpRecordingInformationParser.java
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/OtlpRecordingInformationParser.java
@@ -1,0 +1,103 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.otlpparser;
+
+import io.opentelemetry.proto.profiles.v1development.Profile;
+import io.opentelemetry.proto.profiles.v1development.ProfilesData;
+import io.opentelemetry.proto.profiles.v1development.ResourceProfiles;
+import io.opentelemetry.proto.profiles.v1development.Sample;
+import io.opentelemetry.proto.profiles.v1development.ScopeProfiles;
+import cafe.jeffrey.provider.profile.api.RecordingInformation;
+import cafe.jeffrey.provider.profile.api.RecordingInformationParser;
+import cafe.jeffrey.shared.common.filesystem.FileSystemUtils;
+import cafe.jeffrey.shared.common.model.RecordingEventSource;
+
+import java.nio.file.Path;
+import java.time.Instant;
+
+/**
+ * Derives the recording metadata (event source + profiling start/end) of an OTLP recording by
+ * scanning the profile collection times and sample timestamps of every frame. The resulting start
+ * is the zero point of the relative event timeline, so the computation mirrors the timestamps the
+ * {@link OtlpProfileReader} later assigns to events.
+ */
+public class OtlpRecordingInformationParser implements RecordingInformationParser {
+
+    private static class TimeRange {
+        private long minNanos = Long.MAX_VALUE;
+        private long maxNanos = Long.MIN_VALUE;
+
+        private void accept(long nanos) {
+            if (nanos <= 0) {
+                return;
+            }
+            if (nanos < minNanos) {
+                minNanos = nanos;
+            }
+            if (nanos > maxNanos) {
+                maxNanos = nanos;
+            }
+        }
+
+        private boolean isEmpty() {
+            return minNanos == Long.MAX_VALUE;
+        }
+    }
+
+    @Override
+    public RecordingInformation provide(Path recordingPath) {
+        TimeRange timeRange = new TimeRange();
+
+        OtlpStreamReader streamReader = new OtlpStreamReader();
+        streamReader.read(recordingPath, frame -> acceptFrame(frame, timeRange));
+
+        if (timeRange.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "OTLP recording contains no usable timestamps: " + recordingPath);
+        }
+
+        return new RecordingInformation(
+                FileSystemUtils.size(recordingPath),
+                RecordingEventSource.OPEN_TELEMETRY,
+                Instant.ofEpochSecond(0, timeRange.minNanos),
+                Instant.ofEpochSecond(0, timeRange.maxNanos));
+    }
+
+    private static void acceptFrame(ProfilesData frame, TimeRange timeRange) {
+        for (ResourceProfiles resourceProfiles : frame.getResourceProfilesList()) {
+            for (ScopeProfiles scopeProfiles : resourceProfiles.getScopeProfilesList()) {
+                for (Profile profile : scopeProfiles.getProfilesList()) {
+                    acceptProfile(profile, timeRange);
+                }
+            }
+        }
+    }
+
+    private static void acceptProfile(Profile profile, TimeRange timeRange) {
+        timeRange.accept(profile.getTimeUnixNano());
+        if (profile.getTimeUnixNano() > 0 && profile.getDurationNano() > 0) {
+            timeRange.accept(profile.getTimeUnixNano() + profile.getDurationNano());
+        }
+        for (Sample sample : profile.getSamplesList()) {
+            for (Long timestamp : sample.getTimestampsUnixNanoList()) {
+                timeRange.accept(timestamp);
+            }
+        }
+    }
+}

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/OtlpStreamReader.java
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/OtlpStreamReader.java
@@ -1,0 +1,85 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.otlpparser;
+
+import io.opentelemetry.proto.profiles.v1development.ProfilesData;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.Consumer;
+
+/**
+ * Reads {@code .otlp} files in Jeffrey's file convention (see {@link OtlpFileFormat}) and hands every
+ * decoded {@code ProfilesData} frame to a consumer. Framed files are streamed frame-by-frame; raw
+ * files (no header) are parsed as a single message.
+ */
+public class OtlpStreamReader {
+
+    public void read(Path file, Consumer<ProfilesData> frameConsumer) {
+        try (InputStream input = new BufferedInputStream(Files.newInputStream(file))) {
+            byte[] header = input.readNBytes(OtlpFileFormat.HEADER_SIZE);
+            if (OtlpFileFormat.startsWithMagic(header, header.length)) {
+                int version = OtlpFileFormat.readVersion(header);
+                if (version > OtlpFileFormat.VERSION) {
+                    throw new IllegalArgumentException(
+                            "Unsupported OTLP file format version: file=" + file + " version=" + version);
+                }
+                readDelimitedFrames(file, input, frameConsumer);
+            } else {
+                readRawMessage(file, header, input, frameConsumer);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to read OTLP recording: " + file, e);
+        }
+    }
+
+    private void readDelimitedFrames(Path file, InputStream input, Consumer<ProfilesData> frameConsumer) {
+        try {
+            ProfilesData frame;
+            while ((frame = ProfilesData.parseDelimitedFrom(input)) != null) {
+                frameConsumer.accept(frame);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to parse a frame of the OTLP recording: " + file, e);
+        }
+    }
+
+    private void readRawMessage(
+            Path file,
+            byte[] alreadyReadHeader,
+            InputStream input,
+            Consumer<ProfilesData> frameConsumer) {
+
+        try {
+            byte[] rest = input.readAllBytes();
+            byte[] content = new byte[alreadyReadHeader.length + rest.length];
+            System.arraycopy(alreadyReadHeader, 0, content, 0, alreadyReadHeader.length);
+            System.arraycopy(rest, 0, content, alreadyReadHeader.length, rest.length);
+
+            frameConsumer.accept(ProfilesData.parseFrom(content));
+        } catch (IOException e) {
+            throw new UncheckedIOException(
+                    "Failed to parse the OTLP recording as a raw ProfilesData message: " + file, e);
+        }
+    }
+}

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/dictionary/OtlpDictionary.java
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/dictionary/OtlpDictionary.java
@@ -1,0 +1,115 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.otlpparser.dictionary;
+
+import io.opentelemetry.proto.profiles.v1development.KeyValueAndUnit;
+import io.opentelemetry.proto.profiles.v1development.Link;
+import io.opentelemetry.proto.profiles.v1development.Location;
+import io.opentelemetry.proto.profiles.v1development.Mapping;
+import io.opentelemetry.proto.profiles.v1development.ProfilesDictionary;
+import io.opentelemetry.proto.profiles.v1development.Stack;
+import io.opentelemetry.proto.profiles.v1development.Function;
+
+/**
+ * Index-aware view over an OTLP {@code ProfilesDictionary}.
+ * <p>
+ * Every dictionary table follows the OTLP convention that <em>index 0 is the zero value</em> and an
+ * index of {@code 0} means "null / not set". The accessors therefore return {@code null} (or an empty
+ * string for the string table) for index {@code 0} and for out-of-range indices, so callers never
+ * have to re-implement the bounds/zero handling.
+ */
+public final class OtlpDictionary {
+
+    private final ProfilesDictionary dictionary;
+
+    public OtlpDictionary(ProfilesDictionary dictionary) {
+        this.dictionary = dictionary;
+    }
+
+    /**
+     * @return the referenced string, or an empty string for the null index ({@code 0}) and
+     * out-of-range indices
+     */
+    public String string(int index) {
+        if (index <= 0 || index >= dictionary.getStringTableCount()) {
+            return "";
+        }
+        return dictionary.getStringTable(index);
+    }
+
+    /**
+     * @return the referenced mapping, or {@code null} for the null index and out-of-range indices
+     */
+    public Mapping mapping(int index) {
+        if (index <= 0 || index >= dictionary.getMappingTableCount()) {
+            return null;
+        }
+        return dictionary.getMappingTable(index);
+    }
+
+    /**
+     * @return the referenced location, or {@code null} for the null index and out-of-range indices
+     */
+    public Location location(int index) {
+        if (index <= 0 || index >= dictionary.getLocationTableCount()) {
+            return null;
+        }
+        return dictionary.getLocationTable(index);
+    }
+
+    /**
+     * @return the referenced function, or {@code null} for the null index and out-of-range indices
+     */
+    public Function function(int index) {
+        if (index <= 0 || index >= dictionary.getFunctionTableCount()) {
+            return null;
+        }
+        return dictionary.getFunctionTable(index);
+    }
+
+    /**
+     * @return the referenced stack, or {@code null} for the null index and out-of-range indices
+     */
+    public Stack stack(int index) {
+        if (index <= 0 || index >= dictionary.getStackTableCount()) {
+            return null;
+        }
+        return dictionary.getStackTable(index);
+    }
+
+    /**
+     * @return the referenced link, or {@code null} for the null index and out-of-range indices
+     */
+    public Link link(int index) {
+        if (index <= 0 || index >= dictionary.getLinkTableCount()) {
+            return null;
+        }
+        return dictionary.getLinkTable(index);
+    }
+
+    /**
+     * @return the referenced attribute, or {@code null} for the null index and out-of-range indices
+     */
+    public KeyValueAndUnit attribute(int index) {
+        if (index <= 0 || index >= dictionary.getAttributeTableCount()) {
+            return null;
+        }
+        return dictionary.getAttributeTable(index);
+    }
+}

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/mapping/FunctionNameSplitter.java
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/mapping/FunctionNameSplitter.java
@@ -1,0 +1,57 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.otlpparser.mapping;
+
+/**
+ * Splits a flat JVM function name from an OTLP {@code Function} (e.g.
+ * {@code com.example.Foo$Bar.doWork(Ljava/lang/String;)V}) into the class and method parts of
+ * Jeffrey's frame model. Any method signature (from the first {@code '('}) is stripped first, then
+ * the name is split at the last {@code '.'}.
+ */
+public final class FunctionNameSplitter {
+
+    public record SplitName(String clazz, String method) {
+    }
+
+    private static final char SIGNATURE_START = '(';
+    private static final char PACKAGE_SEPARATOR = '.';
+
+    private FunctionNameSplitter() {
+    }
+
+    public static SplitName split(String functionName) {
+        if (functionName == null || functionName.isBlank()) {
+            return new SplitName("", "");
+        }
+
+        String withoutSignature = functionName;
+        int signatureIndex = functionName.indexOf(SIGNATURE_START);
+        if (signatureIndex >= 0) {
+            withoutSignature = functionName.substring(0, signatureIndex);
+        }
+
+        int lastDot = withoutSignature.lastIndexOf(PACKAGE_SEPARATOR);
+        if (lastDot < 0) {
+            return new SplitName("", withoutSignature);
+        }
+        return new SplitName(
+                withoutSignature.substring(0, lastDot),
+                withoutSignature.substring(lastDot + 1));
+    }
+}

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/mapping/OtelEventTypeNaming.java
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/mapping/OtelEventTypeNaming.java
@@ -1,0 +1,121 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.otlpparser.mapping;
+
+import cafe.jeffrey.shared.common.model.EventTypeName;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Maps the free-form pprof-style sample type of an OTLP {@code Profile.sample_type} onto Jeffrey's
+ * {@code otel.*} event type namespace. Well-known sample types (as emitted by async-profiler's OTLP
+ * export, the OTel eBPF profiler and pprof conversions) are folded onto five canonical event types
+ * so the frontend can light up the matching flamegraph/timeseries cards; everything else becomes a
+ * sanitized {@code otel.<type>} event type that is still browsable in the Event Viewer.
+ */
+public final class OtelEventTypeNaming {
+
+    public record OtelEventType(String name, String label, List<String> categories) {
+    }
+
+    private static final String CATEGORY_OPEN_TELEMETRY = "OpenTelemetry";
+
+    private static final OtelEventType CPU = new OtelEventType(
+            EventTypeName.OTEL_CPU, "CPU (OTel)", List.of(CATEGORY_OPEN_TELEMETRY, "CPU"));
+    private static final OtelEventType SAMPLES = new OtelEventType(
+            EventTypeName.OTEL_SAMPLES, "Execution Samples (OTel)", List.of(CATEGORY_OPEN_TELEMETRY, "CPU"));
+    private static final OtelEventType WALL = new OtelEventType(
+            EventTypeName.OTEL_WALL, "Wall Clock (OTel)", List.of(CATEGORY_OPEN_TELEMETRY, "Wall-Clock"));
+    private static final OtelEventType ALLOC = new OtelEventType(
+            EventTypeName.OTEL_ALLOC, "Allocations (OTel)", List.of(CATEGORY_OPEN_TELEMETRY, "Allocation"));
+    private static final OtelEventType LOCK = new OtelEventType(
+            EventTypeName.OTEL_LOCK, "Lock Contention (OTel)", List.of(CATEGORY_OPEN_TELEMETRY, "Blocking"));
+
+    /**
+     * Sample-type aliases observed across producers: async-profiler emits {@code cpu}/{@code wall}/
+     * {@code alloc}/{@code lock}, the eBPF profiler emits {@code samples}/{@code count}, pprof heap
+     * profiles use {@code alloc_space}/{@code alloc_objects}/{@code allocated_*}, pprof mutex/block
+     * profiles use {@code contentions}/{@code delay}.
+     */
+    private static final Map<String, OtelEventType> WELL_KNOWN_TYPES = Map.ofEntries(
+            Map.entry("cpu", CPU),
+            Map.entry("cpu_time", CPU),
+            Map.entry("samples", SAMPLES),
+            Map.entry("events", SAMPLES),
+            Map.entry("wall", WALL),
+            Map.entry("wallclock", WALL),
+            Map.entry("wall_time", WALL),
+            Map.entry("alloc", ALLOC),
+            Map.entry("allocations", ALLOC),
+            Map.entry("alloc_space", ALLOC),
+            Map.entry("alloc_objects", ALLOC),
+            Map.entry("allocated_space", ALLOC),
+            Map.entry("allocated_objects", ALLOC),
+            Map.entry("alloc_samples", ALLOC),
+            Map.entry("lock", LOCK),
+            Map.entry("locks", LOCK),
+            Map.entry("block", LOCK),
+            Map.entry("mutex", LOCK),
+            Map.entry("contentions", LOCK),
+            Map.entry("delay", LOCK));
+
+    private static final Set<Character> ALLOWED_NAME_CHARACTERS = Set.of('_', '-');
+
+    private OtelEventTypeNaming() {
+    }
+
+    /**
+     * @param sampleType the resolved {@code sample_type.type} string of the profile (may be blank)
+     * @param sampleUnit the resolved {@code sample_type.unit} string of the profile (used only for
+     *                   labeling custom types)
+     */
+    public static OtelEventType resolve(String sampleType, String sampleUnit) {
+        if (sampleType == null || sampleType.isBlank()) {
+            return SAMPLES;
+        }
+        OtelEventType wellKnown = WELL_KNOWN_TYPES.get(sampleType.toLowerCase(Locale.ROOT));
+        if (wellKnown != null) {
+            return wellKnown;
+        }
+        return customType(sampleType, sampleUnit);
+    }
+
+    private static OtelEventType customType(String sampleType, String sampleUnit) {
+        String name = EventTypeName.OTEL_NAMESPACE + sanitize(sampleType);
+        String label = (sampleUnit == null || sampleUnit.isBlank())
+                ? sampleType + " (OTel)"
+                : sampleType + " [" + sampleUnit + "] (OTel)";
+        return new OtelEventType(name, label, List.of(CATEGORY_OPEN_TELEMETRY));
+    }
+
+    private static String sanitize(String sampleType) {
+        StringBuilder sanitized = new StringBuilder(sampleType.length());
+        for (char c : sampleType.toLowerCase(Locale.ROOT).toCharArray()) {
+            if (Character.isLetterOrDigit(c) || ALLOWED_NAME_CHARACTERS.contains(c)) {
+                sanitized.append(c);
+            } else {
+                sanitized.append('_');
+            }
+        }
+        return sanitized.toString();
+    }
+}

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/mapping/OtelFrameMapper.java
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/mapping/OtelFrameMapper.java
@@ -1,0 +1,171 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.otlpparser.mapping;
+
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.profiles.v1development.Line;
+import io.opentelemetry.proto.profiles.v1development.Location;
+import io.opentelemetry.proto.profiles.v1development.Mapping;
+import io.opentelemetry.proto.profiles.v1development.Stack;
+import io.opentelemetry.proto.profiles.v1development.Function;
+import cafe.jeffrey.otlpparser.dictionary.OtlpDictionary;
+import cafe.jeffrey.profile.common.model.FrameType;
+import cafe.jeffrey.provider.profile.api.EventFrame;
+import cafe.jeffrey.shared.common.model.StacktraceType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Maps an OTLP {@code Stack} (leaf-first list of locations) onto Jeffrey's frame model
+ * (root-first list of {@link EventFrame}s).
+ * <ul>
+ *   <li>Location order is reversed (OTLP stacks are leaf-first, Jeffrey persists root-first).</li>
+ *   <li>A location with multiple {@code Line}s is inline-expanded: the last line is the caller
+ *       (the actual compiled frame), the preceding lines are the inlined callees — emitted
+ *       caller-first with {@link FrameType#INLINED} for JVM callees.</li>
+ *   <li>JVM function names are split into class/method; native frames use the mapping's file
+ *       basename as the "class" (module), matching the async-profiler reading of native frames.</li>
+ *   <li>Symbol-less locations render as a hexadecimal address frame.</li>
+ * </ul>
+ */
+public final class OtelFrameMapper {
+
+    /**
+     * A mapped stacktrace: root-first frames plus the resolved stacktrace classification.
+     */
+    public record MappedStack(List<EventFrame> frames, StacktraceType type) {
+    }
+
+    private static final long UNKNOWN_BYTECODE_INDEX = -1;
+    private static final String ADDRESS_PREFIX = "0x";
+    private static final String UNKNOWN_MODULE = "unknown";
+
+    private OtelFrameMapper() {
+    }
+
+    public static MappedStack mapStack(Stack stack, OtlpDictionary dictionary) {
+        List<EventFrame> frames = new ArrayList<>();
+        boolean anyJavaFrame = false;
+
+        List<Integer> locationIndices = stack.getLocationIndicesList();
+        for (int i = locationIndices.size() - 1; i >= 0; i--) {
+            Location location = dictionary.location(locationIndices.get(i));
+            if (location == null) {
+                continue;
+            }
+
+            FrameType frameType = resolveFrameType(location, dictionary);
+            boolean jvmFrame = frameType.isJavaFrame();
+            anyJavaFrame |= jvmFrame;
+
+            String module = resolveModule(location, dictionary);
+            List<Line> lines = location.getLinesList();
+            if (lines.isEmpty()) {
+                frames.add(addressFrame(location, module, frameType));
+                continue;
+            }
+
+            // The last line is the caller (the real compiled frame); the preceding lines were
+            // inlined into it. Root-first output emits the caller before its inlined callees.
+            for (int lineIndex = lines.size() - 1; lineIndex >= 0; lineIndex--) {
+                boolean inlined = lineIndex < lines.size() - 1;
+                FrameType lineFrameType = (inlined && jvmFrame) ? FrameType.INLINED : frameType;
+                frames.add(lineFrame(lines.get(lineIndex), location, module, lineFrameType, jvmFrame, dictionary));
+            }
+        }
+
+        return new MappedStack(frames, resolveStacktraceType(frames, anyJavaFrame));
+    }
+
+    private static StacktraceType resolveStacktraceType(List<EventFrame> frames, boolean anyJavaFrame) {
+        if (frames.isEmpty()) {
+            return StacktraceType.UNKNOWN;
+        }
+        return anyJavaFrame ? StacktraceType.APPLICATION : StacktraceType.NATIVE;
+    }
+
+    private static FrameType resolveFrameType(Location location, OtlpDictionary dictionary) {
+        Map<String, AnyValue> attributes = OtlpAttributes.resolve(location.getAttributeIndicesList(), dictionary);
+        String semconvFrameType = OtlpAttributes.stringValue(attributes.get(OtelSemconv.PROFILE_FRAME_TYPE));
+        return OtelFrameTypeMapper.map(semconvFrameType);
+    }
+
+    private static String resolveModule(Location location, OtlpDictionary dictionary) {
+        Mapping mapping = dictionary.mapping(location.getMappingIndex());
+        if (mapping == null) {
+            return "";
+        }
+        String filename = dictionary.string(mapping.getFilenameStrindex());
+        if (filename.isBlank()) {
+            return "";
+        }
+        int lastSlash = filename.lastIndexOf('/');
+        return lastSlash >= 0 ? filename.substring(lastSlash + 1) : filename;
+    }
+
+    private static EventFrame lineFrame(
+            Line line,
+            Location location,
+            String module,
+            FrameType frameType,
+            boolean jvmFrame,
+            OtlpDictionary dictionary) {
+
+        String functionName = resolveFunctionName(line, dictionary);
+        if (functionName.isBlank()) {
+            return addressFrame(location, module, frameType);
+        }
+
+        if (jvmFrame) {
+            FunctionNameSplitter.SplitName splitName = FunctionNameSplitter.split(functionName);
+            return new EventFrame(
+                    splitName.clazz(),
+                    splitName.method(),
+                    frameType.code(),
+                    UNKNOWN_BYTECODE_INDEX,
+                    line.getLine());
+        }
+        return new EventFrame(
+                module,
+                functionName,
+                frameType.code(),
+                UNKNOWN_BYTECODE_INDEX,
+                line.getLine());
+    }
+
+    private static String resolveFunctionName(Line line, OtlpDictionary dictionary) {
+        Function function = dictionary.function(line.getFunctionIndex());
+        if (function == null) {
+            return "";
+        }
+        String name = dictionary.string(function.getNameStrindex());
+        if (!name.isBlank()) {
+            return name;
+        }
+        return dictionary.string(function.getSystemNameStrindex());
+    }
+
+    private static EventFrame addressFrame(Location location, String module, FrameType frameType) {
+        String method = ADDRESS_PREFIX + Long.toHexString(location.getAddress());
+        String clazz = module.isBlank() ? UNKNOWN_MODULE : module;
+        return new EventFrame(clazz, method, frameType.code(), UNKNOWN_BYTECODE_INDEX, 0);
+    }
+}

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/mapping/OtelFrameTypeMapper.java
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/mapping/OtelFrameTypeMapper.java
@@ -1,0 +1,84 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.otlpparser.mapping;
+
+import cafe.jeffrey.profile.common.model.FrameType;
+
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Maps the OTLP semantic-convention attribute {@code profile.frame.type} onto Jeffrey's persisted
+ * {@link FrameType} codes.
+ * <p>
+ * OTLP does not distinguish interpreted/JIT-compiled/inlined JVM frames, so {@code jvm} maps to
+ * {@link FrameType#JIT_COMPILED} (the dominant state, rendered as a Java frame). All non-JVM
+ * language runtimes map to {@link FrameType#NATIVE} until Jeffrey grows language-specific frame
+ * types.
+ */
+public final class OtelFrameTypeMapper {
+
+    /**
+     * Semantic-convention value marking a JVM frame ({@code profile.frame.type = "jvm"}).
+     */
+    public static final String FRAME_TYPE_JVM = "jvm";
+
+    private static final String FRAME_TYPE_KERNEL = "kernel";
+    private static final String FRAME_TYPE_NATIVE = "native";
+    private static final String FRAME_TYPE_CPYTHON = "cpython";
+    private static final String FRAME_TYPE_V8JS = "v8js";
+    private static final String FRAME_TYPE_GO = "go";
+    private static final String FRAME_TYPE_DOTNET = "dotnet";
+    private static final String FRAME_TYPE_RUBY = "ruby";
+    private static final String FRAME_TYPE_PHP = "php";
+    private static final String FRAME_TYPE_PERL = "perl";
+    private static final String FRAME_TYPE_BEAM = "beam";
+    private static final String FRAME_TYPE_RUST = "rust";
+    private static final String FRAME_TYPE_LUAJIT = "luajit";
+
+    private static final Map<String, FrameType> FRAME_TYPES_BY_SEMCONV = Map.ofEntries(
+            Map.entry(FRAME_TYPE_JVM, FrameType.JIT_COMPILED),
+            Map.entry(FRAME_TYPE_KERNEL, FrameType.KERNEL),
+            Map.entry(FRAME_TYPE_NATIVE, FrameType.NATIVE),
+            Map.entry(FRAME_TYPE_CPYTHON, FrameType.NATIVE),
+            Map.entry(FRAME_TYPE_V8JS, FrameType.NATIVE),
+            Map.entry(FRAME_TYPE_GO, FrameType.NATIVE),
+            Map.entry(FRAME_TYPE_DOTNET, FrameType.NATIVE),
+            Map.entry(FRAME_TYPE_RUBY, FrameType.NATIVE),
+            Map.entry(FRAME_TYPE_PHP, FrameType.NATIVE),
+            Map.entry(FRAME_TYPE_PERL, FrameType.NATIVE),
+            Map.entry(FRAME_TYPE_BEAM, FrameType.NATIVE),
+            Map.entry(FRAME_TYPE_RUST, FrameType.NATIVE),
+            Map.entry(FRAME_TYPE_LUAJIT, FrameType.NATIVE));
+
+    private OtelFrameTypeMapper() {
+    }
+
+    public static FrameType map(String semconvFrameType) {
+        if (semconvFrameType == null || semconvFrameType.isBlank()) {
+            return FrameType.NATIVE;
+        }
+        FrameType mapped = FRAME_TYPES_BY_SEMCONV.get(semconvFrameType.toLowerCase(Locale.ROOT));
+        return mapped != null ? mapped : FrameType.NATIVE;
+    }
+
+    public static boolean isJvmFrame(String semconvFrameType) {
+        return FRAME_TYPE_JVM.equalsIgnoreCase(semconvFrameType);
+    }
+}

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/mapping/OtelSampleUnit.java
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/mapping/OtelSampleUnit.java
@@ -1,0 +1,85 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.otlpparser.mapping;
+
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Interpretation of the unit string of an OTLP {@code Profile.sample_type}. The unit decides how a
+ * sample value maps to Jeffrey's {@code samples}/{@code weight} event columns:
+ * <ul>
+ *   <li>{@link CountUnit} — the value is a number of sampled occurrences ({@code samples} column)</li>
+ *   <li>{@link DurationUnit} — the value is a time span, normalized to nanoseconds ({@code weight} column)</li>
+ *   <li>{@link BytesUnit} — the value is a byte size ({@code weight} column)</li>
+ * </ul>
+ * Unknown units are conservatively treated as {@link CountUnit}.
+ */
+public sealed interface OtelSampleUnit {
+
+    record CountUnit() implements OtelSampleUnit {
+    }
+
+    record DurationUnit(long nanosPerUnit) implements OtelSampleUnit {
+        public long toNanos(long value) {
+            return value * nanosPerUnit;
+        }
+    }
+
+    record BytesUnit() implements OtelSampleUnit {
+    }
+
+    CountUnit COUNT = new CountUnit();
+    BytesUnit BYTES = new BytesUnit();
+    DurationUnit NANOSECONDS = new DurationUnit(1);
+    DurationUnit MICROSECONDS = new DurationUnit(1_000);
+    DurationUnit MILLISECONDS = new DurationUnit(1_000_000);
+    DurationUnit SECONDS = new DurationUnit(1_000_000_000);
+
+    /**
+     * Unit aliases as observed in the wild: pprof-style long names, UCUM codes and common
+     * abbreviations used by OTLP profile producers.
+     */
+    Map<String, OtelSampleUnit> UNITS_BY_NAME = Map.ofEntries(
+            Map.entry("count", COUNT),
+            Map.entry("1", COUNT),
+            Map.entry("bytes", BYTES),
+            Map.entry("by", BYTES),
+            Map.entry("byte", BYTES),
+            Map.entry("nanoseconds", NANOSECONDS),
+            Map.entry("nanosecond", NANOSECONDS),
+            Map.entry("ns", NANOSECONDS),
+            Map.entry("microseconds", MICROSECONDS),
+            Map.entry("microsecond", MICROSECONDS),
+            Map.entry("us", MICROSECONDS),
+            Map.entry("milliseconds", MILLISECONDS),
+            Map.entry("millisecond", MILLISECONDS),
+            Map.entry("ms", MILLISECONDS),
+            Map.entry("seconds", SECONDS),
+            Map.entry("second", SECONDS),
+            Map.entry("s", SECONDS));
+
+    static OtelSampleUnit fromUnitString(String unit) {
+        if (unit == null || unit.isBlank()) {
+            return COUNT;
+        }
+        OtelSampleUnit resolved = UNITS_BY_NAME.get(unit.toLowerCase(Locale.ROOT));
+        return resolved != null ? resolved : COUNT;
+    }
+}

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/mapping/OtelSemconv.java
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/mapping/OtelSemconv.java
@@ -1,0 +1,55 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.otlpparser.mapping;
+
+import java.util.Set;
+
+/**
+ * OpenTelemetry semantic-convention attribute keys consumed structurally by the OTLP parser.
+ */
+public final class OtelSemconv {
+
+    public static final String THREAD_NAME = "thread.name";
+    public static final String THREAD_ID = "thread.id";
+    public static final String PROFILE_FRAME_TYPE = "profile.frame.type";
+    public static final String SERVICE_NAME = "service.name";
+    public static final String SERVICE_INSTANCE_ID = "service.instance.id";
+    public static final String PROCESS_EXECUTABLE_NAME = "process.executable.name";
+    public static final String PROCESS_PID = "process.pid";
+
+    /**
+     * Scope provenance keys synthesized by the parser (not part of semconv) for the Event Types view.
+     */
+    public static final String SCOPE_NAME_SETTING = "otel.scope.name";
+    public static final String SCOPE_VERSION_SETTING = "otel.scope.version";
+
+    /**
+     * Attribute keys carrying the entity (class) associated with an allocation sample's weight.
+     */
+    public static final Set<String> WEIGHT_ENTITY_KEYS = Set.of("class", "allocation.class", "jvm.class.name");
+
+    /**
+     * Sample attribute keys that are consumed structurally (mapped to dedicated columns) and are
+     * therefore excluded from the generic per-event JSON fields.
+     */
+    public static final Set<String> STRUCTURAL_SAMPLE_KEYS = Set.of(THREAD_NAME, THREAD_ID, PROFILE_FRAME_TYPE);
+
+    private OtelSemconv() {
+    }
+}

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/mapping/OtelThreadResolver.java
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/mapping/OtelThreadResolver.java
@@ -1,0 +1,56 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.otlpparser.mapping;
+
+import io.opentelemetry.proto.common.v1.AnyValue;
+import cafe.jeffrey.provider.profile.api.EventThread;
+
+import java.util.Map;
+
+/**
+ * Resolves the thread of an OTLP sample. OTLP has no thread table — thread identity travels as the
+ * semconv sample attributes {@code thread.name} / {@code thread.id} when the producer emits them;
+ * samples without any thread attribute fall back to a synthetic per-resource thread so that every
+ * event still lands on a thread lane in the UI.
+ */
+public final class OtelThreadResolver {
+
+    /**
+     * Name format for threads that only carry an OS thread id — matches the JFR parser's convention
+     * for unnamed threads so downstream name-resolution treats them uniformly.
+     */
+    private static final String TID_NAME_PREFIX = "[tid=";
+    private static final String TID_NAME_SUFFIX = "]";
+
+    private OtelThreadResolver() {
+    }
+
+    public static EventThread resolve(Map<String, AnyValue> sampleAttributes, String fallbackThreadName) {
+        String threadName = OtlpAttributes.stringValue(sampleAttributes.get(OtelSemconv.THREAD_NAME));
+        Long threadId = OtlpAttributes.longValue(sampleAttributes.get(OtelSemconv.THREAD_ID));
+
+        if (threadName != null && !threadName.isBlank()) {
+            return new EventThread(threadName, threadId, null, false);
+        }
+        if (threadId != null) {
+            return new EventThread(TID_NAME_PREFIX + threadId + TID_NAME_SUFFIX, threadId, null, false);
+        }
+        return new EventThread(fallbackThreadName, null, null, false);
+    }
+}

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/mapping/OtlpAttributes.java
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/cafe/jeffrey/otlpparser/mapping/OtlpAttributes.java
@@ -1,0 +1,113 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.otlpparser.mapping;
+
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.profiles.v1development.KeyValueAndUnit;
+import cafe.jeffrey.otlpparser.dictionary.OtlpDictionary;
+import tools.jackson.databind.node.ObjectNode;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Resolves OTLP dictionary-encoded attributes ({@code attribute_indices} referencing
+ * {@code KeyValueAndUnit} entries) into plain key/value maps and JSON nodes.
+ */
+public final class OtlpAttributes {
+
+    private OtlpAttributes() {
+    }
+
+    /**
+     * Resolves attribute indices into an insertion-ordered {@code key -> AnyValue} map. Null/unknown
+     * indices and entries with a blank key are skipped.
+     */
+    public static Map<String, AnyValue> resolve(List<Integer> attributeIndices, OtlpDictionary dictionary) {
+        Map<String, AnyValue> attributes = new LinkedHashMap<>();
+        for (Integer index : attributeIndices) {
+            KeyValueAndUnit attribute = dictionary.attribute(index);
+            if (attribute == null) {
+                continue;
+            }
+            String key = dictionary.string(attribute.getKeyStrindex());
+            if (key.isBlank()) {
+                continue;
+            }
+            attributes.put(key, attribute.getValue());
+        }
+        return attributes;
+    }
+
+    /**
+     * @return the attribute rendered as a string, or {@code null} for unset values and non-scalar types
+     */
+    public static String stringValue(AnyValue value) {
+        if (value == null) {
+            return null;
+        }
+        return switch (value.getValueCase()) {
+            case STRING_VALUE -> value.getStringValue();
+            case BOOL_VALUE -> Boolean.toString(value.getBoolValue());
+            case INT_VALUE -> Long.toString(value.getIntValue());
+            case DOUBLE_VALUE -> Double.toString(value.getDoubleValue());
+            default -> null;
+        };
+    }
+
+    /**
+     * @return the attribute as a long, or {@code null} when the value is not an integer/parsable string
+     */
+    public static Long longValue(AnyValue value) {
+        if (value == null) {
+            return null;
+        }
+        if (value.getValueCase() == AnyValue.ValueCase.INT_VALUE) {
+            return value.getIntValue();
+        }
+        if (value.getValueCase() == AnyValue.ValueCase.STRING_VALUE) {
+            try {
+                return Long.parseLong(value.getStringValue());
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Writes a scalar attribute into the JSON fields node; non-scalar values are rendered via
+     * {@code toString} of their protobuf representation to stay lossless enough for the Event Viewer.
+     */
+    public static void putJsonField(ObjectNode fields, String key, AnyValue value) {
+        if (value == null) {
+            return;
+        }
+        switch (value.getValueCase()) {
+            case STRING_VALUE -> fields.put(key, value.getStringValue());
+            case BOOL_VALUE -> fields.put(key, value.getBoolValue());
+            case INT_VALUE -> fields.put(key, value.getIntValue());
+            case DOUBLE_VALUE -> fields.put(key, value.getDoubleValue());
+            case VALUE_NOT_SET -> {
+            }
+            default -> fields.put(key, value.toString());
+        }
+    }
+}

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/module-info.java
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/java/module-info.java
@@ -1,0 +1,29 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+module cafe.jeffrey.microscope.profile.parser.otlp {
+    requires transitive cafe.jeffrey.microscope.profile.persistence.api;
+    requires transitive cafe.jeffrey.shared.common;
+    requires cafe.jeffrey.microscope.profile.common;
+    requires com.google.protobuf;
+    requires tools.jackson.databind;
+    requires org.slf4j;
+
+    // The vendored OTel protobuf classes (io.opentelemetry.proto.*) stay module-internal —
+    // only the parser entry points are part of the module's API.
+    exports cafe.jeffrey.otlpparser;
+}

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/proto/README.md
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/proto/README.md
@@ -1,0 +1,33 @@
+# Vendored OpenTelemetry Protos
+
+These proto files are vendored (copied verbatim) from the
+[open-telemetry/opentelemetry-proto](https://github.com/open-telemetry/opentelemetry-proto)
+repository, `main` branch, as of 2026-07-15.
+
+Vendored files:
+
+- `opentelemetry/proto/common/v1/common.proto`
+- `opentelemetry/proto/resource/v1/resource.proto`
+- `opentelemetry/proto/profiles/v1development/profiles.proto`
+- `opentelemetry/proto/collector/profiles/v1development/profiles_service.proto`
+
+## Why vendored instead of the `io.opentelemetry.proto` Maven artifact
+
+The profiles signal is in **Alpha** and its proto package is still
+`opentelemetry.proto.profiles.v1development` — the message shapes changed several
+times during 2025 and a mechanical rename to a stable `v1` package is expected.
+Vendoring a pinned copy means:
+
+- Jeffrey upgrades the format on its own schedule (re-vendor + adjust the mappers),
+- the generated classes stay compiled against the repository-wide `protobuf-java`
+  version (`${protobuf.version}` in the root POM), avoiding runtime version skew,
+- the generated OTel types remain an implementation detail of the `otlp-parser`
+  module and never leak past its boundary.
+
+## How to re-vendor
+
+Download the four files from the `main` branch (or a tagged release) and overwrite
+the copies here, then update the date above and fix any compilation fallout in
+`cafe.jeffrey.otlpparser`.
+
+The proto files are licensed under the Apache License 2.0 (see the header in each file).

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/proto/opentelemetry/proto/collector/profiles/v1development/profiles_service.proto
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/proto/opentelemetry/proto/collector/profiles/v1development/profiles_service.proto
@@ -1,0 +1,82 @@
+// Copyright 2023, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package opentelemetry.proto.collector.profiles.v1development;
+
+import "opentelemetry/proto/profiles/v1development/profiles.proto";
+
+option csharp_namespace = "OpenTelemetry.Proto.Collector.Profiles.V1Development";
+option java_multiple_files = true;
+option java_package = "io.opentelemetry.proto.collector.profiles.v1development";
+option java_outer_classname = "ProfilesServiceProto";
+option go_package = "go.opentelemetry.io/proto/otlp/collector/profiles/v1development";
+
+// Service that can be used to push profiles between one Application instrumented with
+// OpenTelemetry and a collector, or between a collector and a central collector.
+service ProfilesService {
+  rpc Export(ExportProfilesServiceRequest) returns (ExportProfilesServiceResponse) {}
+}
+
+// Status: [Alpha]
+message ExportProfilesServiceRequest {
+  // An array of ResourceProfiles.
+  // For data coming from a single resource this array will typically contain one
+  // element. Intermediary nodes (such as OpenTelemetry Collector) that receive
+  // data from multiple origins typically batch the data before forwarding further and
+  // in that case this array will contain multiple elements.
+  repeated opentelemetry.proto.profiles.v1development.ResourceProfiles resource_profiles = 1;
+
+  // The reference table containing all data shared by profiles across the message being sent.
+  opentelemetry.proto.profiles.v1development.ProfilesDictionary dictionary = 2;
+}
+
+// Status: [Alpha]
+message ExportProfilesServiceResponse {
+  // The details of a partially successful export request.
+  //
+  // If the request is only partially accepted
+  // (i.e. when the server accepts only parts of the data and rejects the rest)
+  // the server MUST initialize the `partial_success` field and MUST
+  // set the `rejected_<signal>` with the number of items it rejected.
+  //
+  // Servers MAY also make use of the `partial_success` field to convey
+  // warnings/suggestions to senders even when the request was fully accepted.
+  // In such cases, the `rejected_<signal>` MUST have a value of `0` and
+  // the `error_message` MUST be non-empty.
+  //
+  // A `partial_success` message with an empty value (rejected_<signal> = 0 and
+  // `error_message` = "") is equivalent to it not being set/present. Senders
+  // SHOULD interpret it the same way as in the full success case.
+  ExportProfilesPartialSuccess partial_success = 1;
+}
+
+// Status: [Alpha]
+message ExportProfilesPartialSuccess {
+  // The number of rejected profiles.
+  //
+  // A `rejected_<signal>` field holding a `0` value indicates that the
+  // request was fully accepted.
+  int64 rejected_profiles = 1;
+
+  // A developer-facing human-readable message in English. It should be used
+  // either to explain why the server rejected parts of the data during a partial
+  // success or to convey warnings/suggestions during a full success. The message
+  // should offer guidance on how users can address such issues.
+  //
+  // error_message is an optional field. An error_message with an empty value
+  // is equivalent to it not being set.
+  string error_message = 2;
+}

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/proto/opentelemetry/proto/common/v1/common.proto
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/proto/opentelemetry/proto/common/v1/common.proto
@@ -1,0 +1,154 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package opentelemetry.proto.common.v1;
+
+option csharp_namespace = "OpenTelemetry.Proto.Common.V1";
+option java_multiple_files = true;
+option java_package = "io.opentelemetry.proto.common.v1";
+option java_outer_classname = "CommonProto";
+option go_package = "go.opentelemetry.io/proto/otlp/common/v1";
+
+// Represents any type of attribute value. AnyValue may contain a
+// primitive value such as a string or integer or it may contain an arbitrary nested
+// object containing arrays, key-value lists and primitives.
+message AnyValue {
+  // The value is one of the listed fields. It is valid for all values to be unspecified
+  // in which case this AnyValue is considered to be "empty".
+  oneof value {
+    string string_value = 1;
+    bool bool_value = 2;
+    int64 int_value = 3;
+    double double_value = 4;
+    ArrayValue array_value = 5;
+    KeyValueList kvlist_value = 6;
+    bytes bytes_value = 7;
+    // Reference to the string value in ProfilesDictionary.string_table.
+    //
+    // Note: This is currently used exclusively in the Profiling signal.
+    // Implementers of OTLP receivers for signals other than Profiling should
+    // treat the presence of this value as a non-fatal issue.
+    // Log an error or warning indicating an unexpected field intended for the
+    // Profiling signal and process the data as if this value were absent or
+    // empty, ignoring its semantic content for the non-Profiling signal.
+    //
+    // Status: [Alpha]
+    int32 string_value_strindex = 8;
+  }
+}
+
+// ArrayValue is a list of AnyValue messages. We need ArrayValue as a message
+// since oneof in AnyValue does not allow repeated fields.
+message ArrayValue {
+  // Array of values. The array may be empty (contain 0 elements).
+  repeated AnyValue values = 1;
+}
+
+// KeyValueList is a list of KeyValue messages. We need KeyValueList as a message
+// since `oneof` in AnyValue does not allow repeated fields. Everywhere else where we need
+// a list of KeyValue messages (e.g. in Span) we use `repeated KeyValue` directly to
+// avoid unnecessary extra wrapping (which slows down the protocol). The 2 approaches
+// are semantically equivalent.
+message KeyValueList {
+  // A collection of key/value pairs of key-value pairs. The list may be empty (may
+  // contain 0 elements).
+  //
+  // The keys MUST be unique (it is not allowed to have more than one
+  // value with the same key).
+  // The behavior of software that receives duplicated keys can be unpredictable.
+  repeated KeyValue values = 1;
+}
+
+// Represents a key-value pair that is used to store Span attributes, Link
+// attributes, etc.
+message KeyValue {
+  // The key name of the pair.
+  // key_strindex MUST NOT be set if key is used.
+  string key = 1;
+
+  // The value of the pair.
+  AnyValue value = 2;
+
+  // Reference to the string key in ProfilesDictionary.string_table.
+  // key MUST NOT be set if key_strindex is used.
+  //
+  // Note: This is currently used exclusively in the Profiling signal.
+  // Implementers of OTLP receivers for signals other than Profiling should
+  // treat the presence of this key as a non-fatal issue.
+  // Log an error or warning indicating an unexpected field intended for the
+  // Profiling signal and process the data as if this value were absent or
+  // empty, ignoring its semantic content for the non-Profiling signal.
+  //
+  // Status: [Alpha]
+  int32 key_strindex = 3;
+}
+
+// InstrumentationScope is a message representing the instrumentation scope information
+// such as the fully qualified name and version. 
+message InstrumentationScope {
+  // A name denoting the Instrumentation scope.
+  // An empty instrumentation scope name means the name is unknown.
+  string name = 1;
+
+  // Defines the version of the instrumentation scope.
+  // An empty instrumentation scope version means the version is unknown.
+  string version = 2;
+
+  // Additional attributes that describe the scope. [Optional].
+  // Attribute keys MUST be unique (it is not allowed to have more than one
+  // attribute with the same key).
+  // The behavior of software that receives duplicated keys can be unpredictable.
+  repeated KeyValue attributes = 3;
+
+  // The number of attributes that were discarded. Attributes
+  // can be discarded because their keys are too long or because there are too many
+  // attributes. If this value is 0, then no attributes were dropped.
+  uint32 dropped_attributes_count = 4;
+}
+
+// A reference to an Entity.
+// Entity represents an object of interest associated with produced telemetry: e.g spans, metrics, profiles, or logs.
+//
+// Status: [Development]
+message EntityRef {
+  // The Schema URL, if known. This is the identifier of the Schema that the entity data
+  // is recorded in. To learn more about Schema URL see
+  // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
+  //
+  // This schema_url applies to the data in this message and to the Resource attributes
+  // referenced by id_keys and description_keys.
+  // TODO: discuss if we are happy with this somewhat complicated definition of what
+  // the schema_url applies to.
+  //
+  // This field obsoletes the schema_url field in ResourceMetrics/ResourceSpans/ResourceLogs.
+  string schema_url = 1;
+
+  // Defines the type of the entity. MUST not change during the lifetime of the entity.
+  // For example: "service" or "host". This field is required and MUST not be empty
+  // for valid entities.
+  string type = 2;
+
+  // Attribute Keys that identify the entity.
+  // MUST not change during the lifetime of the entity. The Id must contain at least one attribute.
+  // These keys MUST exist in the containing {message}.attributes.
+  repeated string id_keys = 3;
+
+  // Descriptive (non-identifying) attribute keys of the entity.
+  // MAY change over the lifetime of the entity. MAY be empty.
+  // These attribute keys are not part of entity's identity.
+  // These keys MUST exist in the containing {message}.attributes.
+  repeated string description_keys = 4;
+}

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/proto/opentelemetry/proto/profiles/v1development/profiles.proto
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/proto/opentelemetry/proto/profiles/v1development/profiles.proto
@@ -1,0 +1,537 @@
+// Copyright 2023, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This file includes work covered by the following copyright and permission notices:
+//
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package opentelemetry.proto.profiles.v1development;
+
+import "opentelemetry/proto/common/v1/common.proto";
+import "opentelemetry/proto/resource/v1/resource.proto";
+
+option csharp_namespace = "OpenTelemetry.Proto.Profiles.V1Development";
+option java_multiple_files = true;
+option java_package = "io.opentelemetry.proto.profiles.v1development";
+option java_outer_classname = "ProfilesProto";
+option go_package = "go.opentelemetry.io/proto/otlp/profiles/v1development";
+
+//                Relationships Diagram
+//
+// ┌──────────────────┐                      LEGEND
+// │   ProfilesData   │ ─────┐
+// └──────────────────┘      │           ─────▶ embedded
+//   │                       │
+//   │ 1-n                   │           ─────▷ referenced by index
+//   ▼                       ▼
+// ┌──────────────────┐   ┌────────────────────┐
+// │ ResourceProfiles │   │ ProfilesDictionary │
+// └──────────────────┘   └────────────────────┘
+//   │
+//   │ 1-n
+//   ▼
+// ┌──────────────────┐
+// │  ScopeProfiles   │
+// └──────────────────┘
+//   │
+//   │ 1-n
+//   ▼
+// ┌──────────────────┐
+// │      Profile     │
+// └──────────────────┘
+//   │                                n-1
+//   │ 1-n         ┌───────────────────────────────────────┐
+//   ▼             │                                       ▽
+// ┌──────────────────┐   n-n   ┌─────────────────┐   ┌──────────┐
+// │      Sample      │ ──────▷ │ KeyValueAndUnit │   │   Link   │
+// └──────────────────┘         └─────────────────┘   └──────────┘
+//   │                              △      △
+//   │ n-1                          │      │ n-n
+//   ▽                              │      │
+// ┌──────────────────┐             │      │
+// │      Stack       │             │      │
+// └──────────────────┘             │      │
+//   │                     n-n      │      │
+//   │ n-n         ┌────────────────┘      │
+//   ▽             │                       │
+// ┌──────────────────┐   n-1   ┌─────────────┐
+// │     Location     │ ──────▷ │   Mapping   │
+// └──────────────────┘         └─────────────┘
+//   │
+//   │ 1-n
+//   ▼
+// ┌──────────────────┐
+// │       Line       │
+// └──────────────────┘
+//   │
+//   │ n-1
+//   ▽
+// ┌──────────────────┐
+// │     Function     │
+// └──────────────────┘
+//
+
+// ProfilesDictionary contains all the dictionary tables that are shared
+// across the entire ProfilesData message.
+//
+// The following applies to all fields in this message:
+//
+// - A dictionary is an array of dictionary items. Users of the dictionary
+//   compactly reference the items using the index within the array.
+//
+// - The element at index 0 MUST be the zero value for the dictionary's element
+//   type (e.g. `""` for `string_table`, `Location{}` for `location_table`). This
+//   allows for _index fields pointing into the dictionary to use a 0 pointer
+//   value to indicate 'null' / 'not set'. Unless otherwise defined, a 'zero
+//   value' message value is one with all default field values, so as to
+//   minimize wire encoded size.
+//
+// - There SHOULD NOT be duplicate items in a dictionary. The identity of a
+//   dictionary item is based on its value, recursively as needed. If a particular
+//   implementation does emit duplicate items, it MUST NOT attempt to give them
+//   meaning based on the index or order. A profile processor MAY remove
+//   duplicates and this MUST NOT have any observable effects for consumers.
+//
+// - There SHOULD NOT be orphaned (unreferenced) items in a dictionary. A
+//   profile processor MAY remove ("garbage-collect") orphaned items and this
+//   MUST NOT have any observable effects for consumers.
+//
+// Status: [Alpha]
+message ProfilesDictionary {
+  // Mappings from address ranges to the image/binary/library mapped
+  // into that address range referenced by locations via Location.mapping_index.
+  //
+  // mapping_table[0] MUST be the zero value (Mapping{}) and present.
+  repeated Mapping mapping_table = 1;
+
+  // Locations referenced by samples via Stack.location_indices.
+  //
+  // location_table[0] MUST be the zero value (Location{}) and present.
+  repeated Location location_table = 2;
+
+  // Functions referenced by locations via Line.function_index.
+  //
+  // function_table[0] MUST be the zero value (Function{}) and present.
+  repeated Function function_table = 3;
+
+  // Links referenced by samples via Sample.link_index.
+  //
+  // link_table[0] MUST be the zero value (Link{}) and present.
+  // Note that whilst Link{trace_id=array[0], span_id=array[0]} and
+  // Link{trace_id=array[16], span_id=array[8]} filled with zero-value bytes
+  // are both appropriate zero/invalid values per the trace.proto:Span definition,
+  // the latter SHOULD be used for link_table[0] for better compatibility with codecs
+  // strictly expecting 16/8 byte array lengths.
+  repeated Link link_table = 4;
+
+  // A common table for strings referenced by various messages.
+  //
+  // string_table[0] MUST be "" and present.
+  repeated string string_table = 5;
+
+  // A common table for attributes referenced by the Profile, Sample, Mapping
+  // and Location messages, through their attribute_indices field. Each entry is
+  // a key/value pair with an optional unit in UCUM format. Since this is a
+  // dictionary table, multiple entries with the same key MAY be present,
+  // unlike direct attribute tables like Resource.attributes.
+  // However, the referencing attribute_indices fields MUST maintain the key
+  // uniqueness requirement.
+  //
+  // It's recommended to use attributes for variables with bounded cardinality,
+  // such as categorical variables
+  // (https://en.wikipedia.org/wiki/Categorical_variable). Using an attribute of
+  // a floating point type (e.g., CPU time) in a sample can quickly make every
+  // attribute value unique, defeating the purpose of the dictionary and
+  // impractically increasing the profile size.
+  //
+  // Examples of attributes:
+  //     "/http/user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36"
+  //     "abc.com/myattribute": true
+  //     "allocation_size": 128 bytes
+  //
+  // attribute_table[0] MUST be the zero value (KeyValueAndUnit{}) and present.
+  repeated KeyValueAndUnit attribute_table = 6;
+
+  // Stacks referenced by samples via Sample.stack_index.
+  //
+  // stack_table[0] MUST be the zero value (Stack{}) and present.
+  repeated Stack stack_table = 7;
+}
+
+// ProfilesData represents the profiles data that can be stored in persistent storage,
+// OR can be embedded by other protocols that transfer OTLP profiles data but do not
+// implement the OTLP protocol.
+//
+// The main difference between this message and collector protocol is that
+// in this message there will not be any "control" or "metadata" specific to
+// OTLP protocol.
+//
+// When new fields are added into this message, the OTLP request MUST be updated
+// as well.
+//
+// Status: [Alpha]
+message ProfilesData {
+  // An array of ResourceProfiles.
+  // For data coming from an SDK profiler, this array will typically contain one
+  // element. Host-level profilers will usually create one ResourceProfile per
+  // container, as well as one additional ResourceProfile grouping all samples
+  // from non-containerized processes.
+  // Other resource groupings are possible as well and clarified via
+  // Resource.attributes and semantic conventions.
+  // Tools that visualize profiles SHOULD prefer displaying
+  // resources_profiles[0].scope_profiles[0].profiles[0] by default.
+  repeated ResourceProfiles resource_profiles = 1;
+
+  // A single instance of ProfilesDictionary shared across the entire message.
+  ProfilesDictionary dictionary = 2;
+}
+
+
+// A collection of ScopeProfiles from a Resource.
+//
+// Status: [Alpha]
+message ResourceProfiles {
+  reserved 1000;
+
+  // The resource for the profiles in this message.
+  // If this field is not set then no resource info is known.
+  opentelemetry.proto.resource.v1.Resource resource = 1;
+
+  // A list of ScopeProfiles that originate from this resource.
+  repeated ScopeProfiles scope_profiles = 2;
+
+  // The Schema URL, if known. This is the identifier of the Schema that the resource data
+  // is recorded in. Notably, the last part of the URL path is the version number of the
+  // schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
+  // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
+  // This schema_url applies to the data in the "resource" field. It does not apply
+  // to the data in the "scope_profiles" field, which has its own schema_url field.
+  string schema_url = 3;
+}
+
+// A collection of Profiles produced by an InstrumentationScope.
+//
+// Status: [Alpha]
+message ScopeProfiles {
+  // The instrumentation scope information for the profiles in this message.
+  // Semantically when InstrumentationScope isn't set, it is equivalent with
+  // an empty instrumentation scope name (unknown).
+  opentelemetry.proto.common.v1.InstrumentationScope scope = 1;
+
+  // A list of Profiles that originate from this instrumentation scope.
+  repeated Profile profiles = 2;
+
+  // The Schema URL, if known. This is the identifier of the Schema that the profile data
+  // is recorded in. Notably, the last part of the URL path is the version number of the
+  // schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
+  // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
+  // This schema_url applies to the data in the "scope" field and all profiles in the
+  // "profiles" field.
+  string schema_url = 3;
+}
+
+// Profile is a common stacktrace profile format.
+//
+// Measurements represented with this format should follow the
+// following conventions:
+//
+// - Consumers SHOULD treat unset optional fields as if they had been
+//   set with their default value. We discourage using the protobuf
+//   presence semantics, even if available in the protobuf generated API.
+//
+// - When possible, measurements SHOULD be stored in "unsampled" form
+//   that is most useful to humans. There should be enough
+//   information present to determine the original sampled values.
+//
+// - The profile is represented as a set of samples, where each sample
+//   references a stack trace which is a list of locations, each belonging
+//   to a mapping.
+//
+// - There is a N->1 relationship from Stack.location_indices entries to
+//   locations. For every Stack.location_indices entry there MUST be a
+//   unique Location with that index.
+//
+// - There is an optional N->1 relationship from locations to
+//   mappings. For every nonzero Location.mapping_id there MUST be a
+//   unique Mapping with that index.
+
+// Represents a complete profile, including sample types, samples, mappings to
+// binaries, stacks, locations, functions, string table, and additional
+// metadata. It modifies and annotates pprof Profile with OpenTelemetry
+// specific fields.
+//
+// Status: [Alpha]
+message Profile {
+  // The type and unit of all Sample.values in this profile.
+  // For a cpu or off-cpu profile this might be:
+  //   ["cpu","nanoseconds"] or ["off_cpu","nanoseconds"]
+  // For a heap profile, this might be:
+  //   ["allocated_objects","count"] or ["allocated_space","bytes"],
+  ValueType sample_type = 1;
+  // The set of samples recorded in this profile.
+  repeated Sample samples = 2;
+
+  // The following fields 3-12 are informational, do not affect
+  // interpretation of results.
+
+  // Time of collection (UTC) as nanoseconds since the UNIX epoch.
+  fixed64 time_unix_nano = 3;
+  // Duration of the profile in nanoseconds. For instant profiles like
+  // live heap snapshot, the duration can be zero but it may be preferable
+  // to set time_unix_nano to the process start time and duration_nano to
+  // the relative time when the profile was gathered so that Sample.timestamps_unix_nano
+  // values fall within the profile time range.
+  uint64 duration_nano = 4;
+  // The type and the unit of the events between sampled occurrences for
+  // periodic sampling profiles. It can be the same as sample_type or it can be
+  // different depending on the case, for example:
+  // - sample_type=(cpu, milliseconds), period_type=(cpu, milliseconds),
+  //   period=10 signals that we sample the program every 10 milliseconds and
+  //   capture samples that each represent that sampling distance.
+  // - sample_type=(off_cpu, nanoseconds), period_type=(context_switch, count),
+  //   period=1000 describes a profile where sampling is done every so often in
+  //   terms of context switches, but the recorded metric is the time spent by
+  //   the thread off CPU.
+  // - sample_type=(inuse_space, bytes), period_type=(allocated_bytes, bytes),
+  //   period=262144 might represent a heap profile where the recorded sample
+  //   metric is the size of the live heap while the periodic sampling is done
+  //   using the number of cumulatively allocated bytes.
+  ValueType period_type = 5;
+  // The distance between sampled occurrences for periodic sampling profiles.
+  // The value is of the period_type type and unit.
+  int64 period = 6;
+
+  // A globally unique identifier for a profile. The ID is a 16-byte array. An ID with
+  // all zeroes is considered invalid. It MAY be used for deduplication and signal
+  // correlation purposes. It is acceptable to treat two profiles with different values
+  // in this field as not equal, even if they represented the same object at an earlier
+  // time.
+  // This field is optional; an ID may be assigned to an ID-less profile in a later step.
+  bytes profile_id = 7;
+
+  // The number of attributes that were discarded. Attributes
+  // can be discarded because their keys are too long or because there are too many
+  // attributes. If this value is 0, then no attributes were dropped.
+  uint32 dropped_attributes_count = 8;
+
+  // The original payload format. See also original_payload. It MUST be set
+  // together with original_payload or both left unset [optional].
+  //
+  // The allowed values for the format string are defined by the OpenTelemetry
+  // specification. Some examples are "jfr", "pprof", "linux_perf".
+  //
+  // The original_payload MAY be used when converting from a source format (e.g. JFR)
+  // that carries information which cannot be losslessly represented in the
+  // Profiles format. Including the original data allows receivers to store or
+  // reexport the data without loss. Because the original payload can be large,
+  // its inclusion is optional.
+  string original_payload_format = 9;
+  // The original payload bytes. See also original_payload_format. It MUST be set
+  // together with original_payload_format or both left unset [optional].
+  bytes original_payload = 10;
+
+  // References to attributes in attribute_table. [optional]
+  repeated int32 attribute_indices = 11;
+}
+
+// A pointer from a profile Sample to a trace Span.
+// Connects a profile sample to a trace span, identified by unique trace and span IDs.
+//
+// Status: [Alpha]
+message Link {
+  // A unique identifier of the trace that this linked span is part of. The ID is a
+  // 16-byte array.
+  bytes trace_id = 1;
+
+  // A unique identifier for the linked span. The ID is an 8-byte array.
+  bytes span_id = 2;
+}
+
+// ValueType describes the type and units of a value.
+//
+// Status: [Alpha]
+message ValueType {
+  // Index into ProfilesDictionary.string_table.
+  int32 type_strindex = 1;
+
+  // Index into ProfilesDictionary.string_table.
+  int32 unit_strindex = 2;
+}
+
+// Each Sample records values encountered in some program context. The program
+// context is typically a stack trace, perhaps augmented with auxiliary
+// information like the thread-id, some indicator of a higher level request
+// being handled etc.
+//
+// A Sample MUST have have at least one entry in values or timestamps_unix_nano.
+// If both fields are populated, they MUST contain the same number of elements,
+// and the elements at the same index MUST refer to the same event.
+//
+// For the purposes of efficiently representing aggregated data observations, a Sample is regarded
+// as having a shared identity and an associated collection of per-observation data points.
+// A Sample's identity (i.e. primary key) is the tuple of {stack_index, set_of(attribute_indices), link_index}.
+// Samples having the same identity SHOULD be combined by appending timestamps and values to the data arrays.
+//
+// Examples of different ways ('shapes') of representing a sample with the total value of 10:
+//
+// Timestamps only (consumers must assume the value is 1 for each timestamp):
+//    values: []
+//    timestamps_unix_nano: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+//
+// Single aggregated value without timestamps (one element representing the total):
+//    values: [10]
+//    timestamps_unix_nano: []
+//
+// Per-timestamp value (each point in time records a specific value):
+//    values: [2, 2, 3, 3]
+//    timestamps_unix_nano: [1, 2, 3, 4]
+//
+// All Samples for a Profile SHOULD have the same shape, i.e. all data observation series should consistently
+// adopt the same data recording style.
+//
+// Status: [Alpha]
+message Sample {
+  // Reference to stack in ProfilesDictionary.stack_table.
+  int32 stack_index = 1;
+  // References to attributes in ProfilesDictionary.attribute_table. [optional]
+  repeated int32 attribute_indices = 2;
+  // Reference to link in ProfilesDictionary.link_table. [optional]
+  // 0 means no link exists.
+  int32 link_index = 3;
+
+  // The following fields may contain per-observation data and do not form part of the Sample's identity.
+
+  // Measured values. The type and unit of each value is defined by Profile.sample_type.
+  repeated int64 values = 4;
+  // Timestamps (UTC) as nanoseconds since the UNIX epoch. The timestamps SHOULD fall within the
+  // [Profile.time_unix_nano, Profile.time_unix_nano + Profile.duration_nano) interval.
+  repeated fixed64 timestamps_unix_nano = 5;
+}
+
+// Describes the mapping of a binary in memory, including its address range,
+// file offset, and metadata like build ID
+//
+// Status: [Alpha]
+message Mapping {
+  // Address at which the binary (or DLL) is loaded into memory.
+  uint64 memory_start = 1;
+  // The limit of the address range occupied by this mapping.
+  uint64 memory_limit = 2;
+  // Offset in the binary that corresponds to the first mapped address.
+  uint64 file_offset = 3;
+  // The object this entry is loaded from.  This can be a filename on
+  // disk for the main binary and shared libraries, or a virtual
+  // abstraction like "[vdso]".
+  int32 filename_strindex = 4;  // Index into ProfilesDictionary.string_table.
+  // References to attributes in ProfilesDictionary.attribute_table. [optional]
+  repeated int32 attribute_indices = 5;
+}
+
+// A Stack represents a stack trace as a list of locations (leaf first).
+// For example, the stack trace resulting from the call stack
+// main -> foo -> bar would be encoded into the location_indices list
+// [2, 1, 0] which references the locations in location_table as:
+// [Location{"main"}, Location{"foo"}, Location{"bar"}].
+//
+// Status: [Alpha]
+message Stack {
+  // References to locations in ProfilesDictionary.location_table.
+  // The first location is the leaf frame.
+  repeated int32 location_indices = 1;
+}
+
+// Contains function and line table debug information for a single frame.
+//
+// Status: [Alpha]
+message Location {
+  // Reference to mapping in ProfilesDictionary.mapping_table.
+  // 0 means unknown or not applicable.
+  int32 mapping_index = 1;
+  // The instruction address for this location, if available.  It
+  // SHOULD be within [Mapping.memory_start, Mapping.memory_limit]
+  // for the corresponding mapping. A non-leaf address may be in the
+  // middle of a call instruction. It is up to display tools to find
+  // the beginning of the instruction if necessary.
+  uint64 address = 2;
+  // Multiple lines indicate this location has inlined functions,
+  // where the last entry represents the caller into which the
+  // preceding entries were inlined.
+  //
+  // E.g., if memcpy() is inlined into printf:
+  //    lines[0].function_name == "memcpy"
+  //    lines[1].function_name == "printf"
+  repeated Line lines = 3;
+  // References to attributes in ProfilesDictionary.attribute_table. [optional]
+  repeated int32 attribute_indices = 4;
+}
+
+// Details a specific line in a source code, linked to a function.
+//
+// Status: [Alpha]
+message Line {
+  // Reference to function in ProfilesDictionary.function_table.
+  int32 function_index = 1;
+  // Line number in source code. 1-based, 0 means unset.
+  int64 line = 2;
+  // Column number in source code. 1-based, 0 means unset.
+  int64 column = 3;
+}
+
+// Describes a function, including its human-readable name, system name,
+// source file, and starting line number in the source.  At least one of
+// {name_strindex, system_name_strindex, filename_strindex} MUST be present.
+//
+// Status: [Alpha]
+message Function {
+  // The function name. Empty string if not available.
+  int32 name_strindex = 1;
+  // Function name, as identified by the system. For instance,
+  // it can be a C++ mangled name. Empty string if not available.
+  int32 system_name_strindex = 2;
+  // Source file containing the function. Empty string if not available.
+  int32 filename_strindex = 3;
+  // Line number in source file. 1-based, 0 means unset.
+  int64 start_line = 4;
+}
+
+// A custom 'dictionary native' style of encoding attributes which is more convenient
+// for profiles than opentelemetry.proto.common.v1.KeyValue
+// Specifically, uses the ProfilesDictionary.string_table for keys
+// and allows optional unit information.
+//
+// Status: [Alpha]
+message KeyValueAndUnit {
+  // The index into the string table for the attribute's key.
+  int32 key_strindex  = 1;
+  // The value of the attribute.
+  opentelemetry.proto.common.v1.AnyValue value = 2;
+  // The index into the string table for the attribute's unit.
+  // zero indicates implicit (by semconv) or non-defined unit.
+  // If present, the unit string SHOULD be in UCUM format.
+  int32 unit_strindex = 3;
+}

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/proto/opentelemetry/proto/resource/v1/resource.proto
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/main/proto/opentelemetry/proto/resource/v1/resource.proto
@@ -1,0 +1,45 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package opentelemetry.proto.resource.v1;
+
+import "opentelemetry/proto/common/v1/common.proto";
+
+option csharp_namespace = "OpenTelemetry.Proto.Resource.V1";
+option java_multiple_files = true;
+option java_package = "io.opentelemetry.proto.resource.v1";
+option java_outer_classname = "ResourceProto";
+option go_package = "go.opentelemetry.io/proto/otlp/resource/v1";
+
+// Resource information.
+message Resource {
+  // Set of attributes that describe the resource.
+  // Attribute keys MUST be unique (it is not allowed to have more than one
+  // attribute with the same key).
+  // The behavior of software that receives duplicated keys can be unpredictable.
+  repeated opentelemetry.proto.common.v1.KeyValue attributes = 1;
+
+  // The number of dropped attributes. If the value is 0, then
+  // no attributes were dropped.
+  uint32 dropped_attributes_count = 2;
+
+  // Set of entities that participate in this Resource.
+  //
+  // Note: keys in the references MUST exist in attributes of this message.
+  //
+  // Status: [Development]
+  repeated opentelemetry.proto.common.v1.EntityRef entity_refs = 3;
+}

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/test/java/cafe/jeffrey/otlpparser/OtlpProfileReaderTest.java
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/test/java/cafe/jeffrey/otlpparser/OtlpProfileReaderTest.java
@@ -1,0 +1,269 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.otlpparser;
+
+import io.opentelemetry.proto.profiles.v1development.ProfilesData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import cafe.jeffrey.otlpparser.mapping.OtelSemconv;
+import cafe.jeffrey.provider.profile.api.Event;
+import cafe.jeffrey.provider.profile.api.EventStacktrace;
+import cafe.jeffrey.provider.profile.api.EventType;
+import cafe.jeffrey.shared.common.model.EventTypeName;
+import cafe.jeffrey.shared.common.model.StacktraceType;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OtlpProfileReaderTest {
+
+    private static final long BASE_TIME_NANOS = 1_752_000_000_000_000_000L;
+
+    @TempDir
+    Path tempDir;
+
+    private RecordingEventWriterStub writer;
+
+    @BeforeEach
+    void setUp() {
+        writer = new RecordingEventWriterStub();
+    }
+
+    private Path writeRecording(ProfilesData... frames) {
+        Path file = tempDir.resolve("recording.otlp");
+        OtlpTestFiles.writeFramed(file, List.of(frames));
+        return file;
+    }
+
+    /**
+     * Fixture: a cpu/nanoseconds profile with one sample referencing a stack of a JVM frame on top
+     * of a native frame, thread attributes and per-timestamp values.
+     */
+    private ProfilesData cpuFrame() {
+        OtlpTestFixtures fixtures = new OtlpTestFixtures();
+        fixtures.resourceAttribute(OtelSemconv.SERVICE_NAME, "checkout-service");
+
+        int jvmFrameType = fixtures.stringAttribute(OtelSemconv.PROFILE_FRAME_TYPE, "jvm");
+        int nativeFrameType = fixtures.stringAttribute(OtelSemconv.PROFILE_FRAME_TYPE, "native");
+
+        int libc = fixtures.mapping("/usr/lib/libc.so.6");
+        int jvmFunction = fixtures.function("com.example.Foo.doWork");
+        int nativeFunction = fixtures.function("__libc_start_main");
+
+        int jvmLocation = fixtures.location(0, jvmFunction, 42, jvmFrameType);
+        int nativeLocation = fixtures.location(libc, nativeFunction, 0, nativeFrameType);
+
+        // leaf-first: JVM frame is the leaf, native frame is the root
+        int stack = fixtures.stack(List.of(jvmLocation, nativeLocation));
+
+        int threadName = fixtures.stringAttribute(OtelSemconv.THREAD_NAME, "worker-1");
+        int threadId = fixtures.longAttribute(OtelSemconv.THREAD_ID, 77);
+
+        fixtures.profile(fixtures.profileBuilder("cpu", "nanoseconds", BASE_TIME_NANOS)
+                .addSamples(fixtures.sampleBuilder(stack)
+                        .addAttributeIndices(threadName)
+                        .addAttributeIndices(threadId)
+                        .addValues(10_000_000)
+                        .addValues(10_000_000)
+                        .addTimestampsUnixNano(BASE_TIME_NANOS)
+                        .addTimestampsUnixNano(BASE_TIME_NANOS + 10_000_000))
+                .build());
+        return fixtures.build();
+    }
+
+    @Nested
+    class CpuProfile {
+
+        @Test
+        void emitsOneEventPerTimestamp() {
+            new OtlpProfileReader(writer).read(writeRecording(cpuFrame()));
+
+            assertEquals(2, writer.events.size());
+            Event first = writer.events.getFirst();
+            assertEquals(EventTypeName.OTEL_CPU, first.eventType());
+            assertEquals(Instant.ofEpochSecond(0, BASE_TIME_NANOS), first.startTimestamp());
+            assertEquals(1, first.samples());
+            assertEquals(10_000_000L, first.weight());
+            assertNull(first.duration());
+        }
+
+        @Test
+        void followsAnnounceOnceProtocol() {
+            new OtlpProfileReader(writer).read(writeRecording(cpuFrame()));
+
+            assertEquals(1, writer.threadStarts);
+            assertEquals(1, writer.threadCompletions);
+            assertEquals(1, writer.threadsById.size());
+            assertEquals(1, writer.stacktracesById.size());
+
+            // both events reference the single announced thread/stacktrace
+            Event first = writer.events.get(0);
+            Event second = writer.events.get(1);
+            assertEquals(first.threadId(), second.threadId());
+            assertEquals(first.stacktraceId(), second.stacktraceId());
+        }
+
+        @Test
+        void mapsThreadFromSampleAttributes() {
+            new OtlpProfileReader(writer).read(writeRecording(cpuFrame()));
+
+            var thread = writer.threadsById.values().iterator().next();
+            assertEquals("worker-1", thread.name());
+            assertEquals(77L, thread.osId());
+        }
+
+        @Test
+        void reversesStackToRootFirstAndMapsFrameTypes() {
+            new OtlpProfileReader(writer).read(writeRecording(cpuFrame()));
+
+            EventStacktrace stacktrace = writer.stacktracesById.values().iterator().next();
+            assertEquals(StacktraceType.APPLICATION, stacktrace.type());
+            assertEquals(2, stacktrace.frames().size());
+
+            // root-first: the native root frame first, the JVM leaf frame last
+            var rootFrame = stacktrace.frames().getFirst();
+            assertEquals("libc.so.6", rootFrame.clazz());
+            assertEquals("__libc_start_main", rootFrame.method());
+            assertEquals("Native", rootFrame.type());
+
+            var leafFrame = stacktrace.frames().getLast();
+            assertEquals("com.example.Foo", leafFrame.clazz());
+            assertEquals("doWork", leafFrame.method());
+            assertEquals("JIT compiled", leafFrame.type());
+            assertEquals(42, leafFrame.line());
+        }
+
+        @Test
+        void emitsEventTypeWithOtelCategoriesAndSettings() {
+            new OtlpProfileReader(writer).read(writeRecording(cpuFrame()));
+
+            assertEquals(1, writer.eventTypes.size());
+            EventType eventType = writer.eventTypes.getFirst();
+            assertEquals(EventTypeName.OTEL_CPU, eventType.name());
+            assertTrue(eventType.categories().contains("OpenTelemetry"));
+
+            boolean serviceNameSetting = writer.settings.stream()
+                    .anyMatch(s -> s.eventType().equals(EventTypeName.OTEL_CPU)
+                            && s.name().equals(OtelSemconv.SERVICE_NAME)
+                            && s.value().equals("checkout-service"));
+            assertTrue(serviceNameSetting);
+        }
+    }
+
+    @Nested
+    class SampleShapes {
+
+        private ProfilesData shapeFrame(List<Long> values, List<Long> timestamps) {
+            OtlpTestFixtures fixtures = new OtlpTestFixtures();
+            int function = fixtures.function("com.example.Shape.run");
+            int location = fixtures.location(0, function, 1, 0);
+            int stack = fixtures.stack(List.of(location));
+
+            var sample = fixtures.sampleBuilder(stack);
+            values.forEach(sample::addValues);
+            timestamps.forEach(sample::addTimestampsUnixNano);
+
+            fixtures.profile(fixtures.profileBuilder("samples", "count", BASE_TIME_NANOS)
+                    .addSamples(sample)
+                    .build());
+            return fixtures.build();
+        }
+
+        @Test
+        void aggregateValueWithoutTimestampsBecomesSingleEvent() {
+            new OtlpProfileReader(writer).read(writeRecording(shapeFrame(List.of(25L), List.of())));
+
+            assertEquals(1, writer.events.size());
+            Event event = writer.events.getFirst();
+            assertEquals(25, event.samples());
+            assertNull(event.weight());
+            assertEquals(Instant.ofEpochSecond(0, BASE_TIME_NANOS), event.startTimestamp());
+        }
+
+        @Test
+        void timestampsOnlyShapeCountsOnePerTimestamp() {
+            new OtlpProfileReader(writer).read(writeRecording(
+                    shapeFrame(List.of(), List.of(BASE_TIME_NANOS, BASE_TIME_NANOS + 1, BASE_TIME_NANOS + 2))));
+
+            assertEquals(3, writer.events.size());
+            assertTrue(writer.events.stream().allMatch(e -> e.samples() == 1));
+        }
+
+        @Test
+        void cardinalityMismatchSpreadsTotalEvenly() {
+            new OtlpProfileReader(writer).read(writeRecording(
+                    shapeFrame(List.of(10L), List.of(BASE_TIME_NANOS, BASE_TIME_NANOS + 1, BASE_TIME_NANOS + 2))));
+
+            assertEquals(3, writer.events.size());
+            long total = writer.events.stream().mapToLong(Event::samples).sum();
+            assertEquals(10, total);
+        }
+    }
+
+    @Nested
+    class AllocationProfile {
+
+        @Test
+        void bytesUnitMapsToWeightWithEntity() {
+            OtlpTestFixtures fixtures = new OtlpTestFixtures();
+            int function = fixtures.function("com.example.Alloc.allocate");
+            int jvmFrameType = fixtures.stringAttribute(OtelSemconv.PROFILE_FRAME_TYPE, "jvm");
+            int location = fixtures.location(0, function, 10, jvmFrameType);
+            int stack = fixtures.stack(List.of(location));
+            int classAttr = fixtures.stringAttribute("class", "byte[]");
+
+            fixtures.profile(fixtures.profileBuilder("alloc", "bytes", BASE_TIME_NANOS)
+                    .addSamples(fixtures.sampleBuilder(stack)
+                            .addAttributeIndices(classAttr)
+                            .addValues(4096)
+                            .addTimestampsUnixNano(BASE_TIME_NANOS))
+                    .build());
+
+            new OtlpProfileReader(writer).read(writeRecording(fixtures.build()));
+
+            Event event = writer.events.getFirst();
+            assertEquals(EventTypeName.OTEL_ALLOC, event.eventType());
+            assertEquals(1, event.samples());
+            assertEquals(4096L, event.weight());
+            assertEquals("byte[]", event.weightEntity());
+            assertEquals("byte[]", event.fields().get("class").asString());
+        }
+    }
+
+    @Nested
+    class MultipleFrames {
+
+        @Test
+        void foldsAllFramesIntoTheSameEventTypes() {
+            new OtlpProfileReader(writer).read(writeRecording(cpuFrame(), cpuFrame()));
+
+            assertEquals(4, writer.events.size());
+            assertEquals(1, writer.eventTypes.size());
+            // thread dedup is content-based and survives across frames
+            assertEquals(1, writer.threadsById.size());
+        }
+    }
+}

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/test/java/cafe/jeffrey/otlpparser/OtlpRecordingInformationParserTest.java
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/test/java/cafe/jeffrey/otlpparser/OtlpRecordingInformationParserTest.java
@@ -1,0 +1,94 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.otlpparser;
+
+import io.opentelemetry.proto.profiles.v1development.ProfilesData;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import cafe.jeffrey.provider.profile.api.RecordingInformation;
+import cafe.jeffrey.shared.common.model.RecordingEventSource;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OtlpRecordingInformationParserTest {
+
+    private static final long BASE_TIME_NANOS = 1_752_000_000_000_000_000L;
+    private static final long DURATION_NANOS = 60_000_000_000L;
+
+    @TempDir
+    Path tempDir;
+
+    private final OtlpRecordingInformationParser parser = new OtlpRecordingInformationParser();
+
+    @Test
+    void derivesTimeRangeFromProfileTimesAndDurations() {
+        OtlpTestFixtures fixtures = new OtlpTestFixtures();
+        fixtures.profile(fixtures.profileBuilder("cpu", "nanoseconds", BASE_TIME_NANOS)
+                .setDurationNano(DURATION_NANOS)
+                .build());
+        fixtures.profile(fixtures.profileBuilder("alloc", "bytes", BASE_TIME_NANOS - 5_000_000_000L)
+                .build());
+
+        Path file = tempDir.resolve("recording.otlp");
+        OtlpTestFiles.writeFramed(file, List.of(fixtures.build()));
+
+        RecordingInformation information = parser.provide(file);
+
+        assertEquals(RecordingEventSource.OPEN_TELEMETRY, information.eventSource());
+        assertEquals(Instant.ofEpochSecond(0, BASE_TIME_NANOS - 5_000_000_000L), information.recordingStartedAt());
+        assertEquals(Instant.ofEpochSecond(0, BASE_TIME_NANOS + DURATION_NANOS), information.recordingFinishedAt());
+        assertTrue(information.sizeInBytes() > 0);
+    }
+
+    @Test
+    void includesSampleTimestampsInTheRange() {
+        OtlpTestFixtures fixtures = new OtlpTestFixtures();
+        int function = fixtures.function("com.example.Foo.run");
+        int location = fixtures.location(0, function, 1, 0);
+        int stack = fixtures.stack(List.of(location));
+
+        fixtures.profile(fixtures.profileBuilder("cpu", "nanoseconds", BASE_TIME_NANOS)
+                .addSamples(fixtures.sampleBuilder(stack)
+                        .addValues(1)
+                        .addTimestampsUnixNano(BASE_TIME_NANOS + 90_000_000_000L))
+                .build());
+
+        Path file = tempDir.resolve("recording.otlp");
+        OtlpTestFiles.writeFramed(file, List.of(fixtures.build()));
+
+        RecordingInformation information = parser.provide(file);
+
+        assertEquals(Instant.ofEpochSecond(0, BASE_TIME_NANOS), information.recordingStartedAt());
+        assertEquals(Instant.ofEpochSecond(0, BASE_TIME_NANOS + 90_000_000_000L), information.recordingFinishedAt());
+    }
+
+    @Test
+    void rejectsRecordingWithoutTimestamps() {
+        Path file = tempDir.resolve("empty.otlp");
+        OtlpTestFiles.writeFramed(file, List.of(ProfilesData.getDefaultInstance()));
+
+        assertThrows(IllegalArgumentException.class, () -> parser.provide(file));
+    }
+}

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/test/java/cafe/jeffrey/otlpparser/OtlpRecordingRoundTripTest.java
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/test/java/cafe/jeffrey/otlpparser/OtlpRecordingRoundTripTest.java
@@ -1,0 +1,155 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.otlpparser;
+
+import io.opentelemetry.proto.profiles.v1development.ProfilesData;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import cafe.jeffrey.otlpparser.mapping.OtelSemconv;
+import cafe.jeffrey.provider.profile.jdbc.DuckDBEventWriters;
+import cafe.jeffrey.provider.profile.jdbc.SQLEventWriter;
+import cafe.jeffrey.provider.profile.api.EventWriter;
+import cafe.jeffrey.shared.common.Schedulers;
+import cafe.jeffrey.shared.common.model.RecordingEventSource;
+import cafe.jeffrey.test.DuckDBTest;
+
+import javax.sql.DataSource;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end round trip of an OTLP recording through the real DuckDB event-writing pipeline:
+ * {@code .otlp} file → {@link OtlpRecordingEventParser} → {@code SQLEventWriter} → profile schema
+ * (events / event_types / stacktraces / frames / threads tables).
+ */
+@DuckDBTest(migration = "classpath:db/migration/profile")
+class OtlpRecordingRoundTripTest {
+
+    private static final long BASE_TIME_NANOS = 1_752_000_000_000_000_000L;
+    private static final int BATCH_SIZE = 100;
+
+    @TempDir
+    Path tempDir;
+
+    private ProfilesData cpuAndAllocFrame() {
+        OtlpTestFixtures fixtures = new OtlpTestFixtures();
+        fixtures.resourceAttribute(OtelSemconv.SERVICE_NAME, "checkout-service");
+
+        int jvmFrameType = fixtures.stringAttribute(OtelSemconv.PROFILE_FRAME_TYPE, "jvm");
+        int nativeFrameType = fixtures.stringAttribute(OtelSemconv.PROFILE_FRAME_TYPE, "native");
+
+        int libc = fixtures.mapping("/usr/lib/libc.so.6");
+        int jvmFunction = fixtures.function("com.example.Foo.doWork");
+        int nativeFunction = fixtures.function("__libc_start_main");
+
+        int jvmLocation = fixtures.location(0, jvmFunction, 42, jvmFrameType);
+        int nativeLocation = fixtures.location(libc, nativeFunction, 0, nativeFrameType);
+        int stack = fixtures.stack(List.of(jvmLocation, nativeLocation));
+
+        int threadName = fixtures.stringAttribute(OtelSemconv.THREAD_NAME, "worker-1");
+        int classAttr = fixtures.stringAttribute("class", "byte[]");
+
+        fixtures.profile(fixtures.profileBuilder("cpu", "nanoseconds", BASE_TIME_NANOS)
+                .addSamples(fixtures.sampleBuilder(stack)
+                        .addAttributeIndices(threadName)
+                        .addValues(10_000_000)
+                        .addValues(10_000_000)
+                        .addTimestampsUnixNano(BASE_TIME_NANOS)
+                        .addTimestampsUnixNano(BASE_TIME_NANOS + 10_000_000))
+                .build());
+
+        fixtures.profile(fixtures.profileBuilder("alloc", "bytes", BASE_TIME_NANOS)
+                .addSamples(fixtures.sampleBuilder(stack)
+                        .addAttributeIndices(threadName)
+                        .addAttributeIndices(classAttr)
+                        .addValues(4096)
+                        .addTimestampsUnixNano(BASE_TIME_NANOS + 5_000_000))
+                .build());
+
+        return fixtures.build();
+    }
+
+    @Test
+    void writesOtlpRecordingIntoProfileDatabase(DataSource dataSource) throws SQLException {
+        Path recording = tempDir.resolve("recording.otlp");
+        OtlpTestFiles.writeFramed(recording, List.of(cpuAndAllocFrame()));
+
+        Instant profilingStartedAt = Instant.ofEpochSecond(0, BASE_TIME_NANOS);
+        EventWriter eventWriter = new SQLEventWriter(
+                () -> new DuckDBEventWriters(Schedulers.sharedDbWriter(), dataSource, BATCH_SIZE, profilingStartedAt));
+
+        new OtlpRecordingEventParser().start(eventWriter, recording);
+        eventWriter.onComplete();
+
+        assertEquals(2, count(dataSource, "SELECT COUNT(*) FROM events WHERE event_type = 'otel.cpu'"));
+        assertEquals(1, count(dataSource, "SELECT COUNT(*) FROM events WHERE event_type = 'otel.alloc'"));
+
+        // relative timeline starts at zero for the first cpu event
+        assertEquals(0, count(dataSource,
+                "SELECT MIN(start_timestamp_from_beginning) FROM events WHERE event_type = 'otel.cpu'"));
+
+        // both event types resolve their source to OpenTelemetry (persisted as the source id)
+        String openTelemetrySourceId = String.valueOf(RecordingEventSource.OPEN_TELEMETRY.getId());
+        assertEquals(2, count(dataSource,
+                "SELECT COUNT(*) FROM event_types WHERE source = '" + openTelemetrySourceId + "'"));
+
+        // one deduplicated stacktrace with two frames, root-first native -> jvm
+        assertEquals(1, count(dataSource, "SELECT COUNT(*) FROM stacktraces"));
+        assertEquals(2, count(dataSource, "SELECT COUNT(*) FROM frames"));
+        assertEquals(1, count(dataSource, "SELECT COUNT(*) FROM threads WHERE name = 'worker-1'"));
+
+        assertEquals(1, count(dataSource,
+                "SELECT COUNT(*) FROM frames WHERE class_name = 'com.example.Foo' "
+                        + "AND method_name = 'doWork' AND frame_type = 'JIT compiled'"));
+        assertEquals(1, count(dataSource,
+                "SELECT COUNT(*) FROM frames WHERE class_name = 'libc.so.6' AND frame_type = 'Native'"));
+
+        // allocation weight and entity survived the round trip
+        assertEquals(4096, count(dataSource,
+                "SELECT weight FROM events WHERE event_type = 'otel.alloc'"));
+        assertTrue(queryString(dataSource,
+                "SELECT weight_entity FROM events WHERE event_type = 'otel.alloc'").contains("byte[]"));
+    }
+
+    private static long count(DataSource dataSource, String sql) throws SQLException {
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql);
+             ResultSet resultSet = statement.executeQuery()) {
+            resultSet.next();
+            return resultSet.getLong(1);
+        }
+    }
+
+    private static String queryString(DataSource dataSource, String sql) throws SQLException {
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql);
+             ResultSet resultSet = statement.executeQuery()) {
+            resultSet.next();
+            return resultSet.getString(1);
+        }
+    }
+}

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/test/java/cafe/jeffrey/otlpparser/OtlpStreamReaderTest.java
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/test/java/cafe/jeffrey/otlpparser/OtlpStreamReaderTest.java
@@ -1,0 +1,103 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.otlpparser;
+
+import io.opentelemetry.proto.profiles.v1development.ProfilesData;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class OtlpStreamReaderTest {
+
+    @TempDir
+    Path tempDir;
+
+    private final OtlpStreamReader reader = new OtlpStreamReader();
+
+    private static ProfilesData frameWithProfiles(int profileCount) {
+        OtlpTestFixtures fixtures = new OtlpTestFixtures();
+        for (int i = 0; i < profileCount; i++) {
+            fixtures.profile(fixtures.profileBuilder("cpu", "nanoseconds", 1_000_000 + i).build());
+        }
+        return fixtures.build();
+    }
+
+    @Test
+    void readsAllFramesOfFramedFile() {
+        Path file = tempDir.resolve("framed.otlp");
+        OtlpTestFiles.writeFramed(file, List.of(frameWithProfiles(1), frameWithProfiles(2), frameWithProfiles(3)));
+
+        List<ProfilesData> frames = new ArrayList<>();
+        reader.read(file, frames::add);
+
+        assertEquals(3, frames.size());
+        assertEquals(1, frames.get(0).getResourceProfiles(0).getScopeProfiles(0).getProfilesCount());
+        assertEquals(3, frames.get(2).getResourceProfiles(0).getScopeProfiles(0).getProfilesCount());
+    }
+
+    @Test
+    void readsRawFileAsSingleFrame() {
+        Path file = tempDir.resolve("raw.otlp");
+        OtlpTestFiles.writeRaw(file, frameWithProfiles(2));
+
+        List<ProfilesData> frames = new ArrayList<>();
+        reader.read(file, frames::add);
+
+        assertEquals(1, frames.size());
+        assertEquals(2, frames.getFirst().getResourceProfiles(0).getScopeProfiles(0).getProfilesCount());
+    }
+
+    @Test
+    void rejectsUnsupportedFormatVersion() {
+        Path file = tempDir.resolve("future.otlp");
+        OtlpTestFiles.writeFramed(file, List.of(frameWithProfiles(1)), OtlpFileFormat.VERSION + 1);
+
+        assertThrows(IllegalArgumentException.class, () -> reader.read(file, _ -> {
+        }));
+    }
+
+    @Test
+    void failsOnTruncatedFrame() {
+        Path file = tempDir.resolve("truncated.otlp");
+        OtlpTestFiles.writeFramed(file, List.of(frameWithProfiles(1)));
+        truncate(file);
+
+        assertThrows(UncheckedIOException.class, () -> reader.read(file, _ -> {
+        }));
+    }
+
+    private static void truncate(Path file) {
+        try {
+            byte[] content = Files.readAllBytes(file);
+            Files.write(file, Arrays.copyOf(content, content.length - 3));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/test/java/cafe/jeffrey/otlpparser/OtlpTestFiles.java
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/test/java/cafe/jeffrey/otlpparser/OtlpTestFiles.java
@@ -1,0 +1,64 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.otlpparser;
+
+import io.opentelemetry.proto.profiles.v1development.ProfilesData;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Writes {@code .otlp} test files in both variants of Jeffrey's file convention.
+ */
+public final class OtlpTestFiles {
+
+    private OtlpTestFiles() {
+    }
+
+    public static void writeFramed(Path file, List<ProfilesData> frames) {
+        writeFramed(file, frames, OtlpFileFormat.VERSION);
+    }
+
+    public static void writeFramed(Path file, List<ProfilesData> frames, int version) {
+        try (OutputStream output = Files.newOutputStream(file)) {
+            output.write(OtlpFileFormat.MAGIC);
+            output.write(version & 0xFF);
+            output.write((version >> 8) & 0xFF);
+            output.write((version >> 16) & 0xFF);
+            output.write((version >> 24) & 0xFF);
+            for (ProfilesData frame : frames) {
+                frame.writeDelimitedTo(output);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public static void writeRaw(Path file, ProfilesData data) {
+        try (OutputStream output = Files.newOutputStream(file)) {
+            data.writeTo(output);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/test/java/cafe/jeffrey/otlpparser/OtlpTestFixtures.java
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/test/java/cafe/jeffrey/otlpparser/OtlpTestFixtures.java
@@ -1,0 +1,191 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.otlpparser;
+
+import com.google.protobuf.ByteString;
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.profiles.v1development.Function;
+import io.opentelemetry.proto.profiles.v1development.KeyValueAndUnit;
+import io.opentelemetry.proto.profiles.v1development.Line;
+import io.opentelemetry.proto.profiles.v1development.Link;
+import io.opentelemetry.proto.profiles.v1development.Location;
+import io.opentelemetry.proto.profiles.v1development.Mapping;
+import io.opentelemetry.proto.profiles.v1development.Profile;
+import io.opentelemetry.proto.profiles.v1development.ProfilesData;
+import io.opentelemetry.proto.profiles.v1development.ProfilesDictionary;
+import io.opentelemetry.proto.profiles.v1development.ResourceProfiles;
+import io.opentelemetry.proto.profiles.v1development.Sample;
+import io.opentelemetry.proto.profiles.v1development.ScopeProfiles;
+import io.opentelemetry.proto.profiles.v1development.Stack;
+import io.opentelemetry.proto.profiles.v1development.ValueType;
+import io.opentelemetry.proto.resource.v1.Resource;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Programmatic builder of OTLP {@code ProfilesData} messages for tests. Maintains the dictionary
+ * tables with the mandatory zero-value element at index 0 and deduplicates strings by value.
+ */
+public class OtlpTestFixtures {
+
+    private final Map<String, Integer> stringIndices = new LinkedHashMap<>();
+    private final List<String> stringTable = new ArrayList<>();
+    private final List<Mapping> mappingTable = new ArrayList<>();
+    private final List<Location> locationTable = new ArrayList<>();
+    private final List<Function> functionTable = new ArrayList<>();
+    private final List<Link> linkTable = new ArrayList<>();
+    private final List<KeyValueAndUnit> attributeTable = new ArrayList<>();
+    private final List<Stack> stackTable = new ArrayList<>();
+
+    private final List<Profile> profiles = new ArrayList<>();
+    private final List<KeyValue> resourceAttributes = new ArrayList<>();
+
+    public OtlpTestFixtures() {
+        // index 0 of every dictionary table must be the zero value
+        stringTable.add("");
+        stringIndices.put("", 0);
+        mappingTable.add(Mapping.getDefaultInstance());
+        locationTable.add(Location.getDefaultInstance());
+        functionTable.add(Function.getDefaultInstance());
+        linkTable.add(Link.getDefaultInstance());
+        attributeTable.add(KeyValueAndUnit.getDefaultInstance());
+        stackTable.add(Stack.getDefaultInstance());
+    }
+
+    public int string(String value) {
+        return stringIndices.computeIfAbsent(value, v -> {
+            stringTable.add(v);
+            return stringTable.size() - 1;
+        });
+    }
+
+    public int mapping(String filename) {
+        mappingTable.add(Mapping.newBuilder()
+                .setFilenameStrindex(string(filename))
+                .build());
+        return mappingTable.size() - 1;
+    }
+
+    public int function(String name) {
+        functionTable.add(Function.newBuilder()
+                .setNameStrindex(string(name))
+                .build());
+        return functionTable.size() - 1;
+    }
+
+    public int stringAttribute(String key, String value) {
+        attributeTable.add(KeyValueAndUnit.newBuilder()
+                .setKeyStrindex(string(key))
+                .setValue(AnyValue.newBuilder().setStringValue(value))
+                .build());
+        return attributeTable.size() - 1;
+    }
+
+    public int longAttribute(String key, long value) {
+        attributeTable.add(KeyValueAndUnit.newBuilder()
+                .setKeyStrindex(string(key))
+                .setValue(AnyValue.newBuilder().setIntValue(value))
+                .build());
+        return attributeTable.size() - 1;
+    }
+
+    /**
+     * Adds a location with a single line referencing the given function; {@code frameTypeAttrIndex}
+     * may be {@code 0} to omit the {@code profile.frame.type} attribute.
+     */
+    public int location(int mappingIndex, int functionIndex, long lineNumber, int frameTypeAttrIndex) {
+        Location.Builder location = Location.newBuilder()
+                .setMappingIndex(mappingIndex)
+                .addLines(Line.newBuilder().setFunctionIndex(functionIndex).setLine(lineNumber));
+        if (frameTypeAttrIndex > 0) {
+            location.addAttributeIndices(frameTypeAttrIndex);
+        }
+        locationTable.add(location.build());
+        return locationTable.size() - 1;
+    }
+
+    public int addLocation(Location location) {
+        locationTable.add(location);
+        return locationTable.size() - 1;
+    }
+
+    /**
+     * @param locationIndices leaf-first location indices, per the OTLP convention
+     */
+    public int stack(List<Integer> locationIndices) {
+        stackTable.add(Stack.newBuilder().addAllLocationIndices(locationIndices).build());
+        return stackTable.size() - 1;
+    }
+
+    public int link(byte[] traceId, byte[] spanId) {
+        linkTable.add(Link.newBuilder()
+                .setTraceId(ByteString.copyFrom(traceId))
+                .setSpanId(ByteString.copyFrom(spanId))
+                .build());
+        return linkTable.size() - 1;
+    }
+
+    public void resourceAttribute(String key, String value) {
+        resourceAttributes.add(KeyValue.newBuilder()
+                .setKey(key)
+                .setValue(AnyValue.newBuilder().setStringValue(value))
+                .build());
+    }
+
+    public void profile(Profile profile) {
+        profiles.add(profile);
+    }
+
+    public Profile.Builder profileBuilder(String sampleType, String sampleUnit, long timeUnixNano) {
+        return Profile.newBuilder()
+                .setSampleType(ValueType.newBuilder()
+                        .setTypeStrindex(string(sampleType))
+                        .setUnitStrindex(string(sampleUnit)))
+                .setTimeUnixNano(timeUnixNano);
+    }
+
+    public Sample.Builder sampleBuilder(int stackIndex) {
+        return Sample.newBuilder().setStackIndex(stackIndex);
+    }
+
+    public ProfilesDictionary buildDictionary() {
+        return ProfilesDictionary.newBuilder()
+                .addAllStringTable(stringTable)
+                .addAllMappingTable(mappingTable)
+                .addAllLocationTable(locationTable)
+                .addAllFunctionTable(functionTable)
+                .addAllLinkTable(linkTable)
+                .addAllAttributeTable(attributeTable)
+                .addAllStackTable(stackTable)
+                .build();
+    }
+
+    public ProfilesData build() {
+        return ProfilesData.newBuilder()
+                .setDictionary(buildDictionary())
+                .addResourceProfiles(ResourceProfiles.newBuilder()
+                        .setResource(Resource.newBuilder().addAllAttributes(resourceAttributes))
+                        .addScopeProfiles(ScopeProfiles.newBuilder().addAllProfiles(profiles)))
+                .build();
+    }
+}

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/test/java/cafe/jeffrey/otlpparser/RecordingEventWriterStub.java
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/test/java/cafe/jeffrey/otlpparser/RecordingEventWriterStub.java
@@ -1,0 +1,87 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.otlpparser;
+
+import cafe.jeffrey.provider.profile.api.Event;
+import cafe.jeffrey.provider.profile.api.EventSetting;
+import cafe.jeffrey.provider.profile.api.EventStacktrace;
+import cafe.jeffrey.provider.profile.api.EventThread;
+import cafe.jeffrey.provider.profile.api.EventType;
+import cafe.jeffrey.provider.profile.api.SingleThreadedEventWriter;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Recording {@link SingleThreadedEventWriter} capturing the emission protocol for assertions.
+ */
+public class RecordingEventWriterStub implements SingleThreadedEventWriter {
+
+    public final List<Event> events = new ArrayList<>();
+    public final List<EventSetting> settings = new ArrayList<>();
+    public final List<EventType> eventTypes = new ArrayList<>();
+    public final Map<Long, EventStacktrace> stacktracesById = new LinkedHashMap<>();
+    public final Map<Long, EventThread> threadsById = new LinkedHashMap<>();
+    public int threadStarts;
+    public int threadCompletions;
+
+    private long nextStacktraceId = 100;
+    private long nextThreadId = 1;
+
+    @Override
+    public void onThreadStart() {
+        threadStarts++;
+    }
+
+    @Override
+    public void onEvent(Event event) {
+        events.add(event);
+    }
+
+    @Override
+    public void onEventSetting(EventSetting setting) {
+        settings.add(setting);
+    }
+
+    @Override
+    public void onEventType(EventType eventType) {
+        eventTypes.add(eventType);
+    }
+
+    @Override
+    public long onEventStacktrace(EventStacktrace stacktrace) {
+        long id = nextStacktraceId++;
+        stacktracesById.put(id, stacktrace);
+        return id;
+    }
+
+    @Override
+    public long onEventThread(EventThread thread) {
+        long id = nextThreadId++;
+        threadsById.put(id, thread);
+        return id;
+    }
+
+    @Override
+    public void onThreadComplete() {
+        threadCompletions++;
+    }
+}

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/test/java/cafe/jeffrey/otlpparser/mapping/FunctionNameSplitterTest.java
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/test/java/cafe/jeffrey/otlpparser/mapping/FunctionNameSplitterTest.java
@@ -1,0 +1,70 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.otlpparser.mapping;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import cafe.jeffrey.otlpparser.mapping.FunctionNameSplitter.SplitName;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FunctionNameSplitterTest {
+
+    @Nested
+    class JvmNames {
+
+        @Test
+        void splitsClassAndMethod() {
+            SplitName split = FunctionNameSplitter.split("com.example.Foo.doWork");
+            assertEquals("com.example.Foo", split.clazz());
+            assertEquals("doWork", split.method());
+        }
+
+        @Test
+        void stripsMethodSignature() {
+            SplitName split = FunctionNameSplitter.split("com.example.Foo.doWork(Ljava/lang/String;)V");
+            assertEquals("com.example.Foo", split.clazz());
+            assertEquals("doWork", split.method());
+        }
+
+        @Test
+        void keepsInnerClassInClassPart() {
+            SplitName split = FunctionNameSplitter.split("com.example.Foo$Bar.call");
+            assertEquals("com.example.Foo$Bar", split.clazz());
+            assertEquals("call", split.method());
+        }
+    }
+
+    @Nested
+    class EdgeCases {
+
+        @Test
+        void nameWithoutDotBecomesMethodOnly() {
+            SplitName split = FunctionNameSplitter.split("main");
+            assertEquals("", split.clazz());
+            assertEquals("main", split.method());
+        }
+
+        @Test
+        void nullAndBlankProduceEmptyParts() {
+            assertEquals(new SplitName("", ""), FunctionNameSplitter.split(null));
+            assertEquals(new SplitName("", ""), FunctionNameSplitter.split("  "));
+        }
+    }
+}

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/test/java/cafe/jeffrey/otlpparser/mapping/OtelEventTypeNamingTest.java
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/test/java/cafe/jeffrey/otlpparser/mapping/OtelEventTypeNamingTest.java
@@ -1,0 +1,81 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.otlpparser.mapping;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import cafe.jeffrey.otlpparser.mapping.OtelEventTypeNaming.OtelEventType;
+import cafe.jeffrey.shared.common.model.EventTypeName;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OtelEventTypeNamingTest {
+
+    @Nested
+    class WellKnownTypes {
+
+        @Test
+        void asyncProfilerSampleTypes() {
+            assertEquals(EventTypeName.OTEL_CPU, OtelEventTypeNaming.resolve("cpu", "nanoseconds").name());
+            assertEquals(EventTypeName.OTEL_WALL, OtelEventTypeNaming.resolve("wall", "nanoseconds").name());
+            assertEquals(EventTypeName.OTEL_ALLOC, OtelEventTypeNaming.resolve("alloc", "bytes").name());
+            assertEquals(EventTypeName.OTEL_LOCK, OtelEventTypeNaming.resolve("lock", "nanoseconds").name());
+        }
+
+        @Test
+        void ebpfProfilerSampleTypes() {
+            assertEquals(EventTypeName.OTEL_SAMPLES, OtelEventTypeNaming.resolve("samples", "count").name());
+        }
+
+        @Test
+        void pprofHeapAliases() {
+            assertEquals(EventTypeName.OTEL_ALLOC, OtelEventTypeNaming.resolve("alloc_space", "bytes").name());
+            assertEquals(EventTypeName.OTEL_ALLOC, OtelEventTypeNaming.resolve("allocated_objects", "count").name());
+        }
+
+        @Test
+        void matchingIsCaseInsensitive() {
+            assertEquals(EventTypeName.OTEL_CPU, OtelEventTypeNaming.resolve("CPU", "nanoseconds").name());
+        }
+
+        @Test
+        void blankTypeFallsBackToSamples() {
+            assertEquals(EventTypeName.OTEL_SAMPLES, OtelEventTypeNaming.resolve("", "count").name());
+            assertEquals(EventTypeName.OTEL_SAMPLES, OtelEventTypeNaming.resolve(null, null).name());
+        }
+    }
+
+    @Nested
+    class CustomTypes {
+
+        @Test
+        void sanitizesUnknownSampleTypes() {
+            OtelEventType custom = OtelEventTypeNaming.resolve("off cpu/waits", "nanoseconds");
+            assertEquals("otel.off_cpu_waits", custom.name());
+            assertTrue(custom.label().contains("off cpu/waits"));
+        }
+
+        @Test
+        void categoriesAlwaysContainOpenTelemetry() {
+            assertTrue(OtelEventTypeNaming.resolve("custom_metric", "count").categories().contains("OpenTelemetry"));
+            assertTrue(OtelEventTypeNaming.resolve("cpu", "nanoseconds").categories().contains("OpenTelemetry"));
+        }
+    }
+}

--- a/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/test/java/cafe/jeffrey/otlpparser/mapping/OtelFrameTypeMapperTest.java
+++ b/jeffrey-microscope/profiles/recording-parser/otlp-parser/src/test/java/cafe/jeffrey/otlpparser/mapping/OtelFrameTypeMapperTest.java
@@ -1,0 +1,63 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.otlpparser.mapping;
+
+import org.junit.jupiter.api.Test;
+import cafe.jeffrey.profile.common.model.FrameType;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OtelFrameTypeMapperTest {
+
+    @Test
+    void jvmMapsToJitCompiled() {
+        assertEquals(FrameType.JIT_COMPILED, OtelFrameTypeMapper.map("jvm"));
+        assertTrue(OtelFrameTypeMapper.isJvmFrame("jvm"));
+    }
+
+    @Test
+    void kernelMapsToKernel() {
+        assertEquals(FrameType.KERNEL, OtelFrameTypeMapper.map("kernel"));
+    }
+
+    @Test
+    void otherLanguageRuntimesMapToNative() {
+        assertEquals(FrameType.NATIVE, OtelFrameTypeMapper.map("native"));
+        assertEquals(FrameType.NATIVE, OtelFrameTypeMapper.map("cpython"));
+        assertEquals(FrameType.NATIVE, OtelFrameTypeMapper.map("go"));
+        assertEquals(FrameType.NATIVE, OtelFrameTypeMapper.map("v8js"));
+    }
+
+    @Test
+    void missingOrUnknownValuesMapToNative() {
+        assertEquals(FrameType.NATIVE, OtelFrameTypeMapper.map(null));
+        assertEquals(FrameType.NATIVE, OtelFrameTypeMapper.map(""));
+        assertEquals(FrameType.NATIVE, OtelFrameTypeMapper.map("some-future-runtime"));
+        assertFalse(OtelFrameTypeMapper.isJvmFrame(null));
+    }
+
+    @Test
+    void mappedCodesRoundTripThroughFrameType() {
+        assertEquals(FrameType.JIT_COMPILED, FrameType.fromCode(OtelFrameTypeMapper.map("jvm").code()));
+        assertEquals(FrameType.KERNEL, FrameType.fromCode(OtelFrameTypeMapper.map("kernel").code()));
+        assertEquals(FrameType.NATIVE, FrameType.fromCode(OtelFrameTypeMapper.map("native").code()));
+    }
+}

--- a/jeffrey-microscope/profiles/recording-parser/pom.xml
+++ b/jeffrey-microscope/profiles/recording-parser/pom.xml
@@ -34,5 +34,6 @@
     <modules>
         <module>jfr-parser-api</module>
         <module>jdk-jfr-parser</module>
+        <module>otlp-parser</module>
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,11 @@
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>
+                <artifactId>otlp-parser</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>ai-config</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/EventSourceResolver.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/EventSourceResolver.java
@@ -38,25 +38,36 @@ public final class EventSourceResolver {
     /**
      * Resolves the source of a single event type from its name.
      *
-     * @return {@link RecordingEventSource#ASYNC_PROFILER} for events in the {@code profiler.} namespace,
+     * @return {@link RecordingEventSource#OPEN_TELEMETRY} for events in the {@code otel.} namespace,
+     * {@link RecordingEventSource#ASYNC_PROFILER} for events in the {@code profiler.} namespace,
      * otherwise {@link RecordingEventSource#JDK}
      */
     public static RecordingEventSource fromEventTypeName(String eventTypeName) {
-        return isAsyncProfilerEvent(eventTypeName)
-                ? RecordingEventSource.ASYNC_PROFILER
-                : RecordingEventSource.JDK;
+        if (isOtelEvent(eventTypeName)) {
+            return RecordingEventSource.OPEN_TELEMETRY;
+        }
+        if (isAsyncProfilerEvent(eventTypeName)) {
+            return RecordingEventSource.ASYNC_PROFILER;
+        }
+        return RecordingEventSource.JDK;
     }
 
     /**
      * Resolves the recording-level source from the set of event type names it contains. A recording is
-     * treated as async-profiler as soon as a single {@code profiler.} event is present.
+     * treated as OpenTelemetry as soon as a single {@code otel.} event is present, then as async-profiler
+     * as soon as a single {@code profiler.} event is present.
      *
-     * @return {@link RecordingEventSource#ASYNC_PROFILER} if any name is in the {@code profiler.} namespace,
+     * @return {@link RecordingEventSource#OPEN_TELEMETRY} if any name is in the {@code otel.} namespace,
+     * {@link RecordingEventSource#ASYNC_PROFILER} if any name is in the {@code profiler.} namespace,
      * otherwise {@link RecordingEventSource#JDK}
      */
     public static RecordingEventSource fromEventTypeNames(Collection<String> eventTypeNames) {
         if (eventTypeNames == null) {
             return RecordingEventSource.JDK;
+        }
+        boolean anyOtel = eventTypeNames.stream().anyMatch(EventSourceResolver::isOtelEvent);
+        if (anyOtel) {
+            return RecordingEventSource.OPEN_TELEMETRY;
         }
         boolean anyAsyncProfiler = eventTypeNames.stream().anyMatch(EventSourceResolver::isAsyncProfilerEvent);
         return anyAsyncProfiler ? RecordingEventSource.ASYNC_PROFILER : RecordingEventSource.JDK;
@@ -67,5 +78,12 @@ public final class EventSourceResolver {
      */
     public static boolean isAsyncProfilerEvent(String eventTypeName) {
         return eventTypeName != null && eventTypeName.startsWith(EventTypeName.ASYNC_PROFILER_NAMESPACE);
+    }
+
+    /**
+     * @return {@code true} if the event type belongs to the OpenTelemetry ({@code otel.}) namespace
+     */
+    public static boolean isOtelEvent(String eventTypeName) {
+        return eventTypeName != null && eventTypeName.startsWith(EventTypeName.OTEL_NAMESPACE);
     }
 }

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/EventTypeName.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/EventTypeName.java
@@ -26,6 +26,19 @@ public abstract class EventTypeName {
      */
     public static final String ASYNC_PROFILER_NAMESPACE = "profiler.";
 
+    /**
+     * Namespace prefix for every event type synthesized from an OpenTelemetry profiles recording
+     * (e.g. {@code otel.cpu}, {@code otel.alloc}). Used to classify the recording source.
+     */
+    public static final String OTEL_NAMESPACE = "otel.";
+
+    // OpenTelemetry profile sample types mapped to Jeffrey event types (see otlp-parser)
+    public static final String OTEL_CPU = "otel.cpu";
+    public static final String OTEL_SAMPLES = "otel.samples";
+    public static final String OTEL_WALL = "otel.wall";
+    public static final String OTEL_ALLOC = "otel.alloc";
+    public static final String OTEL_LOCK = "otel.lock";
+
     public static final String EXECUTION_SAMPLE = "jdk.ExecutionSample";
     public static final String CPU_TIME_SAMPLE = "jdk.CPUTimeSample";
     public static final String CPU_TIME_SAMPLES_LOST = "jdk.CPUTimeSamplesLost";

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/RecordingEventSource.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/RecordingEventSource.java
@@ -22,7 +22,8 @@ public enum RecordingEventSource {
     ASYNC_PROFILER(0, "Async-Profiler"),
     JDK(1, "JDK"),
     UNKNOWN(2, "Unknown"),
-    HEAP_DUMP(3, "Heap Dump");
+    HEAP_DUMP(3, "Heap Dump"),
+    OPEN_TELEMETRY(4, "OpenTelemetry");
 
     private final int id;
     private final String label;

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/repository/FileExtensions.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/repository/FileExtensions.java
@@ -27,6 +27,7 @@ public abstract class FileExtensions {
     public static final String HPROF_GZ = "hprof.gz";
     public static final String HPROF = "hprof";
     public static final String PERF_COUNTERS = "hsperfdata";
+    public static final String OTLP = "otlp";
     public static final String JVM_LOG = "-jvm.log(.[0-9]+)?";
     public static final String HS_JVM_ERROR_LOG = "hs-jvm-err.log";
     public static final String APP_LOG = "-app.log(..+)?";

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/repository/SupportedRecordingFile.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/repository/SupportedRecordingFile.java
@@ -84,6 +84,12 @@ public enum SupportedRecordingFile {
             new AppLogFileMatcher(),
             FileCategory.ARTIFACT
     ),
+    OTLP_PROFILE(
+            "OpenTelemetry Profiles",
+            FileExtensions.OTLP,
+            filename -> filename.endsWith("." + FileExtensions.OTLP),
+            FileCategory.RECORDING
+    ),
     UNKNOWN(
             "Unsupported File Type",
             null,

--- a/shared/common/src/test/java/cafe/jeffrey/shared/common/model/EventSourceResolverTest.java
+++ b/shared/common/src/test/java/cafe/jeffrey/shared/common/model/EventSourceResolverTest.java
@@ -52,6 +52,12 @@ class EventSourceResolverTest {
             assertEquals(RecordingEventSource.JDK, EventSourceResolver.fromEventTypeName(""));
             assertEquals(RecordingEventSource.JDK, EventSourceResolver.fromEventTypeName(null));
         }
+
+        @Test
+        void otelNamespaceIsOpenTelemetry() {
+            assertEquals(RecordingEventSource.OPEN_TELEMETRY, EventSourceResolver.fromEventTypeName("otel.cpu"));
+            assertEquals(RecordingEventSource.OPEN_TELEMETRY, EventSourceResolver.fromEventTypeName("otel.alloc"));
+        }
     }
 
     @Nested
@@ -73,6 +79,12 @@ class EventSourceResolverTest {
         void emptyOrNullIsJdk() {
             assertEquals(RecordingEventSource.JDK, EventSourceResolver.fromEventTypeNames(List.of()));
             assertEquals(RecordingEventSource.JDK, EventSourceResolver.fromEventTypeNames(null));
+        }
+
+        @Test
+        void anyOtelEventMakesTheRecordingOpenTelemetry() {
+            List<String> names = List.of("jdk.ExecutionSample", "profiler.Span", "otel.cpu");
+            assertEquals(RecordingEventSource.OPEN_TELEMETRY, EventSourceResolver.fromEventTypeNames(names));
         }
     }
 

--- a/shared/recordings-core/src/main/java/cafe/jeffrey/recordings/core/manager/RecordingsCoreManagerImpl.java
+++ b/shared/recordings-core/src/main/java/cafe/jeffrey/recordings/core/manager/RecordingsCoreManagerImpl.java
@@ -323,10 +323,10 @@ public class RecordingsCoreManagerImpl implements RecordingsCoreManager {
     }
 
     private static RecordingEventSource detectEventSource(String filename) {
-        String lower = filename.toLowerCase();
-        if (lower.endsWith(".hprof") || lower.endsWith(".hprof.gz")) {
-            return RecordingEventSource.HEAP_DUMP;
-        }
-        return RecordingEventSource.UNKNOWN;
+        return switch (SupportedRecordingFile.of(filename.toLowerCase())) {
+            case HEAP_DUMP, HEAP_DUMP_GZ -> RecordingEventSource.HEAP_DUMP;
+            case OTLP_PROFILE -> RecordingEventSource.OPEN_TELEMETRY;
+            default -> RecordingEventSource.UNKNOWN;
+        };
     }
 }

--- a/shared/ui/workspaces/ui/services/api/model/RecordingEventSource.ts
+++ b/shared/ui/workspaces/ui/services/api/model/RecordingEventSource.ts
@@ -20,7 +20,8 @@ enum RecordingEventSource {
   JDK = 'JDK',
   ASYNC_PROFILER = 'ASYNC_PROFILER',
   UNKNOWN = 'UNKNOWN',
-  HEAP_DUMP = 'HEAP_DUMP'
+  HEAP_DUMP = 'HEAP_DUMP',
+  OPEN_TELEMETRY = 'OPEN_TELEMETRY'
 }
 
 export default RecordingEventSource;

--- a/shared/ui/workspaces/ui/services/api/model/RecordingFileType.ts
+++ b/shared/ui/workspaces/ui/services/api/model/RecordingFileType.ts
@@ -26,6 +26,7 @@ enum RecordingFileType {
   JVM_LOG = 'JVM_LOG',
   HS_JVM_ERROR_LOG = 'HS_JVM_ERROR_LOG',
   APP_LOG = 'APP_LOG',
+  OTLP_PROFILE = 'OTLP_PROFILE',
   UNKNOWN = 'UNKNOWN'
 }
 


### PR DESCRIPTION
Introduces file-based ingestion of the OpenTelemetry profiling signal (proto package opentelemetry.proto.profiles.v1development, public Alpha) as a third recording type next to JFR recordings and heap dumps.

- .otlp file convention: optional 'OTLP' magic + u32 version header followed by length-delimited ProfilesData frames (concatenation- mergeable, each frame carries its own dictionary); raw single-message dumps (collector debug exporter, async-profiler 4.1 OTLP output) are accepted as a fallback
- New otlp-parser module with vendored, pinned OTel protos and an OtlpProfileReader that maps OTLP profiles onto the existing per-profile event model: sample types -> otel.* event types (cpu/samples/wall/ alloc/lock + sanitized custom types), leaf-first stacks reversed to root-first frames with inline expansion, profile.frame.type semconv -> Jeffrey frame types, thread.name/thread.id sample attributes -> threads, trace/span links + sample attributes -> per-event JSON fields, resource/ scope attributes -> event-type settings; profile DuckDB schema unchanged
- RecordingEventParserResolver picks the parser by RecordingEventSource (new OPEN_TELEMETRY source); metadata parsing dispatches by file type
- Frontend: otel.* event types bucket into the existing flamegraph/ timeseries cards; otel event-type badge; TS enum mirrors
- Tests: unit tests for framing/mapping/reader protocol plus a DuckDB round-trip through the real event-writing pipeline