### PR TITLE
Suppress HikariPool verbose logging across all modules

### DIFF
--- a/jeffrey-hub/core-hub/src/main/resources/logback-spring.xml
+++ b/jeffrey-hub/core-hub/src/main/resources/logback-spring.xml
@@ -18,6 +18,7 @@
 
 <configuration>
     <logger name="org.flywaydb" level="WARN" />
+    <logger name="com.zaxxer.hikari.pool.HikariPool" level="ERROR" />
 
     <!-- Without debug-file-log/trace-file-log: standard console, level controlled by logging.level property -->
     <springProfile name="!debug-file-log &amp; !trace-file-log">

--- a/jeffrey-microscope/core-microscope/src/main/resources/logback-spring.xml
+++ b/jeffrey-microscope/core-microscope/src/main/resources/logback-spring.xml
@@ -19,6 +19,7 @@
 <configuration>
     <logger name="org.flywaydb" level="WARN" />
     <logger name="org.openjdk.jmc.flightrecorder.internal.parser" level="ERROR" />
+    <logger name="com.zaxxer.hikari.pool.HikariPool" level="ERROR" />
 
     <springProperty scope="context" name="HOME_DIR" source="jeffrey.microscope.home.dir"
                     defaultValue="${user.home}/.jeffrey-microscope"/>

--- a/jeffrey-performance-analyst/core-performance-analyst/src/main/resources/logback-spring.xml
+++ b/jeffrey-performance-analyst/core-performance-analyst/src/main/resources/logback-spring.xml
@@ -17,6 +17,8 @@
   -->
 
 <configuration>
+    <logger name="com.zaxxer.hikari.pool.HikariPool" level="ERROR" />
+
     <!-- Without debug-file-log/trace-file-log: standard console, level controlled by logging.level property -->
     <springProfile name="!debug-file-log &amp; !trace-file-log">
         <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">


### PR DESCRIPTION
## Summary
Adds explicit log level configuration to suppress verbose logging from HikariCP's connection pool across all three main application modules (microscope, hub, and performance-analyst).

## Changes
- Added `<logger name="com.zaxxer.hikari.pool.HikariPool" level="ERROR" />` to logback configuration in:
  - `jeffrey-performance-analyst/core-performance-analyst/src/main/resources/logback-spring.xml`
  - `jeffrey-hub/core-hub/src/main/resources/logback-spring.xml`
  - `jeffrey-microscope/core-microscope/src/main/resources/logback-spring.xml`

## Details
HikariCP's pool logger can be quite verbose at default log levels, producing unnecessary noise in application logs. This change sets the HikariPool logger to ERROR level across all deployments, ensuring only critical connection pool issues are logged while maintaining the configured log levels for other components.

This follows the existing pattern in the codebase where other verbose third-party loggers (e.g., `org.flywaydb`, `org.openjdk.jmc.flightrecorder.internal.parser`) are already suppressed.

https://claude.ai/code/session_015RgWyME8k9znMcDciUrvJ4