### PR TITLE
Fix gzipped heap dump support: decompress .hprof.gz to a sibling .hprof

### DIFF
--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/HeapDumpAnalysisController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/HeapDumpAnalysisController.java
@@ -31,6 +31,7 @@ import cafe.jeffrey.profile.heapdump.model.ClassLoaderDetail;
 import cafe.jeffrey.profile.heapdump.model.ClassLoaderReport;
 import cafe.jeffrey.profile.heapdump.model.CollectionAnalysisReport;
 import cafe.jeffrey.profile.heapdump.model.ConsumerReport;
+import cafe.jeffrey.profile.heapdump.model.DuplicateDataReport;
 import cafe.jeffrey.profile.heapdump.model.LeakSuspectsReport;
 import cafe.jeffrey.profile.heapdump.model.StringAnalysisReport;
 import cafe.jeffrey.profile.heapdump.model.ThreadAnalysisReport;
@@ -185,6 +186,23 @@ public class HeapDumpAnalysisController {
     @PostMapping("/consumers/run")
     public void runConsumerReport(@PathVariable("profileId") String profileId) {
         mgr(profileId).runConsumerReport();
+    }
+
+    @GetMapping("/duplicate-data/exists")
+    public boolean duplicateDataExists(@PathVariable("profileId") String profileId) {
+        return mgr(profileId).duplicateDataExists();
+    }
+
+    @GetMapping("/duplicate-data")
+    public DuplicateDataReport getDuplicateData(@PathVariable("profileId") String profileId) {
+        return mgr(profileId).getDuplicateData();
+    }
+
+    @PostMapping("/duplicate-data/run")
+    public void runDuplicateData(
+            @PathVariable("profileId") String profileId,
+            @RequestParam(value = "topN", defaultValue = "50") int topN) {
+        mgr(profileId).runDuplicateData(topN);
     }
 
     private HeapDumpManager mgr(String profileId) {

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/HeapDumpController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/HeapDumpController.java
@@ -20,7 +20,9 @@ package cafe.jeffrey.microscope.core.web.controllers.profile;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -31,9 +33,11 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
 import cafe.jeffrey.profile.heapdump.model.HeapDumpConfig;
+import cafe.jeffrey.profile.heapdump.model.HeapDumpInitProgress;
 import cafe.jeffrey.profile.heapdump.model.HeapSummary;
 import cafe.jeffrey.profile.heapdump.model.InitPipelineResult;
 import cafe.jeffrey.profile.heapdump.model.InitializeResult;
+import cafe.jeffrey.profile.manager.heapdump.HeapDumpInitService;
 import cafe.jeffrey.profile.manager.heapdump.HeapDumpManager;
 import cafe.jeffrey.shared.common.exception.Exceptions;
 
@@ -54,8 +58,11 @@ public class HeapDumpController {
 
     private final ProfileManagerResolver resolver;
 
-    public HeapDumpController(ProfileManagerResolver resolver) {
+    private final HeapDumpInitService initService;
+
+    public HeapDumpController(ProfileManagerResolver resolver, HeapDumpInitService initService) {
         this.resolver = resolver;
+        this.initService = initService;
     }
 
     @GetMapping("/exists")
@@ -117,6 +124,25 @@ public class HeapDumpController {
             @PathVariable("profileId") String profileId,
             @RequestParam(value = "compressedOops", required = false) Boolean compressedOops) {
         return mgr(profileId).initialize(compressedOops);
+    }
+
+    /**
+     * Starts the full initialization pipeline (index build, dominator tree and
+     * every cached analysis) as a background run; poll {@code /init-progress}
+     * for per-stage statuses. Returns 202 whether a new run was started or one
+     * was already in flight.
+     */
+    @PostMapping("/initialize-all")
+    public ResponseEntity<Void> initializeAll(
+            @PathVariable("profileId") String profileId,
+            @RequestParam(value = "compressedOops", required = false) Boolean compressedOops) {
+        initService.start(profileId, mgr(profileId), compressedOops);
+        return ResponseEntity.status(HttpStatus.ACCEPTED).build();
+    }
+
+    @GetMapping("/init-progress")
+    public HeapDumpInitProgress initProgress(@PathVariable("profileId") String profileId) {
+        return initService.progress(profileId);
     }
 
     @GetMapping("/config")

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/HeapDumpDiffController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/HeapDumpDiffController.java
@@ -1,0 +1,58 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.microscope.core.web.controllers.profile;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
+import cafe.jeffrey.profile.heapdump.model.HeapDumpDiffReport;
+import cafe.jeffrey.profile.manager.heapdump.HeapDumpDiffService;
+import cafe.jeffrey.profile.manager.heapdump.HeapDumpManager;
+
+/**
+ * Heap-dump comparison between two profiles: the primary (current) dump
+ * against a baseline dump, following the {@code /diff/{secondaryProfileId}}
+ * convention established by the differential flamegraph.
+ */
+@RestController
+@RequestMapping({
+        "/api/internal/profiles/{primaryProfileId}/diff/{secondaryProfileId}/heap",
+        "/api/internal/workspaces/{workspaceId}/projects/{projectId}/profiles/{primaryProfileId}/diff/{secondaryProfileId}/heap"
+})
+public class HeapDumpDiffController {
+
+    private final ProfileManagerResolver resolver;
+
+    public HeapDumpDiffController(ProfileManagerResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    @GetMapping("/histogram")
+    public HeapDumpDiffReport histogram(
+            @PathVariable("primaryProfileId") String primaryProfileId,
+            @PathVariable("secondaryProfileId") String secondaryProfileId,
+            @RequestParam(value = "topN", defaultValue = "500") int topN) {
+        HeapDumpManager primary = resolver.resolve(primaryProfileId).heapDumpManager();
+        HeapDumpManager baseline = resolver.resolve(secondaryProfileId).heapDumpManager();
+        return HeapDumpDiffService.diff(primary, baseline, topN);
+    }
+}

--- a/jeffrey-microscope/pages-microscope/src/components/HeapDumpInitTimeline.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/HeapDumpInitTimeline.vue
@@ -174,9 +174,11 @@ const phases: Phase[] = [
   {
     id: 'hotspots',
     name: 'Hotspots',
-    description: 'Class loaders, biggest collections',
+    description: 'Class loaders, biggest collections, waste',
     stages: [
       { id: 'classloaders', label: 'Analyzing class loaders' },
+      { id: 'consumers', label: 'Aggregating memory consumers' },
+      { id: 'duplicates', label: 'Detecting duplicate data' },
       { id: 'biggest-collections', label: 'Finding biggest collections' }
     ]
   }

--- a/jeffrey-microscope/pages-microscope/src/router/profileChildRoutes.ts
+++ b/jeffrey-microscope/pages-microscope/src/router/profileChildRoutes.ts
@@ -393,6 +393,12 @@ const heapDumpRoutes = [
     meta: { layout: 'profile' }
   },
   {
+    path: 'heap-dump/biggest-objects',
+    name: 'profile-heap-dump-biggest-objects',
+    component: () => import('@/views/profiles/detail/ProfileHeapDumpBiggestObjects.vue'),
+    meta: { layout: 'profile' }
+  },
+  {
     path: 'heap-dump/biggest-collections',
     name: 'profile-heap-dump-biggest-collections',
     component: () => import('@/views/profiles/detail/ProfileHeapDumpBiggestCollections.vue'),
@@ -402,6 +408,24 @@ const heapDumpRoutes = [
     path: 'heap-dump/classloader-analysis',
     name: 'profile-heap-dump-classloader-analysis',
     component: () => import('@/views/profiles/detail/ProfileHeapDumpClassLoaderAnalysis.vue'),
+    meta: { layout: 'profile' }
+  },
+  {
+    path: 'heap-dump/consumers',
+    name: 'profile-heap-dump-consumers',
+    component: () => import('@/views/profiles/detail/ProfileHeapDumpConsumers.vue'),
+    meta: { layout: 'profile' }
+  },
+  {
+    path: 'heap-dump/duplicate-data',
+    name: 'profile-heap-dump-duplicate-data',
+    component: () => import('@/views/profiles/detail/ProfileHeapDumpDuplicateData.vue'),
+    meta: { layout: 'profile' }
+  },
+  {
+    path: 'heap-dump/diff',
+    name: 'profile-heap-dump-diff',
+    component: () => import('@/views/profiles/detail/ProfileHeapDumpDiff.vue'),
     meta: { layout: 'profile' }
   }
 ];

--- a/jeffrey-microscope/pages-microscope/src/services/api/HeapDumpClient.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/HeapDumpClient.ts
@@ -40,6 +40,9 @@ import ClassInstancesResponse from '@/services/api/model/ClassInstancesResponse'
 import LeakSuspectsReport from '@/services/api/model/LeakSuspectsReport';
 import BiggestObjectsReport from '@/services/api/model/BiggestObjectsReport';
 import BiggestCollectionsReport from '@/services/api/model/BiggestCollectionsReport';
+import type ConsumerReport from '@/services/api/model/ConsumerReport';
+import type DuplicateDataReport from '@/services/api/model/DuplicateDataReport';
+import type HeapDumpInitProgress from '@/services/api/model/HeapDumpInitProgress';
 import HeapDumpConfig from '@/services/api/model/HeapDumpConfig';
 import type InitPipelineResult from '@/services/api/model/InitPipelineResult';
 import type { SubPhaseTiming } from '@/services/api/model/InitPipelineResult';
@@ -62,6 +65,19 @@ export default class HeapDumpClient extends BaseProfileClient {
 
   public getSummary(): Promise<HeapSummary> {
     return this.get<HeapSummary>('/summary');
+  }
+
+  /**
+   * Starts the full server-side init pipeline in the background; poll
+   * getInitProgress() for per-stage statuses.
+   */
+  public initializeAll(compressedOops?: boolean): Promise<void> {
+    const params = compressedOops !== undefined ? `?compressedOops=${compressedOops}` : '';
+    return this.post<void>(`/initialize-all${params}`, {});
+  }
+
+  public getInitProgress(): Promise<HeapDumpInitProgress> {
+    return this.get<HeapDumpInitProgress>('/init-progress');
   }
 
   public getHistogram(topN: number = 100, sortBy: string = 'SIZE'): Promise<ClassHistogramEntry[]> {
@@ -293,6 +309,34 @@ export default class HeapDumpClient extends BaseProfileClient {
 
   public runBiggestObjects(topN: number = 20): Promise<void> {
     return this.post<void>(`/biggest-objects/run?topN=${topN}`, {});
+  }
+
+  // --- Duplicate Data ---
+
+  public duplicateDataExists(): Promise<boolean> {
+    return this.get<boolean>('/duplicate-data/exists');
+  }
+
+  public getDuplicateData(): Promise<DuplicateDataReport> {
+    return this.get<DuplicateDataReport>('/duplicate-data');
+  }
+
+  public runDuplicateData(topN: number = 50): Promise<void> {
+    return this.post<void>(`/duplicate-data/run?topN=${topN}`, {});
+  }
+
+  // --- Consumers (per-package) ---
+
+  public consumerReportExists(): Promise<boolean> {
+    return this.get<boolean>('/consumers/exists');
+  }
+
+  public getConsumerReport(): Promise<ConsumerReport> {
+    return this.get<ConsumerReport>('/consumers');
+  }
+
+  public runConsumerReport(): Promise<void> {
+    return this.post<void>('/consumers/run', {});
   }
 
   // --- Biggest Collections ---

--- a/jeffrey-microscope/pages-microscope/src/services/api/HeapDumpDiffClient.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/HeapDumpDiffClient.ts
@@ -1,0 +1,34 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import BaseProfileClient from '@/services/api/BaseProfileClient';
+import type HeapDumpDiffReport from '@/services/api/model/HeapDumpDiffReport';
+
+/**
+ * Heap-dump comparison API: primary (current) profile vs a baseline profile,
+ * following the /profiles/{primary}/diff/{secondary}/... URL convention.
+ */
+export default class HeapDumpDiffClient extends BaseProfileClient {
+  constructor(primaryProfileId: string, baselineProfileId: string) {
+    super(primaryProfileId, `diff/${baselineProfileId}/heap`);
+  }
+
+  public getHistogramDiff(topN: number = 500): Promise<HeapDumpDiffReport> {
+    return this.get<HeapDumpDiffReport>(`/histogram?topN=${topN}`);
+  }
+}

--- a/jeffrey-microscope/pages-microscope/src/services/api/model/ConsumerReport.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/model/ConsumerReport.ts
@@ -1,0 +1,23 @@
+export interface ConsumerEntry {
+  packageName: string;
+  classLoaderId: number;
+  classLoaderClassName: string | null;
+  retainedSize: number;
+  shallowSize: number;
+  classCount: number;
+  instanceCount: number;
+}
+
+export interface ComponentEntry {
+  packageName: string;
+  retainedSize: number;
+  shallowSize: number;
+  classCount: number;
+  instanceCount: number;
+}
+
+export default interface ConsumerReport {
+  totalHeapSize: number;
+  topConsumers: ConsumerEntry[];
+  componentReport: ComponentEntry[];
+}

--- a/jeffrey-microscope/pages-microscope/src/services/api/model/DuplicateDataReport.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/model/DuplicateDataReport.ts
@@ -1,0 +1,19 @@
+export interface DuplicateArrayGroup {
+  typeName: string;
+  arrayLength: number;
+  count: number;
+  shallowSize: number;
+  wastedBytes: number;
+  contentPreview: string;
+  sampleObjectIds: number[];
+}
+
+export default interface DuplicateDataReport {
+  totalPrimitiveArrays: number;
+  totalPrimitiveArrayBytes: number;
+  duplicateGroups: number;
+  duplicateArrayCount: number;
+  potentialSavings: number;
+  oversizedSkipped: number;
+  topGroups: DuplicateArrayGroup[];
+}

--- a/jeffrey-microscope/pages-microscope/src/services/api/model/HeapDumpDiffReport.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/model/HeapDumpDiffReport.ts
@@ -1,0 +1,19 @@
+import HeapSummary from '@/services/api/model/HeapSummary';
+
+export interface ClassDiffEntry {
+  className: string;
+  primaryCount: number;
+  baselineCount: number;
+  countDelta: number;
+  primaryBytes: number;
+  baselineBytes: number;
+  bytesDelta: number;
+}
+
+export default interface HeapDumpDiffReport {
+  primarySummary: HeapSummary;
+  baselineSummary: HeapSummary;
+  instanceCountDelta: number;
+  shallowBytesDelta: number;
+  entries: ClassDiffEntry[];
+}

--- a/jeffrey-microscope/pages-microscope/src/services/api/model/HeapDumpInitProgress.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/model/HeapDumpInitProgress.ts
@@ -1,0 +1,15 @@
+import type { SubPhaseTiming } from '@/services/api/model/InitPipelineResult';
+
+export interface HeapDumpInitStageProgress {
+  id: string;
+  status: 'pending' | 'in_progress' | 'completed' | 'failed';
+  durationMs: number | null;
+  subPhases: SubPhaseTiming[] | null;
+}
+
+export default interface HeapDumpInitProgress {
+  state: 'idle' | 'running' | 'completed' | 'failed';
+  errorCode: string | null;
+  errorMessage: string | null;
+  stages: HeapDumpInitStageProgress[];
+}

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileHeapDumpBiggestObjects.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileHeapDumpBiggestObjects.vue
@@ -1,0 +1,288 @@
+<template>
+  <LoadingState v-if="loading" message="Loading biggest objects..." />
+
+  <div v-else-if="!heapExists" class="no-heap-dump">
+    <div class="alert alert-info d-flex align-items-center">
+      <i class="bi bi-info-circle me-3 fs-4"></i>
+      <div>
+        <h6 class="mb-1">No Heap Dump Available</h6>
+        <p class="mb-0 small">No heap dump file (.hprof) was found for this profile.</p>
+      </div>
+    </div>
+  </div>
+
+  <HeapDumpNotInitialized
+    v-else-if="!cacheReady"
+    icon="box-seam"
+    message="The heap dump needs to be initialized before you can view the biggest objects."
+  />
+
+  <ErrorState v-else-if="error" :message="error" />
+
+  <HeapDumpNotInitialized
+    v-else-if="!report"
+    icon="box-seam-fill"
+    message="The biggest objects analysis is not available for this heap dump. Re-initialize the heap dump from the Heap Dump Overview to populate it."
+  />
+
+  <!-- Analysis Results -->
+  <div v-else-if="report">
+    <PageHeader
+      title="Biggest Objects"
+      description="Single objects retaining the most memory — the direct dominator-tree roots"
+      icon="bi-box-seam-fill"
+    />
+
+    <!-- Summary Metrics -->
+    <StatsTable :metrics="summaryMetrics" class="mb-4" />
+
+    <div v-if="report.entries.length > 0">
+      <DataTable>
+        <template #toolbar>
+          <TableToolbar :show-search="false">
+            <span class="toolbar-info">Showing {{ report.entries.length }} objects</span>
+          </TableToolbar>
+        </template>
+        <thead>
+          <tr>
+            <th style="width: 40px">#</th>
+            <th>Class</th>
+            <th class="text-end" style="width: 120px">Shallow</th>
+            <th class="text-end" style="width: 120px">Retained</th>
+            <th style="width: 200px">% of Heap</th>
+            <th style="width: 140px">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(entry, index) in report.entries" :key="entry.objectId">
+            <td class="text-muted">{{ index + 1 }}</td>
+            <td>
+              <ClassNameDisplay :class-name="entry.className" />
+            </td>
+            <td class="text-end font-monospace">
+              {{ FormattingService.formatBytes(entry.shallowSize) }}
+            </td>
+            <td class="text-end font-monospace text-warning">
+              {{ FormattingService.formatBytes(entry.retainedSize) }}
+            </td>
+            <td>
+              <div class="heap-pct-container">
+                <div class="heap-pct-bar">
+                  <div class="heap-pct-inner" :style="{ width: heapPercent(entry) + '%' }"></div>
+                </div>
+                <span class="heap-pct-value">{{ heapPercent(entry).toFixed(1) }}%</span>
+              </div>
+            </td>
+            <td>
+              <InstanceActionButtons
+                :object-id="entry.objectId"
+                @show-referrers="openTreeModal($event, 'REFERRERS')"
+                @show-reachables="openTreeModal($event, 'REACHABLES')"
+                @show-g-c-root-path="openGCRootPath"
+              />
+            </td>
+          </tr>
+        </tbody>
+      </DataTable>
+    </div>
+    <div v-else class="text-center text-muted py-5">
+      <i class="bi bi-box-seam-fill fs-1 mb-3 d-block"></i>
+      <p>No object data available.</p>
+    </div>
+
+    <!-- Modals -->
+    <InstanceTreeModal
+      v-if="treeModalObjectId !== null"
+      :show="showTreeModal"
+      :object-id="treeModalObjectId"
+      :initial-mode="treeModalMode"
+      :profile-id="profileId"
+      @close="showTreeModal = false"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+
+import PageHeader from '@shared/components/layout/PageHeader.vue';
+import LoadingState from '@shared/components/LoadingState.vue';
+import ErrorState from '@shared/components/ErrorState.vue';
+import StatsTable from '@shared/components/table/StatsTable.vue';
+import HeapDumpNotInitialized from '@/components/HeapDumpNotInitialized.vue';
+import ClassNameDisplay from '@/components/heap/ClassNameDisplay.vue';
+import InstanceActionButtons from '@/components/heap/InstanceActionButtons.vue';
+import InstanceTreeModal from '@/components/heap/InstanceTreeModal.vue';
+import DataTable from '@shared/components/table/DataTable.vue';
+import TableToolbar from '@shared/components/table/TableToolbar.vue';
+import HeapDumpClient from '@/services/api/HeapDumpClient';
+import type BiggestObjectsReport from '@/services/api/model/BiggestObjectsReport';
+import type { BiggestObjectEntry } from '@/services/api/model/BiggestObjectsReport';
+import FormattingService from '@shared/services/FormattingService';
+
+const route = useRoute();
+const router = useRouter();
+const profileId = route.params.profileId as string;
+
+const loading = ref(true);
+const error = ref<string | null>(null);
+const heapExists = ref(false);
+const cacheReady = ref(false);
+const report = ref<BiggestObjectsReport | null>(null);
+
+const showTreeModal = ref(false);
+const treeModalObjectId = ref<number | null>(null);
+const treeModalMode = ref<'REFERRERS' | 'REACHABLES'>('REFERRERS');
+
+let client: HeapDumpClient;
+
+const summaryMetrics = computed(() => {
+  if (!report.value) {
+    return [];
+  }
+  const top = report.value.entries[0];
+  const totalHeap = report.value.totalHeapSize;
+  return [
+    {
+      icon: 'box-seam-fill',
+      title: 'Objects Listed',
+      value: FormattingService.formatNumber(report.value.entries.length),
+      variant: 'highlight' as const
+    },
+    {
+      icon: 'hdd-fill',
+      title: 'Total Heap Size',
+      value: FormattingService.formatBytes(totalHeap),
+      variant: 'info' as const
+    },
+    {
+      icon: 'pie-chart-fill',
+      title: 'Retained by Listed',
+      value: FormattingService.formatBytes(report.value.totalRetainedSize),
+      variant: 'warning' as const,
+      breakdown:
+        totalHeap > 0
+          ? [
+              {
+                label: 'Of heap',
+                value: ((report.value.totalRetainedSize * 100) / totalHeap).toFixed(1) + '%'
+              }
+            ]
+          : []
+    },
+    {
+      icon: 'trophy-fill',
+      title: 'Top Object',
+      value: top ? FormattingService.formatBytes(top.retainedSize) : '-',
+      variant: 'danger' as const,
+      breakdown: top ? [{ label: 'Class', value: top.className }] : []
+    }
+  ];
+});
+
+const heapPercent = (entry: BiggestObjectEntry): number => {
+  if (!report.value || report.value.totalHeapSize === 0) {
+    return 0;
+  }
+  return (entry.retainedSize * 100) / report.value.totalHeapSize;
+};
+
+const openTreeModal = (objectId: number, mode: 'REFERRERS' | 'REACHABLES') => {
+  treeModalObjectId.value = objectId;
+  treeModalMode.value = mode;
+  showTreeModal.value = true;
+};
+
+const openGCRootPath = (objectId: number) => {
+  router.push(`/profiles/${profileId}/heap-dump/gc-root-path?objectId=${objectId}`);
+};
+
+const loadAnalysis = async () => {
+  report.value = await client.getBiggestObjects();
+};
+
+const scrollToTop = () => {
+  const workspaceContent = document.querySelector('.workspace-content');
+  if (workspaceContent) {
+    workspaceContent.scrollTop = 0;
+  }
+};
+
+const loadData = async () => {
+  try {
+    loading.value = true;
+    error.value = null;
+
+    client = new HeapDumpClient(profileId);
+
+    heapExists.value = await client.exists();
+    if (!heapExists.value) {
+      loading.value = false;
+      return;
+    }
+
+    cacheReady.value = await client.isCacheReady();
+    if (!cacheReady.value) {
+      loading.value = false;
+      return;
+    }
+
+    await loadAnalysis();
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to load biggest objects';
+  } finally {
+    loading.value = false;
+  }
+};
+
+onMounted(() => {
+  scrollToTop();
+  loadData();
+});
+</script>
+
+<style scoped>
+.no-heap-dump {
+  padding: 2rem;
+}
+
+.heap-pct-container {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.heap-pct-bar {
+  height: 5px;
+  background-color: var(--color-border);
+  border-radius: var(--radius-sm);
+  flex: 1;
+  min-width: 40px;
+}
+
+.heap-pct-inner {
+  height: 100%;
+  border-radius: var(--radius-sm);
+  background-color: var(--color-danger);
+}
+
+.heap-pct-value {
+  font-size: 0.7rem;
+  color: var(--color-text-muted);
+  min-width: 35px;
+}
+
+.toolbar-info {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.font-monospace {
+  font-size: 0.8rem;
+}
+
+.text-warning {
+  color: var(--color-goldenrod) !important;
+}
+</style>

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileHeapDumpConsumers.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileHeapDumpConsumers.vue
@@ -1,0 +1,394 @@
+<template>
+  <LoadingState v-if="loading" message="Loading memory consumers..." />
+
+  <div v-else-if="!heapExists" class="no-heap-dump">
+    <div class="alert alert-info d-flex align-items-center">
+      <i class="bi bi-info-circle me-3 fs-4"></i>
+      <div>
+        <h6 class="mb-1">No Heap Dump Available</h6>
+        <p class="mb-0 small">No heap dump file (.hprof) was found for this profile.</p>
+      </div>
+    </div>
+  </div>
+
+  <HeapDumpNotInitialized
+    v-else-if="!cacheReady"
+    icon="pie-chart"
+    message="The heap dump needs to be initialized before you can view memory consumers."
+  />
+
+  <ErrorState v-else-if="error" :message="error" />
+
+  <HeapDumpNotInitialized
+    v-else-if="!report"
+    icon="pie-chart-fill"
+    message="The consumer report is not available for this heap dump. Re-initialize the heap dump from the Heap Dump Overview to populate it."
+  />
+
+  <!-- Analysis Results -->
+  <div v-else-if="report">
+    <PageHeader
+      title="Memory Consumers"
+      description="Which packages and class loaders own the most heap memory"
+      icon="bi-pie-chart-fill"
+    />
+
+    <!-- Summary Metrics -->
+    <StatsTable :metrics="summaryMetrics" class="mb-4" />
+
+    <!-- Tabbed Results -->
+    <TabBar v-model="activeTab" :tabs="analysisTabs" class="mb-3" />
+
+    <!-- By Package Tab (rolled up across class loaders) -->
+    <div v-show="activeTab === 'by-package'">
+      <DataTable v-if="packageRows.length > 0">
+        <template #toolbar>
+          <TableToolbar v-model="packagesView.query" search-placeholder="Filter packages...">
+            <span class="toolbar-info">{{ packagesView.matchCount }} packages</span>
+          </TableToolbar>
+        </template>
+        <thead>
+          <tr>
+            <th style="width: 40px">#</th>
+            <th>Package</th>
+            <th class="text-end" style="width: 130px">Shallow Size</th>
+            <th style="width: 200px">% of Heap</th>
+            <th class="text-end" style="width: 100px">Classes</th>
+            <th class="text-end" style="width: 120px">Instances</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(entry, index) in packagesView.visible" :key="entry.packageName">
+            <td class="text-muted">{{ index + 1 }}</td>
+            <td class="font-monospace package-name">{{ entry.packageName }}</td>
+            <td class="text-end font-monospace text-warning">
+              {{ FormattingService.formatBytes(entry.shallowSize) }}
+            </td>
+            <td>
+              <div class="heap-pct-container">
+                <div class="heap-pct-bar">
+                  <div
+                    class="heap-pct-inner"
+                    :style="{ width: heapPercent(entry.shallowSize) + '%' }"
+                  ></div>
+                </div>
+                <span class="heap-pct-value">{{ heapPercent(entry.shallowSize).toFixed(1) }}%</span>
+              </div>
+            </td>
+            <td class="text-end font-monospace">
+              {{ FormattingService.formatNumber(entry.classCount) }}
+            </td>
+            <td class="text-end font-monospace">
+              {{ FormattingService.formatNumber(entry.instanceCount) }}
+            </td>
+          </tr>
+        </tbody>
+        <template #footer>
+          <TableShowMore
+            :shown="packagesView.visible.length"
+            :match-count="packagesView.matchCount"
+            :total="packagesView.total"
+            :expanded="packagesView.expanded"
+            :page-size="packagesView.pageSize"
+            @toggle="packagesView.toggle"
+          />
+        </template>
+      </DataTable>
+      <div v-else class="text-center text-muted py-5">
+        <i class="bi bi-pie-chart-fill fs-1 mb-3 d-block"></i>
+        <p>No consumer data available.</p>
+      </div>
+    </div>
+
+    <!-- By Package & Class Loader Tab -->
+    <div v-show="activeTab === 'by-package-loader'">
+      <DataTable v-if="report.topConsumers.length > 0">
+        <template #toolbar>
+          <TableToolbar v-model="consumersView.query" search-placeholder="Filter packages or loaders...">
+            <span class="toolbar-info">{{ consumersView.matchCount }} consumers</span>
+          </TableToolbar>
+        </template>
+        <thead>
+          <tr>
+            <th style="width: 40px">#</th>
+            <th>Package</th>
+            <th>Class Loader</th>
+            <th class="text-end" style="width: 130px">Shallow Size</th>
+            <th style="width: 200px">% of Heap</th>
+            <th class="text-end" style="width: 100px">Classes</th>
+            <th class="text-end" style="width: 120px">Instances</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="(entry, index) in consumersView.visible"
+            :key="entry.packageName + ':' + entry.classLoaderId"
+          >
+            <td class="text-muted">{{ index + 1 }}</td>
+            <td class="font-monospace package-name">{{ entry.packageName }}</td>
+            <td>
+              <ClassNameDisplay
+                v-if="entry.classLoaderClassName"
+                :class-name="entry.classLoaderClassName"
+              />
+              <span v-else class="text-muted loader-empty">bootstrap</span>
+            </td>
+            <td class="text-end font-monospace text-warning">
+              {{ FormattingService.formatBytes(entry.shallowSize) }}
+            </td>
+            <td>
+              <div class="heap-pct-container">
+                <div class="heap-pct-bar">
+                  <div
+                    class="heap-pct-inner"
+                    :style="{ width: heapPercent(entry.shallowSize) + '%' }"
+                  ></div>
+                </div>
+                <span class="heap-pct-value">{{ heapPercent(entry.shallowSize).toFixed(1) }}%</span>
+              </div>
+            </td>
+            <td class="text-end font-monospace">
+              {{ FormattingService.formatNumber(entry.classCount) }}
+            </td>
+            <td class="text-end font-monospace">
+              {{ FormattingService.formatNumber(entry.instanceCount) }}
+            </td>
+          </tr>
+        </tbody>
+        <template #footer>
+          <TableShowMore
+            :shown="consumersView.visible.length"
+            :match-count="consumersView.matchCount"
+            :total="consumersView.total"
+            :expanded="consumersView.expanded"
+            :page-size="consumersView.pageSize"
+            @toggle="consumersView.toggle"
+          />
+        </template>
+      </DataTable>
+      <div v-else class="text-center text-muted py-5">
+        <i class="bi bi-pie-chart-fill fs-1 mb-3 d-block"></i>
+        <p>No consumer data available.</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { useRoute } from 'vue-router';
+
+import PageHeader from '@shared/components/layout/PageHeader.vue';
+import LoadingState from '@shared/components/LoadingState.vue';
+import ErrorState from '@shared/components/ErrorState.vue';
+import StatsTable from '@shared/components/table/StatsTable.vue';
+import HeapDumpNotInitialized from '@/components/HeapDumpNotInitialized.vue';
+import ClassNameDisplay from '@/components/heap/ClassNameDisplay.vue';
+import TabBar from '@shared/components/TabBar.vue';
+import DataTable from '@shared/components/table/DataTable.vue';
+import TableToolbar from '@shared/components/table/TableToolbar.vue';
+import TableShowMore from '@shared/components/table/TableShowMore.vue';
+import { useTableView } from '@/composables/useTableView';
+import HeapDumpClient from '@/services/api/HeapDumpClient';
+import type ConsumerReport from '@/services/api/model/ConsumerReport';
+import type { ComponentEntry, ConsumerEntry } from '@/services/api/model/ConsumerReport';
+import FormattingService from '@shared/services/FormattingService';
+
+const route = useRoute();
+const profileId = route.params.profileId as string;
+
+const loading = ref(true);
+const error = ref<string | null>(null);
+const heapExists = ref(false);
+const cacheReady = ref(false);
+const report = ref<ConsumerReport | null>(null);
+
+let client: HeapDumpClient;
+
+const analysisTabs = [
+  { id: 'by-package', label: 'By Package', icon: 'box' },
+  { id: 'by-package-loader', label: 'By Package & Class Loader', icon: 'diagram-2' }
+];
+const activeTab = ref(analysisTabs[0].id);
+
+/**
+ * Per-package rollup across class loaders. The backend's componentReport is
+ * used when populated; otherwise it is derived from topConsumers client-side.
+ */
+const packageRows = computed<ComponentEntry[]>(() => {
+  if (!report.value) {
+    return [];
+  }
+  if (report.value.componentReport.length > 0) {
+    return report.value.componentReport;
+  }
+  const byPackage = new Map<string, ComponentEntry>();
+  for (const entry of report.value.topConsumers) {
+    const existing = byPackage.get(entry.packageName);
+    if (existing) {
+      byPackage.set(entry.packageName, {
+        packageName: entry.packageName,
+        retainedSize: existing.retainedSize + entry.retainedSize,
+        shallowSize: existing.shallowSize + entry.shallowSize,
+        classCount: existing.classCount + entry.classCount,
+        instanceCount: existing.instanceCount + entry.instanceCount
+      });
+    } else {
+      byPackage.set(entry.packageName, {
+        packageName: entry.packageName,
+        retainedSize: entry.retainedSize,
+        shallowSize: entry.shallowSize,
+        classCount: entry.classCount,
+        instanceCount: entry.instanceCount
+      });
+    }
+  }
+  return Array.from(byPackage.values()).sort((a, b) => b.shallowSize - a.shallowSize);
+});
+
+const packagesView = useTableView<ComponentEntry>(() => packageRows.value, {
+  searchableText: row => row.packageName
+});
+
+const consumersView = useTableView<ConsumerEntry>(() => report.value?.topConsumers ?? [], {
+  searchableText: row => row.packageName + ' ' + (row.classLoaderClassName ?? '')
+});
+
+const summaryMetrics = computed(() => {
+  if (!report.value) {
+    return [];
+  }
+  const topPackage = packageRows.value[0];
+  return [
+    {
+      icon: 'hdd-fill',
+      title: 'Total Heap Size',
+      value: FormattingService.formatBytes(report.value.totalHeapSize),
+      variant: 'highlight' as const
+    },
+    {
+      icon: 'box',
+      title: 'Packages',
+      value: FormattingService.formatNumber(packageRows.value.length),
+      variant: 'info' as const
+    },
+    {
+      icon: 'diagram-2',
+      title: 'Package/Loader Cells',
+      value: FormattingService.formatNumber(report.value.topConsumers.length),
+      variant: 'info' as const
+    },
+    {
+      icon: 'trophy-fill',
+      title: 'Top Package',
+      value: topPackage ? FormattingService.formatBytes(topPackage.shallowSize) : '-',
+      variant: 'danger' as const,
+      breakdown: topPackage ? [{ label: 'Package', value: topPackage.packageName }] : []
+    }
+  ];
+});
+
+const heapPercent = (bytes: number): number => {
+  if (!report.value || report.value.totalHeapSize === 0) {
+    return 0;
+  }
+  return (bytes * 100) / report.value.totalHeapSize;
+};
+
+const loadAnalysis = async () => {
+  report.value = await client.getConsumerReport();
+};
+
+const scrollToTop = () => {
+  const workspaceContent = document.querySelector('.workspace-content');
+  if (workspaceContent) {
+    workspaceContent.scrollTop = 0;
+  }
+};
+
+const loadData = async () => {
+  try {
+    loading.value = true;
+    error.value = null;
+
+    client = new HeapDumpClient(profileId);
+
+    heapExists.value = await client.exists();
+    if (!heapExists.value) {
+      loading.value = false;
+      return;
+    }
+
+    cacheReady.value = await client.isCacheReady();
+    if (!cacheReady.value) {
+      loading.value = false;
+      return;
+    }
+
+    await loadAnalysis();
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to load memory consumers';
+  } finally {
+    loading.value = false;
+  }
+};
+
+onMounted(() => {
+  scrollToTop();
+  loadData();
+});
+</script>
+
+<style scoped>
+.no-heap-dump {
+  padding: 2rem;
+}
+
+.package-name {
+  font-size: 0.8rem;
+}
+
+.loader-empty {
+  font-size: 0.85rem;
+  font-style: italic;
+}
+
+.heap-pct-container {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.heap-pct-bar {
+  height: 5px;
+  background-color: var(--color-border);
+  border-radius: var(--radius-sm);
+  flex: 1;
+  min-width: 40px;
+}
+
+.heap-pct-inner {
+  height: 100%;
+  border-radius: var(--radius-sm);
+  background-color: var(--color-primary);
+}
+
+.heap-pct-value {
+  font-size: 0.7rem;
+  color: var(--color-text-muted);
+  min-width: 35px;
+}
+
+.toolbar-info {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.font-monospace {
+  font-size: 0.8rem;
+}
+
+.text-warning {
+  color: var(--color-goldenrod) !important;
+}
+</style>

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileHeapDumpDiff.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileHeapDumpDiff.vue
@@ -1,0 +1,313 @@
+<template>
+  <LoadingState v-if="loading" message="Comparing heap dumps..." />
+
+  <div v-else-if="!baselineId" class="no-heap-dump">
+    <PageHeader
+      title="Heap Diff"
+      description="Compare this profile's heap dump against a baseline profile"
+      icon="bi-layers-half"
+    />
+    <div class="alert alert-info d-flex align-items-center">
+      <i class="bi bi-layers-half me-3 fs-4"></i>
+      <div>
+        <h6 class="mb-1">No Baseline Profile Selected</h6>
+        <p class="mb-0 small">
+          Select a secondary profile (the baseline heap dump) using the secondary-profile selector
+          in the sidebar, then return to this page.
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <ErrorState v-else-if="error" :message="error" />
+
+  <!-- Diff Results -->
+  <div v-else-if="report">
+    <PageHeader
+      title="Heap Diff"
+      :description="`Current heap vs baseline '${baselineName}' — what grew, appeared or shrank`"
+      icon="bi-layers-half"
+    />
+
+    <!-- Summary Metrics -->
+    <StatsTable :metrics="summaryMetrics" class="mb-4" />
+
+    <!-- Category tabs -->
+    <TabBar v-model="activeCategory" :tabs="categoryTabs" class="mb-3" />
+
+    <DataTable v-if="categoryRows.length > 0">
+      <template #toolbar>
+        <TableToolbar v-model="diffView.query" search-placeholder="Filter classes...">
+          <span class="toolbar-info">{{ diffView.matchCount }} classes</span>
+        </TableToolbar>
+      </template>
+      <thead>
+        <tr>
+          <th style="width: 40px">#</th>
+          <th>Class</th>
+          <th style="width: 100px">Change</th>
+          <th class="text-end" style="width: 130px">Baseline Count</th>
+          <th class="text-end" style="width: 130px">Current Count</th>
+          <th class="text-end" style="width: 110px">Δ Count</th>
+          <th class="text-end" style="width: 130px">Δ Bytes</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="(entry, index) in diffView.visible" :key="entry.className">
+          <td class="text-muted">{{ index + 1 }}</td>
+          <td>
+            <ClassNameDisplay :class-name="entry.className" />
+          </td>
+          <td>
+            <Badge
+              :value="categoryOf(entry).label"
+              :variant="categoryOf(entry).variant"
+              size="s"
+            />
+          </td>
+          <td class="text-end font-monospace">
+            {{ FormattingService.formatNumber(entry.baselineCount) }}
+          </td>
+          <td class="text-end font-monospace">
+            {{ FormattingService.formatNumber(entry.primaryCount) }}
+          </td>
+          <td class="text-end font-monospace" :class="deltaClass(entry.countDelta)">
+            {{ signedNumber(entry.countDelta) }}
+          </td>
+          <td class="text-end font-monospace" :class="deltaClass(entry.bytesDelta)">
+            {{ signedBytes(entry.bytesDelta) }}
+          </td>
+        </tr>
+      </tbody>
+      <template #footer>
+        <TableShowMore
+          :shown="diffView.visible.length"
+          :match-count="diffView.matchCount"
+          :total="diffView.total"
+          :expanded="diffView.expanded"
+          :page-size="diffView.pageSize"
+          @toggle="diffView.toggle"
+        />
+      </template>
+    </DataTable>
+    <div v-else class="text-center text-muted py-5">
+      <i class="bi bi-layers-half fs-1 mb-3 d-block"></i>
+      <p>No class-level differences in this category.</p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from 'vue';
+import { useRoute } from 'vue-router';
+
+import PageHeader from '@shared/components/layout/PageHeader.vue';
+import LoadingState from '@shared/components/LoadingState.vue';
+import ErrorState from '@shared/components/ErrorState.vue';
+import StatsTable from '@shared/components/table/StatsTable.vue';
+import TabBar from '@shared/components/TabBar.vue';
+import Badge from '@shared/components/Badge.vue';
+import ClassNameDisplay from '@/components/heap/ClassNameDisplay.vue';
+import DataTable from '@shared/components/table/DataTable.vue';
+import TableToolbar from '@shared/components/table/TableToolbar.vue';
+import TableShowMore from '@shared/components/table/TableShowMore.vue';
+import { useTableView } from '@/composables/useTableView';
+import HeapDumpDiffClient from '@/services/api/HeapDumpDiffClient';
+import type HeapDumpDiffReport from '@/services/api/model/HeapDumpDiffReport';
+import type { ClassDiffEntry } from '@/services/api/model/HeapDumpDiffReport';
+import SecondaryProfileService from '@/services/SecondaryProfileService';
+import FormattingService from '@shared/services/FormattingService';
+
+type DiffCategory = 'all' | 'grown' | 'new' | 'shrunk' | 'removed';
+
+const route = useRoute();
+const profileId = route.params.profileId as string;
+
+const loading = ref(true);
+const error = ref<string | null>(null);
+const report = ref<HeapDumpDiffReport | null>(null);
+const baselineId = ref<string | null>(null);
+const baselineName = ref<string>('');
+
+const categoryTabs = [
+  { id: 'all', label: 'All Changes', icon: 'layers-half' },
+  { id: 'grown', label: 'Grown', icon: 'arrow-up-right' },
+  { id: 'new', label: 'New', icon: 'plus-circle' },
+  { id: 'shrunk', label: 'Shrunk', icon: 'arrow-down-right' },
+  { id: 'removed', label: 'Removed', icon: 'dash-circle' }
+];
+const activeCategory = ref<string>('all');
+
+const categoryOf = (
+  entry: ClassDiffEntry
+): { id: DiffCategory; label: string; variant: 'danger' | 'success' | 'warning' | 'info' } => {
+  if (entry.baselineCount === 0 && entry.primaryCount > 0) {
+    return { id: 'new', label: 'New', variant: 'danger' };
+  }
+  if (entry.primaryCount === 0 && entry.baselineCount > 0) {
+    return { id: 'removed', label: 'Removed', variant: 'success' };
+  }
+  if (entry.bytesDelta > 0 || (entry.bytesDelta === 0 && entry.countDelta > 0)) {
+    return { id: 'grown', label: 'Grown', variant: 'warning' };
+  }
+  return { id: 'shrunk', label: 'Shrunk', variant: 'info' };
+};
+
+const categoryRows = computed<ClassDiffEntry[]>(() => {
+  if (!report.value) {
+    return [];
+  }
+  if (activeCategory.value === 'all') {
+    return report.value.entries;
+  }
+  return report.value.entries.filter(e => categoryOf(e).id === activeCategory.value);
+});
+
+const diffView = useTableView<ClassDiffEntry>(() => categoryRows.value, {
+  searchableText: row => row.className
+});
+
+const summaryMetrics = computed(() => {
+  if (!report.value) {
+    return [];
+  }
+  const grown = report.value.entries.filter(e => categoryOf(e).id === 'grown').length;
+  const added = report.value.entries.filter(e => categoryOf(e).id === 'new').length;
+  return [
+    {
+      icon: 'hdd-fill',
+      title: 'Heap Size Change',
+      value: signedBytes(report.value.shallowBytesDelta),
+      variant: (report.value.shallowBytesDelta > 0 ? 'danger' : 'success') as 'danger' | 'success',
+      breakdown: [
+        {
+          label: 'Baseline',
+          value: FormattingService.formatBytes(report.value.baselineSummary.totalBytes)
+        },
+        {
+          label: 'Current',
+          value: FormattingService.formatBytes(report.value.primarySummary.totalBytes)
+        }
+      ]
+    },
+    {
+      icon: 'collection',
+      title: 'Instance Change',
+      value: signedNumber(report.value.instanceCountDelta),
+      variant: 'info' as const,
+      breakdown: [
+        {
+          label: 'Baseline',
+          value: FormattingService.formatNumber(report.value.baselineSummary.totalInstances)
+        },
+        {
+          label: 'Current',
+          value: FormattingService.formatNumber(report.value.primarySummary.totalInstances)
+        }
+      ]
+    },
+    {
+      icon: 'arrow-up-right',
+      title: 'Classes Grown',
+      value: FormattingService.formatNumber(grown),
+      variant: 'warning' as const
+    },
+    {
+      icon: 'plus-circle',
+      title: 'New Classes',
+      value: FormattingService.formatNumber(added),
+      variant: 'highlight' as const
+    }
+  ];
+});
+
+const signedNumber = (value: number): string => {
+  const formatted = FormattingService.formatNumber(Math.abs(value));
+  if (value > 0) {
+    return '+' + formatted;
+  }
+  if (value < 0) {
+    return '-' + formatted;
+  }
+  return formatted;
+};
+
+const signedBytes = (value: number): string => {
+  const formatted = FormattingService.formatBytes(Math.abs(value));
+  if (value > 0) {
+    return '+' + formatted;
+  }
+  if (value < 0) {
+    return '-' + formatted;
+  }
+  return formatted;
+};
+
+const deltaClass = (value: number): string => {
+  if (value > 0) {
+    return 'delta-positive';
+  }
+  if (value < 0) {
+    return 'delta-negative';
+  }
+  return '';
+};
+
+const loadData = async () => {
+  try {
+    loading.value = true;
+    error.value = null;
+    report.value = null;
+
+    baselineId.value = SecondaryProfileService.id();
+    baselineName.value = SecondaryProfileService.name() ?? '';
+    if (!baselineId.value) {
+      loading.value = false;
+      return;
+    }
+
+    const client = new HeapDumpDiffClient(profileId, baselineId.value);
+    report.value = await client.getHistogramDiff();
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to compare heap dumps';
+  } finally {
+    loading.value = false;
+  }
+};
+
+const handleBaselineChanged = () => {
+  loadData();
+};
+
+onMounted(() => {
+  loadData();
+  window.addEventListener(SecondaryProfileService.PROFILE_CHANGED, handleBaselineChanged);
+});
+
+onUnmounted(() => {
+  window.removeEventListener(SecondaryProfileService.PROFILE_CHANGED, handleBaselineChanged);
+});
+</script>
+
+<style scoped>
+.no-heap-dump {
+  padding: 0 0 2rem 0;
+}
+
+.toolbar-info {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.font-monospace {
+  font-size: 0.8rem;
+}
+
+.delta-positive {
+  color: var(--color-danger);
+}
+
+.delta-negative {
+  color: var(--color-success);
+}
+</style>

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileHeapDumpDuplicateData.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileHeapDumpDuplicateData.vue
@@ -1,0 +1,286 @@
+<template>
+  <LoadingState v-if="loading" message="Loading duplicate data analysis..." />
+
+  <div v-else-if="!heapExists" class="no-heap-dump">
+    <div class="alert alert-info d-flex align-items-center">
+      <i class="bi bi-info-circle me-3 fs-4"></i>
+      <div>
+        <h6 class="mb-1">No Heap Dump Available</h6>
+        <p class="mb-0 small">No heap dump file (.hprof) was found for this profile.</p>
+      </div>
+    </div>
+  </div>
+
+  <HeapDumpNotInitialized
+    v-else-if="!cacheReady"
+    icon="files"
+    message="The heap dump needs to be initialized before you can view duplicate data."
+  />
+
+  <ErrorState v-else-if="error" :message="error" />
+
+  <HeapDumpNotInitialized
+    v-else-if="!report"
+    icon="files"
+    message="The duplicate data analysis is not available for this heap dump. Re-initialize the heap dump from the Heap Dump Overview to populate it."
+  />
+
+  <!-- Analysis Results -->
+  <div v-else-if="report">
+    <PageHeader
+      title="Duplicate Data"
+      description="Byte-identical primitive arrays that could be shared as a single copy"
+      icon="bi-files"
+    />
+
+    <!-- Summary Metrics -->
+    <StatsTable :metrics="summaryMetrics" class="mb-4" />
+
+    <DataTable v-if="report.topGroups.length > 0">
+      <template #toolbar>
+        <TableToolbar v-model="groupsView.query" search-placeholder="Filter by type or content...">
+          <span class="toolbar-info">{{ groupsView.matchCount }} duplicate groups</span>
+        </TableToolbar>
+      </template>
+      <thead>
+        <tr>
+          <th style="width: 40px">#</th>
+          <th style="width: 110px">Type</th>
+          <th>Content Preview</th>
+          <th class="text-end" style="width: 100px">Length</th>
+          <th class="text-end" style="width: 90px">Copies</th>
+          <th class="text-end" style="width: 120px">Per Copy</th>
+          <th class="text-end" style="width: 120px">Wasted</th>
+          <th style="width: 130px">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="(group, index) in groupsView.visible" :key="index">
+          <td class="text-muted">{{ index + 1 }}</td>
+          <td>
+            <ClassNameDisplay :class-name="group.typeName" />
+          </td>
+          <td class="content-preview" :title="group.contentPreview">
+            {{ group.contentPreview || '—' }}
+          </td>
+          <td class="text-end font-monospace">
+            {{ FormattingService.formatNumber(group.arrayLength) }}
+          </td>
+          <td class="text-end font-monospace">
+            {{ FormattingService.formatNumber(group.count) }}
+          </td>
+          <td class="text-end font-monospace">
+            {{ FormattingService.formatBytes(group.shallowSize) }}
+          </td>
+          <td class="text-end font-monospace text-warning">
+            {{ FormattingService.formatBytes(group.wastedBytes) }}
+          </td>
+          <td>
+            <InstanceActionButtons
+              v-if="group.sampleObjectIds.length > 0"
+              :object-id="group.sampleObjectIds[0]"
+              @show-referrers="openTreeModal($event, 'REFERRERS')"
+              @show-reachables="openTreeModal($event, 'REACHABLES')"
+              @show-g-c-root-path="openGCRootPath"
+            />
+          </td>
+        </tr>
+      </tbody>
+      <template #footer>
+        <TableShowMore
+          :shown="groupsView.visible.length"
+          :match-count="groupsView.matchCount"
+          :total="groupsView.total"
+          :expanded="groupsView.expanded"
+          :page-size="groupsView.pageSize"
+          @toggle="groupsView.toggle"
+        />
+      </template>
+    </DataTable>
+    <div v-else class="text-center text-muted py-5">
+      <i class="bi bi-files fs-1 mb-3 d-block"></i>
+      <p>No duplicate primitive arrays found — nothing to reclaim here.</p>
+    </div>
+
+    <!-- Modals -->
+    <InstanceTreeModal
+      v-if="treeModalObjectId !== null"
+      :show="showTreeModal"
+      :object-id="treeModalObjectId"
+      :initial-mode="treeModalMode"
+      :profile-id="profileId"
+      @close="showTreeModal = false"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+
+import PageHeader from '@shared/components/layout/PageHeader.vue';
+import LoadingState from '@shared/components/LoadingState.vue';
+import ErrorState from '@shared/components/ErrorState.vue';
+import StatsTable from '@shared/components/table/StatsTable.vue';
+import HeapDumpNotInitialized from '@/components/HeapDumpNotInitialized.vue';
+import ClassNameDisplay from '@/components/heap/ClassNameDisplay.vue';
+import InstanceActionButtons from '@/components/heap/InstanceActionButtons.vue';
+import InstanceTreeModal from '@/components/heap/InstanceTreeModal.vue';
+import DataTable from '@shared/components/table/DataTable.vue';
+import TableToolbar from '@shared/components/table/TableToolbar.vue';
+import TableShowMore from '@shared/components/table/TableShowMore.vue';
+import { useTableView } from '@/composables/useTableView';
+import HeapDumpClient from '@/services/api/HeapDumpClient';
+import type DuplicateDataReport from '@/services/api/model/DuplicateDataReport';
+import type { DuplicateArrayGroup } from '@/services/api/model/DuplicateDataReport';
+import FormattingService from '@shared/services/FormattingService';
+
+const route = useRoute();
+const router = useRouter();
+const profileId = route.params.profileId as string;
+
+const loading = ref(true);
+const error = ref<string | null>(null);
+const heapExists = ref(false);
+const cacheReady = ref(false);
+const report = ref<DuplicateDataReport | null>(null);
+
+const showTreeModal = ref(false);
+const treeModalObjectId = ref<number | null>(null);
+const treeModalMode = ref<'REFERRERS' | 'REACHABLES'>('REFERRERS');
+
+let client: HeapDumpClient;
+
+const groupsView = useTableView<DuplicateArrayGroup>(() => report.value?.topGroups ?? [], {
+  searchableText: row => row.typeName + ' ' + row.contentPreview
+});
+
+const summaryMetrics = computed(() => {
+  if (!report.value) {
+    return [];
+  }
+  return [
+    {
+      icon: 'files',
+      title: 'Duplicate Groups',
+      value: FormattingService.formatNumber(report.value.duplicateGroups),
+      variant: 'highlight' as const,
+      breakdown: [
+        {
+          label: 'Redundant copies',
+          value: FormattingService.formatNumber(report.value.duplicateArrayCount)
+        }
+      ]
+    },
+    {
+      icon: 'recycle',
+      title: 'Potential Savings',
+      value: FormattingService.formatBytes(report.value.potentialSavings),
+      variant: 'danger' as const
+    },
+    {
+      icon: 'grid-3x3-gap',
+      title: 'Primitive Arrays Scanned',
+      value: FormattingService.formatNumber(report.value.totalPrimitiveArrays),
+      variant: 'info' as const,
+      breakdown:
+        report.value.oversizedSkipped > 0
+          ? [
+              {
+                label: 'Oversized skipped',
+                value: FormattingService.formatNumber(report.value.oversizedSkipped)
+              }
+            ]
+          : []
+    },
+    {
+      icon: 'hdd-fill',
+      title: 'Total Array Bytes',
+      value: FormattingService.formatBytes(report.value.totalPrimitiveArrayBytes),
+      variant: 'info' as const
+    }
+  ];
+});
+
+const openTreeModal = (objectId: number, mode: 'REFERRERS' | 'REACHABLES') => {
+  treeModalObjectId.value = objectId;
+  treeModalMode.value = mode;
+  showTreeModal.value = true;
+};
+
+const openGCRootPath = (objectId: number) => {
+  router.push(`/profiles/${profileId}/heap-dump/gc-root-path?objectId=${objectId}`);
+};
+
+const loadAnalysis = async () => {
+  report.value = await client.getDuplicateData();
+};
+
+const scrollToTop = () => {
+  const workspaceContent = document.querySelector('.workspace-content');
+  if (workspaceContent) {
+    workspaceContent.scrollTop = 0;
+  }
+};
+
+const loadData = async () => {
+  try {
+    loading.value = true;
+    error.value = null;
+
+    client = new HeapDumpClient(profileId);
+
+    heapExists.value = await client.exists();
+    if (!heapExists.value) {
+      loading.value = false;
+      return;
+    }
+
+    cacheReady.value = await client.isCacheReady();
+    if (!cacheReady.value) {
+      loading.value = false;
+      return;
+    }
+
+    await loadAnalysis();
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to load duplicate data analysis';
+  } finally {
+    loading.value = false;
+  }
+};
+
+onMounted(() => {
+  scrollToTop();
+  loadData();
+});
+</script>
+
+<style scoped>
+.no-heap-dump {
+  padding: 2rem;
+}
+
+.content-preview {
+  font-family: var(--font-monospace, monospace);
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  max-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.toolbar-info {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.font-monospace {
+  font-size: 0.8rem;
+}
+
+.text-warning {
+  color: var(--color-goldenrod) !important;
+}
+</style>

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileHeapDumpSettings.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileHeapDumpSettings.vue
@@ -344,7 +344,7 @@ import HeapDumpInitTimeline, { type TimelineStep } from '@/components/HeapDumpIn
 import HeapSummary from '@/services/api/model/HeapSummary';
 import HeapDumpConfig from '@/services/api/model/HeapDumpConfig';
 import type InitPipelineResult from '@/services/api/model/InitPipelineResult';
-import type { SubPhaseTiming } from '@/services/api/model/InitPipelineResult';
+import type HeapDumpInitProgress from '@/services/api/model/HeapDumpInitProgress';
 import FormattingService from '@shared/services/FormattingService';
 import { ToastService } from '@shared/services/ToastService';
 import MessageBus from '@/services/MessageBus';
@@ -378,8 +378,6 @@ interface ProcessingStep extends TimelineStep {
 }
 
 const STAGE_IDS: string[] = [
-  'load',
-  'parse',
   'index',
   'strings',
   'dominator',
@@ -388,6 +386,8 @@ const STAGE_IDS: string[] = [
   'collections',
   'leaks',
   'classloaders',
+  'consumers',
+  'duplicates',
   'biggest-collections'
 ];
 
@@ -405,32 +405,6 @@ const findStep = (id: string): ProcessingStep | undefined =>
 const resetSteps = () => {
   // Rebuild steps based on current checkbox state
   processingSteps.value = getProcessingSteps();
-};
-
-const setStepStatus = (id: string, status: ProcessingStep['status']) => {
-  const step = findStep(id);
-  if (step) step.status = status;
-};
-
-const startStep = (id: string) => {
-  const step = findStep(id);
-  if (step) {
-    step.status = 'in_progress';
-    step.startMs = Date.now();
-  }
-};
-
-const completeStep = (id: string, subPhases?: SubPhaseTiming[]) => {
-  const step = findStep(id);
-  if (step) {
-    step.status = 'completed';
-    if (step.startMs != null) {
-      step.durationMs = Date.now() - step.startMs;
-    }
-    if (subPhases && subPhases.length > 0) {
-      step.subPhases = subPhases;
-    }
-  }
 };
 
 // Live tick for in-progress elapsed display
@@ -522,122 +496,100 @@ const summaryMetrics = computed(() => {
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
+const POLL_INTERVAL_MS = 750;
+
+/** Consecutive idle polls tolerated before treating the run as lost (e.g. backend restart). */
+const MAX_IDLE_POLLS = 5;
+
+/** Maps backend per-stage statuses onto the live timeline steps. */
+const applyProgress = (progress: HeapDumpInitProgress) => {
+  for (const stage of progress.stages) {
+    const step = findStep(stage.id);
+    if (!step) {
+      continue;
+    }
+    if (stage.status === 'in_progress') {
+      if (step.status !== 'in_progress') {
+        step.status = 'in_progress';
+        step.startMs = Date.now();
+      }
+    } else if (stage.status === 'completed') {
+      step.status = 'completed';
+      step.durationMs = stage.durationMs ?? undefined;
+      step.subPhases = stage.subPhases ?? undefined;
+    }
+    // 'failed' stages stay visually pending; the error panel reports the failure.
+  }
+};
+
+const handleInitFailure = (code: string | null, message: string | null) => {
+  if (code === 'HEAP_DUMP_NEEDS_SANITIZATION') {
+    needsSanitization.value = true;
+    // File still exists - don't set heapExists to false
+  } else if (code === 'HEAP_DUMP_CORRUPTED') {
+    initError.value = message ?? 'Heap dump is corrupted';
+    heapExists.value = false; // File was deleted by backend
+  } else {
+    error.value = message ?? 'Failed to process heap dump';
+  }
+};
+
 const processHeapDump = async () => {
   processing.value = true;
   resetSteps();
   startTick();
 
   try {
-    // Step 1: Load
-    startStep('load');
-    await sleep(300);
-    completeStep('load');
-
-    // Step 2: Parse
-    startStep('parse');
-    await sleep(300);
-    completeStep('parse');
-
-    // Step 3: Index (resolve compressed oops + build indexes)
-    startStep('index');
     const compressedOopsOverride =
       compressedOopsChoice.value === 'enabled'
         ? true
         : compressedOopsChoice.value === 'disabled'
           ? false
           : undefined;
-    const indexResult = await client.initialize(compressedOopsOverride);
-    lastSummary.value = indexResult.summary;
+
+    // One POST kicks off the whole pipeline server-side; from here on the
+    // frontend only mirrors the backend's per-stage progress.
+    await client.initializeAll(compressedOopsOverride);
+
+    let idlePolls = 0;
+    let progress = await client.getInitProgress();
+    while (progress.state === 'running' || progress.state === 'idle') {
+      if (progress.state === 'idle') {
+        idlePolls++;
+        if (idlePolls > MAX_IDLE_POLLS) {
+          throw new Error('Initialization run was lost — please try again.');
+        }
+      } else {
+        idlePolls = 0;
+        applyProgress(progress);
+      }
+      await sleep(POLL_INTERVAL_MS);
+      progress = await client.getInitProgress();
+    }
+    applyProgress(progress);
+
+    if (progress.state === 'failed') {
+      handleInitFailure(progress.errorCode, progress.errorMessage);
+      return;
+    }
+
+    // Completed — the backend owns the persisted snapshot now.
+    lastSummary.value = await client.getSummary();
     heapConfig.value = await client.getConfig();
-    completeStep('index', indexResult.subPhases);
-
-    // Step 4: Strings
-    startStep('strings');
-    await client.runStringAnalysis(100);
-    completeStep('strings');
-
-    // Step 5: Dominator Tree — pre-computed up front because (a) it owns the
-    // single biggest cost on large heaps and (b) retained sizes for threads,
-    // biggest objects, leak suspects and the dominator-tree view all read
-    // from it. Running it as its own stage keeps the timeline honest:
-    // previously this cost hid behind the "Analyzing threads" label because
-    // runThreadAnalysis() built the tree lazily.
-    startStep('dominator');
-    const dominatorSubPhases = await client.runComputeDominator();
-    completeStep('dominator', dominatorSubPhases);
-
-    // Step 6: Threads — tree is already built, so this is purely the
-    // SQL-based thread analysis (sub-second on typical heaps).
-    startStep('threads');
-    await client.runThreadAnalysis();
-    completeStep('threads');
-
-    // Step 7: Biggest Objects
-    startStep('biggest');
-    await client.runBiggestObjects(20);
-    completeStep('biggest');
-
-    // Step 8: Collections
-    startStep('collections');
-    await client.runCollectionAnalysis();
-    completeStep('collections');
-
-    // Step 9: Leak Suspects
-    startStep('leaks');
-    await client.runLeakSuspects();
-    completeStep('leaks');
-
-    // Step 10: Class Loaders
-    startStep('classloaders');
-    await client.runClassLoaderAnalysis();
-    completeStep('classloaders');
-
-    // Step 11: Biggest Collections
-    startStep('biggest-collections');
-    await client.runBiggestCollections(50);
-    completeStep('biggest-collections');
-
     cacheReady.value = true;
     MessageBus.emit(MessageBus.HEAP_DUMP_STATUS_CHANGED, true);
-
-    // Snapshot the timeline so the Overview page can display it on subsequent visits.
-    const snapshot: InitPipelineResult = {
-      totalElapsedMs: processingSteps.value.reduce((sum, s) => sum + (s.durationMs ?? 0), 0),
-      totalSteps: processingSteps.value.length,
-      completedSteps: processingSteps.value.filter(
-        s => s.status === 'completed' || s.status === 'skipped' || s.status === 'on_demand'
-      ).length,
-      completedAt: new Date().toISOString(),
-      stages: processingSteps.value.map(s => {
-        const status: 'completed' | 'skipped' | 'on_demand' =
-          s.status === 'completed'
-            ? 'completed'
-            : s.status === 'on_demand'
-              ? 'on_demand'
-              : 'skipped';
-        return {
-          id: s.id,
-          status,
-          durationMs: s.durationMs ?? null,
-          subPhases: s.subPhases ?? null
-        };
-      })
-    };
-    lastInitResult.value = snapshot;
     try {
-      await client.storeInitPipelineResult(snapshot);
-    } catch (storeErr) {
-      // Snapshot persistence is best-effort — log and move on.
-      console.warn('Failed to persist init pipeline result', storeErr);
+      lastInitResult.value = await client.getInitPipelineResult();
+    } catch (snapshotErr) {
+      console.warn('Failed to load init pipeline result', snapshotErr);
     }
   } catch (err) {
-    // Check if this is a heap dump corruption error that can be repaired
+    // Kick-off/polling errors (the pipeline itself reports failures via progress).
     if (err instanceof ApiError && err.errorResponse?.code === 'HEAP_DUMP_NEEDS_SANITIZATION') {
       needsSanitization.value = true;
-      // File still exists - don't set heapExists to false
     } else if (err instanceof ApiError && err.errorResponse?.code === 'HEAP_DUMP_CORRUPTED') {
       initError.value = err.errorResponse.message;
-      heapExists.value = false; // File was deleted by backend
+      heapExists.value = false;
     } else {
       error.value = err instanceof Error ? err.message : 'Failed to process heap dump';
     }

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/navigation/__tests__/profileNavConfig.spec.ts
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/navigation/__tests__/profileNavConfig.spec.ts
@@ -66,9 +66,9 @@ describe('profileNavConfig', () => {
 
   it('collects a sane number of nav items', () => {
     // 7 Overview (incl. Dashboards) + 19 JVM (incl. GC/JIT submenu parents + children)
-    // + 16 Application (incl. Memory Issues submenu) + 4 Visualization + 13 HeapDump
+    // + 16 Application (incl. Memory Issues submenu) + 4 Visualization + 17 HeapDump
     // + 4 Tools + 34 Technologies
-    expect(allItems.length).toBe(97);
+    expect(allItems.length).toBe(101);
   });
 
   it('every item has a label and a bootstrap icon', () => {

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/navigation/profileNavConfig.ts
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/navigation/profileNavConfig.ts
@@ -387,7 +387,8 @@ export const profileNavSections: Record<
           disabledKeys: [HEAP_DUMP_KEY, AI_ANALYSIS_KEY],
           cssClass: AI_ITEM_CLASS
         }),
-        item('OQL Query', 'bi-terminal', '/heap-dump/oql', { disabledKeys: [HEAP_DUMP_KEY] })
+        item('OQL Query', 'bi-terminal', '/heap-dump/oql', { disabledKeys: [HEAP_DUMP_KEY] }),
+        item('Heap Diff', 'bi-layers-half', '/heap-dump/diff', { disabledKeys: [HEAP_DUMP_KEY] })
       ]
     },
     {
@@ -408,6 +409,12 @@ export const profileNavSections: Record<
         item('GC Roots', 'bi-diagram-3', '/heap-dump/gc-roots', {
           disabledKeys: [HEAP_DUMP_KEY]
         }),
+        item('Biggest Objects', 'bi-box-seam-fill', '/heap-dump/biggest-objects', {
+          disabledKeys: [HEAP_DUMP_KEY]
+        }),
+        item('Memory Consumers', 'bi-pie-chart-fill', '/heap-dump/consumers', {
+          disabledKeys: [HEAP_DUMP_KEY]
+        }),
         item('Collection Analysis', 'bi-collection', '/heap-dump/collection-analysis', {
           disabledKeys: [HEAP_DUMP_KEY]
         }),
@@ -415,6 +422,9 @@ export const profileNavSections: Record<
           disabledKeys: [HEAP_DUMP_KEY]
         }),
         item('String Analysis', 'bi-fonts', '/heap-dump/string-analysis', {
+          disabledKeys: [HEAP_DUMP_KEY]
+        }),
+        item('Duplicate Data', 'bi-files', '/heap-dump/duplicate-data', {
           disabledKeys: [HEAP_DUMP_KEY]
         })
       ]

--- a/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/analyzer/heapview/BiggestCollectionsAnalyzer.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/analyzer/heapview/BiggestCollectionsAnalyzer.java
@@ -31,8 +31,6 @@ import java.util.Set;
 import cafe.jeffrey.profile.heapdump.model.BiggestCollectionEntry;
 import cafe.jeffrey.profile.heapdump.model.BiggestCollectionsReport;
 import cafe.jeffrey.profile.heapdump.view.HeapView;
-import cafe.jeffrey.profile.heapdump.view.HprofTypeSize;
-import cafe.jeffrey.profile.heapdump.view.InstanceFieldDescriptor;
 import cafe.jeffrey.profile.heapdump.view.JavaClassRow;
 
 /**
@@ -56,33 +54,14 @@ import cafe.jeffrey.profile.heapdump.view.JavaClassRow;
  * {@link cafe.jeffrey.profile.heapdump.persistence.HeapDumpSession#buildDominatorTreeIfNeeded()}
  * before calling this analyzer.
  *
- * <p>Supported shapes:
- * <ul>
- *   <li>{@code java.util.ArrayList}: {@code size} / {@code elementData}</li>
- *   <li>{@code java.util.Vector}: {@code elementCount} / {@code elementData}</li>
- *   <li>{@code java.util.HashMap}, {@code java.util.LinkedHashMap}: {@code size} / {@code table}</li>
- *   <li>{@code java.util.Hashtable}: {@code count} / {@code table}</li>
- *   <li>{@code java.util.PriorityQueue}: {@code size} / {@code queue}</li>
- * </ul>
+ * <p>Supported shapes: the shared array-backed catalog in
+ * {@link CollectionShapes} — ArrayList, Vector, HashMap, LinkedHashMap,
+ * Hashtable, PriorityQueue, ArrayDeque, ConcurrentHashMap (approximate count)
+ * and CopyOnWriteArrayList.
  */
 public final class BiggestCollectionsAnalyzer {
 
     private static final int DEFAULT_TOP_N = 50;
-
-    /** HPROF basic-type byte for OBJECT references. */
-    private static final int BASIC_TYPE_OBJECT = 2;
-
-    /** record_kind value for OBJECT_ARRAY_DUMP rows in the {@code instance} table. */
-    private static final byte RECORD_KIND_OBJECT_ARRAY = 1;
-
-    private static final List<Shape> SHAPES = List.of(
-            new Shape("java.util.ArrayList", "size", "elementData"),
-            new Shape("java.util.Vector", "elementCount", "elementData"),
-            new Shape("java.util.HashMap", "size", "table"),
-            new Shape("java.util.LinkedHashMap", "size", "table"),
-            new Shape("java.util.Hashtable", "count", "table"),
-            new Shape("java.util.PriorityQueue", "size", "queue")
-    );
 
     /**
      * Bulk per-shape join. Parameters: {@code 1 = field_id} of the
@@ -131,7 +110,7 @@ public final class BiggestCollectionsAnalyzer {
         }
 
         int idSize = view.metadata().idSize();
-        long instanceHeaderBytes = 2L * idSize + 8L;
+        long instanceHeaderBytes = CollectionShapes.instanceHeaderBytes(idSize);
 
         // class_id -> className for survivor lookups (per-shape, populated lazily).
         Map<Long, String> classNameByClassId = new HashMap<>();
@@ -142,17 +121,18 @@ public final class BiggestCollectionsAnalyzer {
                 topN + 1, Comparator.comparingLong(c -> c.retainedSize));
         int totalAnalyzed = 0;
 
-        for (Shape shape : SHAPES) {
-            for (JavaClassRow cls : view.findClassesByName(shape.className)) {
-                ClassLayout layout = computeLayout(view, cls.classId(), shape, idSize);
+        for (CollectionShapes.ArrayShape shape : CollectionShapes.arrayBackedShapes()) {
+            for (JavaClassRow cls : view.findClassesByName(shape.className())) {
+                CollectionShapes.ArrayLayout layout =
+                        CollectionShapes.computeArrayLayout(view, cls.classId(), shape, idSize);
                 if (layout == null) {
                     continue;
                 }
-                classNameByClassId.put(cls.classId(), shape.className);
+                classNameByClassId.put(cls.classId(), shape.className());
 
                 try (PreparedStatement stmt =
                              view.databaseClient().connection().prepareStatement(COLLECTIONS_SQL)) {
-                    stmt.setInt(1, layout.arrayFieldId);
+                    stmt.setInt(1, layout.arrayFieldId());
                     stmt.setLong(2, cls.classId());
                     try (ResultSet rs = stmt.executeQuery()) {
                         while (rs.next()) {
@@ -168,7 +148,7 @@ public final class BiggestCollectionsAnalyzer {
                                 continue;
                             }
                             int arrKind = rs.getInt(6);
-                            if (rs.wasNull() || arrKind != RECORD_KIND_OBJECT_ARRAY) {
+                            if (rs.wasNull() || arrKind != CollectionShapes.RECORD_KIND_OBJECT_ARRAY) {
                                 continue;
                             }
                             long retained = rs.getLong(7);
@@ -178,8 +158,8 @@ public final class BiggestCollectionsAnalyzer {
 
                             int size;
                             try {
-                                size = view.readInt(
-                                        collOffset + instanceHeaderBytes + layout.sizeFieldByteOffset);
+                                size = layout.sizeReader()
+                                        .read(view, collOffset + instanceHeaderBytes, arrLength);
                             } catch (RuntimeException ignored) {
                                 continue;
                             }
@@ -269,35 +249,6 @@ public final class BiggestCollectionsAnalyzer {
                     ownerClassName));
         }
         return out;
-    }
-
-    private static ClassLayout computeLayout(
-            HeapView view, long classId, Shape shape, int idSize) throws SQLException {
-        List<InstanceFieldDescriptor> chain = view.instanceFieldsWithChain(classId);
-        int arrayFieldId = -1;
-        int sizeFieldOffset = -1;
-        long cursor = 0;
-        for (int i = 0; i < chain.size(); i++) {
-            InstanceFieldDescriptor f = chain.get(i);
-            int fieldSize = HprofTypeSize.sizeOf(f.basicType(), idSize);
-            if (shape.sizeFieldName.equals(f.name()) && fieldSize == 4) {
-                sizeFieldOffset = (int) cursor;
-            }
-            if (shape.arrayFieldName.equals(f.name()) && f.basicType() == BASIC_TYPE_OBJECT) {
-                arrayFieldId = i;
-            }
-            cursor += fieldSize;
-        }
-        if (arrayFieldId < 0 || sizeFieldOffset < 0) {
-            return null;
-        }
-        return new ClassLayout(arrayFieldId, sizeFieldOffset);
-    }
-
-    private record Shape(String className, String sizeFieldName, String arrayFieldName) {
-    }
-
-    private record ClassLayout(int arrayFieldId, int sizeFieldByteOffset) {
     }
 
     private static final class Candidate {

--- a/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/analyzer/heapview/CollectionAnalyzer.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/analyzer/heapview/CollectionAnalyzer.java
@@ -31,7 +31,6 @@ import cafe.jeffrey.profile.heapdump.model.CollectionAnalysisReport;
 import cafe.jeffrey.profile.heapdump.model.CollectionStats;
 import cafe.jeffrey.profile.heapdump.model.FillDistribution;
 import cafe.jeffrey.profile.heapdump.view.HeapView;
-import cafe.jeffrey.profile.heapdump.view.HprofTypeSize;
 import cafe.jeffrey.profile.heapdump.view.InstanceFieldDescriptor;
 import cafe.jeffrey.profile.heapdump.view.JavaClassRow;
 
@@ -39,42 +38,43 @@ import cafe.jeffrey.profile.heapdump.view.JavaClassRow;
  * Bulk-SQL collection analysis.
  *
  * <p>For each supported JDK collection shape, runs a single JOIN that pairs
- * every instance with its backing-array row in one result set. The {@code size}
- * field — an inline {@code int} that has no representation in the index DB —
- * is read directly from the {@code .hprof} via
- * {@link HeapView#readInt(long)} at a per-class precomputed byte offset. This
- * replaces the previous per-instance pattern (two JDBC round-trips per
- * collection: {@code readInstanceFields} + {@code findInstanceById}), which
- * dominated init cost on heaps with hundreds of thousands of collections.
+ * every instance with its backing-array row in one result set. Inline count
+ * fields — which have no representation in the index DB — are read directly
+ * from the {@code .hprof} via {@link HeapView#readInt(long)} /
+ * {@link HeapView#readLong(long)} at per-class precomputed byte offsets.
  *
- * <p>Supported shapes:
+ * <p>Three families of shapes are decoded:
  * <ul>
- *   <li>{@code java.util.ArrayList}, {@code java.util.Vector}: backing field
- *       {@code elementData} (Object[])</li>
- *   <li>{@code java.util.HashMap}, {@code java.util.LinkedHashMap}: backing
- *       field {@code table} (Node[])</li>
- *   <li>{@code java.util.HashSet}, {@code java.util.LinkedHashSet}: backing
- *       field {@code map} (a HashMap — capacity unfolds only one level so
- *       these contribute totals but not fill ratio)</li>
+ *   <li><b>Array-backed</b> (shared catalog in {@link CollectionShapes}):
+ *       ArrayList, Vector, HashMap, LinkedHashMap, Hashtable, PriorityQueue,
+ *       ArrayDeque (head/tail arithmetic), ConcurrentHashMap
+ *       ({@code baseCount}; approximate under concurrent update) and
+ *       CopyOnWriteArrayList (always full). These contribute counts, empties,
+ *       wasted bytes and fill-ratio distributions.</li>
+ *   <li><b>Size-only</b>: TreeMap, LinkedList, ConcurrentLinkedQueue-style
+ *       node chains have no backing array, so they contribute counts and
+ *       empties but no capacity-derived metrics.</li>
+ *   <li><b>Via-map sets</b>: HashSet, LinkedHashSet and TreeSet delegate their
+ *       storage to an internal map; the set's size is read from the referenced
+ *       map instance (layout resolved from the map's actual class), again
+ *       counts/empties only.</li>
  * </ul>
- * Other collection types (LinkedList, TreeMap, ConcurrentHashMap, ArrayDeque,
- * PriorityQueue, CopyOnWriteArrayList) are not decoded here.
  */
 public final class CollectionAnalyzer {
 
-    private static final List<Shape> SHAPES = List.of(
-            new Shape("java.util.ArrayList", "elementData"),
-            new Shape("java.util.Vector", "elementData"),
-            new Shape("java.util.HashMap", "table"),
-            new Shape("java.util.LinkedHashMap", "table"),
-            new Shape("java.util.HashSet", "map"),
-            new Shape("java.util.LinkedHashSet", "map"));
+    private static final List<SizeOnlyShape> SIZE_ONLY_SHAPES = List.of(
+            new SizeOnlyShape("java.util.TreeMap", "size"),
+            new SizeOnlyShape("java.util.LinkedList", "size"));
 
-    /** HPROF basic-type byte for OBJECT references. */
-    private static final int BASIC_TYPE_OBJECT = 2;
+    private static final List<ViaMapShape> VIA_MAP_SHAPES = List.of(
+            new ViaMapShape("java.util.HashSet", "map"),
+            new ViaMapShape("java.util.LinkedHashSet", "map"),
+            new ViaMapShape("java.util.TreeSet", "m"));
 
-    /** record_kind value for OBJECT_ARRAY_DUMP rows in the {@code instance} table. */
-    private static final byte RECORD_KIND_OBJECT_ARRAY = 1;
+    private static final int INT_FIELD_BYTES = 4;
+
+    /** Marker for samples with no meaningful capacity (size-only / via-map shapes). */
+    private static final int CAPACITY_UNKNOWN = -1;
 
     /**
      * Bulk join: every instance of a collection class paired with its
@@ -98,31 +98,56 @@ public final class CollectionAnalyzer {
             WHERE s.class_id = ?
             """;
 
+    /** All instances of a class with their field-block offsets. Parameter: {@code 1 = class_id}. */
+    private static final String INSTANCES_SQL = """
+            SELECT s.instance_id, s.file_offset
+            FROM instance s
+            WHERE s.class_id = ?
+            """;
+
+    /**
+     * Every instance of a set class paired with its backing map instance.
+     * Parameters: {@code 1 = field_id} of the map field, {@code 2 = set class_id}.
+     */
+    private static final String SETS_WITH_MAP_SQL = """
+            SELECT
+                s.instance_id AS set_id,
+                m.class_id    AS map_class_id,
+                m.file_offset AS map_offset
+            FROM instance s
+            LEFT JOIN outbound_ref ref
+                ON ref.source_id = s.instance_id AND ref.field_id = ?
+            LEFT JOIN instance m
+                ON m.instance_id = ref.target_id
+            WHERE s.class_id = ?
+            """;
+
     private CollectionAnalyzer() {
     }
 
     public static CollectionAnalysisReport analyze(HeapView view) throws SQLException {
         int idSize = view.metadata().idSize();
-        long instanceHeaderBytes = 2L * idSize + 8L;
 
-        Map<String, Acc> byType = new LinkedHashMap<>();
-        Map<String, Long> wastedByClass = new HashMap<>();
-        long totalEmpty = 0;
-        long totalWasted = 0;
-        long totalCollections = 0;
-        FillBuckets overallBuckets = new FillBuckets();
+        Totals totals = new Totals(idSize);
+        analyzeArrayBackedShapes(view, idSize, totals);
+        analyzeSizeOnlyShapes(view, idSize, totals);
+        analyzeViaMapShapes(view, idSize, totals);
+        return totals.toReport();
+    }
 
-        for (Shape shape : SHAPES) {
-            for (JavaClassRow cls : view.findClassesByName(shape.className)) {
-                ClassLayout layout = computeLayout(view, cls.classId(), shape, idSize);
+    private static void analyzeArrayBackedShapes(HeapView view, int idSize, Totals totals)
+            throws SQLException {
+        long headerBytes = CollectionShapes.instanceHeaderBytes(idSize);
+        for (CollectionShapes.ArrayShape shape : CollectionShapes.arrayBackedShapes()) {
+            for (JavaClassRow cls : view.findClassesByName(shape.className())) {
+                CollectionShapes.ArrayLayout layout =
+                        CollectionShapes.computeArrayLayout(view, cls.classId(), shape, idSize);
                 if (layout == null) {
-                    continue; // Class has no `size` int or no array field — skip this class.
+                    continue;
                 }
-                Acc acc = byType.computeIfAbsent(shape.className, k -> new Acc());
-
-                try (PreparedStatement stmt =
-                             view.databaseClient().connection().prepareStatement(COLLECTIONS_WITH_ARRAY_SQL)) {
-                    stmt.setInt(1, layout.arrayFieldId);
+                try (PreparedStatement stmt = view.databaseClient().connection()
+                        .prepareStatement(COLLECTIONS_WITH_ARRAY_SQL)) {
+                    stmt.setInt(1, layout.arrayFieldId());
                     stmt.setLong(2, cls.classId());
                     try (ResultSet rs = stmt.executeQuery()) {
                         while (rs.next()) {
@@ -132,119 +157,209 @@ public final class CollectionAnalyzer {
                                 continue;
                             }
                             int arrKind = rs.getInt(5);
-                            if (rs.wasNull() || arrKind != RECORD_KIND_OBJECT_ARRAY) {
-                                // HashSet's `map` points at a HashMap, not an array — skip.
+                            if (rs.wasNull() || arrKind != CollectionShapes.RECORD_KIND_OBJECT_ARRAY) {
                                 continue;
                             }
                             int arrLength = rs.getInt(4);
                             if (rs.wasNull()) {
                                 continue;
                             }
-
-                            // Inline int read: jump to the precomputed offset of `size`
-                            // inside this instance's field block and pull 4 big-endian bytes.
-                            long sizeFieldOffset = collFileOffset + instanceHeaderBytes
-                                    + layout.sizeFieldByteOffset;
                             int size;
                             try {
-                                size = view.readInt(sizeFieldOffset);
+                                size = layout.sizeReader()
+                                        .read(view, collFileOffset + headerBytes, arrLength);
                             } catch (RuntimeException ignored) {
                                 continue;
                             }
-
-                            acc.totalCount++;
-                            totalCollections++;
-                            if (size == 0) {
-                                acc.emptyCount++;
-                                totalEmpty++;
-                            }
-                            long wasted = wastedBytes(size, arrLength);
-                            acc.totalWasted += wasted;
-                            totalWasted += wasted;
-                            wastedByClass.merge(shape.className, wasted, Long::sum);
-
-                            double fillRatio = arrLength == 0 ? 0.0 : (double) size / arrLength;
-                            acc.fillRatioSum += fillRatio;
-                            acc.buckets.add(fillRatio, size);
-                            overallBuckets.add(fillRatio, size);
+                            totals.addSample(shape.className(), size, arrLength);
                         }
                     }
                 }
             }
         }
-
-        List<CollectionStats> stats = new ArrayList<>();
-        for (Map.Entry<String, Acc> e : byType.entrySet()) {
-            Acc a = e.getValue();
-            double avg = a.totalCount == 0 ? 0.0 : a.fillRatioSum / a.totalCount;
-            stats.add(new CollectionStats(
-                    e.getKey(), a.totalCount, a.emptyCount, a.totalWasted, avg,
-                    a.buckets.toFillDistribution()));
-        }
-
-        List<ClassWasteEntry> wasteByClass = wastedByClass.entrySet().stream()
-                .map(e -> new ClassWasteEntry(e.getKey(), 0, 0, e.getValue(),
-                        Map.<String, Integer>of()))
-                .sorted(Comparator.comparingLong(ClassWasteEntry::wastedBytes).reversed())
-                .toList();
-
-        return new CollectionAnalysisReport(
-                (int) Math.min(totalCollections, Integer.MAX_VALUE),
-                (int) Math.min(totalEmpty, Integer.MAX_VALUE),
-                totalWasted,
-                overallBuckets.toFillDistribution(),
-                List.copyOf(stats),
-                wasteByClass);
     }
 
-    /**
-     * Per-class layout: the {@code field_id} (chain-global index) of the
-     * backing-array field, plus the byte offset of the {@code size} int
-     * field within an instance's field block. Returns {@code null} if either
-     * field is missing.
-     */
-    private static ClassLayout computeLayout(HeapView view, long classId, Shape shape, int idSize)
+    private static void analyzeSizeOnlyShapes(HeapView view, int idSize, Totals totals)
             throws SQLException {
-        List<InstanceFieldDescriptor> chain = view.instanceFieldsWithChain(classId);
-        int arrayFieldId = -1;
-        int sizeFieldOffset = -1;
-        long cursor = 0;
+        long headerBytes = CollectionShapes.instanceHeaderBytes(idSize);
+        for (SizeOnlyShape shape : SIZE_ONLY_SHAPES) {
+            for (JavaClassRow cls : view.findClassesByName(shape.className())) {
+                List<InstanceFieldDescriptor> chain = view.instanceFieldsWithChain(cls.classId());
+                int sizeOffset = CollectionShapes.inlineFieldOffset(
+                        chain, shape.sizeFieldName(), INT_FIELD_BYTES, idSize);
+                if (sizeOffset < 0) {
+                    continue;
+                }
+                try (PreparedStatement stmt =
+                             view.databaseClient().connection().prepareStatement(INSTANCES_SQL)) {
+                    stmt.setLong(1, cls.classId());
+                    try (ResultSet rs = stmt.executeQuery()) {
+                        while (rs.next()) {
+                            long fileOffset = rs.getLong(2);
+                            int size;
+                            try {
+                                size = view.readInt(fileOffset + headerBytes + sizeOffset);
+                            } catch (RuntimeException ignored) {
+                                continue;
+                            }
+                            totals.addSample(shape.className(), size, CAPACITY_UNKNOWN);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static void analyzeViaMapShapes(HeapView view, int idSize, Totals totals)
+            throws SQLException {
+        long headerBytes = CollectionShapes.instanceHeaderBytes(idSize);
+        // The referenced map's `size` offset depends on the map's concrete class;
+        // resolved lazily and cached across all set shapes (-1 = size field absent).
+        Map<Long, Integer> sizeOffsetByMapClassId = new HashMap<>();
+
+        for (ViaMapShape shape : VIA_MAP_SHAPES) {
+            for (JavaClassRow cls : view.findClassesByName(shape.className())) {
+                List<InstanceFieldDescriptor> chain = view.instanceFieldsWithChain(cls.classId());
+                int mapFieldId = objectFieldIndex(chain, shape.mapFieldName());
+                if (mapFieldId < 0) {
+                    continue;
+                }
+                try (PreparedStatement stmt =
+                             view.databaseClient().connection().prepareStatement(SETS_WITH_MAP_SQL)) {
+                    stmt.setInt(1, mapFieldId);
+                    stmt.setLong(2, cls.classId());
+                    try (ResultSet rs = stmt.executeQuery()) {
+                        while (rs.next()) {
+                            long mapClassId = rs.getLong(2);
+                            if (rs.wasNull() || mapClassId == 0L) {
+                                continue;
+                            }
+                            long mapOffset = rs.getLong(3);
+                            int sizeOffset = mapSizeOffset(
+                                    view, sizeOffsetByMapClassId, mapClassId, idSize);
+                            if (sizeOffset < 0) {
+                                continue;
+                            }
+                            int size;
+                            try {
+                                size = view.readInt(mapOffset + headerBytes + sizeOffset);
+                            } catch (RuntimeException ignored) {
+                                continue;
+                            }
+                            totals.addSample(shape.className(), size, CAPACITY_UNKNOWN);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static int mapSizeOffset(
+            HeapView view, Map<Long, Integer> cache, long mapClassId, int idSize)
+            throws SQLException {
+        Integer cached = cache.get(mapClassId);
+        if (cached != null) {
+            return cached;
+        }
+        List<InstanceFieldDescriptor> mapChain = view.instanceFieldsWithChain(mapClassId);
+        int offset = CollectionShapes.inlineFieldOffset(mapChain, "size", INT_FIELD_BYTES, idSize);
+        cache.put(mapClassId, offset);
+        return offset;
+    }
+
+    private static int objectFieldIndex(List<InstanceFieldDescriptor> chain, String fieldName) {
         for (int i = 0; i < chain.size(); i++) {
             InstanceFieldDescriptor f = chain.get(i);
-            int fieldSize = HprofTypeSize.sizeOf(f.basicType(), idSize);
-            if ("size".equals(f.name()) && fieldSize == 4) {
-                sizeFieldOffset = (int) cursor;
+            if (fieldName.equals(f.name()) && f.basicType() == CollectionShapes.BASIC_TYPE_OBJECT) {
+                return i;
             }
-            if (shape.arrayFieldName.equals(f.name()) && f.basicType() == BASIC_TYPE_OBJECT) {
-                arrayFieldId = i;
+        }
+        return -1;
+    }
+
+    private record SizeOnlyShape(String className, String sizeFieldName) {
+    }
+
+    private record ViaMapShape(String className, String mapFieldName) {
+    }
+
+    /** Report accumulator shared by all shape families. */
+    private static final class Totals {
+
+        private final int idSize;
+        private final Map<String, Acc> byType = new LinkedHashMap<>();
+        private final Map<String, Long> wastedByClass = new HashMap<>();
+        private final FillBuckets overallBuckets = new FillBuckets();
+        private long totalCollections;
+        private long totalEmpty;
+        private long totalWasted;
+
+        private Totals(int idSize) {
+            this.idSize = idSize;
+        }
+
+        void addSample(String typeName, int size, int capacity) {
+            Acc acc = byType.computeIfAbsent(typeName, k -> new Acc());
+            acc.totalCount++;
+            totalCollections++;
+            if (size == 0) {
+                acc.emptyCount++;
+                totalEmpty++;
             }
-            cursor += fieldSize;
-        }
-        if (arrayFieldId < 0 || sizeFieldOffset < 0) {
-            return null;
-        }
-        return new ClassLayout(arrayFieldId, sizeFieldOffset);
-    }
+            if (capacity == CAPACITY_UNKNOWN) {
+                return;
+            }
+            long wasted = wastedBytes(size, capacity);
+            acc.totalWasted += wasted;
+            totalWasted += wasted;
+            wastedByClass.merge(typeName, wasted, Long::sum);
 
-    private static long wastedBytes(int size, int capacity) {
-        if (capacity <= size) {
-            return 0L;
+            double fillRatio = capacity == 0 ? 0.0 : (double) size / capacity;
+            acc.fillSamples++;
+            acc.fillRatioSum += fillRatio;
+            acc.buckets.add(fillRatio, size);
+            overallBuckets.add(fillRatio, size);
         }
-        // Cost of unused slots is roughly idSize per slot for object-array-backed
-        // collections. Assume idSize=8 (most modern JVMs); minor overcount on idSize=4.
-        return (long) (capacity - size) * 8L;
-    }
 
-    private record Shape(String className, String arrayFieldName) {
-    }
+        private long wastedBytes(int size, int capacity) {
+            if (capacity <= size) {
+                return 0L;
+            }
+            // Cost of unused slots is one reference per slot.
+            return (long) (capacity - size) * idSize;
+        }
 
-    private record ClassLayout(int arrayFieldId, int sizeFieldByteOffset) {
+        CollectionAnalysisReport toReport() {
+            List<CollectionStats> stats = new ArrayList<>();
+            for (Map.Entry<String, Acc> e : byType.entrySet()) {
+                Acc a = e.getValue();
+                double avg = a.fillSamples == 0 ? 0.0 : a.fillRatioSum / a.fillSamples;
+                stats.add(new CollectionStats(
+                        e.getKey(), a.totalCount, a.emptyCount, a.totalWasted, avg,
+                        a.buckets.toFillDistribution()));
+            }
+
+            List<ClassWasteEntry> wasteByClass = wastedByClass.entrySet().stream()
+                    .map(e -> new ClassWasteEntry(e.getKey(), 0, 0, e.getValue(),
+                            Map.<String, Integer>of()))
+                    .sorted(Comparator.comparingLong(ClassWasteEntry::wastedBytes).reversed())
+                    .toList();
+
+            return new CollectionAnalysisReport(
+                    (int) Math.min(totalCollections, Integer.MAX_VALUE),
+                    (int) Math.min(totalEmpty, Integer.MAX_VALUE),
+                    totalWasted,
+                    overallBuckets.toFillDistribution(),
+                    List.copyOf(stats),
+                    wasteByClass);
+        }
     }
 
     private static final class Acc {
         int totalCount;
         int emptyCount;
         long totalWasted;
+        int fillSamples;
         double fillRatioSum;
         final FillBuckets buckets = new FillBuckets();
     }

--- a/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/analyzer/heapview/CollectionShapes.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/analyzer/heapview/CollectionShapes.java
@@ -1,0 +1,245 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package cafe.jeffrey.profile.heapdump.analyzer.heapview;
+
+import java.sql.SQLException;
+import java.util.List;
+import cafe.jeffrey.profile.heapdump.view.HeapView;
+import cafe.jeffrey.profile.heapdump.view.HprofTypeSize;
+import cafe.jeffrey.profile.heapdump.view.InstanceFieldDescriptor;
+
+/**
+ * Shared catalog of JDK collection shapes whose element storage is a single
+ * backing {@code Object[]} reachable through {@code outbound_ref}, used by both
+ * {@link CollectionAnalyzer} and {@link BiggestCollectionsAnalyzer}.
+ *
+ * <p>Each shape names its backing-array field and carries a {@link SizeReaderSpec}
+ * describing how the live element count is stored:
+ * <ul>
+ *   <li>{@link IntFieldSpec} — a plain inline {@code int} ({@code ArrayList.size},
+ *       {@code Vector.elementCount}, {@code Hashtable.count}, ...)</li>
+ *   <li>{@link HeadTailSpec} — {@code ArrayDeque}'s circular-buffer indices;
+ *       size is {@code (tail - head) mod capacity}</li>
+ *   <li>{@link LongFieldSpec} — {@code ConcurrentHashMap.baseCount}; an
+ *       approximation that ignores {@code counterCells}, so counts taken during
+ *       concurrent updates may slightly undercount</li>
+ * </ul>
+ *
+ * <p>Layouts are resolved per concrete class via {@link #computeArrayLayout};
+ * the returned {@link SizeReader} reads the count straight from the mapped
+ * {@code .hprof} given the start of the instance's field block.
+ */
+final class CollectionShapes {
+
+    /** HPROF basic-type byte for OBJECT references. */
+    static final int BASIC_TYPE_OBJECT = 2;
+
+    /** record_kind value for OBJECT_ARRAY_DUMP rows in the {@code instance} table. */
+    static final byte RECORD_KIND_OBJECT_ARRAY = 1;
+
+    private static final int INT_FIELD_BYTES = 4;
+
+    private static final int LONG_FIELD_BYTES = 8;
+
+    private static final List<ArrayShape> ARRAY_BACKED = List.of(
+            new ArrayShape("java.util.ArrayList", "elementData", new IntFieldSpec("size")),
+            new ArrayShape("java.util.Vector", "elementData", new IntFieldSpec("elementCount")),
+            new ArrayShape("java.util.HashMap", "table", new IntFieldSpec("size")),
+            new ArrayShape("java.util.LinkedHashMap", "table", new IntFieldSpec("size")),
+            new ArrayShape("java.util.Hashtable", "table", new IntFieldSpec("count")),
+            new ArrayShape("java.util.PriorityQueue", "queue", new IntFieldSpec("size")),
+            new ArrayShape("java.util.ArrayDeque", "elements", new HeadTailSpec("head", "tail")),
+            new ArrayShape("java.util.concurrent.ConcurrentHashMap", "table",
+                    new LongFieldSpec("baseCount")),
+            new ArrayShape("java.util.concurrent.CopyOnWriteArrayList", "array",
+                    new ArrayLengthSpec()));
+
+    private CollectionShapes() {
+    }
+
+    static List<ArrayShape> arrayBackedShapes() {
+        return ARRAY_BACKED;
+    }
+
+    /** One array-backed collection shape: class, backing-array field, size storage. */
+    record ArrayShape(String className, String arrayFieldName, SizeReaderSpec sizeSpec) {
+    }
+
+    /**
+     * Per-class resolution of an {@link ArrayShape}: the chain-global field index
+     * of the backing array (joins to {@code outbound_ref.field_id}) plus the
+     * reader for the element count. {@code null} when the class layout does not
+     * match the shape (e.g. an unusual JDK version).
+     */
+    record ArrayLayout(int arrayFieldId, SizeReader sizeReader) {
+    }
+
+    static ArrayLayout computeArrayLayout(HeapView view, long classId, ArrayShape shape, int idSize)
+            throws SQLException {
+        List<InstanceFieldDescriptor> chain = view.instanceFieldsWithChain(classId);
+        int arrayFieldId = -1;
+        long cursor = 0;
+        for (int i = 0; i < chain.size(); i++) {
+            InstanceFieldDescriptor f = chain.get(i);
+            if (shape.arrayFieldName().equals(f.name()) && f.basicType() == BASIC_TYPE_OBJECT) {
+                arrayFieldId = i;
+            }
+            cursor += HprofTypeSize.sizeOf(f.basicType(), idSize);
+        }
+        if (arrayFieldId < 0) {
+            return null;
+        }
+        SizeReader reader = shape.sizeSpec().resolve(chain, idSize);
+        if (reader == null) {
+            return null;
+        }
+        return new ArrayLayout(arrayFieldId, reader);
+    }
+
+    /**
+     * Finds the byte offset of the inline field named {@code fieldName} with the
+     * given byte size within a class's field block; {@code -1} when absent.
+     */
+    static int inlineFieldOffset(
+            List<InstanceFieldDescriptor> chain, String fieldName, int requiredBytes, int idSize) {
+        long cursor = 0;
+        for (InstanceFieldDescriptor f : chain) {
+            int fieldSize = HprofTypeSize.sizeOf(f.basicType(), idSize);
+            if (fieldName.equals(f.name()) && fieldSize == requiredBytes) {
+                return (int) cursor;
+            }
+            cursor += fieldSize;
+        }
+        return -1;
+    }
+
+    /** Byte offset of the first field within an INSTANCE_DUMP record body. */
+    static long instanceHeaderBytes(int idSize) {
+        return 2L * idSize + 8L;
+    }
+
+    // ---- Size storage specs (resolved per class) --------------------------
+
+    sealed interface SizeReaderSpec permits IntFieldSpec, LongFieldSpec, HeadTailSpec, ArrayLengthSpec {
+
+        /** Resolves against a concrete class's field chain; {@code null} if the fields are absent. */
+        SizeReader resolve(List<InstanceFieldDescriptor> chain, int idSize);
+    }
+
+    record IntFieldSpec(String fieldName) implements SizeReaderSpec {
+
+        @Override
+        public SizeReader resolve(List<InstanceFieldDescriptor> chain, int idSize) {
+            int offset = inlineFieldOffset(chain, fieldName, INT_FIELD_BYTES, idSize);
+            return offset < 0 ? null : new IntFieldReader(offset);
+        }
+    }
+
+    record LongFieldSpec(String fieldName) implements SizeReaderSpec {
+
+        @Override
+        public SizeReader resolve(List<InstanceFieldDescriptor> chain, int idSize) {
+            int offset = inlineFieldOffset(chain, fieldName, LONG_FIELD_BYTES, idSize);
+            return offset < 0 ? null : new LongFieldReader(offset);
+        }
+    }
+
+    record HeadTailSpec(String headFieldName, String tailFieldName) implements SizeReaderSpec {
+
+        @Override
+        public SizeReader resolve(List<InstanceFieldDescriptor> chain, int idSize) {
+            int headOffset = inlineFieldOffset(chain, headFieldName, INT_FIELD_BYTES, idSize);
+            int tailOffset = inlineFieldOffset(chain, tailFieldName, INT_FIELD_BYTES, idSize);
+            if (headOffset < 0 || tailOffset < 0) {
+                return null;
+            }
+            return new HeadTailReader(headOffset, tailOffset);
+        }
+    }
+
+    /** For collections that are always full (CopyOnWriteArrayList): size == capacity. */
+    record ArrayLengthSpec() implements SizeReaderSpec {
+
+        @Override
+        public SizeReader resolve(List<InstanceFieldDescriptor> chain, int idSize) {
+            return new ArrayLengthReader();
+        }
+    }
+
+    // ---- Size readers (per row) -------------------------------------------
+
+    sealed interface SizeReader permits IntFieldReader, LongFieldReader, HeadTailReader, ArrayLengthReader {
+
+        /**
+         * Reads the element count of one collection instance.
+         *
+         * @param view            the heap view (mmap-attached)
+         * @param fieldBlockStart absolute file offset of the instance's field block
+         * @param capacity        backing-array length of this instance
+         */
+        int read(HeapView view, long fieldBlockStart, int capacity) throws SQLException;
+    }
+
+    record IntFieldReader(int byteOffset) implements SizeReader {
+
+        @Override
+        public int read(HeapView view, long fieldBlockStart, int capacity) throws SQLException {
+            return view.readInt(fieldBlockStart + byteOffset);
+        }
+    }
+
+    record LongFieldReader(int byteOffset) implements SizeReader {
+
+        @Override
+        public int read(HeapView view, long fieldBlockStart, int capacity) throws SQLException {
+            long value = view.readLong(fieldBlockStart + byteOffset);
+            if (value < 0L) {
+                return 0;
+            }
+            return (int) Math.min(value, Integer.MAX_VALUE);
+        }
+    }
+
+    record HeadTailReader(int headByteOffset, int tailByteOffset) implements SizeReader {
+
+        @Override
+        public int read(HeapView view, long fieldBlockStart, int capacity) throws SQLException {
+            if (capacity == 0) {
+                return 0;
+            }
+            int head = view.readInt(fieldBlockStart + headByteOffset);
+            int tail = view.readInt(fieldBlockStart + tailByteOffset);
+            int size = tail - head;
+            if (size < 0) {
+                size += capacity;
+            }
+            if (size < 0 || size > capacity) {
+                return 0;
+            }
+            return size;
+        }
+    }
+
+    record ArrayLengthReader() implements SizeReader {
+
+        @Override
+        public int read(HeapView view, long fieldBlockStart, int capacity) {
+            return capacity;
+        }
+    }
+}

--- a/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/analyzer/heapview/DominatorTreeAnalyzer.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/analyzer/heapview/DominatorTreeAnalyzer.java
@@ -67,16 +67,25 @@ public final class DominatorTreeAnalyzer {
     }
 
     public static DominatorTreeResponse children(HeapView view, long parentId) throws SQLException {
-        return children(view, parentId, DEFAULT_LIMIT);
+        return children(view, parentId, 0, DEFAULT_LIMIT);
     }
 
     public static DominatorTreeResponse children(HeapView view, long parentId, int limit) throws SQLException {
+        return children(view, parentId, 0, limit);
+    }
+
+    public static DominatorTreeResponse children(HeapView view, long parentId, int offset, int limit)
+            throws SQLException {
+
         if (!view.hasDominatorTree()) {
             throw new IllegalStateException(
                     "Dominator tree not built; call DominatorTreeBuilder.build(indexDb) first");
         }
         if (limit <= 0) {
             throw new IllegalArgumentException("limit must be positive: limit=" + limit);
+        }
+        if (offset < 0) {
+            throw new IllegalArgumentException("offset must not be negative: offset=" + offset);
         }
 
         long totalHeapSize = view.totalShallowSize();
@@ -94,7 +103,7 @@ public final class DominatorTreeAnalyzer {
                 : Map.of();
 
         // children: dominator(d.dominator_id = parent) joined to instance + class + retained.
-        // Fetch limit+1 to detect hasMore.
+        // instance_id is the tie-break so retained-size ties paginate deterministically.
         String sql = "SELECT d.instance_id, c.name, i.shallow_size, r.bytes, "
                 + "       EXISTS (SELECT 1 FROM dominator d2 WHERE d2.dominator_id = d.instance_id) AS has_children "
                 + "FROM dominator d "
@@ -102,8 +111,8 @@ public final class DominatorTreeAnalyzer {
                 + "LEFT JOIN class c ON i.class_id = c.class_id "
                 + "JOIN retained_size r ON r.instance_id = d.instance_id "
                 + "WHERE d.dominator_id = ? "
-                + "ORDER BY r.bytes DESC "
-                + "LIMIT ?";
+                + "ORDER BY r.bytes DESC, d.instance_id "
+                + "LIMIT ? OFFSET ?";
 
         // First pass: pull child rows and remember which byte[] (opaque-array) ids we need
         // to enrich with referrer hints. Building the final DominatorNode list is deferred
@@ -115,7 +124,8 @@ public final class DominatorTreeAnalyzer {
         List<Long> opaqueArrayIds = new ArrayList<>();
         try (PreparedStatement stmt = view.databaseClient().connection().prepareStatement(sql)) {
             stmt.setLong(1, parentId);
-            stmt.setInt(2, limit + 1);
+            stmt.setInt(2, limit);
+            stmt.setInt(3, offset);
             try (ResultSet rs = stmt.executeQuery()) {
                 while (rs.next() && rawRows.size() < limit) {
                     long instanceId = rs.getLong(1);
@@ -153,7 +163,7 @@ public final class DominatorTreeAnalyzer {
                     row.shallow(), row.retained(), row.percent(), row.hasChildren(), row.rootKind(),
                     referrers));
         }
-        boolean hasMore = nodes.size() == limit && countChildren(view, parentId) > limit;
+        boolean hasMore = nodes.size() == limit && countChildren(view, parentId) > offset + limit;
         boolean compressedOops = view.metadata().compressedOops();
 
         return new DominatorTreeResponse(nodes, totalHeapSize, compressedOops, hasMore);

--- a/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/analyzer/heapview/DominatorTreeAnalyzer.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/analyzer/heapview/DominatorTreeAnalyzer.java
@@ -52,6 +52,9 @@ public final class DominatorTreeAnalyzer {
 
     private static final int DEFAULT_LIMIT = 100;
 
+    /** Display prefix for class-object nodes (statics holders) in the tree. */
+    private static final String CLASS_NODE_NAME_PREFIX = "class ";
+
     /**
      * Class names whose instances are too opaque to be self-describing — knowing
      * "this is a byte[]" does not tell you whether it backs a String, a HeapByteBuffer,
@@ -103,12 +106,18 @@ public final class DominatorTreeAnalyzer {
                 : Map.of();
 
         // children: dominator(d.dominator_id = parent) joined to instance + class + retained.
+        // A node is either an instance (join via instance -> class) or a class
+        // object (statics holder; join class directly and label it "class <name>").
         // instance_id is the tie-break so retained-size ties paginate deterministically.
-        String sql = "SELECT d.instance_id, c.name, i.shallow_size, r.bytes, "
+        String sql = "SELECT d.instance_id, "
+                + "       COALESCE(ic.name, '" + CLASS_NODE_NAME_PREFIX + "' || cc.name) AS name, "
+                + "       COALESCE(i.shallow_size, cc.static_fields_size, 0) AS shallow, "
+                + "       r.bytes, "
                 + "       EXISTS (SELECT 1 FROM dominator d2 WHERE d2.dominator_id = d.instance_id) AS has_children "
                 + "FROM dominator d "
-                + "JOIN instance i ON i.instance_id = d.instance_id "
-                + "LEFT JOIN class c ON i.class_id = c.class_id "
+                + "LEFT JOIN instance i ON i.instance_id = d.instance_id "
+                + "LEFT JOIN class ic ON i.class_id = ic.class_id "
+                + "LEFT JOIN class cc ON cc.class_id = d.instance_id "
                 + "JOIN retained_size r ON r.instance_id = d.instance_id "
                 + "WHERE d.dominator_id = ? "
                 + "ORDER BY r.bytes DESC, d.instance_id "

--- a/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/analyzer/heapview/DuplicateArrayAnalyzer.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/analyzer/heapview/DuplicateArrayAnalyzer.java
@@ -1,0 +1,261 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package cafe.jeffrey.profile.heapdump.analyzer.heapview;
+
+import java.nio.charset.StandardCharsets;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import cafe.jeffrey.profile.heapdump.model.DuplicateArrayGroup;
+import cafe.jeffrey.profile.heapdump.model.DuplicateDataReport;
+import cafe.jeffrey.profile.heapdump.view.HeapView;
+import cafe.jeffrey.profile.heapdump.view.HprofTag;
+import net.jpountz.xxhash.XXHash64;
+import net.jpountz.xxhash.XXHashFactory;
+
+/**
+ * Finds byte-identical primitive arrays — the raw storage behind buffers,
+ * caches, deserialized payloads and non-deduplicated strings — and reports how
+ * much heap could be reclaimed by sharing a single copy per group.
+ *
+ * <p>Arrays are grouped by {@code (primitiveType, length, XXHash64(content))};
+ * content is read straight from the mapped {@code .hprof} one array at a time,
+ * so peak memory is a single array's payload. A 64-bit content hash stands in
+ * for full byte equality — with equal type and length the collision
+ * probability is negligible for reporting purposes.
+ *
+ * <p>Arrays smaller than {@link #MIN_CONTENT_BYTES} are ignored (empty/near-empty
+ * arrays are dominated by legitimately shared constants), and arrays larger
+ * than {@link #MAX_HASH_BYTES} are skipped rather than partially hashed, so a
+ * prefix collision can never masquerade as a duplicate; the skipped count is
+ * surfaced in the report.
+ */
+public final class DuplicateArrayAnalyzer {
+
+    private static final int DEFAULT_TOP_N = 50;
+
+    /** Arrays with payloads below this size are noise (shared empty arrays etc.). */
+    private static final int MIN_CONTENT_BYTES = 16;
+
+    /** Arrays larger than this are skipped instead of partially hashed. */
+    private static final int MAX_HASH_BYTES = 64 * 1024 * 1024;
+
+    private static final long HASH_SEED = 0x9E3779B97F4A7C15L;
+
+    private static final int SAMPLE_IDS_PER_GROUP = 3;
+
+    private static final int PREVIEW_BYTES = 256;
+
+    private static final int PREVIEW_MAX_CHARS = 60;
+
+    private static final String PRIMITIVE_ARRAYS_SQL = """
+            SELECT i.instance_id, i.array_length, i.primitive_type, i.shallow_size, c.name
+            FROM instance i
+            LEFT JOIN class c ON c.class_id = i.class_id
+            WHERE i.record_kind = 2
+            """;
+
+    private DuplicateArrayAnalyzer() {
+    }
+
+    public static DuplicateDataReport analyze(HeapView view) throws SQLException {
+        return analyze(view, DEFAULT_TOP_N);
+    }
+
+    public static DuplicateDataReport analyze(HeapView view, int topN) throws SQLException {
+        if (topN <= 0) {
+            throw new IllegalArgumentException("topN must be positive: topN=" + topN);
+        }
+
+        XXHash64 hasher = XXHashFactory.fastestJavaInstance().hash64();
+        Map<GroupKey, GroupAcc> groups = new HashMap<>();
+        long totalArrays = 0;
+        long totalArrayBytes = 0;
+        long oversizedSkipped = 0;
+
+        try (PreparedStatement stmt =
+                     view.databaseClient().connection().prepareStatement(PRIMITIVE_ARRAYS_SQL);
+             ResultSet rs = stmt.executeQuery()) {
+            while (rs.next()) {
+                long instanceId = rs.getLong(1);
+                int arrayLength = rs.getInt(2);
+                byte primitiveType = rs.getByte(3);
+                long shallowSize = rs.getLong(4);
+                String typeName = rs.getString(5);
+
+                totalArrays++;
+                totalArrayBytes += shallowSize;
+
+                int elementSize = HprofTag.BasicType.sizeOf(primitiveType);
+                long contentBytes = (long) arrayLength * Math.max(elementSize, 1);
+                if (contentBytes < MIN_CONTENT_BYTES) {
+                    continue;
+                }
+                if (contentBytes > MAX_HASH_BYTES) {
+                    oversizedSkipped++;
+                    continue;
+                }
+
+                byte[] content = view.readPrimitiveArrayBytes(instanceId);
+                if (content.length == 0) {
+                    continue;
+                }
+                long hash = hasher.hash(content, 0, content.length, HASH_SEED);
+                GroupKey key = new GroupKey(primitiveType, arrayLength, hash);
+                GroupAcc acc = groups.computeIfAbsent(key, k -> new GroupAcc(typeName, shallowSize));
+                acc.add(instanceId);
+            }
+        }
+
+        long duplicateGroups = 0;
+        long duplicateArrayCount = 0;
+        long potentialSavings = 0;
+        List<Map.Entry<GroupKey, GroupAcc>> duplicates = new ArrayList<>();
+        for (Map.Entry<GroupKey, GroupAcc> e : groups.entrySet()) {
+            GroupAcc acc = e.getValue();
+            if (acc.count < 2) {
+                continue;
+            }
+            duplicateGroups++;
+            duplicateArrayCount += acc.count - 1;
+            potentialSavings += acc.wastedBytes();
+            duplicates.add(e);
+        }
+        duplicates.sort(Comparator.comparingLong(
+                (Map.Entry<GroupKey, GroupAcc> e) -> e.getValue().wastedBytes()).reversed());
+
+        List<DuplicateArrayGroup> topGroups = new ArrayList<>(Math.min(topN, duplicates.size()));
+        for (Map.Entry<GroupKey, GroupAcc> e : duplicates.subList(0, Math.min(topN, duplicates.size()))) {
+            GroupKey key = e.getKey();
+            GroupAcc acc = e.getValue();
+            String preview = renderPreview(view, acc.firstInstanceId, key.primitiveType());
+            topGroups.add(new DuplicateArrayGroup(
+                    acc.typeName == null ? "<unknown>" : acc.typeName,
+                    key.arrayLength(),
+                    acc.count,
+                    acc.shallowSize,
+                    acc.wastedBytes(),
+                    preview,
+                    acc.sampleIds()));
+        }
+
+        return new DuplicateDataReport(
+                totalArrays,
+                totalArrayBytes,
+                duplicateGroups,
+                duplicateArrayCount,
+                potentialSavings,
+                oversizedSkipped,
+                topGroups);
+    }
+
+    /**
+     * Human preview of the shared content: decoded text for byte/char arrays
+     * that look textual, a hex prefix otherwise.
+     */
+    private static String renderPreview(HeapView view, long instanceId, byte primitiveType) {
+        try {
+            byte[] prefix = view.readPrimitiveArrayBytes(instanceId, PREVIEW_BYTES);
+            if (prefix.length == 0) {
+                return "";
+            }
+            if (primitiveType == HprofTag.BasicType.BYTE && isMostlyPrintableAscii(prefix)) {
+                return truncate(new String(prefix, StandardCharsets.US_ASCII));
+            }
+            if (primitiveType == HprofTag.BasicType.CHAR) {
+                return truncate(new String(prefix, StandardCharsets.UTF_16BE));
+            }
+            return truncate(toHex(prefix));
+        } catch (SQLException | RuntimeException e) {
+            return "";
+        }
+    }
+
+    private static boolean isMostlyPrintableAscii(byte[] bytes) {
+        int printable = 0;
+        for (byte b : bytes) {
+            if (b >= 0x20 && b < 0x7F) {
+                printable++;
+            }
+        }
+        return printable * 10 >= bytes.length * 9;
+    }
+
+    private static String toHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder(Math.min(bytes.length, 16) * 3);
+        for (int i = 0; i < bytes.length && i < 16; i++) {
+            if (i > 0) {
+                sb.append(' ');
+            }
+            sb.append(String.format("%02x", bytes[i]));
+        }
+        return sb.toString();
+    }
+
+    private static String truncate(String value) {
+        String sanitized = value.strip();
+        if (sanitized.length() <= PREVIEW_MAX_CHARS) {
+            return sanitized;
+        }
+        return sanitized.substring(0, PREVIEW_MAX_CHARS) + "…";
+    }
+
+    private record GroupKey(byte primitiveType, int arrayLength, long contentHash) {
+    }
+
+    private static final class GroupAcc {
+
+        private final String typeName;
+        private final long shallowSize;
+        private final long[] samples = new long[SAMPLE_IDS_PER_GROUP];
+        private long firstInstanceId;
+        private int count;
+
+        private GroupAcc(String typeName, long shallowSize) {
+            this.typeName = typeName;
+            this.shallowSize = shallowSize;
+        }
+
+        void add(long instanceId) {
+            if (count == 0) {
+                firstInstanceId = instanceId;
+            }
+            if (count < SAMPLE_IDS_PER_GROUP) {
+                samples[count] = instanceId;
+            }
+            count++;
+        }
+
+        long wastedBytes() {
+            return (long) (count - 1) * shallowSize;
+        }
+
+        List<Long> sampleIds() {
+            List<Long> out = new ArrayList<>(Math.min(count, SAMPLE_IDS_PER_GROUP));
+            for (int i = 0; i < count && i < SAMPLE_IDS_PER_GROUP; i++) {
+                out.add(samples[i]);
+            }
+            return out;
+        }
+    }
+}

--- a/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/model/ClassDiffEntry.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/model/ClassDiffEntry.java
@@ -1,0 +1,41 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.heapdump.model;
+
+/**
+ * Per-class delta between two heap dumps (primary vs baseline).
+ *
+ * @param className     the class both sides are keyed on
+ * @param primaryCount  instance count in the primary dump (0 = class absent)
+ * @param baselineCount instance count in the baseline dump (0 = class absent)
+ * @param countDelta    {@code primaryCount - baselineCount}
+ * @param primaryBytes  shallow bytes in the primary dump
+ * @param baselineBytes shallow bytes in the baseline dump
+ * @param bytesDelta    {@code primaryBytes - baselineBytes}
+ */
+public record ClassDiffEntry(
+        String className,
+        long primaryCount,
+        long baselineCount,
+        long countDelta,
+        long primaryBytes,
+        long baselineBytes,
+        long bytesDelta
+) {
+}

--- a/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/model/DuplicateArrayGroup.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/model/DuplicateArrayGroup.java
@@ -1,0 +1,43 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.heapdump.model;
+
+import java.util.List;
+
+/**
+ * One group of byte-identical primitive arrays.
+ *
+ * @param typeName        array type name (e.g. {@code byte[]})
+ * @param arrayLength     element count of every array in the group
+ * @param count           number of byte-identical instances
+ * @param shallowSize     shallow size of a single instance
+ * @param wastedBytes     {@code (count - 1) * shallowSize} — reclaimable by sharing one copy
+ * @param contentPreview  short human-readable preview of the shared content
+ * @param sampleObjectIds a few instance ids for drill-down
+ */
+public record DuplicateArrayGroup(
+        String typeName,
+        int arrayLength,
+        int count,
+        long shallowSize,
+        long wastedBytes,
+        String contentPreview,
+        List<Long> sampleObjectIds
+) {
+}

--- a/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/model/DuplicateDataReport.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/model/DuplicateDataReport.java
@@ -1,0 +1,46 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.heapdump.model;
+
+import java.util.List;
+
+/**
+ * Duplicate-data ("memory waste") report over primitive arrays: groups of
+ * byte-identical arrays that could be shared as a single copy. Strings are
+ * covered separately by the string analysis; this report captures the raw
+ * arrays behind buffers, caches and deserialized payloads.
+ *
+ * @param totalPrimitiveArrays      primitive arrays scanned
+ * @param totalPrimitiveArrayBytes  their combined shallow size
+ * @param duplicateGroups           groups with at least two identical arrays
+ * @param duplicateArrayCount       redundant instances (beyond one per group)
+ * @param potentialSavings          bytes reclaimable by sharing one copy per group
+ * @param oversizedSkipped          arrays skipped because they exceed the hashing cap
+ * @param topGroups                 largest groups by wasted bytes
+ */
+public record DuplicateDataReport(
+        long totalPrimitiveArrays,
+        long totalPrimitiveArrayBytes,
+        long duplicateGroups,
+        long duplicateArrayCount,
+        long potentialSavings,
+        long oversizedSkipped,
+        List<DuplicateArrayGroup> topGroups
+) {
+}

--- a/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/model/HeapDumpDiffReport.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/model/HeapDumpDiffReport.java
@@ -1,0 +1,42 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.heapdump.model;
+
+import java.util.List;
+
+/**
+ * Class-histogram comparison of two heap dumps — the classic before/after
+ * leak workflow: what grew, what appeared, what shrank between a baseline
+ * dump and the current one.
+ *
+ * @param primarySummary   summary of the primary (current) dump
+ * @param baselineSummary  summary of the baseline dump
+ * @param instanceCountDelta total instance-count difference (primary - baseline)
+ * @param shallowBytesDelta  total shallow-bytes difference (primary - baseline)
+ * @param entries          per-class deltas ordered by absolute shallow-bytes
+ *                         delta descending, capped at the requested topN
+ */
+public record HeapDumpDiffReport(
+        HeapSummary primarySummary,
+        HeapSummary baselineSummary,
+        long instanceCountDelta,
+        long shallowBytesDelta,
+        List<ClassDiffEntry> entries
+) {
+}

--- a/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/model/HeapDumpInitProgress.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/model/HeapDumpInitProgress.java
@@ -1,0 +1,51 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.heapdump.model;
+
+import java.util.List;
+
+/**
+ * Live progress of a server-side heap-dump initialization run, polled by the
+ * frontend while the pipeline executes in the background.
+ *
+ * @param state        {@code idle} (no run for this profile), {@code running},
+ *                     {@code completed} or {@code failed}
+ * @param errorCode    machine-readable error code when {@code failed}, else {@code null}
+ * @param errorMessage human-readable failure description when {@code failed}, else {@code null}
+ * @param stages       per-stage live statuses in pipeline order; empty when {@code idle}
+ */
+public record HeapDumpInitProgress(
+        String state,
+        String errorCode,
+        String errorMessage,
+        List<HeapDumpInitStageProgress> stages
+) {
+
+    public static final String STATE_IDLE = "idle";
+
+    public static final String STATE_RUNNING = "running";
+
+    public static final String STATE_COMPLETED = "completed";
+
+    public static final String STATE_FAILED = "failed";
+
+    public static HeapDumpInitProgress idle() {
+        return new HeapDumpInitProgress(STATE_IDLE, null, null, List.of());
+    }
+}

--- a/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/model/HeapDumpInitStageProgress.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/model/HeapDumpInitStageProgress.java
@@ -1,0 +1,46 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.heapdump.model;
+
+import java.util.List;
+
+/**
+ * One stage of a running (or finished) server-side init pipeline.
+ *
+ * @param id         stage identifier shared with the frontend's pipeline
+ *                   definition (e.g. "index", "dominator", "consumers")
+ * @param status     {@code pending}, {@code in_progress}, {@code completed} or {@code failed}
+ * @param durationMs elapsed milliseconds once terminal, else {@code null}
+ * @param subPhases  fine-grained timing breakdown when available, else {@code null}
+ */
+public record HeapDumpInitStageProgress(
+        String id,
+        String status,
+        Long durationMs,
+        List<SubPhaseTiming> subPhases
+) {
+
+    public static final String STATUS_PENDING = "pending";
+
+    public static final String STATUS_IN_PROGRESS = "in_progress";
+
+    public static final String STATUS_COMPLETED = "completed";
+
+    public static final String STATUS_FAILED = "failed";
+}

--- a/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/parser/BuildOptions.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/parser/BuildOptions.java
@@ -34,7 +34,24 @@ public record BuildOptions(int stringContentThreshold, int walkWorkers) {
 
     public static final int DEFAULT_STRING_CONTENT_THRESHOLD = 4096;
 
-    public static final int DEFAULT_WALK_WORKERS = 4;
+    public static final int MIN_DEFAULT_WALK_WORKERS = 1;
+
+    /**
+     * Ceiling for the CPU-derived default: every Pass B worker owns a private
+     * in-memory DuckDB with open appenders, so the per-worker memory cost is
+     * real and the parquet bulk-load gains flatten out well before this point.
+     */
+    public static final int MAX_DEFAULT_WALK_WORKERS = 16;
+
+    /**
+     * CPU-scaled fanout: one worker per available core, clamped to
+     * [{@link #MIN_DEFAULT_WALK_WORKERS}, {@link #MAX_DEFAULT_WALK_WORKERS}].
+     * Computed once at class load.
+     */
+    public static final int DEFAULT_WALK_WORKERS = Math.clamp(
+            Runtime.getRuntime().availableProcessors(),
+            MIN_DEFAULT_WALK_WORKERS,
+            MAX_DEFAULT_WALK_WORKERS);
 
     public BuildOptions {
         if (walkWorkers < 1) {

--- a/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/parser/HprofClassDumpWalker.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/parser/HprofClassDumpWalker.java
@@ -44,6 +44,9 @@ import static cafe.jeffrey.profile.heapdump.parser.HprofAppenderUtils.primArrayN
  */
 public final class HprofClassDumpWalker {
 
+    /** outbound_ref.field_kind value for class-static references. */
+    private static final byte FIELD_KIND_CLASS_STATIC = 2;
+
     private HprofClassDumpWalker() {
     }
 
@@ -85,7 +88,33 @@ public final class HprofClassDumpWalker {
                     }
                     return classCount[0];
                 });
+        appendStaticRefs(client, byId);
         return new ClassDumpIndex(byId, classCount[0], warnings);
+    }
+
+    /**
+     * Emits one {@code outbound_ref} row per non-null OBJECT-typed static
+     * field: {@code source_id} is the class object id, {@code field_kind = 2}
+     * (class_static), {@code field_id} the static-field index. These edges make
+     * objects retained only through statics reachable in the dominator graph.
+     */
+    private static void appendStaticRefs(
+            HeapDumpDatabaseClient client, MutableLongObjectMap<HprofRecord.ClassDump> byId) {
+        client.withAppender(HeapDumpStatement.APPEND_OUTBOUND_REF, "outbound_ref", app -> {
+            long emitted = 0;
+            for (HprofRecord.ClassDump cd : byId.values()) {
+                for (HprofRecord.StaticRef ref : cd.staticRefs()) {
+                    app.beginRow();
+                    app.append(cd.classId());
+                    app.append(ref.targetId());
+                    app.append(FIELD_KIND_CLASS_STATIC);
+                    app.append(ref.fieldIndex());
+                    app.endRow();
+                    emitted++;
+                }
+            }
+            return emitted;
+        });
     }
 
     private static void appendClass(
@@ -119,8 +148,7 @@ public final class HprofClassDumpWalker {
         appendNullableId(app, cd.signersId());
         appendNullableId(app, cd.protectionDomainId());
         app.append(cd.instanceSize());
-        // static_fields_size: not tracked separately yet; populate with 0 to satisfy NOT NULL.
-        app.append(0);
+        app.append(cd.staticFieldsByteLength());
         app.append(cd.fileOffset());
         app.endRow();
     }

--- a/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/parser/HprofRecord.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/parser/HprofRecord.java
@@ -126,7 +126,19 @@ public sealed interface HprofRecord {
                      long signersId, long protectionDomainId, int instanceSize,
                      int instanceFieldsByteLength, int totalByteLength,
                      long[] instanceFieldNameIds, int[] instanceFieldTypes,
+                     StaticRef[] staticRefs, int staticFieldsByteLength,
                      long fileOffset) implements Sub {
+    }
+
+    /**
+     * One non-null OBJECT-typed static field of a CLASS_DUMP: the source of an
+     * {@code outbound_ref} row with {@code field_kind = 2} (class_static).
+     *
+     * @param fieldIndex index of the field within the class's static-field list
+     * @param nameId     HPROF string id of the field name
+     * @param targetId   referenced object id (never 0)
+     */
+    record StaticRef(int fieldIndex, long nameId, long targetId) {
     }
 
     /**

--- a/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/parser/HprofSubRecordReader.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/parser/HprofSubRecordReader.java
@@ -20,6 +20,9 @@ package cafe.jeffrey.profile.heapdump.parser;
 import cafe.jeffrey.profile.heapdump.view.HprofTag;
 import cafe.jeffrey.profile.heapdump.view.HprofTypeSize;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Streams sub-records out of a HEAP_DUMP or HEAP_DUMP_SEGMENT region.
  *
@@ -42,6 +45,9 @@ import cafe.jeffrey.profile.heapdump.view.HprofTypeSize;
  * because it carries 12 fields and only fires ~22 K times per dump.
  */
 public final class HprofSubRecordReader {
+
+    /** HPROF basic-type byte for OBJECT references. */
+    private static final int BASIC_TYPE_OBJECT = 2;
 
     /**
      * Visitor over sub-records. Each method has primitive arguments so the
@@ -213,17 +219,28 @@ public final class HprofSubRecordReader {
             cursor += sz;
         }
 
-        // Static fields
+        // Static fields — capture non-null OBJECT-typed values so the index
+        // builder can emit class_static outbound_ref rows (field_kind = 2).
         int staticFieldCount = Short.toUnsignedInt(file.readShort(cursor));
         cursor += 2;
+        int staticFieldsByteLength = 0;
+        List<HprofRecord.StaticRef> staticRefs = new ArrayList<>(0);
         for (int i = 0; i < staticFieldCount; i++) {
-            cursor += idSize; // id nameId
+            long staticNameId = file.readId(cursor);
+            cursor += idSize;
             int type = Byte.toUnsignedInt(file.readByte(cursor));
             cursor += 1;
             int sz = HprofTypeSize.sizeOf(type, idSize);
             if (sz < 0) {
                 throw new IllegalStateException("Unknown static-field type: type=" + type);
             }
+            if (type == BASIC_TYPE_OBJECT) {
+                long targetId = file.readId(cursor);
+                if (targetId != 0L) {
+                    staticRefs.add(new HprofRecord.StaticRef(i, staticNameId, targetId));
+                }
+            }
+            staticFieldsByteLength += sz;
             cursor += sz;
         }
 
@@ -256,7 +273,9 @@ public final class HprofSubRecordReader {
                 classId, traceSerial, superClassId, classloaderId,
                 signersId, protectionDomainId, instanceSize,
                 instanceFieldsByteLength, totalByteLength,
-                instanceFieldNameIds, instanceFieldTypes, bodyOffset));
+                instanceFieldNameIds, instanceFieldTypes,
+                staticRefs.toArray(new HprofRecord.StaticRef[0]), staticFieldsByteLength,
+                bodyOffset));
     }
 
     private static void emitInstanceDump(

--- a/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/persistence/DominatorTreeBuilder.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/persistence/DominatorTreeBuilder.java
@@ -614,16 +614,15 @@ public final class DominatorTreeBuilder {
     }
 
     private static InstanceMeta loadInstanceMeta(HeapDumpDatabaseClient client) {
-        int count = (int) client.queryLong(HeapDumpStatement.TOTAL_INSTANCE_COUNT, "SELECT COUNT(*) FROM instance");
+        int count = (int) client.queryLong(HeapDumpStatement.TOTAL_INSTANCE_COUNT, NODE_COUNT_SQL);
         long[] ids = new long[count];
         long[] shallow = new long[count];
         int[] iBox = {0};
-        client.rawStream(HeapDumpStatement.STREAM_INSTANCES_BY_CLASS,
-                "SELECT instance_id, shallow_size FROM instance ORDER BY instance_id",
+        client.rawStream(HeapDumpStatement.STREAM_INSTANCES_BY_CLASS, NODE_META_SQL,
                 rs -> {
                     while (rs.next() && iBox[0] < count) {
                         ids[iBox[0]] = rs.getLong(1);
-                        shallow[iBox[0]] = rs.getInt(2);
+                        shallow[iBox[0]] = rs.getLong(2);
                         iBox[0]++;
                     }
                     return iBox[0];
@@ -652,12 +651,33 @@ public final class DominatorTreeBuilder {
      * the translation into the engine's parallel hash join, replacing 87 M ×
      * two Java-side binary searches per pass with a single multi-threaded scan.
      */
+    /**
+     * The dominator graph's node set: every instance plus every class object.
+     * Class objects are graph nodes so class-static references (outbound_ref
+     * {@code field_kind = 2}, source = class id) and class-targeted GC roots
+     * (e.g. ROOT_STICKY_CLASS) contribute edges — without them, objects
+     * retained only through statics would be unreachable and get no retained
+     * size. A class node's "shallow size" is its static-field footprint.
+     */
+    private static final String NODE_SET_SQL = """
+            SELECT instance_id AS id, CAST(shallow_size AS BIGINT) AS shallow FROM instance
+            UNION ALL
+            SELECT class_id, CAST(static_fields_size AS BIGINT) FROM class
+            WHERE class_id NOT IN (SELECT instance_id FROM instance)
+            """;
+
+    private static final String NODE_COUNT_SQL =
+            "SELECT COUNT(*) FROM (" + NODE_SET_SQL + ")";
+
+    private static final String NODE_META_SQL =
+            "SELECT id, shallow FROM (" + NODE_SET_SQL + ") ORDER BY id";
+
     private static final String CREATE_ID_INDEX_SQL = """
             CREATE TEMP TABLE id_index AS
-            SELECT instance_id,
-                   CAST(ROW_NUMBER() OVER (ORDER BY instance_id) - 1 AS INTEGER) AS node_index
-            FROM instance
-            """;
+            SELECT id AS instance_id,
+                   CAST(ROW_NUMBER() OVER (ORDER BY id) - 1 AS INTEGER) AS node_index
+            FROM (
+            """ + NODE_SET_SQL + ")";
 
     private static final String DROP_ID_INDEX_SQL = "DROP TABLE id_index";
 

--- a/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/persistence/DominatorTreeBuilder.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/persistence/DominatorTreeBuilder.java
@@ -84,6 +84,13 @@ public final class DominatorTreeBuilder {
      */
     private static final String PRAGMA_WAL_AUTOCHECKPOINT = "PRAGMA wal_autocheckpoint = '1TB'";
 
+    /**
+     * The dominator/retained-size bulk loads never rely on row order (reads are
+     * keyed or explicitly ordered), so let DuckDB parallelise the parquet load
+     * without the insertion-order bookkeeping.
+     */
+    private static final String PRAGMA_PRESERVE_INSERTION_ORDER = "SET preserve_insertion_order = false";
+
     public record BuildResult(int reachableInstances, int rootEdges, long iterations,
                               java.time.Duration buildTime, List<SubPhaseTiming> subPhases) {
 
@@ -116,6 +123,7 @@ public final class DominatorTreeBuilder {
             HeapDumpDatabaseClient client = new HeapDumpDatabaseClient(conn, GroupLabel.HEAP_DUMP_INDEX);
 
             client.execute(HeapDumpStatement.WAL_AUTOCHECKPOINT_PRAGMA, PRAGMA_WAL_AUTOCHECKPOINT);
+            client.execute(HeapDumpStatement.PRESERVE_INSERTION_ORDER_PRAGMA, PRAGMA_PRESERVE_INSERTION_ORDER);
             client.execute(HeapDumpStatement.DELETE_DOMINATOR, "DELETE FROM dominator");
             client.execute(HeapDumpStatement.DELETE_RETAINED_SIZE, "DELETE FROM retained_size");
 

--- a/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/persistence/DuckDbHeapView.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/persistence/DuckDbHeapView.java
@@ -435,6 +435,16 @@ public final class DuckDbHeapView implements HeapView {
     }
 
     @Override
+    public long readLong(long fileOffset) {
+        if (hprof == null) {
+            throw new IllegalStateException(
+                    "HeapView opened without a .hprof file; readLong is unavailable. "
+                            + "Use HeapView.open(indexDb, hprof).");
+        }
+        return hprof.readLong(fileOffset);
+    }
+
+    @Override
     public List<InstanceFieldValue> readInstanceFields(long instanceId) throws SQLException {
         if (hprof == null) {
             throw new IllegalStateException(

--- a/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/persistence/HeapDumpIndexDb.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/persistence/HeapDumpIndexDb.java
@@ -57,6 +57,14 @@ public final class HeapDumpIndexDb implements AutoCloseable {
      */
     private static final String PRAGMA_WAL_AUTOCHECKPOINT = "PRAGMA wal_autocheckpoint = '1TB'";
 
+    /**
+     * Insertion order is semantically irrelevant for every index table — all
+     * reads are keyed or carry an explicit {@code ORDER BY} — and dropping the
+     * guarantee lets DuckDB parallelise the {@code read_parquet} bulk loads
+     * more aggressively while using less memory.
+     */
+    private static final String PRAGMA_PRESERVE_INSERTION_ORDER = "SET preserve_insertion_order = false";
+
     private final Path path;
     private final DuckDBConnection connection;
     private final HeapDumpDatabaseClient databaseClient;
@@ -127,6 +135,7 @@ public final class HeapDumpIndexDb implements AutoCloseable {
         // DuckDB JDBC supports running multiple ;-delimited statements in a single execute.
         databaseClient.execute(HeapDumpStatement.APPLY_SCHEMA, loadResource(SCHEMA_RESOURCE));
         databaseClient.execute(HeapDumpStatement.WAL_AUTOCHECKPOINT_PRAGMA, PRAGMA_WAL_AUTOCHECKPOINT);
+        databaseClient.execute(HeapDumpStatement.PRESERVE_INSERTION_ORDER_PRAGMA, PRAGMA_PRESERVE_INSERTION_ORDER);
     }
 
     private static String loadResource(String resource) throws IOException {

--- a/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/persistence/HeapDumpStatement.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/persistence/HeapDumpStatement.java
@@ -31,6 +31,7 @@ public enum HeapDumpStatement {
     CREATE_INDEXES,
     CHECKPOINT,
     WAL_AUTOCHECKPOINT_PRAGMA,
+    PRESERVE_INSERTION_ORDER_PRAGMA,
     READ_ONLY_PRAGMA,
 
     // ---- appender writes (HprofIndex Pass 1/2A/2B + content phase) ----

--- a/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/persistence/ParquetSink.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/persistence/ParquetSink.java
@@ -26,6 +26,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Per-worker parquet sink: an in-memory DuckDB instance plus one
@@ -45,6 +46,22 @@ import java.util.Map;
 public final class ParquetSink implements AutoCloseable {
 
     private static final String JDBC_URL = "jdbc:duckdb:";
+
+    /**
+     * Shard row order is irrelevant (the coordinator re-reads shards through
+     * DuckDB's parallel parquet reader), so skip the insertion-order
+     * bookkeeping on the staging tables and the {@code COPY} output.
+     */
+    private static final String SET_PRESERVE_INSERTION_ORDER = "SET preserve_insertion_order = false";
+
+    /**
+     * An in-memory DuckDB has no temp directory by default and therefore
+     * cannot spill — a worker whose slice outgrows the memory limit would
+     * hard-fail. Pointing {@code temp_directory} into the staging area (next
+     * to the shard this sink writes) restores spilling; the staging directory
+     * is deleted wholesale at the end of the build.
+     */
+    private static final String SPILL_DIR_PREFIX = "duckdb-spill-";
 
     private final DuckDBConnection conn;
 
@@ -82,6 +99,7 @@ public final class ParquetSink implements AutoCloseable {
 
         Map<String, TableSink> sinks = new LinkedHashMap<>();
         try {
+            configureSession(conn, outputPaths.values().iterator().next());
             for (Map.Entry<String, String> e : tableDdls.entrySet()) {
                 String table = e.getKey();
                 String columnDdl = e.getValue();
@@ -105,6 +123,16 @@ public final class ParquetSink implements AutoCloseable {
         }
 
         return new ParquetSink(conn, sinks);
+    }
+
+    private static void configureSession(DuckDBConnection conn, Path anyOutputPath) throws SQLException {
+        Path spillDir = anyOutputPath.toAbsolutePath().getParent()
+                .resolve(SPILL_DIR_PREFIX + UUID.randomUUID());
+        String escapedSpillDir = spillDir.toString().replace("'", "''");
+        try (Statement s = conn.createStatement()) {
+            s.execute(SET_PRESERVE_INSERTION_ORDER);
+            s.execute("SET temp_directory = '" + escapedSpillDir + "'");
+        }
     }
 
     /**

--- a/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/view/HeapView.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/view/HeapView.java
@@ -256,6 +256,12 @@ public interface HeapView extends AutoCloseable {
      */
     int readInt(long fileOffset) throws SQLException;
 
+    /**
+     * Reads a big-endian {@code long} straight from the mapped {@code .hprof}
+     * at an absolute file offset. Same contract as {@link #readInt(long)}.
+     */
+    long readLong(long fileOffset) throws SQLException;
+
     // ---- Escape hatch ----------------------------------------------------
 
     /**

--- a/jeffrey-microscope/profiles/heap-dump/src/main/java/module-info.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/main/java/module-info.java
@@ -26,6 +26,7 @@ module cafe.jeffrey.microscope.profile.heapdump {
     requires org.slf4j;
     requires org.eclipse.collections.api;
     requires org.eclipse.collections.impl;
+    requires org.lz4.java;
 
     exports cafe.jeffrey.profile.heapdump.analyzer.heapview;
     exports cafe.jeffrey.profile.heapdump.model;

--- a/jeffrey-microscope/profiles/heap-dump/src/test/java/cafe/jeffrey/profile/heapdump/analyzer/heapview/CollectionAnalyzerTest.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/test/java/cafe/jeffrey/profile/heapdump/analyzer/heapview/CollectionAnalyzerTest.java
@@ -109,9 +109,11 @@ class CollectionAnalyzerTest {
     }
 
     @Test
-    void unsupportedCollectionsAbsentFromReport(@TempDir Path tmp) throws IOException, SQLException {
+    void classWithoutRecognizedSizeFieldSkipped(@TempDir Path tmp) throws IOException, SQLException {
         long linkedListClass = 0xC001L;
 
+        // A "LinkedList" whose only int field is named "f" — the size-only shape
+        // requires a field literally named "size", so the class is skipped.
         Path hprof = SyntheticHprof.create("1.0.2", ID_SIZE, 0L)
                 .string(0xA001L, "java.util.LinkedList")
                 .string(0xA002L, "f")
@@ -129,7 +131,280 @@ class CollectionAnalyzerTest {
              HeapView view = HeapView.open(indexDb, file)) {
             CollectionAnalysisReport report = CollectionAnalyzer.analyze(view);
             assertEquals(0, report.totalCollections(),
-                    "LinkedList not in the supported shape list — counted as zero");
+                    "class layout not matching any shape — counted as zero");
+        }
+    }
+
+    @Test
+    void linkedListCountedWithoutCapacityMetrics(@TempDir Path tmp) throws IOException, SQLException {
+        long linkedListClass = 0xC001L;
+
+        Path hprof = SyntheticHprof.create("1.0.2", ID_SIZE, 0L)
+                .string(0xA001L, "java.util.LinkedList")
+                .string(0xA002L, "size")
+                .loadClass(1, linkedListClass, 0, 0xA001L)
+                .heapDumpSegment(seg -> seg
+                        .classDumpWithFields(linkedListClass, 0L, 0L, 4,
+                                new SyntheticHprof.SubBuilder.FieldSpec(0xA002L, HprofTag.BasicType.INT))
+                        .instanceDump(0x100L, linkedListClass, intBytes(5))
+                        .instanceDump(0x101L, linkedListClass, intBytes(0)))
+                .heapDumpEnd()
+                .writeTo(tmp, "linkedlist-size.hprof");
+        Path indexDb = HeapDumpIndexPaths.indexFor(hprof);
+        try (HprofMappedFile file = HprofMappedFile.open(hprof)) {
+            HprofIndex.build(file, indexDb, CLOCK);
+        }
+        try (HprofMappedFile file = HprofMappedFile.open(hprof);
+             HeapView view = HeapView.open(indexDb, file)) {
+            CollectionAnalysisReport report = CollectionAnalyzer.analyze(view);
+            assertEquals(2, report.totalCollections());
+            assertEquals(1, report.totalEmptyCount());
+            assertEquals(0L, report.totalWastedBytes(), "no capacity concept, no waste");
+
+            CollectionStats stats = statsFor(report, "java.util.LinkedList");
+            assertEquals(2, stats.totalCount());
+            assertEquals(1, stats.emptyCount());
+        }
+    }
+
+    @Test
+    void treeMapCountedViaSizeOnlyShape(@TempDir Path tmp) throws IOException, SQLException {
+        long treeMapClass = 0xC001L;
+
+        Path hprof = SyntheticHprof.create("1.0.2", ID_SIZE, 0L)
+                .string(0xA001L, "java.util.TreeMap")
+                .string(0xA002L, "size")
+                .loadClass(1, treeMapClass, 0, 0xA001L)
+                .heapDumpSegment(seg -> seg
+                        .classDumpWithFields(treeMapClass, 0L, 0L, 4,
+                                new SyntheticHprof.SubBuilder.FieldSpec(0xA002L, HprofTag.BasicType.INT))
+                        .instanceDump(0x100L, treeMapClass, intBytes(7)))
+                .heapDumpEnd()
+                .writeTo(tmp, "treemap.hprof");
+        Path indexDb = HeapDumpIndexPaths.indexFor(hprof);
+        try (HprofMappedFile file = HprofMappedFile.open(hprof)) {
+            HprofIndex.build(file, indexDb, CLOCK);
+        }
+        try (HprofMappedFile file = HprofMappedFile.open(hprof);
+             HeapView view = HeapView.open(indexDb, file)) {
+            CollectionAnalysisReport report = CollectionAnalyzer.analyze(view);
+            CollectionStats stats = statsFor(report, "java.util.TreeMap");
+            assertEquals(1, stats.totalCount());
+            assertEquals(0, stats.emptyCount());
+        }
+    }
+
+    @Test
+    void vectorElementCountFieldDetected(@TempDir Path tmp) throws IOException, SQLException {
+        long vectorClass = 0xC001L;
+        long elementClass = 0xC002L;
+        long backingArray = 0x9001L;
+
+        long[] arr = new long[4];
+        arr[0] = 0x2001L;
+
+        Path hprof = SyntheticHprof.create("1.0.2", ID_SIZE, 0L)
+                .string(0xA001L, "java.util.Vector")
+                .string(0xA002L, "Element")
+                .string(0xA003L, "elementCount")
+                .string(0xA004L, "elementData")
+                .loadClass(1, vectorClass, 0, 0xA001L)
+                .loadClass(2, elementClass, 0, 0xA002L)
+                .heapDumpSegment(seg -> seg
+                        .classDumpWithFields(vectorClass, 0L, 0L, 4 + ID_SIZE,
+                                new SyntheticHprof.SubBuilder.FieldSpec(0xA003L, HprofTag.BasicType.INT),
+                                new SyntheticHprof.SubBuilder.FieldSpec(0xA004L, HprofTag.BasicType.OBJECT))
+                        .topLevelObjectClassDump(elementClass, 0xA003L)
+                        .objectArrayDump(backingArray, elementClass, arr)
+                        .instanceDump(0x2001L, elementClass, idBytes(0L, ID_SIZE))
+                        .instanceDump(0x100L, vectorClass, arrayListFields(1, backingArray)))
+                .heapDumpEnd()
+                .writeTo(tmp, "vector.hprof");
+        Path indexDb = HeapDumpIndexPaths.indexFor(hprof);
+        try (HprofMappedFile file = HprofMappedFile.open(hprof)) {
+            HprofIndex.build(file, indexDb, CLOCK);
+        }
+        try (HprofMappedFile file = HprofMappedFile.open(hprof);
+             HeapView view = HeapView.open(indexDb, file)) {
+            CollectionAnalysisReport report = CollectionAnalyzer.analyze(view);
+            CollectionStats stats = statsFor(report, "java.util.Vector");
+            assertEquals(1, stats.totalCount());
+            assertEquals(0, stats.emptyCount());
+            // (4 - 1) * 8 bytes wasted
+            assertEquals(24L, stats.totalWastedBytes());
+        }
+    }
+
+    @Test
+    void arrayDequeSizeComputedFromHeadTail(@TempDir Path tmp) throws IOException, SQLException {
+        long dequeClass = 0xC001L;
+        long elementClass = 0xC002L;
+        long array1 = 0x9001L;
+        long array2 = 0x9002L;
+
+        Path hprof = SyntheticHprof.create("1.0.2", ID_SIZE, 0L)
+                .string(0xA001L, "java.util.ArrayDeque")
+                .string(0xA002L, "Element")
+                .string(0xA003L, "head")
+                .string(0xA004L, "tail")
+                .string(0xA005L, "elements")
+                .loadClass(1, dequeClass, 0, 0xA001L)
+                .loadClass(2, elementClass, 0, 0xA002L)
+                .heapDumpSegment(seg -> seg
+                        .classDumpWithFields(dequeClass, 0L, 0L, 4 + 4 + ID_SIZE,
+                                new SyntheticHprof.SubBuilder.FieldSpec(0xA003L, HprofTag.BasicType.INT),
+                                new SyntheticHprof.SubBuilder.FieldSpec(0xA004L, HprofTag.BasicType.INT),
+                                new SyntheticHprof.SubBuilder.FieldSpec(0xA005L, HprofTag.BasicType.OBJECT))
+                        .topLevelObjectClassDump(elementClass, 0xA003L)
+                        .objectArrayDump(array1, elementClass, new long[8])
+                        .objectArrayDump(array2, elementClass, new long[8])
+                        // head=2, tail=5 → size 3
+                        .instanceDump(0x100L, dequeClass, dequeFields(2, 5, array1))
+                        // wrapped: head=6, tail=2 → size 4
+                        .instanceDump(0x101L, dequeClass, dequeFields(6, 2, array2)))
+                .heapDumpEnd()
+                .writeTo(tmp, "deque.hprof");
+        Path indexDb = HeapDumpIndexPaths.indexFor(hprof);
+        try (HprofMappedFile file = HprofMappedFile.open(hprof)) {
+            HprofIndex.build(file, indexDb, CLOCK);
+        }
+        try (HprofMappedFile file = HprofMappedFile.open(hprof);
+             HeapView view = HeapView.open(indexDb, file)) {
+            CollectionAnalysisReport report = CollectionAnalyzer.analyze(view);
+            CollectionStats stats = statsFor(report, "java.util.ArrayDeque");
+            assertEquals(2, stats.totalCount());
+            assertEquals(0, stats.emptyCount());
+            // deque #1 wastes 8-3=5 slots, deque #2 wastes 8-4=4 slots → 9 * 8 bytes
+            assertEquals(72L, stats.totalWastedBytes());
+        }
+    }
+
+    @Test
+    void concurrentHashMapSizeReadFromBaseCount(@TempDir Path tmp) throws IOException, SQLException {
+        long chmClass = 0xC001L;
+        long nodeClass = 0xC002L;
+        long tableArray = 0x9001L;
+
+        Path hprof = SyntheticHprof.create("1.0.2", ID_SIZE, 0L)
+                .string(0xA001L, "java.util.concurrent.ConcurrentHashMap")
+                .string(0xA002L, "Node")
+                .string(0xA003L, "baseCount")
+                .string(0xA004L, "table")
+                .loadClass(1, chmClass, 0, 0xA001L)
+                .loadClass(2, nodeClass, 0, 0xA002L)
+                .heapDumpSegment(seg -> seg
+                        .classDumpWithFields(chmClass, 0L, 0L, 8 + ID_SIZE,
+                                new SyntheticHprof.SubBuilder.FieldSpec(0xA003L, HprofTag.BasicType.LONG),
+                                new SyntheticHprof.SubBuilder.FieldSpec(0xA004L, HprofTag.BasicType.OBJECT))
+                        .topLevelObjectClassDump(nodeClass, 0xA003L)
+                        .objectArrayDump(tableArray, nodeClass, new long[16])
+                        .instanceDump(0x100L, chmClass, chmFields(3L, tableArray)))
+                .heapDumpEnd()
+                .writeTo(tmp, "chm.hprof");
+        Path indexDb = HeapDumpIndexPaths.indexFor(hprof);
+        try (HprofMappedFile file = HprofMappedFile.open(hprof)) {
+            HprofIndex.build(file, indexDb, CLOCK);
+        }
+        try (HprofMappedFile file = HprofMappedFile.open(hprof);
+             HeapView view = HeapView.open(indexDb, file)) {
+            CollectionAnalysisReport report = CollectionAnalyzer.analyze(view);
+            CollectionStats stats = statsFor(report, "java.util.concurrent.ConcurrentHashMap");
+            assertEquals(1, stats.totalCount());
+            assertEquals(0, stats.emptyCount());
+            // (16 - 3) * 8 bytes wasted
+            assertEquals(104L, stats.totalWastedBytes());
+        }
+    }
+
+    @Test
+    void hashSetSizeReadThroughBackingMap(@TempDir Path tmp) throws IOException, SQLException {
+        long hashSetClass = 0xC001L;
+        long hashMapClass = 0xC002L;
+        long nodeClass = 0xC003L;
+        long mapInstance = 0x200L;
+        long tableArray = 0x9001L;
+
+        Path hprof = SyntheticHprof.create("1.0.2", ID_SIZE, 0L)
+                .string(0xA001L, "java.util.HashSet")
+                .string(0xA002L, "java.util.HashMap")
+                .string(0xA003L, "Node")
+                .string(0xA004L, "map")
+                .string(0xA005L, "size")
+                .string(0xA006L, "table")
+                .loadClass(1, hashSetClass, 0, 0xA001L)
+                .loadClass(2, hashMapClass, 0, 0xA002L)
+                .loadClass(3, nodeClass, 0, 0xA003L)
+                .heapDumpSegment(seg -> seg
+                        .classDumpWithFields(hashSetClass, 0L, 0L, ID_SIZE,
+                                new SyntheticHprof.SubBuilder.FieldSpec(0xA004L, HprofTag.BasicType.OBJECT))
+                        .classDumpWithFields(hashMapClass, 0L, 0L, 4 + ID_SIZE,
+                                new SyntheticHprof.SubBuilder.FieldSpec(0xA005L, HprofTag.BasicType.INT),
+                                new SyntheticHprof.SubBuilder.FieldSpec(0xA006L, HprofTag.BasicType.OBJECT))
+                        .topLevelObjectClassDump(nodeClass, 0xA005L)
+                        .objectArrayDump(tableArray, nodeClass, new long[16])
+                        .instanceDump(0x100L, hashSetClass, idBytes(mapInstance, ID_SIZE))
+                        .instanceDump(mapInstance, hashMapClass, arrayListFields(7, tableArray)))
+                .heapDumpEnd()
+                .writeTo(tmp, "hashset.hprof");
+        Path indexDb = HeapDumpIndexPaths.indexFor(hprof);
+        try (HprofMappedFile file = HprofMappedFile.open(hprof)) {
+            HprofIndex.build(file, indexDb, CLOCK);
+        }
+        try (HprofMappedFile file = HprofMappedFile.open(hprof);
+             HeapView view = HeapView.open(indexDb, file)) {
+            CollectionAnalysisReport report = CollectionAnalyzer.analyze(view);
+
+            CollectionStats setStats = statsFor(report, "java.util.HashSet");
+            assertEquals(1, setStats.totalCount());
+            assertEquals(0, setStats.emptyCount());
+
+            // The backing HashMap instance is independently counted by the
+            // array-backed HashMap shape.
+            CollectionStats mapStats = statsFor(report, "java.util.HashMap");
+            assertEquals(1, mapStats.totalCount());
+        }
+    }
+
+    private static CollectionStats statsFor(CollectionAnalysisReport report, String type) {
+        return report.byType().stream()
+                .filter(s -> type.equals(s.collectionType()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("missing stats for " + type));
+    }
+
+    private static byte[] intBytes(int value) {
+        try {
+            ByteArrayOutputStream b = new ByteArrayOutputStream();
+            DataOutputStream d = new DataOutputStream(b);
+            d.writeInt(value);
+            return b.toByteArray();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static byte[] dequeFields(int head, int tail, long elementsRef) {
+        try {
+            ByteArrayOutputStream b = new ByteArrayOutputStream();
+            DataOutputStream d = new DataOutputStream(b);
+            d.writeInt(head);
+            d.writeInt(tail);
+            d.writeLong(elementsRef);
+            return b.toByteArray();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static byte[] chmFields(long baseCount, long tableRef) {
+        try {
+            ByteArrayOutputStream b = new ByteArrayOutputStream();
+            DataOutputStream d = new DataOutputStream(b);
+            d.writeLong(baseCount);
+            d.writeLong(tableRef);
+            return b.toByteArray();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/jeffrey-microscope/profiles/heap-dump/src/test/java/cafe/jeffrey/profile/heapdump/analyzer/heapview/DominatorTreeAnalyzerTest.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/test/java/cafe/jeffrey/profile/heapdump/analyzer/heapview/DominatorTreeAnalyzerTest.java
@@ -182,6 +182,62 @@ class DominatorTreeAnalyzerTest {
     }
 
     @Test
+    void offsetPaginationReturnsDisjointPagesInStableOrder(@TempDir Path tmp) throws IOException, SQLException {
+        int idSize = 8;
+        long classId = 0xC001L;
+        long arrayId = 0x9000L;
+
+        long[] children = new long[20];
+        for (int i = 0; i < children.length; i++) {
+            children[i] = 0x1000L + i;
+        }
+
+        Path hprof = SyntheticHprof.create("1.0.2", idSize, 0L)
+                .string(0xA001L, "Holder")
+                .string(0xA002L, "next")
+                .loadClass(1, classId, 0, 0xA001L)
+                .heapDumpSegment(seg -> {
+                    seg.topLevelObjectClassDump(classId, 0xA002L);
+                    seg.gcRoot(HprofTag.Sub.ROOT_STICKY_CLASS, arrayId);
+                    seg.objectArrayDump(arrayId, classId, children);
+                    for (long id : children) {
+                        seg.instanceDump(id, classId, idBytes(0L, idSize));
+                    }
+                })
+                .heapDumpEnd()
+                .writeTo(tmp, "paging.hprof");
+        Path indexDb = HeapDumpIndexPaths.indexFor(hprof);
+        try (HprofMappedFile file = HprofMappedFile.open(hprof)) {
+            HprofIndex.build(file, indexDb, CLOCK);
+        }
+        DominatorTreeBuilder.build(indexDb);
+
+        try (HeapView view = HeapView.open(indexDb)) {
+            // All 20 leaves have identical retained sizes, so the instance_id
+            // tie-break alone defines the paging order.
+            DominatorTreeResponse firstPage = DominatorTreeAnalyzer.children(view, arrayId, 0, 5);
+            DominatorTreeResponse secondPage = DominatorTreeAnalyzer.children(view, arrayId, 5, 5);
+            DominatorTreeResponse lastPage = DominatorTreeAnalyzer.children(view, arrayId, 15, 5);
+            DominatorTreeResponse beyondEnd = DominatorTreeAnalyzer.children(view, arrayId, 20, 5);
+
+            assertEquals(List.of(0x1000L, 0x1001L, 0x1002L, 0x1003L, 0x1004L), objectIds(firstPage));
+            assertEquals(List.of(0x1005L, 0x1006L, 0x1007L, 0x1008L, 0x1009L), objectIds(secondPage));
+            assertTrue(firstPage.hasMore());
+            assertTrue(secondPage.hasMore());
+
+            assertEquals(List.of(0x100FL, 0x1010L, 0x1011L, 0x1012L, 0x1013L), objectIds(lastPage));
+            assertFalse(lastPage.hasMore(), "final full page must not report more children");
+
+            assertTrue(beyondEnd.nodes().isEmpty());
+            assertFalse(beyondEnd.hasMore());
+        }
+    }
+
+    private static List<Long> objectIds(DominatorTreeResponse response) {
+        return response.nodes().stream().map(DominatorNode::objectId).toList();
+    }
+
+    @Test
     void retainedPercentIsRelativeToParentNotTotalHeap(@TempDir Path tmp) throws IOException, SQLException {
         // Two independent GC-root subtrees:
         //   ROOT_A → arrayA → leafA1, leafA2     (one heavy subtree we will drill into)

--- a/jeffrey-microscope/profiles/heap-dump/src/test/java/cafe/jeffrey/profile/heapdump/analyzer/heapview/DuplicateArrayAnalyzerTest.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/test/java/cafe/jeffrey/profile/heapdump/analyzer/heapview/DuplicateArrayAnalyzerTest.java
@@ -1,0 +1,115 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package cafe.jeffrey.profile.heapdump.analyzer.heapview;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.sql.SQLException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import cafe.jeffrey.profile.heapdump.model.DuplicateArrayGroup;
+import cafe.jeffrey.profile.heapdump.model.DuplicateDataReport;
+import cafe.jeffrey.profile.heapdump.persistence.HeapDumpIndexPaths;
+import cafe.jeffrey.profile.heapdump.parser.HprofIndex;
+import cafe.jeffrey.profile.heapdump.parser.HprofMappedFile;
+import cafe.jeffrey.profile.heapdump.parser.SyntheticHprof;
+import cafe.jeffrey.profile.heapdump.view.HeapView;
+import cafe.jeffrey.profile.heapdump.view.HprofTag;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DuplicateArrayAnalyzerTest {
+
+    private static final Clock CLOCK =
+            Clock.fixed(Instant.ofEpochMilli(1L), ZoneOffset.UTC);
+    private static final int ID_SIZE = 8;
+
+    @Test
+    void groupsByteIdenticalArraysAndComputesSavings(@TempDir Path tmp)
+            throws IOException, SQLException {
+        byte[] shared = "this-content-repeats-many-times!".getBytes(StandardCharsets.US_ASCII);
+        byte[] unique = "completely-different-payload...!".getBytes(StandardCharsets.US_ASCII);
+        byte[] tiny = new byte[]{1, 2, 3, 4}; // below the 16-byte floor — ignored
+
+        Path hprof = SyntheticHprof.create("1.0.2", ID_SIZE, 0L)
+                .heapDumpSegment(seg -> seg
+                        .primitiveArrayDump(0x100L, HprofTag.BasicType.BYTE, shared, shared.length)
+                        .primitiveArrayDump(0x101L, HprofTag.BasicType.BYTE, shared, shared.length)
+                        .primitiveArrayDump(0x102L, HprofTag.BasicType.BYTE, shared, shared.length)
+                        .primitiveArrayDump(0x200L, HprofTag.BasicType.BYTE, unique, unique.length)
+                        .primitiveArrayDump(0x300L, HprofTag.BasicType.BYTE, tiny, tiny.length))
+                .heapDumpEnd()
+                .writeTo(tmp, "dup.hprof");
+
+        Path indexDb = HeapDumpIndexPaths.indexFor(hprof);
+        try (HprofMappedFile file = HprofMappedFile.open(hprof)) {
+            HprofIndex.build(file, indexDb, CLOCK);
+        }
+        try (HprofMappedFile file = HprofMappedFile.open(hprof);
+             HeapView view = HeapView.open(indexDb, file)) {
+            DuplicateDataReport report = DuplicateArrayAnalyzer.analyze(view);
+
+            assertEquals(5, report.totalPrimitiveArrays());
+            assertEquals(1, report.duplicateGroups());
+            assertEquals(2, report.duplicateArrayCount(), "two redundant copies of the shared array");
+            assertEquals(0, report.oversizedSkipped());
+            assertTrue(report.potentialSavings() > 0);
+
+            assertEquals(1, report.topGroups().size());
+            DuplicateArrayGroup group = report.topGroups().get(0);
+            assertEquals(3, group.count());
+            assertEquals(shared.length, group.arrayLength());
+            assertEquals(2L * group.shallowSize(), group.wastedBytes());
+            assertTrue(group.contentPreview().contains("this-content-repeats"),
+                    "ASCII byte[] content must be previewed as text: " + group.contentPreview());
+            assertEquals(3, group.sampleObjectIds().size());
+        }
+    }
+
+    @Test
+    void arraysWithSameLengthDifferentContentNotGrouped(@TempDir Path tmp)
+            throws IOException, SQLException {
+        byte[] a = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".getBytes(StandardCharsets.US_ASCII);
+        byte[] b = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".getBytes(StandardCharsets.US_ASCII);
+
+        Path hprof = SyntheticHprof.create("1.0.2", ID_SIZE, 0L)
+                .heapDumpSegment(seg -> seg
+                        .primitiveArrayDump(0x100L, HprofTag.BasicType.BYTE, a, a.length)
+                        .primitiveArrayDump(0x101L, HprofTag.BasicType.BYTE, b, b.length))
+                .heapDumpEnd()
+                .writeTo(tmp, "nodup.hprof");
+
+        Path indexDb = HeapDumpIndexPaths.indexFor(hprof);
+        try (HprofMappedFile file = HprofMappedFile.open(hprof)) {
+            HprofIndex.build(file, indexDb, CLOCK);
+        }
+        try (HprofMappedFile file = HprofMappedFile.open(hprof);
+             HeapView view = HeapView.open(indexDb, file)) {
+            DuplicateDataReport report = DuplicateArrayAnalyzer.analyze(view);
+            assertEquals(0, report.duplicateGroups());
+            assertEquals(0, report.potentialSavings());
+            assertTrue(report.topGroups().isEmpty());
+        }
+    }
+}

--- a/jeffrey-microscope/profiles/heap-dump/src/test/java/cafe/jeffrey/profile/heapdump/parser/BuildOptionsTest.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/test/java/cafe/jeffrey/profile/heapdump/parser/BuildOptionsTest.java
@@ -42,8 +42,14 @@ class BuildOptionsTest {
         }
 
         @Test
-        void walkWorkersMatchesDocumentedValue() {
-            assertEquals(4, BuildOptions.DEFAULT_WALK_WORKERS);
+        void walkWorkersScaleWithAvailableCpusWithinClamp() {
+            int expected = Math.clamp(
+                    Runtime.getRuntime().availableProcessors(),
+                    BuildOptions.MIN_DEFAULT_WALK_WORKERS,
+                    BuildOptions.MAX_DEFAULT_WALK_WORKERS);
+            assertEquals(expected, BuildOptions.DEFAULT_WALK_WORKERS);
+            assertTrue(BuildOptions.DEFAULT_WALK_WORKERS >= BuildOptions.MIN_DEFAULT_WALK_WORKERS);
+            assertTrue(BuildOptions.DEFAULT_WALK_WORKERS <= BuildOptions.MAX_DEFAULT_WALK_WORKERS);
         }
     }
 

--- a/jeffrey-microscope/profiles/heap-dump/src/test/java/cafe/jeffrey/profile/heapdump/parser/StaticFieldRefsIntegrationTest.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/test/java/cafe/jeffrey/profile/heapdump/parser/StaticFieldRefsIntegrationTest.java
@@ -1,0 +1,172 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package cafe.jeffrey.profile.heapdump.parser;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import cafe.jeffrey.profile.heapdump.analyzer.heapview.DominatorTreeAnalyzer;
+import cafe.jeffrey.profile.heapdump.model.DominatorNode;
+import cafe.jeffrey.profile.heapdump.model.DominatorTreeResponse;
+import cafe.jeffrey.profile.heapdump.persistence.DominatorTreeBuilder;
+import cafe.jeffrey.profile.heapdump.persistence.HeapDumpIndexPaths;
+import cafe.jeffrey.profile.heapdump.view.HeapView;
+import cafe.jeffrey.profile.heapdump.view.HprofTag;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end coverage of class-static references: CLASS_DUMP static OBJECT
+ * fields become {@code outbound_ref field_kind=2} rows, class objects become
+ * dominator-graph nodes, and objects retained only through statics get
+ * retained sizes and appear under their holder class in the dominator tree.
+ */
+class StaticFieldRefsIntegrationTest {
+
+    private static final Clock CLOCK =
+            Clock.fixed(Instant.ofEpochMilli(1L), ZoneOffset.UTC);
+    private static final int ID_SIZE = 8;
+    private static final byte FIELD_KIND_CLASS_STATIC = 2;
+
+    @Test
+    void staticObjectRefsEmittedToOutboundRef(@TempDir Path tmp) throws IOException, SQLException {
+        long holderClass = 0xC001L;
+        long cachedInstance = 0x100L;
+
+        Path hprof = buildStaticHolderDump(tmp, holderClass, cachedInstance, "static-refs.hprof");
+
+        Path indexDb = HeapDumpIndexPaths.indexFor(hprof);
+        try (HprofMappedFile file = HprofMappedFile.open(hprof)) {
+            HprofIndex.build(file, indexDb, CLOCK);
+        }
+        try (HeapView view = HeapView.open(indexDb)) {
+            try (PreparedStatement stmt = view.databaseClient().connection().prepareStatement(
+                    "SELECT source_id, target_id, field_id FROM outbound_ref WHERE field_kind = ?")) {
+                stmt.setByte(1, FIELD_KIND_CLASS_STATIC);
+                try (ResultSet rs = stmt.executeQuery()) {
+                    assertTrue(rs.next(), "one class_static outbound_ref row expected");
+                    assertEquals(holderClass, rs.getLong(1));
+                    assertEquals(cachedInstance, rs.getLong(2));
+                    assertEquals(1, rs.getInt(3), "CACHE is the second static field (index 1)");
+                }
+            }
+            // Static footprint: INT(4) + OBJECT(8) = 12 bytes.
+            try (PreparedStatement stmt = view.databaseClient().connection().prepareStatement(
+                    "SELECT static_fields_size FROM class WHERE class_id = ?")) {
+                stmt.setLong(1, holderClass);
+                try (ResultSet rs = stmt.executeQuery()) {
+                    assertTrue(rs.next());
+                    assertEquals(12, rs.getInt(1));
+                }
+            }
+        }
+    }
+
+    @Test
+    void staticallyRetainedObjectAppearsUnderClassNode(@TempDir Path tmp)
+            throws IOException, SQLException {
+        long holderClass = 0xC001L;
+        long cachedInstance = 0x100L;
+
+        Path hprof = buildStaticHolderDump(tmp, holderClass, cachedInstance, "static-dominators.hprof");
+
+        Path indexDb = HeapDumpIndexPaths.indexFor(hprof);
+        try (HprofMappedFile file = HprofMappedFile.open(hprof)) {
+            HprofIndex.build(file, indexDb, CLOCK);
+        }
+        DominatorTreeBuilder.build(indexDb);
+
+        try (HeapView view = HeapView.open(indexDb)) {
+            // The cached instance is reachable ONLY through the class static —
+            // before class nodes existed it had no retained size at all.
+            try (PreparedStatement stmt = view.databaseClient().connection().prepareStatement(
+                    "SELECT bytes FROM retained_size WHERE instance_id = ?")) {
+                stmt.setLong(1, cachedInstance);
+                try (ResultSet rs = stmt.executeQuery()) {
+                    assertTrue(rs.next(), "statics-retained object must have a retained size");
+                    assertTrue(rs.getLong(1) > 0);
+                }
+            }
+
+            // Top level shows the class node (rooted via ROOT_STICKY_CLASS)...
+            DominatorTreeResponse topLevel = DominatorTreeAnalyzer.children(view, 0L);
+            DominatorNode classNode = topLevel.nodes().stream()
+                    .filter(n -> n.objectId() == holderClass)
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("class node missing from dominator roots"));
+            assertEquals("class Holder", classNode.className());
+            assertTrue(classNode.hasChildren(), "class node dominates its static-held instance");
+
+            // ...and drilling into it surfaces the statics-held instance.
+            DominatorTreeResponse children = DominatorTreeAnalyzer.children(view, holderClass);
+            assertEquals(1, children.nodes().size());
+            assertEquals(cachedInstance, children.nodes().get(0).objectId());
+        }
+    }
+
+    /**
+     * A class "Holder" with statics {@code COUNT:int=42, CACHE:Object -> cachedInstance};
+     * the class object is a sticky-class GC root, and the cached instance is
+     * reachable only through the static.
+     */
+    private static Path buildStaticHolderDump(
+            Path tmp, long holderClass, long cachedInstance, String fileName) throws IOException {
+        return SyntheticHprof.create("1.0.2", ID_SIZE, 0L)
+                .string(0xA001L, "Holder")
+                .string(0xA002L, "COUNT")
+                .string(0xA003L, "CACHE")
+                .string(0xA004L, "next")
+                .loadClass(1, holderClass, 0, 0xA001L)
+                .heapDumpSegment(seg -> seg
+                        .classDumpWithStatics(holderClass, 0L, 0L, ID_SIZE,
+                                new SyntheticHprof.SubBuilder.StaticSpec[]{
+                                        new SyntheticHprof.SubBuilder.StaticSpec(
+                                                0xA002L, HprofTag.BasicType.INT, 42L),
+                                        new SyntheticHprof.SubBuilder.StaticSpec(
+                                                0xA003L, HprofTag.BasicType.OBJECT, cachedInstance)
+                                },
+                                new SyntheticHprof.SubBuilder.FieldSpec(0xA004L, HprofTag.BasicType.OBJECT))
+                        .gcRoot(HprofTag.Sub.ROOT_STICKY_CLASS, holderClass)
+                        .instanceDump(cachedInstance, holderClass, idBytes(0L)))
+                .heapDumpEnd()
+                .writeTo(tmp, fileName);
+    }
+
+    private static byte[] idBytes(long id) {
+        try {
+            ByteArrayOutputStream b = new ByteArrayOutputStream();
+            DataOutputStream d = new DataOutputStream(b);
+            d.writeLong(id);
+            return b.toByteArray();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/jeffrey-microscope/profiles/heap-dump/src/test/java/cafe/jeffrey/profile/heapdump/parser/SyntheticHprof.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/test/java/cafe/jeffrey/profile/heapdump/parser/SyntheticHprof.java
@@ -289,6 +289,54 @@ public final class SyntheticHprof {
         }
 
         /**
+         * A static-field declaration with its value. OBJECT values are written
+         * as ids; INT as 4 bytes; LONG as 8 bytes (the types tests need).
+         */
+        public record StaticSpec(long nameId, int basicType, long value) {
+        }
+
+        /**
+         * CLASS_DUMP with static fields and an arbitrary instance-field list.
+         */
+        public SubBuilder classDumpWithStatics(long classId, long superClassId, long classloaderId,
+                                               int instanceSize, StaticSpec[] statics,
+                                               FieldSpec... fields) {
+            try {
+                out.writeByte(HprofTag.Sub.CLASS_DUMP);
+                writeId(classId);
+                out.writeInt(0);
+                writeId(superClassId);
+                writeId(classloaderId);
+                writeId(0L);
+                writeId(0L);
+                writeId(0L);
+                writeId(0L);
+                out.writeInt(instanceSize);
+                out.writeShort(0); // const pool count
+                out.writeShort(statics.length);
+                for (StaticSpec s : statics) {
+                    writeId(s.nameId());
+                    out.writeByte(s.basicType());
+                    switch (s.basicType()) {
+                        case HprofTag.BasicType.OBJECT -> writeId(s.value());
+                        case HprofTag.BasicType.INT -> out.writeInt((int) s.value());
+                        case HprofTag.BasicType.LONG -> out.writeLong(s.value());
+                        default -> throw new IllegalArgumentException(
+                                "Unsupported static basic type in fixture: " + s.basicType());
+                    }
+                }
+                out.writeShort(fields.length);
+                for (FieldSpec f : fields) {
+                    writeId(f.nameId());
+                    out.writeByte(f.basicType());
+                }
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+            return this;
+        }
+
+        /**
          * CLASS_DUMP with arbitrary field list. Useful for tests that need
          * specific multi-field layouts (e.g. String = [value:OBJECT, coder:BYTE, hash:INT]).
          */

--- a/jeffrey-microscope/profiles/heapdump-oql/src/test/java/cafe/jeffrey/profile/heapdump/oql/executor/TestHeapView.java
+++ b/jeffrey-microscope/profiles/heapdump-oql/src/test/java/cafe/jeffrey/profile/heapdump/oql/executor/TestHeapView.java
@@ -400,4 +400,9 @@ final class TestHeapView implements HeapView {
     public int readInt(long fileOffset) {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public long readLong(long fileOffset) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/main/java/cafe/jeffrey/profile/manager/heapdump/HeapDumpDecompressor.java
+++ b/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/main/java/cafe/jeffrey/profile/manager/heapdump/HeapDumpDecompressor.java
@@ -1,0 +1,125 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.heapdump;
+
+import cafe.jeffrey.shared.common.measure.Elapsed;
+import cafe.jeffrey.shared.common.measure.Measuring;
+import cafe.jeffrey.shared.common.model.repository.FileExtensions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+import java.util.zip.GZIPInputStream;
+
+/**
+ * Resolves the analyzable {@code .hprof} path for a heap dump that may have
+ * been captured gzip-compressed ({@code .hprof.gz}). The native parser mmaps
+ * raw HPROF bytes, so a gzipped dump is decompressed once into a sibling
+ * {@code .hprof} file; that sibling then owns the DuckDB index sidecar and is
+ * the path every analysis opens.
+ *
+ * <p>Decompression is idempotent: the sibling is reused while it is at least
+ * as new as the gzipped source. Concurrent callers may decompress twice, but
+ * each writes to a unique temp file and atomically moves it into place, so
+ * readers never observe a partially written dump.</p>
+ */
+public final class HeapDumpDecompressor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HeapDumpDecompressor.class);
+
+    private static final String GZIPPED_HPROF_SUFFIX = "." + FileExtensions.HPROF_GZ;
+
+    private static final String GZ_EXTENSION = ".gz";
+
+    private static final String TMP_FILE_PREFIX = ".decompress-";
+
+    private static final String TMP_FILE_SUFFIX = ".tmp";
+
+    private HeapDumpDecompressor() {
+    }
+
+    public static boolean isGzipped(Path heapDumpPath) {
+        return heapDumpPath.getFileName().toString().toLowerCase().endsWith(GZIPPED_HPROF_SUFFIX);
+    }
+
+    /**
+     * The path analyses (and the index sidecar) are keyed on: the sibling
+     * {@code .hprof} for a gzipped dump, the path itself otherwise. Does not
+     * touch the filesystem.
+     */
+    public static Path analyzablePath(Path heapDumpPath) {
+        if (!isGzipped(heapDumpPath)) {
+            return heapDumpPath;
+        }
+        String fileName = heapDumpPath.getFileName().toString();
+        String decompressedName = fileName.substring(0, fileName.length() - GZ_EXTENSION.length());
+        return heapDumpPath.resolveSibling(decompressedName);
+    }
+
+    /**
+     * Ensures the analyzable {@code .hprof} exists and is up to date with the
+     * gzipped source, decompressing it if needed, and returns its path.
+     */
+    public static Path ensureDecompressed(Path heapDumpPath) throws IOException {
+        if (!isGzipped(heapDumpPath)) {
+            return heapDumpPath;
+        }
+
+        Path target = analyzablePath(heapDumpPath);
+        if (isUpToDate(target, heapDumpPath)) {
+            return target;
+        }
+
+        Path tmpFile = target.resolveSibling(TMP_FILE_PREFIX + UUID.randomUUID() + TMP_FILE_SUFFIX);
+        try {
+            Elapsed<Long> decompressed = Measuring.s(() -> decompressToFile(heapDumpPath, tmpFile));
+            Files.move(tmpFile, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+            LOG.info("Decompressed gzipped heap dump: source={} target={} bytes={} duration_ms={}",
+                    heapDumpPath, target, decompressed.entity(), decompressed.duration().toMillis());
+        } catch (UncheckedIOException e) {
+            throw e.getCause();
+        } finally {
+            Files.deleteIfExists(tmpFile);
+        }
+        return target;
+    }
+
+    private static boolean isUpToDate(Path target, Path gzSource) throws IOException {
+        if (!Files.exists(target)) {
+            return false;
+        }
+        long targetMtime = Files.getLastModifiedTime(target).toMillis();
+        long sourceMtime = Files.getLastModifiedTime(gzSource).toMillis();
+        return targetMtime >= sourceMtime;
+    }
+
+    private static long decompressToFile(Path gzSource, Path targetFile) {
+        try (InputStream gzipStream = new GZIPInputStream(Files.newInputStream(gzSource))) {
+            return Files.copy(gzipStream, targetFile);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/main/java/cafe/jeffrey/profile/manager/heapdump/HeapDumpDiffService.java
+++ b/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/main/java/cafe/jeffrey/profile/manager/heapdump/HeapDumpDiffService.java
@@ -1,0 +1,123 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.heapdump;
+
+import cafe.jeffrey.profile.heapdump.model.ClassDiffEntry;
+import cafe.jeffrey.profile.heapdump.model.ClassHistogramEntry;
+import cafe.jeffrey.profile.heapdump.model.HeapDumpDiffReport;
+import cafe.jeffrey.profile.heapdump.model.HeapSummary;
+import cafe.jeffrey.profile.heapdump.model.SortBy;
+import cafe.jeffrey.shared.common.exception.Exceptions;
+
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Compares two profiles' heap dumps by class histogram — the before/after leak
+ * workflow. Mirrors the differential-flamegraph pattern: both sides keep their
+ * own index database and the merge happens in Java keyed by class name.
+ */
+public final class HeapDumpDiffService {
+
+    /** Effectively "all classes" — a heap has tens of thousands, not millions. */
+    private static final int FULL_HISTOGRAM_LIMIT = 1_000_000;
+
+    private HeapDumpDiffService() {
+    }
+
+    /**
+     * Builds the class-level diff between the primary (current) and baseline
+     * dumps. Both dumps must exist and be initialized.
+     *
+     * @param topN cap for the returned entries (ordered by absolute
+     *             shallow-bytes delta descending)
+     */
+    public static HeapDumpDiffReport diff(HeapDumpManager primary, HeapDumpManager baseline, int topN) {
+        if (topN <= 0) {
+            throw new IllegalArgumentException("topN must be positive: topN=" + topN);
+        }
+        requireInitialized(primary, "primary");
+        requireInitialized(baseline, "baseline");
+
+        HeapSummary primarySummary = primary.getSummary();
+        HeapSummary baselineSummary = baseline.getSummary();
+
+        Map<String, ClassSide> byClass = new LinkedHashMap<>();
+        for (ClassHistogramEntry entry : primary.getClassHistogram(FULL_HISTOGRAM_LIMIT, SortBy.SIZE)) {
+            byClass.computeIfAbsent(entry.className(), k -> new ClassSide())
+                    .primary(entry.instanceCount(), entry.totalSize());
+        }
+        for (ClassHistogramEntry entry : baseline.getClassHistogram(FULL_HISTOGRAM_LIMIT, SortBy.SIZE)) {
+            byClass.computeIfAbsent(entry.className(), k -> new ClassSide())
+                    .baseline(entry.instanceCount(), entry.totalSize());
+        }
+
+        List<ClassDiffEntry> entries = byClass.entrySet().stream()
+                .map(e -> e.getValue().toEntry(e.getKey()))
+                .filter(e -> e.countDelta() != 0 || e.bytesDelta() != 0)
+                .sorted(Comparator.comparingLong((ClassDiffEntry e) -> Math.abs(e.bytesDelta())).reversed())
+                .limit(topN)
+                .toList();
+
+        long instanceCountDelta = primarySummary.totalInstances() - baselineSummary.totalInstances();
+        long shallowBytesDelta = primarySummary.totalBytes() - baselineSummary.totalBytes();
+
+        return new HeapDumpDiffReport(
+                primarySummary, baselineSummary, instanceCountDelta, shallowBytesDelta, entries);
+    }
+
+    private static void requireInitialized(HeapDumpManager manager, String side) {
+        if (!manager.heapDumpExists()) {
+            throw Exceptions.invalidRequest(
+                    "No heap dump available for the " + side + " profile");
+        }
+        if (!manager.isCacheReady()) {
+            throw Exceptions.invalidRequest(
+                    "Heap dump of the " + side + " profile is not initialized");
+        }
+    }
+
+    /** Mutable per-class accumulator for the two sides. */
+    private static final class ClassSide {
+
+        private long primaryCount;
+        private long primaryBytes;
+        private long baselineCount;
+        private long baselineBytes;
+
+        void primary(long count, long bytes) {
+            primaryCount += count;
+            primaryBytes += bytes;
+        }
+
+        void baseline(long count, long bytes) {
+            baselineCount += count;
+            baselineBytes += bytes;
+        }
+
+        ClassDiffEntry toEntry(String className) {
+            return new ClassDiffEntry(
+                    className,
+                    primaryCount, baselineCount, primaryCount - baselineCount,
+                    primaryBytes, baselineBytes, primaryBytes - baselineBytes);
+        }
+    }
+}

--- a/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/main/java/cafe/jeffrey/profile/manager/heapdump/HeapDumpInitService.java
+++ b/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/main/java/cafe/jeffrey/profile/manager/heapdump/HeapDumpInitService.java
@@ -1,0 +1,282 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.heapdump;
+
+import cafe.jeffrey.profile.heapdump.model.HeapDumpInitProgress;
+import cafe.jeffrey.profile.heapdump.model.HeapDumpInitStageProgress;
+import cafe.jeffrey.profile.heapdump.model.InitPipelineResult;
+import cafe.jeffrey.profile.heapdump.model.InitStageResult;
+import cafe.jeffrey.profile.heapdump.model.InitializeResult;
+import cafe.jeffrey.profile.heapdump.model.SubPhaseTiming;
+import cafe.jeffrey.shared.common.Schedulers;
+import cafe.jeffrey.shared.common.exception.JeffreyException;
+import cafe.jeffrey.shared.common.measure.Elapsed;
+import cafe.jeffrey.shared.common.measure.Measuring;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Server-side heap-dump initialization pipeline: one POST starts the whole
+ * run in the background (index build, dominator tree and every cached
+ * analysis), and the frontend polls {@link #progress(String)} for live
+ * per-stage statuses instead of orchestrating eleven sequential requests
+ * itself.
+ *
+ * <p>Process-wide (managers are recreated per request), keyed by profile id.
+ * At most one run per profile is active at a time; the terminal state stays
+ * queryable until the next run replaces it. The final snapshot is persisted
+ * through {@code HeapDumpManager.storeInitPipelineResult}, so the "last run"
+ * summary the overview page shows is now backend-owned.
+ */
+public final class HeapDumpInitService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HeapDumpInitService.class);
+
+    /** Stage ids shared with the frontend's timeline definition, in run order. */
+    public static final String STAGE_INDEX = "index";
+    public static final String STAGE_STRINGS = "strings";
+    public static final String STAGE_DOMINATOR = "dominator";
+    public static final String STAGE_THREADS = "threads";
+    public static final String STAGE_BIGGEST = "biggest";
+    public static final String STAGE_COLLECTIONS = "collections";
+    public static final String STAGE_LEAKS = "leaks";
+    public static final String STAGE_CLASSLOADERS = "classloaders";
+    public static final String STAGE_BIGGEST_COLLECTIONS = "biggest-collections";
+    public static final String STAGE_CONSUMERS = "consumers";
+    public static final String STAGE_DUPLICATES = "duplicates";
+
+    private static final List<String> STAGE_ORDER = List.of(
+            STAGE_INDEX, STAGE_STRINGS, STAGE_DOMINATOR, STAGE_THREADS, STAGE_BIGGEST,
+            STAGE_COLLECTIONS, STAGE_LEAKS, STAGE_CLASSLOADERS, STAGE_BIGGEST_COLLECTIONS,
+            STAGE_CONSUMERS, STAGE_DUPLICATES);
+
+    private static final int STRING_ANALYSIS_TOP_N = 100;
+
+    private static final int BIGGEST_OBJECTS_TOP_N = 20;
+
+    private static final int BIGGEST_COLLECTIONS_TOP_N = 50;
+
+    private static final int DUPLICATE_DATA_TOP_N = 50;
+
+    private final Clock clock;
+
+    private final ConcurrentMap<String, RunState> runsByProfileId = new ConcurrentHashMap<>();
+
+    public HeapDumpInitService(Clock clock) {
+        if (clock == null) {
+            throw new IllegalArgumentException("clock must not be null");
+        }
+        this.clock = clock;
+    }
+
+    /**
+     * Starts a background init run for the profile. Returns {@code false} when
+     * a run is already in progress (the caller should just poll), {@code true}
+     * when a new run was started.
+     */
+    public boolean start(String profileId, HeapDumpManager manager, Boolean compressedOopsOverride) {
+        RunState fresh = new RunState();
+        RunState existing = runsByProfileId.compute(profileId, (id, current) -> {
+            if (current != null && current.isRunning()) {
+                return current;
+            }
+            return fresh;
+        });
+        if (existing != fresh) {
+            LOG.debug("Heap dump init already running: profileId={}", profileId);
+            return false;
+        }
+        CompletableFuture
+                .runAsync(() -> runPipeline(profileId, manager, compressedOopsOverride, fresh),
+                        Schedulers.sharedVirtual())
+                .exceptionally(ex -> {
+                    LOG.error("Heap dump init pipeline crashed: profileId={}", profileId, ex);
+                    return null;
+                });
+        return true;
+    }
+
+    /** Live progress of the current (or last finished) run; idle when none exists. */
+    public HeapDumpInitProgress progress(String profileId) {
+        RunState run = runsByProfileId.get(profileId);
+        if (run == null) {
+            return HeapDumpInitProgress.idle();
+        }
+        return run.snapshot();
+    }
+
+    private void runPipeline(
+            String profileId, HeapDumpManager manager, Boolean compressedOopsOverride, RunState run) {
+        Instant startedAt = clock.instant();
+        try {
+            run.runStage(STAGE_INDEX, () -> {
+                InitializeResult result = manager.initialize(compressedOopsOverride);
+                return result == null ? null : result.subPhases();
+            });
+            run.runStage(STAGE_STRINGS, () -> {
+                manager.runStringAnalysis(STRING_ANALYSIS_TOP_N);
+                return null;
+            });
+            run.runStage(STAGE_DOMINATOR, manager::runComputeDominator);
+            run.runStage(STAGE_THREADS, () -> {
+                manager.runThreadAnalysis();
+                return null;
+            });
+            run.runStage(STAGE_BIGGEST, () -> {
+                manager.runBiggestObjects(BIGGEST_OBJECTS_TOP_N);
+                return null;
+            });
+            run.runStage(STAGE_COLLECTIONS, () -> {
+                manager.runCollectionAnalysis();
+                return null;
+            });
+            run.runStage(STAGE_LEAKS, () -> {
+                manager.runLeakSuspects();
+                return null;
+            });
+            run.runStage(STAGE_CLASSLOADERS, () -> {
+                manager.runClassLoaderAnalysis();
+                return null;
+            });
+            run.runStage(STAGE_BIGGEST_COLLECTIONS, () -> {
+                manager.runBiggestCollections(BIGGEST_COLLECTIONS_TOP_N);
+                return null;
+            });
+            run.runStage(STAGE_CONSUMERS, () -> {
+                manager.runConsumerReport();
+                return null;
+            });
+            run.runStage(STAGE_DUPLICATES, () -> {
+                manager.runDuplicateData(DUPLICATE_DATA_TOP_N);
+                return null;
+            });
+
+            Instant completedAt = clock.instant();
+            persistSnapshot(manager, run, startedAt, completedAt);
+            run.complete();
+            LOG.info("Heap dump init pipeline completed: profileId={} duration_ms={}",
+                    profileId, Duration.between(startedAt, completedAt).toMillis());
+        } catch (RuntimeException e) {
+            String code = e instanceof JeffreyException jeffreyException
+                    ? jeffreyException.getCode().name()
+                    : null;
+            run.fail(code, e.getMessage());
+            LOG.warn("Heap dump init pipeline failed: profileId={} error_code={} error={}",
+                    profileId, code, e.getMessage());
+        }
+    }
+
+    private static void persistSnapshot(
+            HeapDumpManager manager, RunState run, Instant startedAt, Instant completedAt) {
+        List<InitStageResult> stages = new ArrayList<>();
+        for (HeapDumpInitStageProgress stage : run.snapshot().stages()) {
+            stages.add(new InitStageResult(
+                    stage.id(), stage.status(), stage.durationMs(), stage.subPhases()));
+        }
+        InitPipelineResult snapshot = new InitPipelineResult(
+                Duration.between(startedAt, completedAt).toMillis(),
+                stages.size(),
+                (int) stages.stream()
+                        .filter(s -> HeapDumpInitStageProgress.STATUS_COMPLETED.equals(s.status()))
+                        .count(),
+                completedAt,
+                stages);
+        try {
+            manager.storeInitPipelineResult(snapshot);
+        } catch (RuntimeException e) {
+            LOG.warn("Failed to persist init pipeline snapshot: error={}", e.getMessage());
+        }
+    }
+
+    @FunctionalInterface
+    private interface StageWork {
+
+        /** Runs the stage; may return sub-phase timings for the accordion, or {@code null}. */
+        List<SubPhaseTiming> run();
+    }
+
+    /** Mutable per-run state; all stage mutations happen on the single pipeline thread. */
+    private static final class RunState {
+
+        private final Map<String, HeapDumpInitStageProgress> stages = new LinkedHashMap<>();
+        private volatile String state = HeapDumpInitProgress.STATE_RUNNING;
+        private volatile String errorCode;
+        private volatile String errorMessage;
+
+        private RunState() {
+            synchronized (stages) {
+                for (String id : STAGE_ORDER) {
+                    stages.put(id, new HeapDumpInitStageProgress(
+                            id, HeapDumpInitStageProgress.STATUS_PENDING, null, null));
+                }
+            }
+        }
+
+        boolean isRunning() {
+            return HeapDumpInitProgress.STATE_RUNNING.equals(state);
+        }
+
+        void runStage(String id, StageWork work) {
+            updateStage(id, HeapDumpInitStageProgress.STATUS_IN_PROGRESS, null, null);
+            try {
+                Elapsed<List<SubPhaseTiming>> elapsed = Measuring.s(work::run);
+                updateStage(id, HeapDumpInitStageProgress.STATUS_COMPLETED,
+                        elapsed.duration().toMillis(), elapsed.entity());
+            } catch (RuntimeException e) {
+                updateStage(id, HeapDumpInitStageProgress.STATUS_FAILED, null, null);
+                throw e;
+            }
+        }
+
+        void complete() {
+            state = HeapDumpInitProgress.STATE_COMPLETED;
+        }
+
+        void fail(String code, String message) {
+            errorCode = code;
+            errorMessage = message;
+            state = HeapDumpInitProgress.STATE_FAILED;
+        }
+
+        HeapDumpInitProgress snapshot() {
+            List<HeapDumpInitStageProgress> ordered;
+            synchronized (stages) {
+                ordered = List.copyOf(stages.values());
+            }
+            return new HeapDumpInitProgress(state, errorCode, errorMessage, ordered);
+        }
+
+        private void updateStage(String id, String status, Long durationMs, List<SubPhaseTiming> subPhases) {
+            synchronized (stages) {
+                stages.put(id, new HeapDumpInitStageProgress(id, status, durationMs, subPhases));
+            }
+        }
+    }
+}

--- a/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/main/java/cafe/jeffrey/profile/manager/heapdump/HeapDumpManager.java
+++ b/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/main/java/cafe/jeffrey/profile/manager/heapdump/HeapDumpManager.java
@@ -45,6 +45,7 @@ import cafe.jeffrey.profile.heapdump.model.OQLQueryRequest;
 import cafe.jeffrey.profile.heapdump.model.OQLQueryResult;
 import cafe.jeffrey.profile.heapdump.model.SortBy;
 import cafe.jeffrey.profile.heapdump.model.ConsumerReport;
+import cafe.jeffrey.profile.heapdump.model.DuplicateDataReport;
 import cafe.jeffrey.profile.heapdump.model.StringAnalysisReport;
 import cafe.jeffrey.profile.heapdump.model.SubPhaseTiming;
 import cafe.jeffrey.profile.heapdump.model.ThreadAnalysisReport;
@@ -503,5 +504,22 @@ public interface HeapDumpManager {
      * Run the consumer / component analysis and save results to JSON file.
      */
     void runConsumerReport();
+
+    // --- Duplicate Data ---
+
+    /**
+     * Check if the duplicate-data (byte-identical primitive arrays) report exists for this profile.
+     */
+    boolean duplicateDataExists();
+
+    /**
+     * Get the pre-computed duplicate-data report.
+     */
+    DuplicateDataReport getDuplicateData();
+
+    /**
+     * Run the duplicate-data analysis and save results to JSON file.
+     */
+    void runDuplicateData(int topN);
 
 }

--- a/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/main/java/cafe/jeffrey/profile/manager/heapdump/HeapDumpManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/main/java/cafe/jeffrey/profile/manager/heapdump/HeapDumpManagerImpl.java
@@ -42,6 +42,7 @@ import cafe.jeffrey.profile.heapdump.model.ClassLoaderDetail;
 import cafe.jeffrey.profile.heapdump.model.ClassLoaderReport;
 import cafe.jeffrey.profile.heapdump.model.CollectionAnalysisReport;
 import cafe.jeffrey.profile.heapdump.model.ConsumerReport;
+import cafe.jeffrey.profile.heapdump.model.DuplicateDataReport;
 import cafe.jeffrey.profile.heapdump.model.DominatorTreeResponse;
 import cafe.jeffrey.profile.heapdump.model.GCRootClassAggregate;
 import cafe.jeffrey.profile.heapdump.model.GCRootClassLoaderAggregate;
@@ -85,6 +86,7 @@ import cafe.jeffrey.profile.manager.heapdump.analysis.BiggestObjectsAnalysis;
 import cafe.jeffrey.profile.manager.heapdump.analysis.ClassLoaderHeapAnalysis;
 import cafe.jeffrey.profile.manager.heapdump.analysis.CollectionHeapAnalysis;
 import cafe.jeffrey.profile.manager.heapdump.analysis.ConsumerReportAnalysis;
+import cafe.jeffrey.profile.manager.heapdump.analysis.DuplicateDataAnalysis;
 import cafe.jeffrey.profile.manager.heapdump.analysis.LeakSuspectsAnalysis;
 import cafe.jeffrey.profile.manager.heapdump.analysis.StringHeapAnalysis;
 import cafe.jeffrey.profile.manager.heapdump.analysis.ThreadHeapAnalysis;
@@ -592,5 +594,22 @@ public class HeapDumpManagerImpl implements HeapDumpManager {
     @Override
     public void runConsumerReport() {
         runner.run(new ConsumerReportAnalysis());
+    }
+
+    // --- Duplicate Data --------------------------------------------------
+
+    @Override
+    public boolean duplicateDataExists() {
+        return reports.exists(new DuplicateDataAnalysis());
+    }
+
+    @Override
+    public DuplicateDataReport getDuplicateData() {
+        return reports.read(new DuplicateDataAnalysis()).orElse(null);
+    }
+
+    @Override
+    public void runDuplicateData(int topN) {
+        runner.run(new DuplicateDataAnalysis(topN));
     }
 }

--- a/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/main/java/cafe/jeffrey/profile/manager/heapdump/HeapDumpManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/main/java/cafe/jeffrey/profile/manager/heapdump/HeapDumpManagerImpl.java
@@ -96,16 +96,15 @@ import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
 import java.sql.SQLException;
-import java.time.Clock;
 import java.util.List;
 import java.util.Optional;
 
 /**
  * Implementation of HeapDumpManager on the native parser path
- * ({@link HeapDumpSession} + {@code analyzer.heapview}). Each method opens
- * a short-lived session over the heap dump's {@code .idx.duckdb} sibling,
- * runs the corresponding analyzer, and lets try-with-resources close the
- * session afterwards.
+ * ({@link HeapDumpSession} + {@code analyzer.heapview}). Each method runs
+ * the corresponding analyzer against the {@link HeapDumpSessionCache}-managed
+ * session over the heap dump's {@code .idx.duckdb} sibling; the session is
+ * kept open across requests and evicted when idle or invalidated.
  *
  * <p>Compressed-oops correction is not applied on this path; shallow sizes
  * are computed with the parser's fixed 16-byte header constant. The
@@ -141,17 +140,18 @@ public class HeapDumpManagerImpl implements HeapDumpManager {
             ProfileInfo profileInfo,
             AdditionalFilesManager additionalFilesManager,
             ProfileEventRepository eventRepository,
-            Clock clock,
+            HeapDumpSessionCache sessionCache,
             OqlEngine oqlEngine) {
 
         this.oqlEngine = oqlEngine;
         this.reports = new HeapDumpReportStore(additionalFilesManager.getHeapDumpAnalysisPath());
-        this.sessions = new HeapDumpSessionTemplate(profileInfo, additionalFilesManager, clock);
+        this.sessions = new HeapDumpSessionTemplate(profileInfo, additionalFilesManager, sessionCache);
         this.runner = new CachedAnalysisRunner(sessions, reports);
         this.jvmStringFlagsProvider = new JvmStringFlagsProvider(eventRepository);
         this.compressedOopsResolver = new CompressedOopsResolver(profileInfo, sessions, eventRepository, reports);
         this.uploadService = new HeapDumpUploadService(
-                profileInfo, additionalFilesManager, reports, additionalFilesManager.getHeapDumpAnalysisPath());
+                profileInfo, additionalFilesManager, reports,
+                additionalFilesManager.getHeapDumpAnalysisPath(), sessionCache);
     }
 
     // --- Lifecycle helpers ------------------------------------------------
@@ -454,12 +454,9 @@ public class HeapDumpManagerImpl implements HeapDumpManager {
 
     @Override
     public DominatorTreeResponse getDominatorTreeChildren(long objectId, int offset, int limit) {
-        // The native DominatorTreeAnalyzer does not currently support offset-based
-        // pagination; offset is ignored. The frontend uses lazy expansion, so the
-        // first `limit` children is what each call needs.
         return withSession(session -> {
             session.buildDominatorTreeIfNeeded();
-            return DominatorTreeAnalyzer.children(session.view(), objectId, limit);
+            return DominatorTreeAnalyzer.children(session.view(), objectId, offset, limit);
         }).orElse(EMPTY_DOMINATOR_TREE);
     }
 

--- a/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/main/java/cafe/jeffrey/profile/manager/heapdump/HeapDumpReportStore.java
+++ b/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/main/java/cafe/jeffrey/profile/manager/heapdump/HeapDumpReportStore.java
@@ -24,6 +24,7 @@ import cafe.jeffrey.profile.manager.heapdump.analysis.CachedAnalysis;
 import cafe.jeffrey.profile.manager.heapdump.analysis.ClassLoaderHeapAnalysis;
 import cafe.jeffrey.profile.manager.heapdump.analysis.CollectionHeapAnalysis;
 import cafe.jeffrey.profile.manager.heapdump.analysis.ConsumerReportAnalysis;
+import cafe.jeffrey.profile.manager.heapdump.analysis.DuplicateDataAnalysis;
 import cafe.jeffrey.profile.manager.heapdump.analysis.LeakSuspectsAnalysis;
 import cafe.jeffrey.profile.manager.heapdump.analysis.StringHeapAnalysis;
 import cafe.jeffrey.profile.manager.heapdump.analysis.ThreadHeapAnalysis;
@@ -61,7 +62,8 @@ public final class HeapDumpReportStore {
             new BiggestObjectsAnalysis(),
             new BiggestCollectionsAnalysis(),
             new ClassLoaderHeapAnalysis(),
-            new ConsumerReportAnalysis());
+            new ConsumerReportAnalysis(),
+            new DuplicateDataAnalysis());
 
     private final Path analysisDir;
 

--- a/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/main/java/cafe/jeffrey/profile/manager/heapdump/HeapDumpSessionCache.java
+++ b/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/main/java/cafe/jeffrey/profile/manager/heapdump/HeapDumpSessionCache.java
@@ -1,0 +1,226 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.heapdump;
+
+import cafe.jeffrey.profile.heapdump.persistence.HeapDumpIndexPaths;
+import cafe.jeffrey.profile.heapdump.persistence.HeapDumpSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.SQLException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Process-wide cache of open {@link HeapDumpSession}s, keyed by the analyzable
+ * {@code .hprof} path. Opening a session is expensive — it mmaps the dump and
+ * opens the DuckDB index (losing DuckDB's warm buffer pool on every close) —
+ * so instead of the previous open-per-request pattern, the session opened for
+ * the first request is kept and reused by subsequent requests for the same
+ * dump.
+ *
+ * <p>A {@link HeapDumpSession} wraps a single DuckDB connection and is not
+ * safe for concurrent use, so work units against the same dump are serialized
+ * on a per-dump lock. Different dumps proceed concurrently.
+ *
+ * <p>Freshness: a cached session is transparently replaced when the dump's
+ * mtime changes or its index sidecar disappears. Lifecycle events that make a
+ * session invalid by construction (re-upload, cache deletion, dump deletion)
+ * additionally call {@link #invalidate(Path)} so file handles are released
+ * before the underlying files are removed. Idle sessions are closed by a
+ * background sweep after {@link #DEFAULT_IDLE_TIMEOUT}; the sweep uses the
+ * injected {@link Clock}, so tests drive eviction by calling
+ * {@link #evictIdle()} directly with a controlled clock.
+ */
+public final class HeapDumpSessionCache implements AutoCloseable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HeapDumpSessionCache.class);
+
+    public static final Duration DEFAULT_IDLE_TIMEOUT = Duration.ofMinutes(10);
+
+    private static final Duration EVICTION_SWEEP_PERIOD = Duration.ofMinutes(1);
+
+    private static final String EVICTOR_THREAD_NAME = "heap-dump-session-evictor";
+
+    @FunctionalInterface
+    public interface SessionWork<R> {
+        R apply(HeapDumpSession session) throws SQLException, IOException;
+    }
+
+    private static final class Entry {
+        private final ReentrantLock lock = new ReentrantLock();
+        private HeapDumpSession session;
+        private long hprofMtime;
+        private volatile Instant lastUsed;
+    }
+
+    private final Clock clock;
+
+    private final Duration idleTimeout;
+
+    private final ConcurrentMap<Path, Entry> entries = new ConcurrentHashMap<>();
+
+    private final ScheduledExecutorService evictor;
+
+    public HeapDumpSessionCache(Clock clock) {
+        this(clock, DEFAULT_IDLE_TIMEOUT);
+    }
+
+    public HeapDumpSessionCache(Clock clock, Duration idleTimeout) {
+        if (clock == null) {
+            throw new IllegalArgumentException("clock must not be null");
+        }
+        if (idleTimeout == null || idleTimeout.isNegative() || idleTimeout.isZero()) {
+            throw new IllegalArgumentException("idleTimeout must be positive: idleTimeout=" + idleTimeout);
+        }
+        this.clock = clock;
+        this.idleTimeout = idleTimeout;
+        this.evictor = Executors.newSingleThreadScheduledExecutor(runnable -> {
+            Thread thread = new Thread(runnable, EVICTOR_THREAD_NAME);
+            thread.setDaemon(true);
+            return thread;
+        });
+        this.evictor.scheduleAtFixedRate(
+                this::evictIdle,
+                EVICTION_SWEEP_PERIOD.toMillis(),
+                EVICTION_SWEEP_PERIOD.toMillis(),
+                TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Runs {@code work} against the cached session for {@code hprofPath},
+     * opening (and building the index of) the session first if it is absent or
+     * stale. Work units for the same dump are serialized; the session stays
+     * open afterwards for the next caller.
+     */
+    public <R> R withSession(Path hprofPath, SessionWork<R> work) throws IOException, SQLException {
+        Path key = cacheKey(hprofPath);
+        while (true) {
+            Entry entry = entries.computeIfAbsent(key, k -> new Entry());
+            entry.lock.lock();
+            try {
+                if (entries.get(key) != entry) {
+                    // Evicted/invalidated between lookup and lock — retry with a fresh entry.
+                    continue;
+                }
+                ensureOpen(entry, key);
+                entry.lastUsed = clock.instant();
+                return work.apply(entry.session);
+            } finally {
+                entry.lock.unlock();
+            }
+        }
+    }
+
+    /**
+     * Closes and discards the cached session for {@code hprofPath}, waiting
+     * for any in-flight work unit on it to finish first. Callers must
+     * invalidate before deleting the dump or its index sidecar so no open
+     * file handles outlive the files.
+     */
+    public void invalidate(Path hprofPath) {
+        Entry entry = entries.remove(cacheKey(hprofPath));
+        if (entry == null) {
+            return;
+        }
+        entry.lock.lock();
+        try {
+            closeSession(entry);
+        } finally {
+            entry.lock.unlock();
+        }
+    }
+
+    /**
+     * Closes every cached session whose last use is older than the idle
+     * timeout. Entries currently running a work unit are skipped. Invoked
+     * periodically by the background sweep; public so tests can drive
+     * eviction deterministically with a controlled clock.
+     */
+    public void evictIdle() {
+        Instant cutoff = clock.instant().minus(idleTimeout);
+        for (Map.Entry<Path, Entry> mapEntry : entries.entrySet()) {
+            Entry entry = mapEntry.getValue();
+            if (!entry.lock.tryLock()) {
+                continue;
+            }
+            try {
+                if (entry.session != null && entry.lastUsed != null && entry.lastUsed.isBefore(cutoff)) {
+                    LOG.debug("Evicting idle heap dump session: path={} last_used={}",
+                            mapEntry.getKey(), entry.lastUsed);
+                    closeSession(entry);
+                }
+                if (entry.session == null) {
+                    entries.remove(mapEntry.getKey(), entry);
+                }
+            } finally {
+                entry.lock.unlock();
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+        evictor.shutdownNow();
+        for (Path key : entries.keySet()) {
+            invalidate(key);
+        }
+    }
+
+    private void ensureOpen(Entry entry, Path hprofPath) throws IOException, SQLException {
+        long hprofMtime = Files.getLastModifiedTime(hprofPath).toMillis();
+        if (entry.session != null) {
+            boolean indexPresent = Files.exists(HeapDumpIndexPaths.indexFor(hprofPath));
+            if (entry.hprofMtime == hprofMtime && indexPresent) {
+                return;
+            }
+            LOG.debug("Cached heap dump session is stale, reopening: path={}", hprofPath);
+            closeSession(entry);
+        }
+        entry.session = HeapDumpSession.openOrBuild(hprofPath, clock);
+        entry.hprofMtime = hprofMtime;
+    }
+
+    private static void closeSession(Entry entry) {
+        if (entry.session == null) {
+            return;
+        }
+        try {
+            entry.session.close();
+        } catch (RuntimeException e) {
+            LOG.warn("Failed to close cached heap dump session: error={}", e.getMessage());
+        }
+        entry.session = null;
+    }
+
+    private static Path cacheKey(Path hprofPath) {
+        return hprofPath.toAbsolutePath().normalize();
+    }
+}

--- a/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/main/java/cafe/jeffrey/profile/manager/heapdump/HeapDumpSessionTemplate.java
+++ b/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/main/java/cafe/jeffrey/profile/manager/heapdump/HeapDumpSessionTemplate.java
@@ -30,13 +30,13 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.SQLException;
-import java.time.Clock;
 import java.util.Optional;
 
 /**
- * Lifecycle wrapper around {@link HeapDumpSession}. Opens (or builds) a
- * short-lived session over a profile's heap dump, runs a unit of work, and
- * always closes the session afterwards.
+ * Lifecycle wrapper around {@link HeapDumpSession}. Resolves the profile's
+ * analyzable heap dump (decompressing a gzipped dump on first access), runs a
+ * unit of work against the {@link HeapDumpSessionCache}-managed session, and
+ * maps failures to the profile-scoped error contract.
  */
 public final class HeapDumpSessionTemplate {
 
@@ -46,16 +46,16 @@ public final class HeapDumpSessionTemplate {
 
     private final AdditionalFilesManager additionalFilesManager;
 
-    private final Clock clock;
+    private final HeapDumpSessionCache sessionCache;
 
     public HeapDumpSessionTemplate(
             ProfileInfo profileInfo,
             AdditionalFilesManager additionalFilesManager,
-            Clock clock) {
+            HeapDumpSessionCache sessionCache) {
 
         this.profileInfo = profileInfo;
         this.additionalFilesManager = additionalFilesManager;
-        this.clock = clock;
+        this.sessionCache = sessionCache;
     }
 
     @FunctionalInterface
@@ -69,8 +69,9 @@ public final class HeapDumpSessionTemplate {
             LOG.debug("No heap dump available: profileId={}", profileInfo.id());
             return Optional.empty();
         }
-        try (HeapDumpSession session = HeapDumpSession.openOrBuild(heapPath.get(), clock)) {
-            return Optional.ofNullable(work.apply(session));
+        try {
+            Path hprofPath = HeapDumpDecompressor.ensureDecompressed(heapPath.get());
+            return Optional.ofNullable(sessionCache.withSession(hprofPath, work::apply));
         } catch (IOException | SQLException e) {
             LOG.warn("Heap dump operation failed: profileId={} path={} error={}",
                     profileInfo.id(), heapPath.get(), e.getMessage());
@@ -87,12 +88,15 @@ public final class HeapDumpSessionTemplate {
         if (heapPath.isEmpty()) {
             return false;
         }
-        Path indexPath = HeapDumpIndexPaths.indexFor(heapPath.get());
-        if (!Files.exists(indexPath)) {
+        // The index sidecar is keyed on the decompressed .hprof, which for a
+        // gzipped dump may not have been materialized yet.
+        Path hprofPath = HeapDumpDecompressor.analyzablePath(heapPath.get());
+        Path indexPath = HeapDumpIndexPaths.indexFor(hprofPath);
+        if (!Files.exists(hprofPath) || !Files.exists(indexPath)) {
             return false;
         }
         try {
-            long hprofMtime = Files.getLastModifiedTime(heapPath.get()).toMillis();
+            long hprofMtime = Files.getLastModifiedTime(hprofPath).toMillis();
             long indexMtime = Files.getLastModifiedTime(indexPath).toMillis();
             return indexMtime >= hprofMtime;
         } catch (IOException e) {

--- a/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/main/java/cafe/jeffrey/profile/manager/heapdump/HeapDumpUploadService.java
+++ b/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/main/java/cafe/jeffrey/profile/manager/heapdump/HeapDumpUploadService.java
@@ -48,7 +48,7 @@ public final class HeapDumpUploadService {
 
     private static final String HPROF_SUFFIX = "." + FileExtensions.HPROF;
 
-    private static final int GZ_SUFFIX_LENGTH = 3; // ".gz"
+    private static final String GZ_EXTENSION = ".gz";
 
     private static final Set<String> ACCEPTED_SUFFIXES = Set.of(HPROF_SUFFIX, GZ_SUFFIX);
 
@@ -68,20 +68,25 @@ public final class HeapDumpUploadService {
 
     private final Path heapDumpAnalysisPath;
 
+    private final HeapDumpSessionCache sessionCache;
+
     public HeapDumpUploadService(
             ProfileInfo profileInfo,
             AdditionalFilesManager additionalFilesManager,
             HeapDumpReportStore reports,
-            Path heapDumpAnalysisPath) {
+            Path heapDumpAnalysisPath,
+            HeapDumpSessionCache sessionCache) {
 
         this.profileInfo = profileInfo;
         this.additionalFilesManager = additionalFilesManager;
         this.reports = reports;
         this.heapDumpAnalysisPath = heapDumpAnalysisPath;
+        this.sessionCache = sessionCache;
     }
 
     public void upload(InputStream inputStream, String filename) {
         validateFilename(filename);
+        invalidateCachedSession();
 
         try {
             FileSystemUtils.removeDirectory(heapDumpAnalysisPath);
@@ -110,12 +115,17 @@ public final class HeapDumpUploadService {
     }
 
     public void unloadHeap() {
-        // The native parser path doesn't hold long-lived heap state; every
-        // analyzer call opens and closes its own short-lived session.
+        // Release the cached session for this dump; the next analyzer call
+        // transparently reopens it from the on-disk index.
+        invalidateCachedSession();
     }
 
     public void deleteCache() {
-        additionalFilesManager.getHeapDumpPath().ifPresent(path -> deleteIndex(HeapDumpIndexPaths.indexFor(path)));
+        additionalFilesManager.getHeapDumpPath().ifPresent(path -> {
+            Path hprofPath = HeapDumpDecompressor.analyzablePath(path);
+            sessionCache.invalidate(hprofPath);
+            deleteIndex(HeapDumpIndexPaths.indexFor(hprofPath));
+        });
         reports.deleteAllCachedAnalyses();
         reports.delete(CONFIG_FILE, CONFIG_DISPLAY_NAME);
         reports.delete(INIT_PIPELINE_RESULT_FILE, INIT_PIPELINE_DISPLAY_NAME);
@@ -128,28 +138,35 @@ public final class HeapDumpUploadService {
         }
 
         Path path = heapPath.get();
-        String fileName = path.getFileName().toString().toLowerCase();
 
         Path hprofPath;
         Path gzPath = null;
-        if (fileName.endsWith(GZ_SUFFIX)) {
+        if (HeapDumpDecompressor.isGzipped(path)) {
             gzPath = path;
-            String decompressedName = path.getFileName().toString();
-            decompressedName = decompressedName.substring(0, decompressedName.length() - GZ_SUFFIX_LENGTH);
-            hprofPath = path.resolveSibling(decompressedName);
+            hprofPath = HeapDumpDecompressor.analyzablePath(path);
         } else {
             hprofPath = path;
-            Path potentialGz = path.resolveSibling(path.getFileName() + ".gz");
+            Path potentialGz = path.resolveSibling(path.getFileName() + GZ_EXTENSION);
             if (Files.exists(potentialGz)) {
                 gzPath = potentialGz;
             }
         }
 
+        sessionCache.invalidate(hprofPath);
         deleteIndex(HeapDumpIndexPaths.indexFor(hprofPath));
         deleteIfPresent(hprofPath, "heap dump");
         if (gzPath != null) {
             deleteIfPresent(gzPath, "compressed heap dump");
         }
+    }
+
+    /**
+     * Releases the cached session (and its open file handles) for the current
+     * dump before the file layout changes underneath it.
+     */
+    private void invalidateCachedSession() {
+        additionalFilesManager.getHeapDumpPath().ifPresent(
+                path -> sessionCache.invalidate(HeapDumpDecompressor.analyzablePath(path)));
     }
 
     private void validateFilename(String filename) {

--- a/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/main/java/cafe/jeffrey/profile/manager/heapdump/analysis/CachedAnalysis.java
+++ b/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/main/java/cafe/jeffrey/profile/manager/heapdump/analysis/CachedAnalysis.java
@@ -43,7 +43,8 @@ public sealed interface CachedAnalysis<T> permits
         BiggestObjectsAnalysis,
         BiggestCollectionsAnalysis,
         ClassLoaderHeapAnalysis,
-        ConsumerReportAnalysis {
+        ConsumerReportAnalysis,
+        DuplicateDataAnalysis {
 
     String fileName();
 

--- a/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/main/java/cafe/jeffrey/profile/manager/heapdump/analysis/DuplicateDataAnalysis.java
+++ b/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/main/java/cafe/jeffrey/profile/manager/heapdump/analysis/DuplicateDataAnalysis.java
@@ -1,0 +1,69 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.heapdump.analysis;
+
+import cafe.jeffrey.profile.heapdump.analyzer.heapview.DuplicateArrayAnalyzer;
+import cafe.jeffrey.profile.heapdump.model.DuplicateDataReport;
+import cafe.jeffrey.profile.heapdump.view.HeapView;
+
+import java.sql.SQLException;
+
+public final class DuplicateDataAnalysis implements CachedAnalysis<DuplicateDataReport> {
+
+    private static final String FILE_NAME = "duplicate-data.json";
+
+    private static final String DISPLAY_NAME = "Duplicate data";
+
+    private static final int DEFAULT_TOP_N = 50;
+
+    private final int topN;
+
+    public DuplicateDataAnalysis(int topN) {
+        this.topN = topN;
+    }
+
+    public DuplicateDataAnalysis() {
+        this(DEFAULT_TOP_N);
+    }
+
+    @Override
+    public String fileName() {
+        return FILE_NAME;
+    }
+
+    @Override
+    public Class<DuplicateDataReport> type() {
+        return DuplicateDataReport.class;
+    }
+
+    @Override
+    public boolean needsDominatorTree() {
+        return false;
+    }
+
+    @Override
+    public String displayName() {
+        return DISPLAY_NAME;
+    }
+
+    @Override
+    public DuplicateDataReport compute(HeapView view) throws SQLException {
+        return DuplicateArrayAnalyzer.analyze(view, topN);
+    }
+}

--- a/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/test/java/cafe/jeffrey/profile/manager/heapdump/HeapDumpDecompressorTest.java
+++ b/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/test/java/cafe/jeffrey/profile/manager/heapdump/HeapDumpDecompressorTest.java
@@ -1,0 +1,140 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.heapdump;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import java.util.zip.GZIPOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HeapDumpDecompressorTest {
+
+    private static final byte[] DUMP_CONTENT = "JAVA PROFILE 1.0.2 synthetic-bytes".getBytes(StandardCharsets.UTF_8);
+
+    @TempDir
+    Path tempDir;
+
+    private Path writeGzippedDump(String fileName) throws IOException {
+        Path gzPath = tempDir.resolve(fileName);
+        try (OutputStream out = new GZIPOutputStream(Files.newOutputStream(gzPath))) {
+            out.write(DUMP_CONTENT);
+        }
+        return gzPath;
+    }
+
+    @Nested
+    class PathResolution {
+
+        @Test
+        void stripsGzExtensionForGzippedDump() {
+            Path gzPath = tempDir.resolve("heap-dump.hprof.gz");
+            assertEquals(tempDir.resolve("heap-dump.hprof"), HeapDumpDecompressor.analyzablePath(gzPath));
+        }
+
+        @Test
+        void keepsPlainHprofPathUntouched() {
+            Path hprofPath = tempDir.resolve("heap-dump.hprof");
+            assertEquals(hprofPath, HeapDumpDecompressor.analyzablePath(hprofPath));
+        }
+
+        @Test
+        void detectsGzippedSuffixCaseInsensitively() {
+            assertTrue(HeapDumpDecompressor.isGzipped(tempDir.resolve("DUMP.HPROF.GZ")));
+            assertFalse(HeapDumpDecompressor.isGzipped(tempDir.resolve("dump.hprof")));
+        }
+    }
+
+    @Nested
+    class Decompression {
+
+        @Test
+        void decompressesGzippedDumpToSibling() throws IOException {
+            Path gzPath = writeGzippedDump("heap-dump.hprof.gz");
+
+            Path result = HeapDumpDecompressor.ensureDecompressed(gzPath);
+
+            assertEquals(tempDir.resolve("heap-dump.hprof"), result);
+            assertArrayEquals(DUMP_CONTENT, Files.readAllBytes(result));
+        }
+
+        @Test
+        void returnsPlainHprofWithoutTouchingFilesystem() throws IOException {
+            Path hprofPath = tempDir.resolve("heap-dump.hprof");
+            Files.write(hprofPath, DUMP_CONTENT);
+
+            Path result = HeapDumpDecompressor.ensureDecompressed(hprofPath);
+
+            assertEquals(hprofPath, result);
+            try (var files = Files.list(tempDir)) {
+                assertEquals(1, files.count());
+            }
+        }
+
+        @Test
+        void reusesUpToDateSibling() throws IOException {
+            Path gzPath = writeGzippedDump("heap-dump.hprof.gz");
+            Path sibling = tempDir.resolve("heap-dump.hprof");
+            byte[] sentinel = "already-decompressed".getBytes(StandardCharsets.UTF_8);
+            Files.write(sibling, sentinel);
+            Files.setLastModifiedTime(sibling, FileTime.from(
+                    Files.getLastModifiedTime(gzPath).toInstant().plusSeconds(60)));
+
+            Path result = HeapDumpDecompressor.ensureDecompressed(gzPath);
+
+            assertEquals(sibling, result);
+            assertArrayEquals(sentinel, Files.readAllBytes(sibling));
+        }
+
+        @Test
+        void reDecompressesWhenSiblingIsStale() throws IOException {
+            Path gzPath = writeGzippedDump("heap-dump.hprof.gz");
+            Path sibling = tempDir.resolve("heap-dump.hprof");
+            Files.write(sibling, "stale-content".getBytes(StandardCharsets.UTF_8));
+            Files.setLastModifiedTime(sibling, FileTime.from(Instant.EPOCH));
+
+            Path result = HeapDumpDecompressor.ensureDecompressed(gzPath);
+
+            assertArrayEquals(DUMP_CONTENT, Files.readAllBytes(result));
+        }
+
+        @Test
+        void leavesNoTempFilesBehind() throws IOException {
+            Path gzPath = writeGzippedDump("heap-dump.hprof.gz");
+
+            HeapDumpDecompressor.ensureDecompressed(gzPath);
+
+            try (var files = Files.list(tempDir)) {
+                assertEquals(2, files.count());
+            }
+        }
+    }
+}

--- a/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/test/java/cafe/jeffrey/profile/manager/heapdump/HeapDumpDiffServiceTest.java
+++ b/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/test/java/cafe/jeffrey/profile/manager/heapdump/HeapDumpDiffServiceTest.java
@@ -1,0 +1,159 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.heapdump;
+
+import cafe.jeffrey.profile.heapdump.model.ClassDiffEntry;
+import cafe.jeffrey.profile.heapdump.model.ClassHistogramEntry;
+import cafe.jeffrey.profile.heapdump.model.HeapDumpDiffReport;
+import cafe.jeffrey.profile.heapdump.model.HeapSummary;
+import cafe.jeffrey.profile.heapdump.model.SortBy;
+import cafe.jeffrey.shared.common.exception.JeffreyException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class HeapDumpDiffServiceTest {
+
+    @Mock
+    HeapDumpManager primary;
+
+    @Mock
+    HeapDumpManager baseline;
+
+    private void ready(HeapDumpManager manager) {
+        when(manager.heapDumpExists()).thenReturn(true);
+        when(manager.isCacheReady()).thenReturn(true);
+    }
+
+    private static HeapSummary summary(long bytes, long instances) {
+        return new HeapSummary(bytes, instances, 10, 5, Instant.ofEpochMilli(1L));
+    }
+
+    private static ClassHistogramEntry entry(String className, long count, long size) {
+        return new ClassHistogramEntry(className, count, size, List.of());
+    }
+
+    @Nested
+    class Diffing {
+
+        @Test
+        void computesPerClassDeltasWithNewAndRemovedClasses() {
+            ready(primary);
+            ready(baseline);
+            when(primary.getSummary()).thenReturn(summary(2_000L, 30L));
+            when(baseline.getSummary()).thenReturn(summary(1_000L, 20L));
+            when(primary.getClassHistogram(anyInt(), eq(SortBy.SIZE))).thenReturn(List.of(
+                    entry("com.app.Grown", 20, 1_200L),
+                    entry("com.app.New", 5, 500L),
+                    entry("com.app.Stable", 5, 300L)));
+            when(baseline.getClassHistogram(anyInt(), eq(SortBy.SIZE))).thenReturn(List.of(
+                    entry("com.app.Grown", 10, 600L),
+                    entry("com.app.Removed", 3, 100L),
+                    entry("com.app.Stable", 5, 300L)));
+
+            HeapDumpDiffReport report = HeapDumpDiffService.diff(primary, baseline, 50);
+
+            assertEquals(10L, report.instanceCountDelta());
+            assertEquals(1_000L, report.shallowBytesDelta());
+            // Stable class has no delta and is filtered out.
+            assertEquals(3, report.entries().size());
+
+            ClassDiffEntry grown = report.entries().get(0);
+            assertEquals("com.app.Grown", grown.className(), "largest |bytes delta| first");
+            assertEquals(10L, grown.countDelta());
+            assertEquals(600L, grown.bytesDelta());
+
+            ClassDiffEntry added = findEntry(report, "com.app.New");
+            assertEquals(0L, added.baselineCount());
+            assertEquals(500L, added.bytesDelta());
+
+            ClassDiffEntry removed = findEntry(report, "com.app.Removed");
+            assertEquals(0L, removed.primaryCount());
+            assertEquals(-100L, removed.bytesDelta());
+        }
+
+        @Test
+        void capsEntriesAtTopN() {
+            ready(primary);
+            ready(baseline);
+            when(primary.getSummary()).thenReturn(summary(100L, 10L));
+            when(baseline.getSummary()).thenReturn(summary(50L, 5L));
+            when(primary.getClassHistogram(anyInt(), eq(SortBy.SIZE))).thenReturn(List.of(
+                    entry("a.A", 1, 100L),
+                    entry("a.B", 1, 50L),
+                    entry("a.C", 1, 10L)));
+            when(baseline.getClassHistogram(anyInt(), eq(SortBy.SIZE))).thenReturn(List.of());
+
+            HeapDumpDiffReport report = HeapDumpDiffService.diff(primary, baseline, 2);
+
+            assertEquals(2, report.entries().size());
+            assertEquals("a.A", report.entries().get(0).className());
+        }
+    }
+
+    @Nested
+    class Validation {
+
+        @Test
+        void rejectsUninitializedBaseline() {
+            ready(primary);
+            when(baseline.heapDumpExists()).thenReturn(true);
+            when(baseline.isCacheReady()).thenReturn(false);
+
+            assertThrows(JeffreyException.class,
+                    () -> HeapDumpDiffService.diff(primary, baseline, 10));
+        }
+
+        @Test
+        void rejectsMissingPrimaryDump() {
+            when(primary.heapDumpExists()).thenReturn(false);
+
+            assertThrows(JeffreyException.class,
+                    () -> HeapDumpDiffService.diff(primary, baseline, 10));
+        }
+
+        @Test
+        void rejectsNonPositiveTopN() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> HeapDumpDiffService.diff(primary, baseline, 0));
+        }
+    }
+
+    private static ClassDiffEntry findEntry(HeapDumpDiffReport report, String className) {
+        return report.entries().stream()
+                .filter(e -> className.equals(e.className()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("missing entry for " + className));
+    }
+}

--- a/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/test/java/cafe/jeffrey/profile/manager/heapdump/HeapDumpSessionCacheTest.java
+++ b/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/test/java/cafe/jeffrey/profile/manager/heapdump/HeapDumpSessionCacheTest.java
@@ -1,0 +1,188 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.heapdump;
+
+import cafe.jeffrey.profile.heapdump.persistence.HeapDumpIndexPaths;
+import cafe.jeffrey.profile.heapdump.persistence.HeapDumpSession;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.sql.SQLException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HeapDumpSessionCacheTest {
+
+    private static final Instant START = Instant.ofEpochMilli(1_000_000L);
+
+    private static final Duration IDLE_TIMEOUT = Duration.ofMinutes(10);
+
+    /** Mutable, manually advanced clock so idle eviction is deterministic. */
+    private static final class MutableClock extends Clock {
+
+        private Instant now = START;
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return now;
+        }
+
+        void advance(Duration duration) {
+            now = now.plus(duration);
+        }
+    }
+
+    @TempDir
+    Path tempDir;
+
+    private final MutableClock clock = new MutableClock();
+
+    private final HeapDumpSessionCache cache = new HeapDumpSessionCache(clock, IDLE_TIMEOUT);
+
+    @AfterEach
+    void closeCache() {
+        cache.close();
+    }
+
+    private Path writeSyntheticDump(String fileName) throws IOException {
+        return SyntheticHeapDumps.writeMinimalDump(tempDir, fileName);
+    }
+
+    private HeapDumpSession leaseSession(Path hprof) throws IOException, SQLException {
+        return cache.withSession(hprof, session -> session);
+    }
+
+    @Nested
+    class Reuse {
+
+        @Test
+        void reusesSessionAcrossWorkUnits() throws IOException, SQLException {
+            Path hprof = writeSyntheticDump("reuse.hprof");
+
+            HeapDumpSession first = leaseSession(hprof);
+            HeapDumpSession second = leaseSession(hprof);
+
+            assertSame(first, second, "second work unit must reuse the cached session");
+        }
+
+        @Test
+        void sessionStaysUsableAcrossWorkUnits() throws IOException, SQLException {
+            Path hprof = writeSyntheticDump("usable.hprof");
+
+            leaseSession(hprof);
+            long recordCount = cache.withSession(hprof,
+                    session -> session.view().metadata().recordCount());
+
+            assertTrue(recordCount > 0, "cached session must serve queries");
+        }
+    }
+
+    @Nested
+    class Freshness {
+
+        @Test
+        void reopensWhenDumpMtimeChanges() throws IOException, SQLException {
+            Path hprof = writeSyntheticDump("mtime.hprof");
+
+            HeapDumpSession first = leaseSession(hprof);
+            Files.setLastModifiedTime(hprof, FileTime.from(
+                    Files.getLastModifiedTime(hprof).toInstant().plusSeconds(60)));
+            HeapDumpSession second = leaseSession(hprof);
+
+            assertNotSame(first, second, "mtime change must evict the cached session");
+        }
+
+        @Test
+        void reopensWhenIndexIsDeletedUnderneath() throws IOException, SQLException {
+            Path hprof = writeSyntheticDump("index-gone.hprof");
+
+            HeapDumpSession first = leaseSession(hprof);
+            // Deleted without invalidate() — the freshness check is the safety
+            // net for callers that bypass the lifecycle hooks.
+            Files.deleteIfExists(HeapDumpIndexPaths.indexFor(hprof));
+            HeapDumpSession second = leaseSession(hprof);
+
+            assertNotSame(first, second);
+            assertTrue(Files.exists(HeapDumpIndexPaths.indexFor(hprof)), "index must be rebuilt");
+        }
+    }
+
+    @Nested
+    class Lifecycle {
+
+        @Test
+        void invalidateForcesReopen() throws IOException, SQLException {
+            Path hprof = writeSyntheticDump("invalidate.hprof");
+
+            HeapDumpSession first = leaseSession(hprof);
+            cache.invalidate(hprof);
+            HeapDumpSession second = leaseSession(hprof);
+
+            assertNotSame(first, second);
+        }
+
+        @Test
+        void evictIdleClosesSessionAfterTimeout() throws IOException, SQLException {
+            Path hprof = writeSyntheticDump("idle.hprof");
+
+            HeapDumpSession first = leaseSession(hprof);
+            clock.advance(IDLE_TIMEOUT.plusSeconds(1));
+            cache.evictIdle();
+            HeapDumpSession second = leaseSession(hprof);
+
+            assertNotSame(first, second, "idle session must be evicted after the timeout");
+        }
+
+        @Test
+        void evictIdleKeepsRecentlyUsedSession() throws IOException, SQLException {
+            Path hprof = writeSyntheticDump("recent.hprof");
+
+            HeapDumpSession first = leaseSession(hprof);
+            clock.advance(IDLE_TIMEOUT.minusSeconds(1));
+            cache.evictIdle();
+            HeapDumpSession second = leaseSession(hprof);
+
+            assertSame(first, second, "recently used session must survive the sweep");
+        }
+    }
+
+}

--- a/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/test/java/cafe/jeffrey/profile/manager/heapdump/HeapDumpSessionTemplateTest.java
+++ b/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/test/java/cafe/jeffrey/profile/manager/heapdump/HeapDumpSessionTemplateTest.java
@@ -1,0 +1,108 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.heapdump;
+
+import cafe.jeffrey.profile.manager.additional.AdditionalFilesManager;
+import cafe.jeffrey.shared.common.model.ProfileInfo;
+import cafe.jeffrey.shared.common.model.RecordingEventSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.zip.GZIPOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HeapDumpSessionTemplateTest {
+
+    private static final Clock CLOCK = Clock.fixed(Instant.ofEpochMilli(1L), ZoneOffset.UTC);
+
+    @TempDir
+    Path tempDir;
+
+    @Mock
+    AdditionalFilesManager additionalFilesManager;
+
+    private final HeapDumpSessionCache cache = new HeapDumpSessionCache(CLOCK);
+
+    @AfterEach
+    void closeCache() {
+        cache.close();
+    }
+
+    @Test
+    void executesWorkAgainstGzippedHeapDump(@TempDir Path dumpDir) throws IOException {
+        Path gzPath = writeGzippedSyntheticDump(dumpDir);
+        when(additionalFilesManager.getHeapDumpPath()).thenReturn(Optional.of(gzPath));
+        HeapDumpSessionTemplate template = new HeapDumpSessionTemplate(
+                profileInfo(), additionalFilesManager, cache);
+
+        Optional<Long> recordCount = template.execute(
+                session -> session.view().metadata().recordCount());
+
+        assertTrue(recordCount.isPresent(), "gzipped dump must be analyzable");
+        assertTrue(recordCount.get() > 0);
+        assertTrue(Files.exists(dumpDir.resolve("dump.hprof")),
+                "decompressed sibling must be materialized next to the .gz");
+    }
+
+    @Test
+    void returnsEmptyWhenNoHeapDumpPresent() {
+        when(additionalFilesManager.getHeapDumpPath()).thenReturn(Optional.empty());
+        HeapDumpSessionTemplate template = new HeapDumpSessionTemplate(
+                profileInfo(), additionalFilesManager, cache);
+
+        Optional<Long> result = template.execute(
+                session -> session.view().metadata().recordCount());
+
+        assertEquals(Optional.empty(), result);
+    }
+
+    private Path writeGzippedSyntheticDump(Path dumpDir) throws IOException {
+        Path hprof = SyntheticHeapDumps.writeMinimalDump(tempDir, "dump.hprof");
+        Path gzPath = dumpDir.resolve("dump.hprof.gz");
+        try (OutputStream out = new GZIPOutputStream(Files.newOutputStream(gzPath))) {
+            Files.copy(hprof, out);
+        }
+        return gzPath;
+    }
+
+    private static ProfileInfo profileInfo() {
+        return new ProfileInfo(
+                "test-profile", "test-project", "test-workspace", "Test Profile",
+                RecordingEventSource.HEAP_DUMP,
+                Instant.EPOCH, Instant.EPOCH, Instant.EPOCH,
+                true, false, "test-recording");
+    }
+
+}

--- a/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/test/java/cafe/jeffrey/profile/manager/heapdump/SyntheticHeapDumps.java
+++ b/jeffrey-microscope/profiles/profile-heapdump-orchestration/src/test/java/cafe/jeffrey/profile/manager/heapdump/SyntheticHeapDumps.java
@@ -1,0 +1,135 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.heapdump;
+
+import cafe.jeffrey.profile.heapdump.view.HprofTag;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Writes a minimal-but-valid HPROF 1.0.2 dump for orchestration tests: one
+ * class ("Holder") with a single object field, one sticky-class-rooted
+ * instance of it. Mirrors the byte layout of the {@code SyntheticHprof}
+ * builder in the heap-dump module's tests, which cannot be shared here — the
+ * orchestration module is compiled on the module path and a test-jar would
+ * split the parser package of the named heap-dump module.
+ */
+final class SyntheticHeapDumps {
+
+    private static final String MAGIC_1_0_2 = "JAVA PROFILE 1.0.2";
+
+    private static final int ID_SIZE = 8;
+
+    private static final long HOLDER_CLASS_NAME_ID = 0xA001L;
+
+    private static final long FIELD_NAME_ID = 0xA002L;
+
+    private static final long HOLDER_CLASS_ID = 0xC001L;
+
+    private static final long INSTANCE_ID = 0x100L;
+
+    private SyntheticHeapDumps() {
+    }
+
+    /** Writes the minimal dump to {@code dir/fileName} and returns its path. */
+    static Path writeMinimalDump(Path dir, String fileName) throws IOException {
+        ByteArrayOutputStream sink = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(sink);
+
+        out.writeBytes(MAGIC_1_0_2);
+        out.writeByte(0);
+        out.writeInt(ID_SIZE);
+        out.writeLong(0L);
+
+        writeRecord(out, HprofTag.Top.STRING, stringBody(HOLDER_CLASS_NAME_ID, "Holder"));
+        writeRecord(out, HprofTag.Top.STRING, stringBody(FIELD_NAME_ID, "next"));
+        writeRecord(out, HprofTag.Top.LOAD_CLASS, loadClassBody());
+        writeRecord(out, HprofTag.Top.HEAP_DUMP_SEGMENT, heapSegmentBody());
+        writeRecord(out, HprofTag.Top.HEAP_DUMP_END, new byte[0]);
+
+        Path path = dir.resolve(fileName);
+        Files.write(path, sink.toByteArray());
+        return path;
+    }
+
+    private static void writeRecord(DataOutputStream out, int tag, byte[] body) throws IOException {
+        out.writeByte(tag);
+        out.writeInt(0); // timestamp delta
+        out.writeInt(body.length);
+        out.write(body);
+    }
+
+    private static byte[] stringBody(long stringId, String value) throws IOException {
+        ByteArrayOutputStream sink = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(sink);
+        out.writeLong(stringId);
+        out.write(value.getBytes(StandardCharsets.UTF_8));
+        return sink.toByteArray();
+    }
+
+    private static byte[] loadClassBody() throws IOException {
+        ByteArrayOutputStream sink = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(sink);
+        out.writeInt(1); // class serial
+        out.writeLong(HOLDER_CLASS_ID);
+        out.writeInt(0); // stack trace serial
+        out.writeLong(HOLDER_CLASS_NAME_ID);
+        return sink.toByteArray();
+    }
+
+    private static byte[] heapSegmentBody() throws IOException {
+        ByteArrayOutputStream sink = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(sink);
+
+        // CLASS_DUMP: Holder, no super, one OBJECT-typed instance field.
+        out.writeByte(HprofTag.Sub.CLASS_DUMP);
+        out.writeLong(HOLDER_CLASS_ID);
+        out.writeInt(0);      // stack trace serial
+        out.writeLong(0L);    // super class
+        out.writeLong(0L);    // classloader
+        out.writeLong(0L);    // signers
+        out.writeLong(0L);    // protection domain
+        out.writeLong(0L);    // reserved 1
+        out.writeLong(0L);    // reserved 2
+        out.writeInt(ID_SIZE); // instance size = one object reference
+        out.writeShort(0);    // const pool count
+        out.writeShort(0);    // static fields count
+        out.writeShort(1);    // instance fields count
+        out.writeLong(FIELD_NAME_ID);
+        out.writeByte(HprofTag.BasicType.OBJECT);
+
+        // GC root + one Holder instance with a null field value.
+        out.writeByte(HprofTag.Sub.ROOT_STICKY_CLASS);
+        out.writeLong(INSTANCE_ID);
+
+        out.writeByte(HprofTag.Sub.INSTANCE_DUMP);
+        out.writeLong(INSTANCE_ID);
+        out.writeInt(0); // stack trace serial
+        out.writeLong(HOLDER_CLASS_ID);
+        out.writeInt(ID_SIZE);
+        out.writeLong(0L); // field value: null
+
+        return sink.toByteArray();
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/configuration/ProfileJvmInsightConfiguration.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/configuration/ProfileJvmInsightConfiguration.java
@@ -38,6 +38,7 @@ import cafe.jeffrey.profile.manager.memory.NativeMemoryTrackingManagerImpl;
 import cafe.jeffrey.profile.manager.gc.GarbageCollectionManagerImpl;
 import cafe.jeffrey.profile.manager.heapdump.HeapDumpManager;
 import cafe.jeffrey.profile.manager.heapdump.HeapDumpManagerImpl;
+import cafe.jeffrey.profile.manager.heapdump.HeapDumpSessionCache;
 import cafe.jeffrey.profile.manager.registry.JvmInsightFactories;
 import cafe.jeffrey.profile.manager.thread.ThreadManager;
 import cafe.jeffrey.profile.manager.thread.ThreadManagerImpl;
@@ -189,10 +190,15 @@ public class ProfileJvmInsightConfiguration {
         };
     }
 
+    @Bean(destroyMethod = "close")
+    public HeapDumpSessionCache heapDumpSessionCache(Clock clock) {
+        return new HeapDumpSessionCache(clock);
+    }
+
     @Bean
     public HeapDumpManager.Factory heapDumpManagerFactory(
             AdditionalFilesManager.Factory additionalFilesManagerFactory,
-            Clock clock,
+            HeapDumpSessionCache heapDumpSessionCache,
             OqlEngine oqlEngine) {
 
         return profileInfo -> {
@@ -201,7 +207,7 @@ public class ProfileJvmInsightConfiguration {
                     profileInfo,
                     additionalFilesManagerFactory.apply(profileInfo),
                     profileRepositories.newEventRepository(profileDb),
-                    clock,
+                    heapDumpSessionCache,
                     oqlEngine);
         };
     }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/configuration/ProfileJvmInsightConfiguration.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/configuration/ProfileJvmInsightConfiguration.java
@@ -38,6 +38,7 @@ import cafe.jeffrey.profile.manager.memory.NativeMemoryTrackingManagerImpl;
 import cafe.jeffrey.profile.manager.gc.GarbageCollectionManagerImpl;
 import cafe.jeffrey.profile.manager.heapdump.HeapDumpManager;
 import cafe.jeffrey.profile.manager.heapdump.HeapDumpManagerImpl;
+import cafe.jeffrey.profile.manager.heapdump.HeapDumpInitService;
 import cafe.jeffrey.profile.manager.heapdump.HeapDumpSessionCache;
 import cafe.jeffrey.profile.manager.registry.JvmInsightFactories;
 import cafe.jeffrey.profile.manager.thread.ThreadManager;
@@ -193,6 +194,11 @@ public class ProfileJvmInsightConfiguration {
     @Bean(destroyMethod = "close")
     public HeapDumpSessionCache heapDumpSessionCache(Clock clock) {
         return new HeapDumpSessionCache(clock);
+    }
+
+    @Bean
+    public HeapDumpInitService heapDumpInitService(Clock clock) {
+        return new HeapDumpInitService(clock);
     }
 
     @Bean

--- a/jeffrey-pages/src/views/docs/microscope/profiles/ProfilesPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/profiles/ProfilesPage.vue
@@ -289,7 +289,22 @@ const folderStructure = `$JEFFREY_HOME/
         <DocsFeatureCard
           icon="bi bi-collection"
           title="Biggest Collections"
-          description="Find the largest collections by size, capacity, and fill ratio — surface over-allocated maps and lists that waste memory."
+          description="Find the largest collections by size, capacity, and fill ratio — surface over-allocated maps and lists that waste memory. Covers array-backed collections plus ArrayDeque, ConcurrentHashMap, TreeMap, LinkedList and the Set family."
+        />
+        <DocsFeatureCard
+          icon="bi bi-box-seam-fill"
+          title="Biggest Objects & Memory Consumers"
+          description="Single objects retaining the most memory (the dominator-tree roots), plus per-package and per-classloader rollups showing which subsystem owns the heap."
+        />
+        <DocsFeatureCard
+          icon="bi bi-files"
+          title="Duplicate Data"
+          description="Byte-identical primitive arrays that could be shared as a single copy — the raw storage behind buffers, caches and deserialized payloads — with reclaimable savings per group."
+        />
+        <DocsFeatureCard
+          icon="bi bi-layers-half"
+          title="Heap Diff"
+          description="Compare the current heap dump against a baseline profile's dump: per-class growth, new and removed classes — the classic before/after leak workflow."
         />
         <DocsFeatureCard
           icon="bi bi-fonts"


### PR DESCRIPTION
.hprof.gz uploads were accepted, stored, and detected, but the native
parser mmaps the path directly and rejects gzip magic, so gzipped dumps
were never analyzable. HeapDumpDecompressor materializes the decompressed
sibling once (atomic move, mtime-based reuse) and every analysis path now
opens that sibling, which also owns the DuckDB index sidecar.

Claude-Session: https://claude.ai/code/session_013cDGEK5NhnrmZYQGMMY7Vx