### PR TITLE
Add jfr-otlp-converter CLI (JFR → OpenTelemetry profiles, with frame types)

### DIFF
--- a/utilities/jfr-otlp-converter/README.md
+++ b/utilities/jfr-otlp-converter/README.md
@@ -1,0 +1,59 @@
+# jfr-otlp-converter
+
+A standalone CLI that converts a **JDK Flight Recording (JFR)** into the **OpenTelemetry profiles
+signal** (`opentelemetry.proto.profiles.v1development`) — a single serialized `ProfilesData`
+message written to a `.otlp` file.
+
+## Why not async-profiler's `jfr-converter`?
+
+async-profiler's converter can already emit OTLP, but it does **not** populate the
+`profile.frame.type` semantic-convention attribute, so every frame is indistinguishable and
+downstream tools render Java, native, and kernel frames identically (all "native").
+
+This converter derives `profile.frame.type` from the JFR frame type on every location:
+
+| JFR frame type | `profile.frame.type` |
+|---|---|
+| `Interpreted`, `JIT compiled`, `Inlined`, `C1 compiled` | `jvm` |
+| `Native`, `C++` | `native` |
+| `Kernel` | `kernel` |
+
+> OTLP's `profile.frame.type` has a single `jvm` value, so the JVM sub-types (interpreted / JIT /
+> inlined / C1) collapse to `jvm`. The Java-vs-native-vs-kernel distinction is preserved; the
+> JIT-vs-interpreted distinction is not representable in OTLP.
+
+## Usage
+
+```bash
+java -jar jfr-otlp-converter.jar <input.jfr> <output.otlp> [options]
+
+Options:
+  --event cpu|alloc|lock   Which JFR events to convert (default: cpu)
+  --service-name NAME      Value of the resource service.name attribute
+                           (default: the input file name without extension)
+```
+
+### Event categories
+
+| `--event` | JFR event types | OTLP `sample_type` (type/unit) | value |
+|---|---|---|---|
+| `cpu` (default) | `jdk.ExecutionSample`, `jdk.NativeMethodSample` | `cpu` / `count` | 1 per sample |
+| `alloc` | `jdk.ObjectAllocationSample`, `jdk.ObjectAllocationInNewTLAB`, `jdk.ObjectAllocationOutsideTLAB` | `alloc` / `bytes` | allocated bytes |
+| `lock` | `jdk.JavaMonitorEnter`, `jdk.JavaMonitorWait`, `jdk.ThreadPark` | `lock` / `nanoseconds` | blocked duration |
+
+Each sample carries its event timestamp (`timestamps_unix_nano`) and the sampled thread
+(`thread.name` attribute); the resource carries `service.name`.
+
+## Build
+
+```bash
+mvn -pl utilities/jfr-otlp-converter package
+# -> utilities/jfr-otlp-converter/target/jfr-otlp-converter.jar (runnable, dependencies shaded in)
+```
+
+## Notes
+
+- The OTLP profiles signal is in **Alpha** (`v1development`); the proto shape may still change.
+- Reads JFR with the JDK's built-in `jdk.jfr.consumer` — no dependency on Jeffrey's runtime.
+- JFR stacks are already leaf-first, matching the OTLP `Stack` convention, so no frame reordering
+  is needed.

--- a/utilities/jfr-otlp-converter/pom.xml
+++ b/utilities/jfr-otlp-converter/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Jeffrey
+  ~ Copyright (C) 2026 Petr Bouda
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>cafe.jeffrey-analyst</groupId>
+    <artifactId>jfr-otlp-converter</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+    <description>Standalone CLI converting JDK Flight Recordings (JFR) into the OpenTelemetry
+        profiles signal (OTLP), preserving frame types via the profile.frame.type semantic
+        convention that async-profiler's own converter omits.</description>
+    <url>https://github.com/petrbouda/jeffrey</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>17</maven.compiler.release>
+        <opentelemetry-proto.version>1.10.0-alpha</opentelemetry-proto.version>
+        <main.class>cafe.jeffrey.tools.jfrotlp.JfrToOtlpConverter</main.class>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.opentelemetry.proto</groupId>
+            <artifactId>opentelemetry-proto</artifactId>
+            <version>${opentelemetry-proto.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.4</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>jfr-otlp-converter</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.14.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.2</version>
+            </plugin>
+            <!-- Produce a self-contained runnable jar: java -jar jfr-otlp-converter.jar ... -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>${main.class}</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/utilities/jfr-otlp-converter/src/main/java/cafe/jeffrey/tools/jfrotlp/Dictionary.java
+++ b/utilities/jfr-otlp-converter/src/main/java/cafe/jeffrey/tools/jfrotlp/Dictionary.java
@@ -1,0 +1,163 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.tools.jfrotlp;
+
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.profiles.v1development.Function;
+import io.opentelemetry.proto.profiles.v1development.KeyValueAndUnit;
+import io.opentelemetry.proto.profiles.v1development.Line;
+import io.opentelemetry.proto.profiles.v1development.Link;
+import io.opentelemetry.proto.profiles.v1development.Location;
+import io.opentelemetry.proto.profiles.v1development.Mapping;
+import io.opentelemetry.proto.profiles.v1development.ProfilesDictionary;
+import io.opentelemetry.proto.profiles.v1development.Stack;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds an OTLP {@link ProfilesDictionary}, deduplicating entries and maintaining the required
+ * "index 0 is the zero value / null" convention for every table.
+ */
+final class Dictionary {
+
+    private final List<String> strings = new ArrayList<>();
+    private final Map<String, Integer> stringIndex = new HashMap<>();
+
+    private final List<Function> functions = new ArrayList<>();
+    private final Map<String, Integer> functionIndex = new HashMap<>();
+
+    private final List<Location> locations = new ArrayList<>();
+    private final Map<String, Integer> locationIndex = new HashMap<>();
+
+    private final List<Stack> stacks = new ArrayList<>();
+    private final Map<String, Integer> stackIndex = new HashMap<>();
+
+    private final List<KeyValueAndUnit> attributes = new ArrayList<>();
+    private final Map<String, Integer> attributeIndex = new HashMap<>();
+
+    Dictionary() {
+        // index 0 of every table must be the zero value so a 0 reference means "null / not set"
+        strings.add("");
+        stringIndex.put("", 0);
+        functions.add(Function.getDefaultInstance());
+        locations.add(Location.getDefaultInstance());
+        stacks.add(Stack.getDefaultInstance());
+        attributes.add(KeyValueAndUnit.getDefaultInstance());
+    }
+
+    int string(String value) {
+        Integer existing = stringIndex.get(value);
+        if (existing != null) {
+            return existing;
+        }
+        int index = strings.size();
+        strings.add(value);
+        stringIndex.put(value, index);
+        return index;
+    }
+
+    int function(String className, String methodName) {
+        String key = className + '\0' + methodName;
+        Integer existing = functionIndex.get(key);
+        if (existing != null) {
+            return existing;
+        }
+        String qualifiedName = className.isEmpty() ? methodName : className + '.' + methodName;
+        int index = functions.size();
+        functions.add(Function.newBuilder()
+                .setNameStrindex(string(qualifiedName))
+                .build());
+        functionIndex.put(key, index);
+        return index;
+    }
+
+    int location(int functionIndexRef, long line, int frameTypeAttrIndex) {
+        String key = functionIndexRef + "|" + line + "|" + frameTypeAttrIndex;
+        Integer existing = locationIndex.get(key);
+        if (existing != null) {
+            return existing;
+        }
+        Line.Builder lineBuilder = Line.newBuilder().setFunctionIndex(functionIndexRef);
+        if (line > 0) {
+            lineBuilder.setLine(line);
+        }
+        int index = locations.size();
+        locations.add(Location.newBuilder()
+                .addLines(lineBuilder)
+                .addAttributeIndices(frameTypeAttrIndex)
+                .build());
+        locationIndex.put(key, index);
+        return index;
+    }
+
+    int stack(List<Integer> locationIndices) {
+        String key = locationIndices.toString();
+        Integer existing = stackIndex.get(key);
+        if (existing != null) {
+            return existing;
+        }
+        int index = stacks.size();
+        stacks.add(Stack.newBuilder().addAllLocationIndices(locationIndices).build());
+        stackIndex.put(key, index);
+        return index;
+    }
+
+    int stringAttribute(String key, String value) {
+        String cacheKey = key + '\0' + value;
+        Integer existing = attributeIndex.get(cacheKey);
+        if (existing != null) {
+            return existing;
+        }
+        int index = attributes.size();
+        attributes.add(KeyValueAndUnit.newBuilder()
+                .setKeyStrindex(string(key))
+                .setValue(AnyValue.newBuilder().setStringValue(value))
+                .build());
+        attributeIndex.put(cacheKey, index);
+        return index;
+    }
+
+    ProfilesDictionary build() {
+        return ProfilesDictionary.newBuilder()
+                .addAllStringTable(strings)
+                // one zero-value mapping is enough — this converter does not track binary mappings
+                .addMappingTable(Mapping.getDefaultInstance())
+                .addAllLocationTable(locations)
+                .addAllFunctionTable(functions)
+                .addLinkTable(Link.getDefaultInstance())
+                .addAllAttributeTable(attributes)
+                .addAllStackTable(stacks)
+                .build();
+    }
+
+    int stackCount() {
+        return stacks.size() - 1;
+    }
+
+    int functionCount() {
+        return functions.size() - 1;
+    }
+
+    int locationCount() {
+        return locations.size() - 1;
+    }
+}

--- a/utilities/jfr-otlp-converter/src/main/java/cafe/jeffrey/tools/jfrotlp/JfrToOtlpConverter.java
+++ b/utilities/jfr-otlp-converter/src/main/java/cafe/jeffrey/tools/jfrotlp/JfrToOtlpConverter.java
@@ -1,0 +1,392 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.tools.jfrotlp;
+
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.InstrumentationScope;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.profiles.v1development.Profile;
+import io.opentelemetry.proto.profiles.v1development.ProfilesData;
+import io.opentelemetry.proto.profiles.v1development.ResourceProfiles;
+import io.opentelemetry.proto.profiles.v1development.Sample;
+import io.opentelemetry.proto.profiles.v1development.ScopeProfiles;
+import io.opentelemetry.proto.profiles.v1development.ValueType;
+import io.opentelemetry.proto.resource.v1.Resource;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordedFrame;
+import jdk.jfr.consumer.RecordedMethod;
+import jdk.jfr.consumer.RecordedStackTrace;
+import jdk.jfr.consumer.RecordedThread;
+import jdk.jfr.consumer.RecordingFile;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Standalone CLI converting a JDK Flight Recording (JFR) into the OpenTelemetry profiles signal
+ * ({@code opentelemetry.proto.profiles.v1development}, a single serialized {@code ProfilesData}
+ * message).
+ * <p>
+ * Unlike async-profiler's {@code jfr-converter}, this converter sets the
+ * {@code profile.frame.type} semantic-convention attribute ({@code jvm} / {@code native} /
+ * {@code kernel}) on every location, derived from the JFR frame type — so downstream consumers can
+ * distinguish Java from native/kernel frames instead of rendering everything as native.
+ * <p>
+ * Usage:
+ * <pre>
+ *   java -jar jfr-otlp-converter.jar &lt;input.jfr&gt; &lt;output.otlp&gt; [--event cpu|alloc|lock] [--service-name NAME]
+ * </pre>
+ */
+public final class JfrToOtlpConverter {
+
+    private static final String OPT_EVENT = "--event";
+    private static final String OPT_SERVICE_NAME = "--service-name";
+
+    private static final String SEMCONV_FRAME_TYPE = "profile.frame.type";
+    private static final String SEMCONV_THREAD_NAME = "thread.name";
+    private static final String SEMCONV_SERVICE_NAME = "service.name";
+
+    private static final String FRAME_TYPE_JVM = "jvm";
+    private static final String FRAME_TYPE_NATIVE = "native";
+    private static final String FRAME_TYPE_KERNEL = "kernel";
+
+    private static final String SCOPE_NAME = "jeffrey-jfr-otlp-converter";
+    private static final String SCOPE_VERSION = "1.0";
+
+    private JfrToOtlpConverter() {
+    }
+
+    public static void main(String[] args) throws IOException {
+        Options options = Options.parse(args);
+        if (options == null) {
+            printUsage();
+            System.exit(1);
+            return;
+        }
+
+        long start = System.currentTimeMillis();
+        ConversionResult result = convert(options);
+        long elapsedMs = System.currentTimeMillis() - start;
+
+        System.out.printf(
+                "Converted %s -> %s%n  event=%s samples=%d stacks=%d functions=%d locations=%d skipped_no_stack=%d bytes=%d elapsed_ms=%d%n",
+                options.input(), options.output(), options.event().id,
+                result.samples(), result.stacks(), result.functions(), result.locations(),
+                result.skippedNoStack(), result.outputBytes(), elapsedMs);
+    }
+
+    static ConversionResult convert(Options options) throws IOException {
+        Dictionary dictionary = new Dictionary();
+
+        // one attribute per semconv frame-type value, reused across all locations
+        int jvmFrameAttr = dictionary.stringAttribute(SEMCONV_FRAME_TYPE, FRAME_TYPE_JVM);
+        int nativeFrameAttr = dictionary.stringAttribute(SEMCONV_FRAME_TYPE, FRAME_TYPE_NATIVE);
+        int kernelFrameAttr = dictionary.stringAttribute(SEMCONV_FRAME_TYPE, FRAME_TYPE_KERNEL);
+
+        EventCategory category = options.event();
+        List<Sample> samples = new ArrayList<>();
+
+        long minTimeNanos = Long.MAX_VALUE;
+        long maxTimeNanos = Long.MIN_VALUE;
+        long skippedNoStack = 0;
+
+        try (RecordingFile recordingFile = new RecordingFile(options.input())) {
+            while (recordingFile.hasMoreEvents()) {
+                RecordedEvent event = recordingFile.readEvent();
+                if (!category.matches(event.getEventType().getName())) {
+                    continue;
+                }
+                RecordedStackTrace stackTrace = event.getStackTrace();
+                if (stackTrace == null || stackTrace.getFrames().isEmpty()) {
+                    skippedNoStack++;
+                    continue;
+                }
+
+                int stackIndex = dictionary.stack(mapStack(stackTrace, dictionary,
+                        jvmFrameAttr, nativeFrameAttr, kernelFrameAttr));
+
+                long value = category.value(event);
+                long timeNanos = toEpochNanos(event.getStartTime());
+                minTimeNanos = Math.min(minTimeNanos, timeNanos);
+                maxTimeNanos = Math.max(maxTimeNanos, timeNanos);
+
+                Sample.Builder sample = Sample.newBuilder()
+                        .setStackIndex(stackIndex)
+                        .addValues(value)
+                        .addTimestampsUnixNano(timeNanos);
+
+                int threadAttr = threadAttribute(event.getThread(), dictionary);
+                if (threadAttr > 0) {
+                    sample.addAttributeIndices(threadAttr);
+                }
+                samples.add(sample.build());
+            }
+        }
+
+        if (samples.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "No '" + category.id + "' samples with stack traces found in " + options.input());
+        }
+
+        long timeUnixNano = minTimeNanos == Long.MAX_VALUE ? 0 : minTimeNanos;
+        long durationNano = maxTimeNanos > minTimeNanos ? maxTimeNanos - minTimeNanos : 0;
+
+        Profile profile = Profile.newBuilder()
+                .setSampleType(ValueType.newBuilder()
+                        .setTypeStrindex(dictionary.string(category.sampleType))
+                        .setUnitStrindex(dictionary.string(category.sampleUnit)))
+                .addAllSamples(samples)
+                .setTimeUnixNano(timeUnixNano)
+                .setDurationNano(durationNano)
+                .build();
+
+        ProfilesData data = ProfilesData.newBuilder()
+                .addResourceProfiles(ResourceProfiles.newBuilder()
+                        .setResource(Resource.newBuilder()
+                                .addAttributes(stringKeyValue(SEMCONV_SERVICE_NAME, options.serviceName())))
+                        .addScopeProfiles(ScopeProfiles.newBuilder()
+                                .setScope(InstrumentationScope.newBuilder()
+                                        .setName(SCOPE_NAME)
+                                        .setVersion(SCOPE_VERSION))
+                                .addProfiles(profile)))
+                .setDictionary(dictionary.build())
+                .build();
+
+        byte[] serialized = data.toByteArray();
+        try (OutputStream output = Files.newOutputStream(options.output())) {
+            output.write(serialized);
+        }
+
+        return new ConversionResult(
+                samples.size(), dictionary.stackCount(), dictionary.functionCount(),
+                dictionary.locationCount(), skippedNoStack, serialized.length);
+    }
+
+    /**
+     * Maps a JFR stack trace to leaf-first OTLP location indices. JFR frames are already leaf-first,
+     * matching the OTLP {@code Stack} convention, so no reversal is needed.
+     */
+    private static List<Integer> mapStack(
+            RecordedStackTrace stackTrace,
+            Dictionary dictionary,
+            int jvmFrameAttr,
+            int nativeFrameAttr,
+            int kernelFrameAttr) {
+
+        List<RecordedFrame> frames = stackTrace.getFrames();
+        List<Integer> locationIndices = new ArrayList<>(frames.size());
+        for (RecordedFrame frame : frames) {
+            RecordedMethod method = frame.getMethod();
+            String className = method != null && method.getType() != null ? method.getType().getName() : "";
+            String methodName = method != null ? method.getName() : "unknown";
+            int functionIndex = dictionary.function(className, methodName);
+
+            int frameTypeAttr = switch (semconvFrameType(frame.getType())) {
+                case FRAME_TYPE_JVM -> jvmFrameAttr;
+                case FRAME_TYPE_KERNEL -> kernelFrameAttr;
+                default -> nativeFrameAttr;
+            };
+
+            long line = frame.getLineNumber();
+            locationIndices.add(dictionary.location(functionIndex, line, frameTypeAttr));
+        }
+        return locationIndices;
+    }
+
+    /**
+     * Maps a JFR frame type ({@link RecordedFrame#getType()}) to a {@code profile.frame.type}
+     * semantic-convention value. OTLP has only a single {@code jvm} value, so the JFR JVM
+     * sub-types (interpreted / JIT / inlined / C1) all collapse to {@code jvm}.
+     */
+    private static String semconvFrameType(String jfrFrameType) {
+        if (jfrFrameType == null) {
+            return FRAME_TYPE_NATIVE;
+        }
+        return switch (jfrFrameType) {
+            case "Interpreted", "JIT compiled", "Inlined", "C1 compiled" -> FRAME_TYPE_JVM;
+            case "Kernel" -> FRAME_TYPE_KERNEL;
+            default -> FRAME_TYPE_NATIVE;
+        };
+    }
+
+    private static int threadAttribute(RecordedThread thread, Dictionary dictionary) {
+        if (thread == null) {
+            return 0;
+        }
+        String name = thread.getJavaName() != null ? thread.getJavaName() : thread.getOSName();
+        if (name == null || name.isBlank()) {
+            name = "[tid=" + thread.getOSThreadId() + "]";
+        }
+        return dictionary.stringAttribute(SEMCONV_THREAD_NAME, name);
+    }
+
+    private static KeyValue stringKeyValue(String key, String value) {
+        return KeyValue.newBuilder()
+                .setKey(key)
+                .setValue(AnyValue.newBuilder().setStringValue(value))
+                .build();
+    }
+
+    private static long toEpochNanos(Instant instant) {
+        return instant.getEpochSecond() * 1_000_000_000L + instant.getNano();
+    }
+
+    private static void printUsage() {
+        System.err.println("""
+                Usage: java -jar jfr-otlp-converter.jar <input.jfr> <output.otlp> [options]
+
+                Converts a JDK Flight Recording into an OpenTelemetry profiles (.otlp) file,
+                setting the profile.frame.type attribute (jvm/native/kernel) on every frame.
+
+                Options:
+                  --event cpu|alloc|lock   Which JFR events to convert (default: cpu)
+                  --service-name NAME      Value of the resource service.name attribute
+                                           (default: the input file name without extension)""");
+    }
+
+    /**
+     * The category of JFR events to convert, with the OTLP sample type/unit and per-event value.
+     */
+    enum EventCategory {
+        CPU("cpu", "cpu", "count",
+                List.of("jdk.ExecutionSample", "jdk.NativeMethodSample")) {
+            @Override
+            long value(RecordedEvent event) {
+                return 1;
+            }
+        },
+        ALLOC("alloc", "alloc", "bytes",
+                List.of("jdk.ObjectAllocationSample", "jdk.ObjectAllocationInNewTLAB",
+                        "jdk.ObjectAllocationOutsideTLAB")) {
+            @Override
+            long value(RecordedEvent event) {
+                return firstLongField(event, "weight", "allocationSize", "tlabSize");
+            }
+        },
+        LOCK("lock", "lock", "nanoseconds",
+                List.of("jdk.JavaMonitorEnter", "jdk.JavaMonitorWait", "jdk.ThreadPark")) {
+            @Override
+            long value(RecordedEvent event) {
+                return event.getDuration() != null ? event.getDuration().toNanos() : 0;
+            }
+        };
+
+        private final String id;
+        private final String sampleType;
+        private final String sampleUnit;
+        private final List<String> eventTypeNames;
+
+        EventCategory(String id, String sampleType, String sampleUnit, List<String> eventTypeNames) {
+            this.id = id;
+            this.sampleType = sampleType;
+            this.sampleUnit = sampleUnit;
+            this.eventTypeNames = eventTypeNames;
+        }
+
+        abstract long value(RecordedEvent event);
+
+        boolean matches(String eventTypeName) {
+            return eventTypeNames.contains(eventTypeName);
+        }
+
+        static EventCategory fromId(String id) {
+            for (EventCategory category : values()) {
+                if (category.id.equalsIgnoreCase(id)) {
+                    return category;
+                }
+            }
+            return null;
+        }
+
+        private static long firstLongField(RecordedEvent event, String... fields) {
+            for (String field : fields) {
+                if (event.hasField(field)) {
+                    return event.getLong(field);
+                }
+            }
+            return 1;
+        }
+    }
+
+    /**
+     * Parsed command-line options.
+     */
+    record Options(Path input, Path output, EventCategory event, String serviceName) {
+
+        static Options parse(String[] args) {
+            Path input = null;
+            Path output = null;
+            EventCategory event = EventCategory.CPU;
+            String serviceName = null;
+
+            for (int i = 0; i < args.length; i++) {
+                String arg = args[i];
+                switch (arg) {
+                    case OPT_EVENT -> {
+                        if (++i >= args.length) {
+                            return null;
+                        }
+                        event = EventCategory.fromId(args[i]);
+                        if (event == null) {
+                            return null;
+                        }
+                    }
+                    case OPT_SERVICE_NAME -> {
+                        if (++i >= args.length) {
+                            return null;
+                        }
+                        serviceName = args[i];
+                    }
+                    default -> {
+                        if (input == null) {
+                            input = Path.of(arg);
+                        } else if (output == null) {
+                            output = Path.of(arg);
+                        } else {
+                            return null;
+                        }
+                    }
+                }
+            }
+
+            if (input == null || output == null) {
+                return null;
+            }
+            if (serviceName == null) {
+                serviceName = defaultServiceName(input);
+            }
+            return new Options(input, output, event, serviceName);
+        }
+
+        private static String defaultServiceName(Path input) {
+            String fileName = input.getFileName().toString();
+            int dot = fileName.indexOf('.');
+            return dot > 0 ? fileName.substring(0, dot) : fileName;
+        }
+    }
+
+    record ConversionResult(
+            int samples, int stacks, int functions, int locations, long skippedNoStack, int outputBytes) {
+    }
+}

--- a/utilities/jfr-otlp-converter/src/test/java/cafe/jeffrey/tools/jfrotlp/DictionaryTest.java
+++ b/utilities/jfr-otlp-converter/src/test/java/cafe/jeffrey/tools/jfrotlp/DictionaryTest.java
@@ -1,0 +1,110 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.tools.jfrotlp;
+
+import io.opentelemetry.proto.profiles.v1development.ProfilesDictionary;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DictionaryTest {
+
+    @Test
+    void indexZeroIsAlwaysTheZeroValue() {
+        ProfilesDictionary dictionary = new Dictionary().build();
+
+        // every table's index 0 must be the default (zero) value so a 0 reference means "not set"
+        assertEquals("", dictionary.getStringTable(0));
+        assertEquals(0, dictionary.getFunctionTable(0).getNameStrindex());
+        assertEquals(0, dictionary.getLocationTable(0).getLinesCount());
+        assertEquals(0, dictionary.getStackTable(0).getLocationIndicesCount());
+        assertEquals(0, dictionary.getAttributeTable(0).getKeyStrindex());
+        assertEquals(1, dictionary.getLinkTableCount());
+        assertEquals(1, dictionary.getMappingTableCount());
+    }
+
+    @Test
+    void stringsAreDeduplicatedAndStable() {
+        Dictionary dictionary = new Dictionary();
+        int first = dictionary.string("cpu");
+        int second = dictionary.string("cpu");
+        int other = dictionary.string("nanoseconds");
+
+        assertEquals(first, second);
+        assertNotEquals(first, other);
+        assertTrue(first > 0);
+    }
+
+    @Test
+    void functionsAreDeduplicatedByClassAndMethod() {
+        Dictionary dictionary = new Dictionary();
+        int a = dictionary.function("com.example.Foo", "bar");
+        int b = dictionary.function("com.example.Foo", "bar");
+        int c = dictionary.function("com.example.Foo", "baz");
+
+        assertEquals(a, b);
+        assertNotEquals(a, c);
+        assertEquals(2, dictionary.functionCount());
+    }
+
+    @Test
+    void locationsAreDeduplicatedByFunctionLineAndFrameType() {
+        Dictionary dictionary = new Dictionary();
+        int fn = dictionary.function("com.example.Foo", "bar");
+        int jvmAttr = dictionary.stringAttribute("profile.frame.type", "jvm");
+        int nativeAttr = dictionary.stringAttribute("profile.frame.type", "native");
+
+        int a = dictionary.location(fn, 42, jvmAttr);
+        int b = dictionary.location(fn, 42, jvmAttr);
+        int differentLine = dictionary.location(fn, 43, jvmAttr);
+        int differentType = dictionary.location(fn, 42, nativeAttr);
+
+        assertEquals(a, b);
+        assertNotEquals(a, differentLine);
+        assertNotEquals(a, differentType);
+        assertEquals(3, dictionary.locationCount());
+    }
+
+    @Test
+    void stacksAreDeduplicatedByContent() {
+        Dictionary dictionary = new Dictionary();
+        int a = dictionary.stack(List.of(3, 2, 1));
+        int b = dictionary.stack(List.of(3, 2, 1));
+        int other = dictionary.stack(List.of(1, 2, 3));
+
+        assertEquals(a, b);
+        assertNotEquals(a, other);
+        assertEquals(2, dictionary.stackCount());
+    }
+
+    @Test
+    void frameTypeAttributesAreDeduplicatedByKeyAndValue() {
+        Dictionary dictionary = new Dictionary();
+        int jvm1 = dictionary.stringAttribute("profile.frame.type", "jvm");
+        int jvm2 = dictionary.stringAttribute("profile.frame.type", "jvm");
+        int nativeAttr = dictionary.stringAttribute("profile.frame.type", "native");
+
+        assertEquals(jvm1, jvm2);
+        assertNotEquals(jvm1, nativeAttr);
+    }
+}

--- a/utilities/pom.xml
+++ b/utilities/pom.xml
@@ -40,5 +40,6 @@
     <modules>
         <module>jeffrey-events</module>
         <module>jeffrey-jib</module>
+        <module>jfr-otlp-converter</module>
     </modules>
 </project>


### PR DESCRIPTION
A standalone CLI in `utilities/` that converts a JDK Flight Recording into the OpenTelemetry profiles signal (`opentelemetry.proto.profiles.v1development`) — a single serialized `ProfilesData` written to a `.otlp` file.

## Why

async-profiler's own `jfr-converter` can emit OTLP but does **not** set the `profile.frame.type` semantic-convention attribute, so every frame is untyped and downstream tools render Java, native, and kernel frames identically ("all native"). This converter derives `profile.frame.type` from the JFR frame type on every location.

Verified on a real ~52 MB JFR (Jeffrey's own `persons` CPU recording), read back through an OTLP parser:

| Converter | Resulting frame types |
|---|---|
| async-profiler `jfr-converter` | `Native=651728` (everything) |
| **this converter** | `JIT compiled=490346, Native=119364, Kernel=42018` |

## What's in it

- **Standalone module** `utilities/jfr-otlp-converter` (groupId `cafe.jeffrey-analyst`), depends only on `io.opentelemetry.proto`; reads JFR via the JDK's built-in `jdk.jfr.consumer` — no dependency on Jeffrey's runtime.
- **`main()`**: `java -jar jfr-otlp-converter.jar <in.jfr> <out.otlp> [--event cpu|alloc|lock] [--service-name NAME]`
  - `cpu` → `(cpu, count)`, `alloc` → `(alloc, bytes)`, `lock` → `(lock, nanoseconds)`
  - each sample carries its event timestamp and the sampled `thread.name`; the resource carries `service.name`
- **Frame-type mapping**: `Interpreted`/`JIT compiled`/`Inlined`/`C1 compiled` → `jvm`, `Native`/`C++` → `native`, `Kernel` → `kernel`. (OTLP has one `jvm` value, so the JVM sub-types collapse — Java/native/kernel is preserved, JIT-vs-interpreted is not representable in OTLP.)
- **`Dictionary`** maintains the OTLP index-0 = zero-value convention and dedups strings/functions/locations/stacks/attributes.
- **maven-shade** produces a runnable jar; `DictionaryTest` (6 tests) covers the dedup and index-0 invariants. JFR stacks are already leaf-first, matching OTLP's `Stack`, so no reordering.

Standalone — no changes to any existing module beyond registering it in `utilities/pom.xml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnFTty9iKzjNUyswHDGF1S

---
_Generated by [Claude Code](https://claude.ai/code/session_01WnFTty9iKzjNUyswHDGF1S)_