### PR TITLE
Enable secondary (baseline) profile selection in Heap Dump mode

### DIFF
--- a/jeffrey-microscope/pages-microscope/src/components/SecondaryProfileSelectionModal.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/SecondaryProfileSelectionModal.vue
@@ -21,7 +21,7 @@
     :show="show"
     @update:show="emit('update:show', $event)"
     modal-id="secondary-profile-selection"
-    title="Select Secondary Profile"
+    :title="modalTitle"
     icon="bi-layers-half"
     size="xl"
     :show-footer="true"
@@ -52,7 +52,13 @@
         <i class="bi bi-file-earmark-bar-graph"></i>
       </div>
       <h5>No profiles found</h5>
-      <p class="mb-0">No profiles available for selection</p>
+      <p class="mb-0">
+        {{
+          heapDumpBaseline
+            ? 'No heap dump profiles available for selection'
+            : 'No profiles available for selection'
+        }}
+      </p>
     </div>
 
     <!-- Split-Pane Layout -->
@@ -170,6 +176,9 @@ import GenericModal from '@shared/components/GenericModal.vue';
 import type { ProfileListResponse } from '@/services/api/DirectProfileClient';
 import RecordingsClient from '@workspaces/services/api/RecordingsClient';
 import type RecordingGroup from '@workspaces/services/api/model/RecordingGroup';
+import type Recording from '@workspaces/services/api/model/Recording';
+import RecordingEventSource from '@workspaces/services/api/model/RecordingEventSource';
+import RecordingFileType from '@workspaces/services/api/model/RecordingFileType';
 
 const recordingsClient = new RecordingsClient();
 import FormattingService from '@shared/services/FormattingService';
@@ -183,6 +192,8 @@ interface Props {
   currentSecondaryProfileId?: string;
   currentSecondaryProjectId?: string;
   workspaceId: string;
+  /** Restrict candidates to heap-dump-capable profiles (baseline selection for the Heap Diff). */
+  heapDumpBaseline?: boolean;
 }
 
 interface Emits {
@@ -206,6 +217,10 @@ const RECORDINGS_WORKSPACE_ID = 'recordings';
 const RECORDINGS_WORKSPACE_NAME = 'Recordings';
 const ALL_GROUP_KEY = 'all';
 const UNGROUPED_KEY = '__ungrouped__';
+const HEAP_DUMP_FILE_TYPES = new Set<RecordingFileType>([
+  RecordingFileType.HEAP_DUMP,
+  RecordingFileType.HEAP_DUMP_GZ
+]);
 
 const props = defineProps<Props>();
 const emit = defineEmits<Emits>();
@@ -222,6 +237,19 @@ const selectedGroupKey = ref<string>(ALL_GROUP_KEY);
 
 // Saved state for search restore
 const savedSelectionState = ref<{ groupKey: string } | null>(null);
+
+const modalTitle = computed(() =>
+  props.heapDumpBaseline ? 'Select Baseline Heap Dump' : 'Select Secondary Profile'
+);
+
+// A profile qualifies as a heap-dump baseline when the recording itself is a heap dump
+// or carries an attached heap-dump file next to its JFR data.
+const hasHeapDump = (recording: Recording): boolean => {
+  if (recording.eventSource === RecordingEventSource.HEAP_DUMP) {
+    return true;
+  }
+  return (recording.files ?? []).some(file => HEAP_DUMP_FILE_TYPES.has(file.type));
+};
 
 // Computed properties
 const filteredProfiles = computed(() => {
@@ -375,7 +403,8 @@ const loadAllProfiles = async () => {
       recordingsClient.listProfiles(),
       recordingsClient.listGroups()
     ]);
-    allProfiles.value = profiles.map(p => ({
+    const candidates = props.heapDumpBaseline ? profiles.filter(hasHeapDump) : profiles;
+    allProfiles.value = candidates.map(p => ({
       id: p.profileId!,
       name: p.profileName || p.filename,
       projectId: RECORDINGS_WORKSPACE_ID,

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/ProfileDetail.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/ProfileDetail.vue
@@ -133,8 +133,8 @@
           </button>
         </div>
 
-        <!-- Comparison Panel Toggle (hidden for heap-dump-only profiles) -->
-        <div v-if="!isHeapDumpOnlyProfile" class="comparison-toggle-wrapper">
+        <!-- Comparison Panel Toggle (in Heap Dump mode the secondary profile is the diff baseline) -->
+        <div class="comparison-toggle-wrapper">
           <button
             class="comparison-toggle-btn"
             :class="{ active: comparisonPanelVisible, 'has-profile': secondaryProfile }"
@@ -168,8 +168,13 @@
 
       <!-- Main Content -->
       <div class="detail-main-content" :class="{ 'no-sidebar': isTechnologiesHub }">
-        <!-- Heap Dump Profile Info (replaces comparison bar for heap-dump-only profiles) -->
-        <div v-if="selectedMode === 'HeapDump' && profile" class="heap-dump-profile-info mb-3">
+        <!-- Heap Dump Profile Info (hidden while the comparison bar already shows the primary profile) -->
+        <div
+          v-if="
+            selectedMode === 'HeapDump' && profile && !(comparisonPanelVisible && !sidebarCollapsed)
+          "
+          class="heap-dump-profile-info mb-3"
+        >
           <i class="bi bi-file-earmark"></i>
           <span class="profile-name">{{ profile.name }}</span>
           <span class="info-separator">&middot;</span>
@@ -177,10 +182,7 @@
         </div>
 
         <!-- Compact Differential Analysis Bar -->
-        <div
-          v-if="selectedMode !== 'HeapDump' && !sidebarCollapsed && comparisonPanelVisible"
-          class="compact-comparison-bar mb-3"
-        >
+        <div v-if="!sidebarCollapsed && comparisonPanelVisible" class="compact-comparison-bar mb-3">
           <div class="comparison-cards">
             <!-- Primary Profile -->
             <div class="compact-card primary">
@@ -275,6 +277,7 @@
           :current-secondary-profile-id="selectedSecondaryProfileId"
           :current-secondary-project-id="selectedSecondaryProjectId"
           :workspace-id="workspaceId"
+          :heap-dump-baseline="selectedMode === 'HeapDump'"
           @profile-selected="handleSecondaryProfileSelected"
           @profile-cleared="handleSecondaryProfileCleared"
         />

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileHeapDumpDiff.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileHeapDumpDiff.vue
@@ -12,8 +12,8 @@
       <div>
         <h6 class="mb-1">No Baseline Profile Selected</h6>
         <p class="mb-0 small">
-          Select a secondary profile (the baseline heap dump) using the secondary-profile selector
-          in the sidebar, then return to this page.
+          Open the <strong>Secondary Profile</strong> panel in the top navigation bar and select a
+          baseline heap dump to compare against.
         </p>
       </div>
     </div>


### PR DESCRIPTION
The Heap Diff page requires a baseline profile from SecondaryProfileService,
but the Secondary Profile toggle and comparison bar in ProfileDetail were
hidden in Heap Dump mode and for heap-dump-only profiles, so the selector
was unreachable.

- Show the Secondary Profile toggle and the comparison bar in Heap Dump
  mode, reusing the same mechanism as the JFR profile detail; the compact
  hprof info bar hides while the comparison bar shows the primary card.
- Add a heap-dump-baseline mode to SecondaryProfileSelectionModal that
  filters candidates to heap-dump-capable profiles (HEAP_DUMP event source
  or an attached heap-dump file) and adapts the modal title.
- Fix the Heap Diff empty state to point at the top-nav Secondary Profile
  panel instead of a non-existent sidebar selector.

Claude-Session: https://claude.ai/code/session_01NVVmuCJpTBYK9e3BvqaoxK