### PR TITLE
Zero-config application onboarding: env-only provisioner, fail-open entrypoint, self-identifying jeffrey-jib images

### DIFF
--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/HeapDumpControllerTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/HeapDumpControllerTest.java
@@ -24,6 +24,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
 import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
+import cafe.jeffrey.profile.manager.heapdump.HeapDumpInitService;
 import cafe.jeffrey.profile.manager.heapdump.HeapDumpManager;
 import cafe.jeffrey.profile.manager.ProfileManager;
 import cafe.jeffrey.shared.common.exception.Exceptions;
@@ -44,13 +45,16 @@ class HeapDumpControllerTest {
     @Mock
     HeapDumpManager heapDumpManager;
 
+    @Mock
+    HeapDumpInitService initService;
+
     @Test
     void existsReportsFalseWhenAbsent() {
         when(resolver.resolve("p-1")).thenReturn(profileManager);
         when(profileManager.heapDumpManager()).thenReturn(heapDumpManager);
         when(heapDumpManager.heapDumpExists()).thenReturn(false);
 
-        MockMvcTester mvc = mockMvcTesterFor(new HeapDumpController(resolver));
+        MockMvcTester mvc = mockMvcTesterFor(new HeapDumpController(resolver, initService));
 
         assertThat(mvc.get().uri("/api/internal/profiles/p-1/heap/exists"))
                 .hasStatusOk()
@@ -61,7 +65,7 @@ class HeapDumpControllerTest {
     void profileNotFoundReturns404() {
         when(resolver.resolve("ghost")).thenThrow(Exceptions.profileNotFound("ghost"));
 
-        MockMvcTester mvc = mockMvcTesterFor(new HeapDumpController(resolver));
+        MockMvcTester mvc = mockMvcTesterFor(new HeapDumpController(resolver, initService));
 
         assertThat(mvc.get().uri("/api/internal/profiles/ghost/heap/exists"))
                 .hasStatus(404)

--- a/jeffrey-pages/src/views/docs/provisioner/ProvisionerConfigurationPage.vue
+++ b/jeffrey-pages/src/views/docs/provisioner/ProvisionerConfigurationPage.vue
@@ -38,13 +38,13 @@ onMounted(() => {
 });
 
 const envOnlySetup = `# The complete environment-only setup - no config file needed:
-JEFFREY_HOME=/mnt/jeffrey            # shared volume root (baked by jeffrey-jib)
-JEFFREY_PROJECT_NAME=my-service      # baked by jeffrey-jib from the artifactId
-JEFFREY_WORKSPACE_REF_ID=production         # optional (default: the hub's default workspace)
+JEFFREY_HOME=/mnt/jeffrey             # shared volume root (baked by jeffrey-jib)
+JEFFREY_PROJECT_NAME=my-service       # baked by jeffrey-jib from the artifactId
+JEFFREY_WORKSPACE_REF_ID=production   # optional (default: the hub's default workspace)
 
 # Optional extras:
 JEFFREY_PROJECT_LABEL="My Service"
-JEFFREY_INSTANCE_NAME=instance-1     # default: HOSTNAME (= pod name), then UUID
+JEFFREY_INSTANCE_NAME=instance-1      # default: HOSTNAME (= pod name), then UUID
 JEFFREY_ATTRIBUTES="cluster=blue,namespace=production"
 JEFFREY_HEAP_DUMP=crash              # exit | crash | off
 JEFFREY_PERF_COUNTERS=true

--- a/jeffrey-pages/src/views/docs/provisioner/ProvisionerConfigurationPage.vue
+++ b/jeffrey-pages/src/views/docs/provisioner/ProvisionerConfigurationPage.vue
@@ -27,6 +27,7 @@ import { useDocHeadings } from '@/composables/useDocHeadings';
 const { setHeadings } = useDocHeadings();
 
 const headings = [
+  { id: 'env-only', text: 'Environment-Only Configuration', level: 2 },
   { id: 'config-file', text: 'Configuration File', level: 2 },
   { id: 'configuration-options', text: 'Configuration Options', level: 2 },
   { id: 'features', text: 'Features', level: 2 }
@@ -35,6 +36,20 @@ const headings = [
 onMounted(() => {
   setHeadings(headings);
 });
+
+const envOnlySetup = `# The complete environment-only setup - no config file needed:
+JEFFREY_HOME=/mnt/jeffrey            # shared volume root (baked by jeffrey-jib)
+JEFFREY_PROJECT_NAME=my-service      # baked by jeffrey-jib from the artifactId
+JEFFREY_WORKSPACE=production         # optional (default: the hub's default workspace)
+
+# Optional extras:
+JEFFREY_PROJECT_LABEL="My Service"
+JEFFREY_INSTANCE_NAME=instance-1     # default: HOSTNAME (= pod name), then UUID
+JEFFREY_ATTRIBUTES="cluster=blue,namespace=production"
+JEFFREY_HEAP_DUMP=crash              # exit | crash | off
+JEFFREY_PERF_COUNTERS=true
+JEFFREY_JVM_LOGGING="jfr*=trace:file=<<JEFFREY_CURRENT_SESSION>>/jfr-jvm.log"
+JEFFREY_ADDITIONAL_JVM_OPTIONS="-Xmx2g"`;
 
 const minimalConfig = `jeffrey-home = "/opt/jeffrey"
 project {
@@ -73,7 +88,18 @@ additional-jvm-options = "-Xmx2g -Xms2g -Djeffrey.logging.trace-file.path=<<JEFF
       />
 
       <div class="docs-content">
-        <p>Jeffrey Provisioner uses <strong>HOCON</strong> (Human-Optimized Config Object Notation) for configuration. HOCON is a superset of JSON with more readable syntax.</p>
+        <p>Jeffrey Provisioner can be configured two ways: entirely through <strong><code>JEFFREY_*</code> environment variables</strong> (the zero-file path — recommended for containers) or through a <strong>HOCON</strong> configuration file for advanced setups. Resolution order is always <strong>HOCON value &rarr; environment variable &rarr; built-in default</strong>, so a config file wins wherever it sets a value.</p>
+
+        <h2 id="env-only">Environment-Only Configuration</h2>
+        <p>When <code>provisioner init</code> runs without <code>--base-config</code> (or the jeffrey-jib entrypoint finds no config file), it configures itself from environment variables. Images built with the jeffrey-jib extension already bake <code>JEFFREY_HOME</code> and <code>JEFFREY_PROJECT_NAME</code> (derived from the Maven artifactId / Gradle project name), so the common case needs <em>no per-application configuration at all</em> beyond mounting the shared volume:</p>
+        <DocsCodeBlock
+          language="bash"
+          :code="envOnlySetup"
+        />
+
+        <DocsCallout type="tip">
+          <strong>Fail-open:</strong> any misconfiguration (missing binaries, missing project name, broken config) starts the application <em>without profiling</em> instead of preventing it from starting — look for the single <code>Jeffrey profiling ENABLED: …</code> / <code>profiling DISABLED: &lt;reason&gt;</code> line in the container log to see the outcome.
+        </DocsCallout>
 
         <h2 id="config-file">Configuration File</h2>
 
@@ -124,7 +150,7 @@ additional-jvm-options = "-Xmx2g -Xms2g -Djeffrey.logging.trace-file.path=<<JEFF
             <tr>
               <td><code>project.workspace-ref-id</code></td>
               <td>No</td>
-              <td>—</td>
+              <td><code>JEFFREY_WORKSPACE</code></td>
               <td>
                 Reference ID of the workspace on the target Jeffrey Hub. Optional — when
                 omitted (or blank), events route to the server's default workspace
@@ -139,8 +165,8 @@ additional-jvm-options = "-Xmx2g -Xms2g -Djeffrey.logging.trace-file.path=<<JEFF
             <tr>
               <td><code>project.name</code></td>
               <td>Yes</td>
-              <td>—</td>
-              <td>Project name for organizing recordings</td>
+              <td><code>JEFFREY_PROJECT_NAME</code></td>
+              <td>Project name for organizing recordings. Images built with jeffrey-jib bake this env var from the Maven artifactId / Gradle project name.</td>
             </tr>
             <tr>
               <td><code>profiler-path</code></td>
@@ -151,13 +177,13 @@ additional-jvm-options = "-Xmx2g -Xms2g -Djeffrey.logging.trace-file.path=<<JEFF
             <tr>
               <td><code>project.instance-name</code></td>
               <td>No</td>
-              <td>—</td>
+              <td><code>JEFFREY_INSTANCE_NAME</code></td>
               <td>Instance name (defaults to <code>HOSTNAME</code> environment variable or generated UUID)</td>
             </tr>
             <tr>
               <td><code>project.label</code></td>
               <td>No</td>
-              <td>—</td>
+              <td><code>JEFFREY_PROJECT_LABEL</code></td>
               <td>Human-readable project label</td>
             </tr>
             <tr>
@@ -199,7 +225,7 @@ additional-jvm-options = "-Xmx2g -Xms2g -Djeffrey.logging.trace-file.path=<<JEFF
             <tr>
               <td><code>additional-jvm-options</code></td>
               <td>No</td>
-              <td>—</td>
+              <td><code>JEFFREY_ADDITIONAL_JVM_OPTIONS</code></td>
               <td>Extra JVM flags appended to the generated arguments. Supports the <code>&lt;&lt;JEFFREY_CURRENT_SESSION&gt;&gt;</code> placeholder.</td>
             </tr>
             <tr>
@@ -211,8 +237,26 @@ additional-jvm-options = "-Xmx2g -Xms2g -Djeffrey.logging.trace-file.path=<<JEFF
             <tr>
               <td><code>attributes</code></td>
               <td>No</td>
-              <td>—</td>
-              <td>Custom key-value metadata (e.g., cluster, namespace)</td>
+              <td><code>JEFFREY_ATTRIBUTES</code></td>
+              <td>Custom key-value metadata (e.g., cluster, namespace). Env form: <code>key=value,key=value</code></td>
+            </tr>
+            <tr>
+              <td><code>perf-counters.enabled</code></td>
+              <td>No</td>
+              <td><code>JEFFREY_PERF_COUNTERS</code></td>
+              <td>Save JVM performance counters into the session directory</td>
+            </tr>
+            <tr>
+              <td><code>heap-dump</code></td>
+              <td>No</td>
+              <td><code>JEFFREY_HEAP_DUMP</code></td>
+              <td>Heap dump on OutOfMemoryError. Env form: <code>exit</code> | <code>crash</code> | <code>off</code></td>
+            </tr>
+            <tr>
+              <td><code>jvm-logging.command</code></td>
+              <td>No</td>
+              <td><code>JEFFREY_JVM_LOGGING</code></td>
+              <td>JVM unified logging command (<code>-Xlog:&lt;command&gt;</code>); a non-blank env value enables the feature</td>
             </tr>
           </tbody>
         </table>

--- a/jeffrey-pages/src/views/docs/provisioner/ProvisionerConfigurationPage.vue
+++ b/jeffrey-pages/src/views/docs/provisioner/ProvisionerConfigurationPage.vue
@@ -40,7 +40,7 @@ onMounted(() => {
 const envOnlySetup = `# The complete environment-only setup - no config file needed:
 JEFFREY_HOME=/mnt/jeffrey            # shared volume root (baked by jeffrey-jib)
 JEFFREY_PROJECT_NAME=my-service      # baked by jeffrey-jib from the artifactId
-JEFFREY_WORKSPACE=production         # optional (default: the hub's default workspace)
+JEFFREY_WORKSPACE_REF_ID=production         # optional (default: the hub's default workspace)
 
 # Optional extras:
 JEFFREY_PROJECT_LABEL="My Service"
@@ -150,7 +150,7 @@ additional-jvm-options = "-Xmx2g -Xms2g -Djeffrey.logging.trace-file.path=<<JEFF
             <tr>
               <td><code>project.workspace-ref-id</code></td>
               <td>No</td>
-              <td><code>JEFFREY_WORKSPACE</code></td>
+              <td><code>JEFFREY_WORKSPACE_REF_ID</code></td>
               <td>
                 Reference ID of the workspace on the target Jeffrey Hub. Optional — when
                 omitted (or blank), events route to the server's default workspace

--- a/jeffrey-pages/src/views/docs/provisioner/ProvisionerConfigurationPage.vue
+++ b/jeffrey-pages/src/views/docs/provisioner/ProvisionerConfigurationPage.vue
@@ -101,6 +101,18 @@ additional-jvm-options = "-Xmx2g -Xms2g -Djeffrey.logging.trace-file.path=<<JEFF
           <strong>Fail-open:</strong> any misconfiguration (missing binaries, missing project name, broken config) starts the application <em>without profiling</em> instead of preventing it from starting — look for the single <code>Jeffrey profiling ENABLED: …</code> / <code>profiling DISABLED: &lt;reason&gt;</code> line in the container log to see the outcome.
         </DocsCallout>
 
+        <DocsCallout type="warning">
+          <strong>The project name is a stable identity — keep it the same across deployments.</strong>
+          It keys the project directory on the shared volume (<code>workspaces/&lt;workspace&gt;/&lt;project-name&gt;/</code>),
+          and the project id stored there links all sessions to the same project on Jeffrey Hub.
+          Changing the name creates a <em>new</em> project; the old one stops receiving sessions and
+          keeps its history separately. If you rely on the jeffrey-jib default (the Maven artifactId /
+          Gradle project name), renaming the module changes the project too — pin
+          <code>projectName</code> in the jib configuration (or set <code>JEFFREY_PROJECT_NAME</code>
+          on the pod) to keep continuity. The <code>label</code> (<code>JEFFREY_PROJECT_LABEL</code>)
+          is display-only and can change freely.
+        </DocsCallout>
+
         <h2 id="config-file">Configuration File</h2>
 
         <h3>Minimal Configuration</h3>

--- a/jeffrey-provisioner/src/main/java/cafe/jeffrey/provisioner/InitConfig.java
+++ b/jeffrey-provisioner/src/main/java/cafe/jeffrey/provisioner/InitConfig.java
@@ -59,7 +59,7 @@ public class InitConfig {
     private static final String ENV_PROVISIONER_VERBOSE = "JEFFREY_PROVISIONER_VERBOSE";
     private static final String ENV_PROJECT_NAME = "JEFFREY_PROJECT_NAME";
     private static final String ENV_PROJECT_LABEL = "JEFFREY_PROJECT_LABEL";
-    private static final String ENV_WORKSPACE = "JEFFREY_WORKSPACE";
+    private static final String ENV_WORKSPACE_REF_ID = "JEFFREY_WORKSPACE_REF_ID";
     private static final String ENV_INSTANCE_NAME = "JEFFREY_INSTANCE_NAME";
     private static final String ENV_ATTRIBUTES = "JEFFREY_ATTRIBUTES";
     private static final String ENV_HEAP_DUMP = "JEFFREY_HEAP_DUMP";
@@ -214,7 +214,7 @@ public class InitConfig {
 
         Config projectCfg = resolved.getConfig("project");
         ProjectConfig project = new ProjectConfig();
-        project.setWorkspaceRefId(resolveWithEnv(projectCfg.getString("workspace-ref-id"), ENV_WORKSPACE, envLookup));
+        project.setWorkspaceRefId(resolveWithEnv(projectCfg.getString("workspace-ref-id"), ENV_WORKSPACE_REF_ID, envLookup));
         project.setName(resolveWithEnv(projectCfg.getString("name"), ENV_PROJECT_NAME, envLookup));
         project.setLabel(resolveWithEnv(projectCfg.getString("label"), ENV_PROJECT_LABEL, envLookup));
         project.setInstanceName(resolveWithEnv(projectCfg.getString("instance-name"), ENV_INSTANCE_NAME, envLookup));

--- a/jeffrey-provisioner/src/main/java/cafe/jeffrey/provisioner/InitConfig.java
+++ b/jeffrey-provisioner/src/main/java/cafe/jeffrey/provisioner/InitConfig.java
@@ -29,18 +29,49 @@ import cafe.jeffrey.shared.common.model.RepositoryType;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 /**
- * Configuration class for HOCON-based initialization.
- * Used with {@link com.typesafe.config.ConfigBeanFactory} for automatic parsing.
+ * Provisioner initialization configuration. Sources, highest priority first:
+ * override HOCON file &gt; base HOCON file &gt; {@code JEFFREY_*} environment
+ * variables &gt; built-in defaults. The HOCON files are optional — a container
+ * can be fully configured through environment variables alone
+ * ({@link #fromEnvironment()}), which removes the need to mount a config file
+ * for the common case.
  */
 public class InitConfig {
 
     private static final Logger LOG = LoggerFactory.getLogger(InitConfig.class);
 
     private static final String DEFAULT_AGENT_RELATIVE_PATH = "libs/current/jeffrey-agent.jar";
+
+    /* Environment variables accepted as fallbacks for blank/absent HOCON values.
+       JEFFREY_PROFILER_CONFIG is deliberately NOT an input — the generated .env
+       file exports a variable of that name as an OUTPUT, and accepting it as an
+       input would feed a previous run's fully-resolved command back in. */
+    private static final String ENV_JEFFREY_HOME = "JEFFREY_HOME";
+    private static final String ENV_PROFILER_PATH = "JEFFREY_PROFILER_PATH";
+    private static final String ENV_AGENT_PATH = "JEFFREY_AGENT_PATH";
+    private static final String ENV_ARG_FILE = "JEFFREY_ARG_FILE";
+    private static final String ENV_PROVISIONER_VERBOSE = "JEFFREY_PROVISIONER_VERBOSE";
+    private static final String ENV_PROJECT_NAME = "JEFFREY_PROJECT_NAME";
+    private static final String ENV_PROJECT_LABEL = "JEFFREY_PROJECT_LABEL";
+    private static final String ENV_WORKSPACE = "JEFFREY_WORKSPACE";
+    private static final String ENV_INSTANCE_NAME = "JEFFREY_INSTANCE_NAME";
+    private static final String ENV_ATTRIBUTES = "JEFFREY_ATTRIBUTES";
+    private static final String ENV_HEAP_DUMP = "JEFFREY_HEAP_DUMP";
+    private static final String ENV_PERF_COUNTERS = "JEFFREY_PERF_COUNTERS";
+    private static final String ENV_JVM_LOGGING = "JEFFREY_JVM_LOGGING";
+    private static final String ENV_ADDITIONAL_JVM_OPTIONS = "JEFFREY_ADDITIONAL_JVM_OPTIONS";
+
+    private static final String HEAP_DUMP_OFF = "off";
+    private static final Set<String> HEAP_DUMP_TYPES = Set.of("exit", "crash");
+
+    private static final String ATTRIBUTE_PAIR_SEPARATOR = ",";
+    private static final String ATTRIBUTE_KV_SEPARATOR = "=";
 
     /**
      * Detected runtime arch, null on unsupported platforms. Computed once at class load so
@@ -109,6 +140,23 @@ public class InitConfig {
         return fromHoconFile(baseConfigFile, overrideConfigFile, System::getenv);
     }
 
+    /**
+     * Creates an InitConfig purely from {@code JEFFREY_*} environment variables and built-in
+     * defaults — no HOCON file involved. This is the zero-file setup path: a container only
+     * needs {@code JEFFREY_HOME} (usually baked by jeffrey-jib) and {@code JEFFREY_PROJECT_NAME}
+     * to be fully configured.
+     */
+    public static InitConfig fromEnvironment() {
+        return fromEnvironment(System::getenv);
+    }
+
+    static InitConfig fromEnvironment(Function<String, String> envLookup) {
+        Config defaults = ConfigFactory.parseString(DEFAULTS);
+        InitConfig config = fromConfig(defaults.resolve(), envLookup);
+        config.validate();
+        return config;
+    }
+
     static InitConfig fromHoconFile(
             Path baseConfigFile, Path overrideConfigFile, Function<String, String> envLookup) {
         if (!Files.exists(baseConfigFile)) {
@@ -147,36 +195,40 @@ public class InitConfig {
         String jeffreyHome = resolved.getString("jeffrey-home");
         String workspacesDir = resolved.getString("workspaces-dir");
         if (isNullOrBlank(jeffreyHome) && isNullOrBlank(workspacesDir)) {
-            String envHome = envLookup.apply("JEFFREY_HOME");
+            String envHome = envLookup.apply(ENV_JEFFREY_HOME);
             if (!isNullOrBlank(envHome)) {
                 jeffreyHome = envHome;
             }
         }
         config.setJeffreyHome(jeffreyHome);
         config.setWorkspacesDir(workspacesDir);
-        config.setProfilerPath(resolveWithEnv(resolved.getString("profiler-path"), "JEFFREY_PROFILER_PATH", envLookup));
+        config.setProfilerPath(resolveWithEnv(resolved.getString("profiler-path"), ENV_PROFILER_PATH, envLookup));
         config.setProfilerConfig(resolved.getString("profiler-config"));
         config.setRepositoryType(resolved.getString("repository-type"));
-        config.setAgentPath(resolveWithEnv(resolved.getString("agent-path"), "JEFFREY_AGENT_PATH", envLookup));
+        config.setAgentPath(resolveWithEnv(resolved.getString("agent-path"), ENV_AGENT_PATH, envLookup));
         config.setEnvFilePath(resolved.getString("env-file"));
 
-        config.setArgFilePath(resolveWithEnv(resolved.getString("arg-file"), "JEFFREY_ARG_FILE", envLookup));
+        config.setArgFilePath(resolveWithEnv(resolved.getString("arg-file"), ENV_ARG_FILE, envLookup));
         config.setPrintEnv(resolved.getBoolean("print-env"));
-        config.setProvisionerVerbose(resolveBoolWithEnv(resolved.getBoolean("provisioner-verbose"), "JEFFREY_PROVISIONER_VERBOSE", envLookup));
+        config.setProvisionerVerbose(resolveBoolWithEnv(resolved.getBoolean("provisioner-verbose"), ENV_PROVISIONER_VERBOSE, envLookup));
 
         Config projectCfg = resolved.getConfig("project");
         ProjectConfig project = new ProjectConfig();
-        project.setWorkspaceRefId(projectCfg.getString("workspace-ref-id"));
-        project.setName(projectCfg.getString("name"));
-        project.setLabel(projectCfg.getString("label"));
-        project.setInstanceName(projectCfg.getString("instance-name"));
+        project.setWorkspaceRefId(resolveWithEnv(projectCfg.getString("workspace-ref-id"), ENV_WORKSPACE, envLookup));
+        project.setName(resolveWithEnv(projectCfg.getString("name"), ENV_PROJECT_NAME, envLookup));
+        project.setLabel(resolveWithEnv(projectCfg.getString("label"), ENV_PROJECT_LABEL, envLookup));
+        project.setInstanceName(resolveWithEnv(projectCfg.getString("instance-name"), ENV_INSTANCE_NAME, envLookup));
         config.setProject(project);
 
-        config.setAttributes(resolved.getObject("attributes").unwrapped());
+        Map<String, Object> attributes = resolved.getObject("attributes").unwrapped();
+        if (attributes.isEmpty()) {
+            attributes = parseAttributesEnv(envLookup.apply(ENV_ATTRIBUTES));
+        }
+        config.setAttributes(attributes);
 
         Config perfCfg = resolved.getConfig("perf-counters");
         PerfCountersConfig perfCounters = new PerfCountersConfig();
-        perfCounters.setEnabled(perfCfg.getBoolean("enabled"));
+        perfCounters.setEnabled(resolveBoolWithEnv(perfCfg.getBoolean("enabled"), ENV_PERF_COUNTERS, envLookup));
         config.setPerfCounters(perfCounters);
 
         Config heapCfg = resolved.getConfig("heap-dump");
@@ -185,6 +237,7 @@ public class InitConfig {
         if (heapCfg.hasPath("type")) {
             heapDump.setType(heapCfg.getString("type"));
         }
+        applyHeapDumpEnv(heapDump, envLookup.apply(ENV_HEAP_DUMP));
         config.setHeapDump(heapDump);
 
         Config jvmLogCfg = resolved.getConfig("jvm-logging");
@@ -193,6 +246,13 @@ public class InitConfig {
         if (jvmLogCfg.hasPath("command")) {
             jvmLogging.setCommand(jvmLogCfg.getString("command"));
         }
+        if (!jvmLogging.isEnabled()) {
+            String envCommand = envLookup.apply(ENV_JVM_LOGGING);
+            if (!isNullOrBlank(envCommand)) {
+                jvmLogging.setEnabled(true);
+                jvmLogging.setCommand(envCommand);
+            }
+        }
         config.setJvmLogging(jvmLogging);
 
         Config jdkCfg = resolved.getConfig("jdk-java-options");
@@ -200,7 +260,8 @@ public class InitConfig {
         jdkJavaOptions.setEnabled(jdkCfg.getBoolean("enabled"));
         config.setJdkJavaOptions(jdkJavaOptions);
 
-        config.setAdditionalJvmOptions(resolved.getString("additional-jvm-options"));
+        config.setAdditionalJvmOptions(
+                resolveWithEnv(resolved.getString("additional-jvm-options"), ENV_ADDITIONAL_JVM_OPTIONS, envLookup));
 
         Config dnsCfg = resolved.getConfig("debug-non-safepoints");
         DebugNonSafepointsConfig debugNonSafepoints = new DebugNonSafepointsConfig();
@@ -211,8 +272,57 @@ public class InitConfig {
     }
 
     /**
+     * Parses the {@code JEFFREY_ATTRIBUTES} value ({@code key=value,key=value}) into an
+     * attributes map. Malformed pairs are skipped with a warning — attributes are metadata
+     * and must never stop the application from being provisioned.
+     */
+    private static Map<String, Object> parseAttributesEnv(String envValue) {
+        Map<String, Object> attributes = new HashMap<>();
+        if (isNullOrBlank(envValue)) {
+            return attributes;
+        }
+        for (String pair : envValue.split(ATTRIBUTE_PAIR_SEPARATOR)) {
+            int separatorIndex = pair.indexOf(ATTRIBUTE_KV_SEPARATOR);
+            if (separatorIndex <= 0) {
+                LOG.warn("Skipping malformed attribute pair (expected key=value): pair={}", pair.trim());
+                continue;
+            }
+            String key = pair.substring(0, separatorIndex).trim();
+            String value = pair.substring(separatorIndex + 1).trim();
+            if (key.isEmpty()) {
+                LOG.warn("Skipping attribute pair with empty key: pair={}", pair.trim());
+                continue;
+            }
+            attributes.put(key, value);
+        }
+        return attributes;
+    }
+
+    /**
+     * Applies the {@code JEFFREY_HEAP_DUMP} value ({@code exit} | {@code crash} | {@code off})
+     * when HOCON left heap dumps disabled. HOCON wins when it enabled the feature; an
+     * unrecognized env value is skipped with a warning instead of failing provisioning.
+     */
+    private static void applyHeapDumpEnv(HeapDumpConfig heapDump, String envValue) {
+        if (heapDump.isEnabled() || isNullOrBlank(envValue)) {
+            return;
+        }
+        String normalized = envValue.trim().toLowerCase();
+        if (normalized.equals(HEAP_DUMP_OFF)) {
+            return;
+        }
+        if (!HEAP_DUMP_TYPES.contains(normalized)) {
+            LOG.warn("Unrecognized JEFFREY_HEAP_DUMP value, heap dumps stay disabled: value={} expected={}",
+                    envValue, HEAP_DUMP_TYPES);
+            return;
+        }
+        heapDump.setEnabled(true);
+        heapDump.setType(normalized);
+    }
+
+    /**
      * Returns {@code hoconValue} if non-blank; otherwise consults the named environment variable.
-     * Used for path-style settings that prefer HOCON but accept env-var defaults baked into the
+     * Used for settings that prefer HOCON but accept env-var defaults baked into the
      * image by jeffrey-jib (or set on the pod) when the HOCON entry is absent.
      */
     private static String resolveWithEnv(String hoconValue, String envName, Function<String, String> envLookup) {
@@ -632,7 +742,8 @@ public class InitConfig {
         }
 
         if (isNullOrBlank(project.getName())) {
-            throw new IllegalArgumentException("'project.name' must be specified");
+            throw new IllegalArgumentException(
+                    "'project.name' must be specified (HOCON 'project.name' or env JEFFREY_PROJECT_NAME)");
         }
 
         String projectName = project.getName();

--- a/jeffrey-provisioner/src/main/java/cafe/jeffrey/provisioner/InitExecutor.java
+++ b/jeffrey-provisioner/src/main/java/cafe/jeffrey/provisioner/InitExecutor.java
@@ -208,6 +208,11 @@ public class InitExecutor {
             Files.writeString(config.getArgFilePath(), argsContent);
             LOG.debug("Arg file written: argFile={}", config.getArgFilePath());
         }
+
+        // Single greppable verdict line — the one place that tells a user their setup works
+        LOG.info("Jeffrey profiling ENABLED: project={} workspace={} instance={} session={} profiler_source={} arg_file={}",
+                config.getProjectName(), config.getWorkspaceRefId(), instanceId, sessionId,
+                resolvedSettings.source(), config.getArgFilePath());
     }
 
     private static Path createDirectories(Path path) throws IOException {

--- a/jeffrey-provisioner/src/main/java/cafe/jeffrey/provisioner/command/InitCommand.java
+++ b/jeffrey-provisioner/src/main/java/cafe/jeffrey/provisioner/command/InitCommand.java
@@ -24,37 +24,56 @@ import cafe.jeffrey.provisioner.InitConfig;
 import cafe.jeffrey.provisioner.InitExecutor;
 import cafe.jeffrey.provisioner.VerboseLogging;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.ExitCode;
 import picocli.CommandLine.Option;
 
 import java.nio.file.Path;
+import java.util.concurrent.Callable;
 
 @Command(
         name = InitCommand.COMMAND_NAME,
-        description = "Initialize Jeffrey project and current session from a HOCON configuration file.",
+        description = "Initialize Jeffrey project and current session from a HOCON configuration file "
+                + "or, when no file is given, from JEFFREY_* environment variables.",
         mixinStandardHelpOptions = true
 )
-public class InitCommand implements Runnable {
+public class InitCommand implements Callable<Integer> {
 
     private static final Logger LOG = LoggerFactory.getLogger(InitCommand.class);
 
     public static final String COMMAND_NAME = "init";
 
-    @Option(names = "--base-config", required = true, description = "Path to the base HOCON configuration file.")
+    @Option(names = "--base-config", description = "Path to the base HOCON configuration file. "
+            + "Optional — without it, configuration is read from JEFFREY_* environment variables.")
     private Path baseConfigFile;
 
     @Option(names = "--override-config", description = "Path to an override HOCON configuration file.")
     private Path overrideConfigFile;
 
+    /**
+     * Returns a non-zero exit code on any failure so callers (the jeffrey-jib entrypoint
+     * wrapper) can distinguish "provisioned" from "failed" and start the application
+     * without profiling instead of pointing the JVM at an argfile that was never written.
+     */
     @Override
-    public void run() {
+    public Integer call() {
         try {
-            InitConfig config = InitConfig.fromHoconFile(baseConfigFile, overrideConfigFile);
+            InitConfig config = resolveConfig();
             if (config.isProvisionerVerbose()) {
                 VerboseLogging.enable();
             }
             new InitExecutor().execute(config);
+            return ExitCode.OK;
         } catch (Exception e) {
             LOG.error("Init failed", e);
+            return ExitCode.SOFTWARE;
         }
+    }
+
+    private InitConfig resolveConfig() {
+        if (baseConfigFile != null) {
+            return InitConfig.fromHoconFile(baseConfigFile, overrideConfigFile);
+        }
+        LOG.info("No --base-config given, configuring from JEFFREY_* environment variables");
+        return InitConfig.fromEnvironment();
     }
 }

--- a/jeffrey-provisioner/src/test/java/cafe/jeffrey/provisioner/InitConfigTest.java
+++ b/jeffrey-provisioner/src/test/java/cafe/jeffrey/provisioner/InitConfigTest.java
@@ -681,7 +681,7 @@ class InitConfigTest {
                     "JEFFREY_HOME", "/mnt/jeffrey",
                     "JEFFREY_PROJECT_NAME", "my-service",
                     "JEFFREY_PROJECT_LABEL", "My Service",
-                    "JEFFREY_WORKSPACE", "production",
+                    "JEFFREY_WORKSPACE_REF_ID", "production",
                     "JEFFREY_INSTANCE_NAME", "instance-7",
                     "JEFFREY_ATTRIBUTES", "cluster=blue, namespace=klingon",
                     "JEFFREY_HEAP_DUMP", "crash",

--- a/jeffrey-provisioner/src/test/java/cafe/jeffrey/provisioner/InitConfigTest.java
+++ b/jeffrey-provisioner/src/test/java/cafe/jeffrey/provisioner/InitConfigTest.java
@@ -29,6 +29,8 @@ import cafe.jeffrey.shared.common.model.RepositoryType;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
+import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -589,7 +591,7 @@ class InitConfigTest {
                     IllegalArgumentException.class,
                     () -> InitConfig.fromHoconFile(configFile, null)
             );
-            assertEquals("'project.name' must be specified", exception.getMessage());
+            assertEquals("'project.name' must be specified (HOCON 'project.name' or env JEFFREY_PROJECT_NAME)", exception.getMessage());
         }
 
         @Test
@@ -604,7 +606,7 @@ class InitConfigTest {
                     IllegalArgumentException.class,
                     () -> InitConfig.fromHoconFile(configFile, null)
             );
-            assertEquals("'project.name' must be specified", exception.getMessage());
+            assertEquals("'project.name' must be specified (HOCON 'project.name' or env JEFFREY_PROJECT_NAME)", exception.getMessage());
         }
 
         @Test
@@ -649,5 +651,123 @@ class InitConfigTest {
             assertEquals("my_project-123", config.getProjectName());
         }
 
+    }
+
+    @Nested
+    class EnvironmentOnlyConfig {
+
+        private static Function<String, String> env(Map<String, String> values) {
+            return values::get;
+        }
+
+        @Test
+        void minimalEnv_homeAndProjectName_producesValidConfig() {
+            InitConfig config = InitConfig.fromEnvironment(env(Map.of(
+                    "JEFFREY_HOME", "/mnt/jeffrey",
+                    "JEFFREY_PROJECT_NAME", "my-service")));
+
+            assertEquals("/mnt/jeffrey", config.getJeffreyHome());
+            assertEquals("my-service", config.getProjectName());
+            assertEquals(CliConstants.DEFAULT_WORKSPACE_REF_ID, config.getWorkspaceRefId());
+            assertEquals(Path.of("/tmp/jvm.args"), config.getArgFilePath());
+            assertTrue(config.isDebugNonSafepointsEnabled());
+            assertFalse(config.isPerfCountersEnabled());
+            assertNull(config.resolveHeapDumpType());
+        }
+
+        @Test
+        void fullEnv_allSettingsApplied() {
+            InitConfig config = InitConfig.fromEnvironment(env(Map.of(
+                    "JEFFREY_HOME", "/mnt/jeffrey",
+                    "JEFFREY_PROJECT_NAME", "my-service",
+                    "JEFFREY_PROJECT_LABEL", "My Service",
+                    "JEFFREY_WORKSPACE", "production",
+                    "JEFFREY_INSTANCE_NAME", "instance-7",
+                    "JEFFREY_ATTRIBUTES", "cluster=blue, namespace=klingon",
+                    "JEFFREY_HEAP_DUMP", "crash",
+                    "JEFFREY_PERF_COUNTERS", "true",
+                    "JEFFREY_JVM_LOGGING", "jfr*=trace:file=<<JEFFREY_CURRENT_SESSION>>/jfr-jvm.log",
+                    "JEFFREY_ADDITIONAL_JVM_OPTIONS", "-Xmx2g")));
+
+            assertEquals("My Service", config.getProjectLabel());
+            assertEquals("production", config.getWorkspaceRefId());
+            assertEquals("instance-7", config.getInstanceName());
+            assertEquals(Map.of("cluster", "blue", "namespace", "klingon"), config.getAttributes());
+            assertEquals(HeapDumpType.CRASH, config.resolveHeapDumpType());
+            assertTrue(config.isPerfCountersEnabled());
+            assertEquals("jfr*=trace:file=<<JEFFREY_CURRENT_SESSION>>/jfr-jvm.log", config.getJvmLoggingCommand());
+            assertEquals("-Xmx2g", config.getAdditionalJvmOptions());
+        }
+
+        @Test
+        void missingProjectName_failsWithEnvHint() {
+            IllegalArgumentException exception = assertThrows(
+                    IllegalArgumentException.class,
+                    () -> InitConfig.fromEnvironment(env(Map.of("JEFFREY_HOME", "/mnt/jeffrey"))));
+
+            assertTrue(exception.getMessage().contains("JEFFREY_PROJECT_NAME"));
+        }
+
+        @Test
+        void malformedAttributePairs_skipped() {
+            InitConfig config = InitConfig.fromEnvironment(env(Map.of(
+                    "JEFFREY_HOME", "/mnt/jeffrey",
+                    "JEFFREY_PROJECT_NAME", "my-service",
+                    "JEFFREY_ATTRIBUTES", "cluster=blue,broken,=novalue,region=eu")));
+
+            assertEquals(Map.of("cluster", "blue", "region", "eu"), config.getAttributes());
+        }
+
+        @Test
+        void unrecognizedHeapDumpValue_staysDisabled() {
+            InitConfig config = InitConfig.fromEnvironment(env(Map.of(
+                    "JEFFREY_HOME", "/mnt/jeffrey",
+                    "JEFFREY_PROJECT_NAME", "my-service",
+                    "JEFFREY_HEAP_DUMP", "sometimes")));
+
+            assertNull(config.resolveHeapDumpType());
+        }
+
+        @Test
+        void heapDumpOff_staysDisabled() {
+            InitConfig config = InitConfig.fromEnvironment(env(Map.of(
+                    "JEFFREY_HOME", "/mnt/jeffrey",
+                    "JEFFREY_PROJECT_NAME", "my-service",
+                    "JEFFREY_HEAP_DUMP", "off")));
+
+            assertNull(config.resolveHeapDumpType());
+        }
+    }
+
+    @Nested
+    class HoconEnvPrecedence {
+
+        @TempDir
+        Path tempDir;
+
+        @Test
+        void hoconProjectName_winsOverEnv() throws IOException {
+            Path configFile = tempDir.resolve("config.conf");
+            Files.writeString(configFile, configWithOverrides(
+                    "jeffrey-home = \"/tmp/jeffrey\"",
+                    "project { name = \"from-hocon\" }"
+            ));
+
+            InitConfig config = InitConfig.fromHoconFile(configFile, null,
+                    name -> name.equals("JEFFREY_PROJECT_NAME") ? "from-env" : null);
+
+            assertEquals("from-hocon", config.getProjectName());
+        }
+
+        @Test
+        void blankHoconProjectName_filledFromEnv() throws IOException {
+            Path configFile = tempDir.resolve("config.conf");
+            Files.writeString(configFile, configWithOverrides("jeffrey-home = \"/tmp/jeffrey\""));
+
+            InitConfig config = InitConfig.fromHoconFile(configFile, null,
+                    name -> name.equals("JEFFREY_PROJECT_NAME") ? "from-env" : null);
+
+            assertEquals("from-env", config.getProjectName());
+        }
     }
 }

--- a/utilities/jeffrey-jib/README.md
+++ b/utilities/jeffrey-jib/README.md
@@ -37,7 +37,7 @@ volumes:
   - { name: jeffrey, persistentVolumeClaim: { claimName: jeffrey-pvc } }
 ```
 
-Optional pod-level env overrides: `JEFFREY_PROJECT_NAME`, `JEFFREY_WORKSPACE`,
+Optional pod-level env overrides: `JEFFREY_PROJECT_NAME`, `JEFFREY_WORKSPACE_REF_ID`,
 `JEFFREY_PROJECT_LABEL`, `JEFFREY_ATTRIBUTES` (`key=value,key=value`),
 `JEFFREY_HEAP_DUMP` (`exit`|`crash`|`off`), `JEFFREY_PERF_COUNTERS`,
 `JEFFREY_JVM_LOGGING`, `JEFFREY_ADDITIONAL_JVM_OPTIONS`. A mounted HOCON file still wins

--- a/utilities/jeffrey-jib/README.md
+++ b/utilities/jeffrey-jib/README.md
@@ -19,6 +19,40 @@ container start the wrapper runs `provisioner init` (resolved from
 shared volume) and `exec`s the JIB command with the provisioner-produced argfile inserted right
 after the `java` binary.
 
+## Zero-config setup
+
+The config file is optional. Without `/jeffrey/jeffrey-base.conf` the provisioner configures
+itself from `JEFFREY_*` environment variables, and the extension bakes
+`JEFFREY_PROJECT_NAME` into the image (from the `projectName` property, defaulting to the
+Maven artifactId / Gradle project name). An image built with this extension is therefore
+fully self-identifying — the only Kubernetes YAML an application needs is the shared-volume
+mount:
+
+```yaml
+containers:
+  - name: app                       # image built with jeffrey-jib
+    volumeMounts:
+      - { name: jeffrey, mountPath: /mnt/jeffrey }   # = JEFFREY_HOME
+volumes:
+  - { name: jeffrey, persistentVolumeClaim: { claimName: jeffrey-pvc } }
+```
+
+Optional pod-level env overrides: `JEFFREY_PROJECT_NAME`, `JEFFREY_WORKSPACE`,
+`JEFFREY_PROJECT_LABEL`, `JEFFREY_ATTRIBUTES` (`key=value,key=value`),
+`JEFFREY_HEAP_DUMP` (`exit`|`crash`|`off`), `JEFFREY_PERF_COUNTERS`,
+`JEFFREY_JVM_LOGGING`, `JEFFREY_ADDITIONAL_JVM_OPTIONS`. A mounted HOCON file still wins
+over environment variables wherever it sets a value.
+
+## Fail-open guarantee
+
+Any misconfiguration starts the application **without profiling** instead of preventing it
+from starting: a missing provisioner binary, a broken or missing config, or a failed
+`provisioner init` all log one `profiling DISABLED: <reason>` line and `exec` the original
+command. On success the provisioner logs a single greppable verdict:
+`Jeffrey profiling ENABLED: project=… workspace=… instance=… session=… profiler_source=…`.
+Set `JEFFREY_WAIT_FOR_LIBS=<seconds>` to wait for the hub's copy-libs to populate the shared
+volume on fresh clusters (default `0`).
+
 ## Gradle usage
 
 ```kotlin
@@ -77,10 +111,11 @@ comparisons. No rebuild required.
 |---|---|---|
 | `enabled` | — | `true` (build-time gate) |
 | `jeffreyHome` | `JEFFREY_HOME` | `/mnt/azure/runtime/shared/jeffrey` |
-| `baseConfig` | `JEFFREY_BASE_CONFIG` | `/jeffrey/jeffrey-base.conf` |
+| `baseConfig` | `JEFFREY_BASE_CONFIG` | `/jeffrey/jeffrey-base.conf` (optional file) |
 | `overrideConfig` | `JEFFREY_OVERRIDE_CONFIG` | `/jeffrey/jeffrey-overrides.conf` (optional) |
 | `provisionerPath` | `JEFFREY_PROVISIONER_PATH` | `${JEFFREY_HOME}/libs/current/provisioner-<arch>` |
 | `argFile` | `JEFFREY_ARG_FILE` | `/tmp/jvm.args` |
+| `projectName` | `JEFFREY_PROJECT_NAME` | Maven artifactId / Gradle project name |
 
 All string properties are optional. Non-null values are baked as image-level ENV defaults;
 Kubernetes pod-level env vars still override them.

--- a/utilities/jeffrey-jib/README.md
+++ b/utilities/jeffrey-jib/README.md
@@ -43,6 +43,12 @@ Optional pod-level env overrides: `JEFFREY_PROJECT_NAME`, `JEFFREY_WORKSPACE_REF
 `JEFFREY_JVM_LOGGING`, `JEFFREY_ADDITIONAL_JVM_OPTIONS`. A mounted HOCON file still wins
 over environment variables wherever it sets a value.
 
+**The project name is a stable identity** — it keys the project directory on the shared
+volume and links every session to the same project on Jeffrey Hub. Changing it creates a
+new project. If you rename the Maven artifactId / Gradle project, pin `projectName` in the
+jib configuration to keep the project's history continuous; only the label
+(`JEFFREY_PROJECT_LABEL`) is safe to change freely.
+
 ## Fail-open guarantee
 
 Any misconfiguration starts the application **without profiling** instead of preventing it

--- a/utilities/jeffrey-jib/jeffrey-jib-core/src/main/java/cafe/jeffrey/jib/JeffreyBuildPlanExtender.java
+++ b/utilities/jeffrey-jib/jeffrey-jib-core/src/main/java/cafe/jeffrey/jib/JeffreyBuildPlanExtender.java
@@ -139,6 +139,7 @@ public final class JeffreyBuildPlanExtender {
         putIfPresent(env, "JEFFREY_ARG_FILE", config.getArgFile());
         putIfPresent(env, "JEFFREY_PROFILER_PATH", config.getProfilerPath());
         putIfPresent(env, "JEFFREY_AGENT_PATH", config.getAgentPath());
+        putIfPresent(env, "JEFFREY_PROJECT_NAME", config.getProjectName());
         return env;
     }
 
@@ -157,8 +158,8 @@ public final class JeffreyBuildPlanExtender {
      * <p>Recognised keys map one-to-one to the {@link JeffreyJibConfig} setters:
      * {@code enabled}, {@code keepJvmFlags}, {@code jeffreyHome}, {@code baseConfig},
      * {@code overrideConfig}, {@code provisionerPath}, {@code argFile}, {@code profilerPath},
-     * {@code agentPath}. Null / empty values are ignored; unknown keys are logged at WARN
-     * and otherwise ignored.
+     * {@code agentPath}, {@code projectName}. Null / empty values are ignored; unknown keys
+     * are logged at WARN and otherwise ignored.
      */
     public static void applyProperties(
             JeffreyJibConfig config,
@@ -183,6 +184,7 @@ public final class JeffreyBuildPlanExtender {
                 case JeffreyJibConfig.ARG_FILE -> config.setArgFile(value);
                 case JeffreyJibConfig.PROFILER_PATH -> config.setProfilerPath(value);
                 case JeffreyJibConfig.AGENT_PATH -> config.setAgentPath(value);
+                case JeffreyJibConfig.PROJECT_NAME -> config.setProjectName(value);
                 default -> logger.log(
                         LogLevel.WARN,
                         "jeffrey-jib: unknown plugin-extension property '" + key + "'; ignored");

--- a/utilities/jeffrey-jib/jeffrey-jib-core/src/main/java/cafe/jeffrey/jib/JeffreyJibConfig.java
+++ b/utilities/jeffrey-jib/jeffrey-jib-core/src/main/java/cafe/jeffrey/jib/JeffreyJibConfig.java
@@ -44,6 +44,7 @@ public class JeffreyJibConfig {
     public static final String ARG_FILE = "argFile";
     public static final String PROFILER_PATH = "profilerPath";
     public static final String AGENT_PATH = "agentPath";
+    public static final String PROJECT_NAME = "projectName";
 
     private boolean enabled = true;
     private String jeffreyHome;
@@ -53,6 +54,7 @@ public class JeffreyJibConfig {
     private String argFile;
     private String profilerPath;
     private String agentPath;
+    private String projectName;
 
     public boolean isEnabled() {
         return enabled;
@@ -116,5 +118,13 @@ public class JeffreyJibConfig {
 
     public void setAgentPath(String agentPath) {
         this.agentPath = agentPath;
+    }
+
+    public String getProjectName() {
+        return projectName;
+    }
+
+    public void setProjectName(String projectName) {
+        this.projectName = projectName;
     }
 }

--- a/utilities/jeffrey-jib/jeffrey-jib-core/src/main/resources/cafe/jeffrey/jib/jeffrey-entrypoint.sh
+++ b/utilities/jeffrey-jib/jeffrey-jib-core/src/main/resources/cafe/jeffrey/jib/jeffrey-entrypoint.sh
@@ -15,7 +15,7 @@
 #   JEFFREY_PROVISIONER_PATH default ${JEFFREY_HOME}/libs/current/provisioner-<arch>
 #   JEFFREY_BASE_CONFIG   default /jeffrey/jeffrey-base.conf (optional — without the file,
 #                         the provisioner configures itself from JEFFREY_* env vars such as
-#                         JEFFREY_PROJECT_NAME and JEFFREY_WORKSPACE)
+#                         JEFFREY_PROJECT_NAME and JEFFREY_WORKSPACE_REF_ID)
 #   JEFFREY_OVERRIDE_CONFIG default /jeffrey/jeffrey-overrides.conf (optional)
 #   JEFFREY_ARG_FILE      default /tmp/jvm.args
 #   JEFFREY_WAIT_FOR_LIBS seconds to wait for the shared volume to contain the provisioner
@@ -101,7 +101,7 @@ ARG_FILE="${JEFFREY_ARG_FILE:-/tmp/jvm.args}"
 rm -f "$ARG_FILE"
 
 # The config file is optional: when absent, the provisioner configures itself from
-# JEFFREY_* environment variables (JEFFREY_PROJECT_NAME, JEFFREY_WORKSPACE, ...).
+# JEFFREY_* environment variables (JEFFREY_PROJECT_NAME, JEFFREY_WORKSPACE_REF_ID, ...).
 INIT_OK=true
 if [ -f "$BASE_CONFIG" ]; then
   if [ -f "$OVERRIDE_CONFIG" ]; then

--- a/utilities/jeffrey-jib/jeffrey-jib-core/src/main/resources/cafe/jeffrey/jib/jeffrey-entrypoint.sh
+++ b/utilities/jeffrey-jib/jeffrey-jib-core/src/main/resources/cafe/jeffrey/jib/jeffrey-entrypoint.sh
@@ -13,9 +13,16 @@
 # All paths are overridable via environment variables:
 #   JEFFREY_HOME             required (unless JEFFREY_PROVISIONER_PATH is set directly)
 #   JEFFREY_PROVISIONER_PATH default ${JEFFREY_HOME}/libs/current/provisioner-<arch>
-#   JEFFREY_BASE_CONFIG   default /jeffrey/jeffrey-base.conf
+#   JEFFREY_BASE_CONFIG   default /jeffrey/jeffrey-base.conf (optional — without the file,
+#                         the provisioner configures itself from JEFFREY_* env vars such as
+#                         JEFFREY_PROJECT_NAME and JEFFREY_WORKSPACE)
 #   JEFFREY_OVERRIDE_CONFIG default /jeffrey/jeffrey-overrides.conf (optional)
 #   JEFFREY_ARG_FILE      default /tmp/jvm.args
+#   JEFFREY_WAIT_FOR_LIBS seconds to wait for the shared volume to contain the provisioner
+#                         binary (copy-libs startup ordering); default 0
+#
+# Fail-open guarantee: any misconfiguration (missing binaries, broken config, failed init)
+# starts the application WITHOUT profiling instead of preventing it from starting.
 
 set -e
 
@@ -63,25 +70,54 @@ for var in JEFFREY_PROVISIONER_PATH JEFFREY_PROFILER_PATH JEFFREY_AGENT_PATH; do
 done
 
 PROVISIONER="${JEFFREY_PROVISIONER_PATH:-${JEFFREY_HOME}/libs/current/provisioner-${ARCH}}"
-if [ ! -x "$PROVISIONER" ]; then
-  echo "jeffrey-jib: provisioner not found or not executable: $PROVISIONER" >&2
-  echo "jeffrey-jib: set JEFFREY_HOME to the shared volume, or JEFFREY_PROVISIONER_PATH directly." >&2
+
+# Optionally wait for the shared volume to be populated by the hub's copy-libs — covers
+# the ordering race when application pods start before jeffrey-hub on a fresh cluster.
+WAIT_SECS="${JEFFREY_WAIT_FOR_LIBS:-0}"
+waited=0
+while [ ! -x "$PROVISIONER" ] && [ "$waited" -lt "$WAIT_SECS" ]; do
+  echo "jeffrey-jib: waiting for provisioner on the shared volume (${waited}/${WAIT_SECS}s): $PROVISIONER" >&2
+  sleep 2
+  waited=$((waited + 2))
+done
+
+if [ $# -eq 0 ]; then
+  echo "jeffrey-jib: no command provided (JIB CMD missing); cannot launch JVM." >&2
   exit 1
+fi
+
+# Fail-open: a missing provisioner binary must never stop the application.
+if [ ! -x "$PROVISIONER" ]; then
+  echo "jeffrey-jib: profiling DISABLED: provisioner not found or not executable: $PROVISIONER" >&2
+  echo "jeffrey-jib: is jeffrey-hub running with copy-libs enabled and the shared volume mounted at JEFFREY_HOME?" >&2
+  exec "$@"
 fi
 
 BASE_CONFIG="${JEFFREY_BASE_CONFIG:-/jeffrey/jeffrey-base.conf}"
 OVERRIDE_CONFIG="${JEFFREY_OVERRIDE_CONFIG:-/jeffrey/jeffrey-overrides.conf}"
 ARG_FILE="${JEFFREY_ARG_FILE:-/tmp/jvm.args}"
 
-if [ -f "$OVERRIDE_CONFIG" ]; then
-  "$PROVISIONER" init --base-config="$BASE_CONFIG" --override-config="$OVERRIDE_CONFIG"
+# Make sure the argfile check below reflects THIS run, not a leftover file.
+rm -f "$ARG_FILE"
+
+# The config file is optional: when absent, the provisioner configures itself from
+# JEFFREY_* environment variables (JEFFREY_PROJECT_NAME, JEFFREY_WORKSPACE, ...).
+INIT_OK=true
+if [ -f "$BASE_CONFIG" ]; then
+  if [ -f "$OVERRIDE_CONFIG" ]; then
+    "$PROVISIONER" init --base-config="$BASE_CONFIG" --override-config="$OVERRIDE_CONFIG" || INIT_OK=false
+  else
+    "$PROVISIONER" init --base-config="$BASE_CONFIG" || INIT_OK=false
+  fi
 else
-  "$PROVISIONER" init --base-config="$BASE_CONFIG"
+  "$PROVISIONER" init || INIT_OK=false
 fi
 
-if [ $# -eq 0 ]; then
-  echo "jeffrey-jib: no command provided (JIB CMD missing); cannot launch JVM." >&2
-  exit 1
+# Fail-open: a failed init (or an init that produced no argfile) starts the
+# application without profiling instead of pointing the JVM at a missing argfile.
+if [ "$INIT_OK" != "true" ] || [ ! -f "$ARG_FILE" ]; then
+  echo "jeffrey-jib: profiling DISABLED: provisioner init failed or produced no argfile (${ARG_FILE}); starting application without profiling." >&2
+  exec "$@"
 fi
 
 # JIB CMD is ["java","-cp","@/app/jib-classpath-file","<MainClass>"] or ["java","-jar",…].

--- a/utilities/jeffrey-jib/jeffrey-jib-core/src/test/java/cafe/jeffrey/jib/JeffreyBuildPlanExtenderTest.java
+++ b/utilities/jeffrey-jib/jeffrey-jib-core/src/test/java/cafe/jeffrey/jib/JeffreyBuildPlanExtenderTest.java
@@ -206,6 +206,7 @@ class JeffreyBuildPlanExtenderTest {
             config.setOverrideConfig("/etc/jeffrey/override.conf");
             config.setProvisionerPath("/opt/jeffrey/bin/provisioner");
             config.setArgFile("/var/jeffrey/jvm.args");
+            config.setProjectName("my-service");
 
             Map<String, String> env = extender.extend(input, config, logger).getEnvironment();
 
@@ -214,6 +215,7 @@ class JeffreyBuildPlanExtenderTest {
             assertEquals("/etc/jeffrey/override.conf", env.get("JEFFREY_OVERRIDE_CONFIG"));
             assertEquals("/opt/jeffrey/bin/provisioner", env.get("JEFFREY_PROVISIONER_PATH"));
             assertEquals("/var/jeffrey/jvm.args", env.get("JEFFREY_ARG_FILE"));
+            assertEquals("my-service", env.get("JEFFREY_PROJECT_NAME"));
         }
 
         @Test
@@ -230,6 +232,7 @@ class JeffreyBuildPlanExtenderTest {
             assertFalse(env.containsKey("JEFFREY_OVERRIDE_CONFIG"));
             assertFalse(env.containsKey("JEFFREY_PROVISIONER_PATH"));
             assertFalse(env.containsKey("JEFFREY_ARG_FILE"));
+            assertFalse(env.containsKey("JEFFREY_PROJECT_NAME"));
         }
 
         @Test

--- a/utilities/jeffrey-jib/jeffrey-jib-gradle/src/main/java/cafe/jeffrey/jib/gradle/JeffreyJibGradleExtension.java
+++ b/utilities/jeffrey-jib/jeffrey-jib-gradle/src/main/java/cafe/jeffrey/jib/gradle/JeffreyJibGradleExtension.java
@@ -64,6 +64,8 @@ import java.util.Optional;
  *       {@code /jeffrey/jeffrey-overrides.conf}.
  *   <li>{@code provisionerPath} — bypass {@code jeffreyHome} and point directly at the provisioner binary.
  *   <li>{@code argFile} — location of the generated JVM argfile, default {@code /tmp/jvm.args}.
+ *   <li>{@code projectName} — Jeffrey project name baked as {@code JEFFREY_PROJECT_NAME};
+ *       defaults to the Gradle project name. Pod-level env still overrides it.
  * </ul>
  *
  * <p>The typed {@code configuration(Action<JeffreyJibConfig>) { … }} DSL is also accepted, but
@@ -88,6 +90,39 @@ public class JeffreyJibGradleExtension implements JibGradlePluginExtension<Jeffr
 
         JeffreyJibConfig effective = config.orElseGet(JeffreyJibConfig::new);
         JeffreyBuildPlanExtender.applyProperties(effective, properties, logger);
+
+        // Default the Jeffrey project name to the Gradle project name — baked as the
+        // JEFFREY_PROJECT_NAME image ENV, it makes the image self-identifying so the
+        // container needs no config file and no per-pod env for the common case.
+        // A pod-level JEFFREY_PROJECT_NAME still overrides the baked default.
+        if (effective.getProjectName() == null) {
+            resolveGradleProjectName(gradleData, logger).ifPresent(effective::setProjectName);
+        }
+
         return new JeffreyBuildPlanExtender(getClass()).extend(buildPlan, effective, logger);
+    }
+
+    /**
+     * Reads {@code gradleData.getProject().getName()} reflectively. This module is built with
+     * Maven, where the Gradle API ({@code org.gradle.api.Project}) is not available as a compile
+     * dependency — at runtime inside a Gradle build the type is always present. Any reflective
+     * failure only skips the default; an explicit {@code projectName} property always works.
+     */
+    private static Optional<String> resolveGradleProjectName(GradleData gradleData, ExtensionLogger logger) {
+        if (gradleData == null) {
+            return Optional.empty();
+        }
+        try {
+            Object project = GradleData.class.getMethod("getProject").invoke(gradleData);
+            if (project == null) {
+                return Optional.empty();
+            }
+            Object name = project.getClass().getMethod("getName").invoke(project);
+            return Optional.ofNullable(name).map(Object::toString);
+        } catch (ReflectiveOperationException e) {
+            logger.log(ExtensionLogger.LogLevel.WARN,
+                    "jeffrey-jib: could not derive the default project name from the Gradle project: " + e);
+            return Optional.empty();
+        }
     }
 }

--- a/utilities/jeffrey-jib/jeffrey-jib-maven/pom.xml
+++ b/utilities/jeffrey-jib/jeffrey-jib-maven/pom.xml
@@ -41,6 +41,13 @@
             <artifactId>jib-maven-plugin-extension-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <!-- MavenProject for the artifactId-derived default project name; provided by the
+             running Maven at execution time, never shipped. -->
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/utilities/jeffrey-jib/jeffrey-jib-maven/src/main/java/cafe/jeffrey/jib/maven/JeffreyJibMavenExtension.java
+++ b/utilities/jeffrey-jib/jeffrey-jib-maven/src/main/java/cafe/jeffrey/jib/maven/JeffreyJibMavenExtension.java
@@ -81,6 +81,15 @@ public class JeffreyJibMavenExtension implements JibMavenPluginExtension<Jeffrey
 
         JeffreyJibConfig effective = config.orElseGet(JeffreyJibConfig::new);
         JeffreyBuildPlanExtender.applyProperties(effective, properties, logger);
+
+        // Default the Jeffrey project name to the Maven artifactId — baked as the
+        // JEFFREY_PROJECT_NAME image ENV, it makes the image self-identifying so the
+        // container needs no config file and no per-pod env for the common case.
+        // A pod-level JEFFREY_PROJECT_NAME still overrides the baked default.
+        if (effective.getProjectName() == null && mavenData != null && mavenData.getMavenProject() != null) {
+            effective.setProjectName(mavenData.getMavenProject().getArtifactId());
+        }
+
         return new JeffreyBuildPlanExtender(getClass()).extend(buildPlan, effective, logger);
     }
 }

--- a/utilities/jeffrey-jib/pom.xml
+++ b/utilities/jeffrey-jib/pom.xml
@@ -63,6 +63,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jib.extension.version>0.4.0</jib.extension.version>
+        <maven-core.version>3.9.9</maven-core.version>
         <junit.version>5.14.3</junit.version>
         <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
     </properties>
@@ -83,6 +84,11 @@
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin-extension-api</artifactId>
                 <version>${jib.extension.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-core</artifactId>
+                <version>${maven-core.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Simplifies how applications are onboarded for profiling with the entrypoint (jeffrey-jib) approach: the common case now needs **no config file, no ConfigMap, and no per-pod env** — just the shared-volume mount on an image built with jeffrey-jib.

## What changed

### Environment-only provisioner configuration (`9a797a1`, `d6b843c`)
`provisioner init` no longer requires `--base-config`. Without it, `InitConfig` builds itself from `JEFFREY_*` environment variables (each mirrors its HOCON key one-to-one):

| Variable | Maps to |
|---|---|
| `JEFFREY_PROJECT_NAME` | `project.name` |
| `JEFFREY_WORKSPACE_REF_ID` | `project.workspace-ref-id` |
| `JEFFREY_PROJECT_LABEL` | `project.label` |
| `JEFFREY_INSTANCE_NAME` | `project.instance-name` (then `HOSTNAME`, then UUID) |
| `JEFFREY_ATTRIBUTES` | `attributes` (`key=value,key=value`) |
| `JEFFREY_HEAP_DUMP` | `heap-dump` (`exit` \| `crash` \| `off`) |
| `JEFFREY_PERF_COUNTERS` | `perf-counters.enabled` |
| `JEFFREY_JVM_LOGGING` | `jvm-logging.command` (non-blank enables) |
| `JEFFREY_ADDITIONAL_JVM_OPTIONS` | `additional-jvm-options` |

Precedence is uniform and backward compatible: **HOCON value → env var → built-in default** — an existing config file keeps winning wherever it sets a value. `JEFFREY_PROFILER_CONFIG` is deliberately *not* an input (the generated `.env` exports a variable of that name as an output).

`InitCommand` now returns a non-zero exit code on failure (previously swallowed), and `InitExecutor` ends with one greppable verdict line:
`Jeffrey profiling ENABLED: project=… workspace=… instance=… session=… profiler_source=… arg_file=…`

### Fail-open entrypoint (`f4763d0`)
Two misconfigurations previously stopped the application instead of degrading to no-profiling:
- a missing/broken config file left no argfile, and the wrapper still exec'd `java @/tmp/jvm.args` → JVM refused to start;
- a missing provisioner binary (app pod starting before the hub populated the shared volume) hit `exit 1` → crash loop.

The wrapper now removes stale argfiles, passes `--base-config` only when the file exists, treats failed init / missing argfile / missing binary as `profiling DISABLED: <reason>` and starts the app without profiling, and supports `JEFFREY_WAIT_FOR_LIBS=<seconds>` to ride out the copy-libs startup ordering on fresh clusters.

### Self-identifying images (`61d652b`)
The jeffrey-jib extensions bake `JEFFREY_PROJECT_NAME` as an image ENV default — from the new `projectName` property, otherwise derived from the Maven artifactId / Gradle project name (reflective in the Gradle module, which builds under Maven without the Gradle API). Pod-level env still overrides.

### Resulting Kubernetes YAML per application

```yaml
containers:
  - name: app                       # image built with jeffrey-jib — nothing else needed
    volumeMounts:
      - { name: jeffrey, mountPath: /mnt/jeffrey }
volumes:
  - { name: jeffrey, persistentVolumeClaim: { claimName: jeffrey-pvc } }
```

### Docs (`6c304ec`)
Provisioner Configuration page now leads with an "Environment-Only Configuration" section + env-override table entries; jeffrey-jib README gains "Zero-config setup" and "Fail-open guarantee" sections.

### Master test fix (`54343c2`)
`HeapDumpControllerTest` was broken on master by 7995cbb (new `HeapDumpInitService` constructor parameter, test not updated) — it breaks *test compilation* of core-microscope, making a full `mvn verify` impossible. Fixed by mocking the service.

## Verification
- Full `mvn verify` on JDK 25 (Corretto 25.0.4): **77/77 modules SUCCESS**, 1,737 tests, 0 failures (`GrpcDocsControllerTest` excluded in the sandbox only because `protoc-gen-doc` was unavailable there; no flags needed where it is installed).
- Live end-to-end smoke test of the real entrypoint + built provisioner: env-only success (argfile generated, session created with instance = `HOSTNAME`, verdict logged), init failure → app still starts, missing binary → app still starts, `JEFFREY_WAIT_FOR_LIBS` waits then continues, `JEFFREY_ENABLED=false` execs verbatim.

## Rollout note
An older provisioner binary on the shared volume doesn't understand env-only mode; the entrypoint's argfile check makes that degrade safely to "no profiling", but the zero-config experience requires the hub's copy-libs to distribute this provisioner version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qo5DrVD3RzP56s9h3Xao1K