### PR TITLE
Load the busiest threads first in the Threads Timeline

### DIFF
--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/ThreadController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/ThreadController.java
@@ -35,7 +35,9 @@ import cafe.jeffrey.profile.manager.model.thread.dump.ParsedDump;
 import cafe.jeffrey.profile.manager.model.thread.dump.ThreadDumpAnalysis;
 import cafe.jeffrey.profile.thread.ThreadEventDetail;
 import cafe.jeffrey.profile.thread.ThreadEventsQuery;
-import cafe.jeffrey.profile.thread.ThreadRoot;
+import cafe.jeffrey.profile.thread.ThreadPage;
+import cafe.jeffrey.profile.thread.ThreadPageQuery;
+import cafe.jeffrey.profile.thread.ThreadSort;
 import cafe.jeffrey.profile.thread.ThreadState;
 import cafe.jeffrey.provider.profile.api.AllocatingThread;
 import cafe.jeffrey.shared.common.model.ThreadInfo;
@@ -59,6 +61,12 @@ public class ThreadController {
      */
     private static final int MAX_BAND_EVENTS = 20;
 
+    /**
+     * The ceiling on one page of threads. Each row still carries a lane's worth of bands, so an
+     * unbounded page would put us back where we started.
+     */
+    private static final int MAX_THREAD_PAGE = 250;
+
     public record ThreadStatistics(
             ThreadStats statistics,
             List<AllocatingThread> allocators,
@@ -73,11 +81,25 @@ public class ThreadController {
         this.resolver = resolver;
     }
 
+    /**
+     * One page of the timeline. A recording can hold thousands of threads, so the page asks for the
+     * busiest ones first and comes back for more; sorting and filtering happen here rather than in
+     * the browser, because a client that holds one page can only sort and filter that page.
+     */
     @GetMapping
-    public ThreadRoot list(@PathVariable("profileId") String profileId) {
-        var result = mgr(profileId).threadRows();
-        LOG.debug("Listed threads: profileId={}", profileId);
-        return result;
+    public ThreadPage list(
+            @PathVariable("profileId") String profileId,
+            @RequestParam(value = "sort", defaultValue = "EVENT_COUNT") ThreadSort sort,
+            @RequestParam(value = "nameFilter", required = false) String nameFilter,
+            @RequestParam(value = "offset", defaultValue = "0") int offset,
+            @RequestParam(value = "limit", defaultValue = "50") int limit) {
+
+        ThreadPageQuery query = new ThreadPageQuery(sort, nameFilter, offset, Math.min(limit, MAX_THREAD_PAGE));
+
+        ThreadPage page = mgr(profileId).threadPage(query);
+        LOG.debug("Listed threads: profileId={} sort={} offset={} returned={} matched={}",
+                profileId, sort, offset, page.rows().size(), page.matchedCount());
+        return page;
     }
 
     /**

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/ThreadControllerTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/ThreadControllerTest.java
@@ -30,8 +30,12 @@ import cafe.jeffrey.profile.manager.ProfileManager;
 import cafe.jeffrey.profile.manager.thread.ThreadManager;
 import cafe.jeffrey.profile.manager.model.thread.dump.ParsedDump;
 import cafe.jeffrey.profile.manager.model.thread.dump.ThreadDumpAnalysis;
+import cafe.jeffrey.profile.thread.ThreadCommon;
 import cafe.jeffrey.profile.thread.ThreadEventDetail;
 import cafe.jeffrey.profile.thread.ThreadEventsQuery;
+import cafe.jeffrey.profile.thread.ThreadPage;
+import cafe.jeffrey.profile.thread.ThreadPageQuery;
+import cafe.jeffrey.profile.thread.ThreadSort;
 import cafe.jeffrey.profile.thread.ThreadState;
 import cafe.jeffrey.shared.common.exception.Exceptions;
 import cafe.jeffrey.timeseries.SingleSerie;
@@ -106,6 +110,100 @@ class ThreadControllerTest {
         MockMvcTester mvc = mockMvcTesterFor(new ThreadController(resolver));
 
         assertThat(mvc.get().uri("/api/internal/profiles/p-1/thread/reserved-stack")).hasStatusOk();
+    }
+
+    @Nested
+    class ThreadPaging {
+
+        private ThreadPage emptyPage() {
+            return new ThreadPage(new ThreadCommon(60_000, false, null), List.of(), 0, 1204, 1204);
+        }
+
+        private ThreadPageQuery capturedQuery() {
+            ArgumentCaptor<ThreadPageQuery> captor = ArgumentCaptor.forClass(ThreadPageQuery.class);
+            verify(threadManager).threadPage(captor.capture());
+            return captor.getValue();
+        }
+
+        /**
+         * Opening the page asks for the busiest threads and nothing else — the defaults are what
+         * keeps a recording with a thousand threads off the wire.
+         */
+        @Test
+        void defaultsToTheFirstPageOfTheBusiestThreads() {
+            when(resolver.resolve("p-1")).thenReturn(profileManager);
+            when(profileManager.threadManager()).thenReturn(threadManager);
+            when(threadManager.threadPage(any(ThreadPageQuery.class))).thenReturn(emptyPage());
+
+            MockMvcTester mvc = mockMvcTesterFor(new ThreadController(resolver));
+
+            assertThat(mvc.get().uri("/api/internal/profiles/p-1/thread")).hasStatusOk();
+
+            ThreadPageQuery query = capturedQuery();
+            assertThat(query.sort()).isEqualTo(ThreadSort.EVENT_COUNT);
+            assertThat(query.offset()).isZero();
+            assertThat(query.limit()).isEqualTo(50);
+            assertThat(query.hasNameFilter()).isFalse();
+        }
+
+        @Test
+        void passesSortFilterAndOffsetThrough() {
+            when(resolver.resolve("p-1")).thenReturn(profileManager);
+            when(profileManager.threadManager()).thenReturn(threadManager);
+            when(threadManager.threadPage(any(ThreadPageQuery.class))).thenReturn(emptyPage());
+
+            MockMvcTester mvc = mockMvcTesterFor(new ThreadController(resolver));
+
+            assertThat(mvc.get().uri("/api/internal/profiles/p-1/thread"
+                    + "?sort=LIFESPAN&nameFilter=connection-adder&offset=50&limit=50"))
+                    .hasStatusOk();
+
+            ThreadPageQuery query = capturedQuery();
+            assertThat(query.sort()).isEqualTo(ThreadSort.LIFESPAN);
+            assertThat(query.nameFilter()).isEqualTo("connection-adder");
+            assertThat(query.offset()).isEqualTo(50);
+        }
+
+        /**
+         * Each row still carries a lane's worth of bands, so an unbounded page would put us back
+         * where we started.
+         */
+        @Test
+        void capsThePageSizeWhateverIsAskedFor() {
+            when(resolver.resolve("p-1")).thenReturn(profileManager);
+            when(profileManager.threadManager()).thenReturn(threadManager);
+            when(threadManager.threadPage(any(ThreadPageQuery.class))).thenReturn(emptyPage());
+
+            MockMvcTester mvc = mockMvcTesterFor(new ThreadController(resolver));
+
+            assertThat(mvc.get().uri("/api/internal/profiles/p-1/thread?limit=100000")).hasStatusOk();
+
+            assertThat(capturedQuery().limit()).isEqualTo(250);
+        }
+
+        /**
+         * The footer counts come from the response, so they have to survive serialization.
+         */
+        @Test
+        void reportsHowManyThreadsWereHeldBack() {
+            when(resolver.resolve("p-1")).thenReturn(profileManager);
+            when(profileManager.threadManager()).thenReturn(threadManager);
+            when(threadManager.threadPage(any(ThreadPageQuery.class))).thenReturn(emptyPage());
+
+            MockMvcTester mvc = mockMvcTesterFor(new ThreadController(resolver));
+
+            assertThat(mvc.get().uri("/api/internal/profiles/p-1/thread"))
+                    .hasStatusOk()
+                    .bodyJson()
+                    .extractingPath("$.matchedCount").asNumber().isEqualTo(1204);
+        }
+
+        @Test
+        void rejectsANegativeOffset() {
+            MockMvcTester mvc = mockMvcTesterFor(new ThreadController(resolver));
+
+            assertThat(mvc.get().uri("/api/internal/profiles/p-1/thread?offset=-1")).hasStatus(400);
+        }
     }
 
     @Nested

--- a/jeffrey-microscope/pages-microscope/src/services/api/ProfileThreadClient.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/ProfileThreadClient.ts
@@ -18,6 +18,7 @@
 
 import BaseProfileClient from '@/services/api/BaseProfileClient';
 import ThreadResponse from '@/services/api/model/ThreadResponse';
+import type { ThreadSort } from '@/services/api/model/ThreadResponse';
 import ThreadStatisticsResponse from '@/services/api/model/ThreadStatisticsResponse';
 import Serie from '@/services/timeseries/model/Serie';
 import type { ParsedDump, ThreadDumpAnalysis } from '@/services/api/model/ThreadDumpModels';
@@ -32,8 +33,22 @@ export default class ProfileThreadClient extends BaseProfileClient {
     super(profileId, 'thread');
   }
 
-  public list(): Promise<ThreadResponse> {
-    return this.get<ThreadResponse>('');
+  /**
+   * One page of threads, ordered and filtered by the server. Both have to happen there: a client
+   * that holds a single page can only sort and filter that page.
+   */
+  public list(page: {
+    sort: ThreadSort;
+    nameFilter?: string;
+    offset?: number;
+    limit?: number;
+  }): Promise<ThreadResponse> {
+    return this.get<ThreadResponse>('', {
+      sort: page.sort,
+      nameFilter: page.nameFilter ?? '',
+      offset: page.offset ?? 0,
+      limit: page.limit ?? 50
+    });
   }
 
   /**

--- a/jeffrey-microscope/pages-microscope/src/services/api/model/ThreadResponse.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/model/ThreadResponse.ts
@@ -19,9 +19,21 @@
 import ThreadCommon from './ThreadCommon';
 import ThreadRowData from '@/services/api/model/ThreadRowData';
 
+/**
+ * One page of a profile's threads.
+ *
+ * A recording can hold thousands of threads, so the timeline asks for the busiest ones first and
+ * comes back for more. `matchedCount` is what "showing 50 of N" counts — it narrows with the filter,
+ * while `totalCount` stays the size of the recording.
+ */
 export default class ThreadResponse {
   constructor(
     public common: ThreadCommon,
-    public rows: ThreadRowData[]
+    public rows: ThreadRowData[],
+    public offset: number,
+    public matchedCount: number,
+    public totalCount: number
   ) {}
 }
+
+export type ThreadSort = 'EVENT_COUNT' | 'LIFESPAN' | 'NAME';

--- a/jeffrey-microscope/pages-microscope/src/services/tooltip/Tooltip.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/tooltip/Tooltip.ts
@@ -25,6 +25,12 @@ import router from '@/router';
 export default class Tooltip {
   private static readonly HIDE_DELAY_MS = 600;
 
+  /** Kept clear of the window edges so the tooltip never sits flush against them. */
+  private static readonly VIEWPORT_MARGIN = 8;
+
+  /** Distance between the pointer and the edge of the tooltip. */
+  private static readonly CURSOR_GAP = 5;
+
   private tooltipTimeoutId: number | null = null;
   private hideTimeoutId: number | null = null;
   private displayedContent: string | null = null;
@@ -86,7 +92,7 @@ export default class Tooltip {
     }
     const profileId = (router.currentRoute.value.params.profileId as string) ?? '';
     const token = ++this.ideGateToken;
-    IdeButtonGate.check(profileId, fqn).then((present) => {
+    IdeButtonGate.check(profileId, fqn).then(present => {
       if (token !== this.ideGateToken || !present) {
         return;
       }
@@ -130,7 +136,7 @@ export default class Tooltip {
       this.displayedContent = null;
     });
 
-    this.tooltip.addEventListener('click', (event) => {
+    this.tooltip.addEventListener('click', event => {
       const target = (event.target as HTMLElement | null)?.closest(
         '[data-ide-action]'
       ) as HTMLElement | null;
@@ -161,29 +167,83 @@ export default class Tooltip {
     });
   }
 
+  /**
+   * Places the tooltip beside the pointer, wholly inside the window.
+   *
+   * <p>The content has no fixed size: a pointer resting where several event categories overlap
+   * produces a box listing every one of them with its fields. Such a box does not fit above the
+   * pointer, and moving it there regardless put its top outside the card — which clips its overflow
+   * — leaving the part that mattered unreachable. So the height is capped first, and the side is
+   * chosen by what actually fits.
+   *
+   * <p>Two coordinate systems meet here. The tooltip is positioned against the canvas's offset
+   * parent, while the room available for it is measured in the window. They differ by a constant,
+   * computed once as {@code layoutOffset}: the fitting is done in window coordinates and shifted
+   * into layout coordinates at the end.
+   */
   private static placeTooltip(
     canvas: HTMLElement,
     tooltip: HTMLElement,
     position: TooltipPosition,
     currentScrollY: number
   ): void {
-    const currWindowHeight = window.innerHeight;
+    const viewportHeight = window.innerHeight;
+    const viewportWidth = window.innerWidth;
     const canvasPos = canvas.getBoundingClientRect();
 
-    if (canvasPos.y + position.offsetY > currWindowHeight / 2) {
-      tooltip.style.top =
-        canvas.offsetTop - currentScrollY + position.offsetY - tooltip.offsetHeight + 5 + 'px';
+    // Capped before measuring: a box taller than the window has no correct placement at all, and
+    // scrolling its content is the only way to keep the rest of it reachable.
+    tooltip.style.maxHeight = viewportHeight - 2 * Tooltip.VIEWPORT_MARGIN + 'px';
+    tooltip.style.overflowY = 'auto';
+
+    const layoutOffsetY = canvas.offsetTop - currentScrollY - canvasPos.y;
+    const pointerY = canvasPos.y + position.offsetY;
+    const height = tooltip.offsetHeight;
+
+    // Above is preferred — it leaves the hovered lane visible — but only when it fits there.
+    let top: number;
+    if (height + Tooltip.CURSOR_GAP <= pointerY - Tooltip.VIEWPORT_MARGIN) {
+      top = pointerY - height - Tooltip.CURSOR_GAP;
+    } else if (height + Tooltip.CURSOR_GAP <= viewportHeight - pointerY - Tooltip.VIEWPORT_MARGIN) {
+      top = pointerY + Tooltip.CURSOR_GAP;
     } else {
-      tooltip.style.top = canvas.offsetTop - currentScrollY + position.offsetY + 5 + 'px';
+      top = Tooltip.VIEWPORT_MARGIN;
     }
 
-    if (position.offsetX > canvas.offsetWidth / 2) {
-      tooltip.style.left = canvas.offsetLeft + position.offsetX - tooltip.offsetWidth - 5 + 'px';
-    } else {
-      tooltip.style.left = canvas.offsetLeft + position.offsetX + 5 + 'px';
-    }
+    // Flooring the layout value at 0 as well: the timeline nests its canvases in cards that clip
+    // their overflow, which the window clamp on its own does nothing about.
+    const clampedTop = Tooltip.clamp(
+      top,
+      Tooltip.VIEWPORT_MARGIN,
+      viewportHeight - height - Tooltip.VIEWPORT_MARGIN
+    );
+    tooltip.style.top = Math.max(clampedTop + layoutOffsetY, 0) + 'px';
+
+    const layoutOffsetX = canvas.offsetLeft - canvasPos.x;
+    const pointerX = canvasPos.x + position.offsetX;
+    const width = tooltip.offsetWidth;
+
+    const left =
+      position.offsetX > canvas.offsetWidth / 2
+        ? pointerX - width - Tooltip.CURSOR_GAP
+        : pointerX + Tooltip.CURSOR_GAP;
+
+    const clampedLeft = Tooltip.clamp(
+      left,
+      Tooltip.VIEWPORT_MARGIN,
+      viewportWidth - width - Tooltip.VIEWPORT_MARGIN
+    );
+    tooltip.style.left = clampedLeft + layoutOffsetX + 'px';
 
     tooltip.style.visibility = 'visible';
+  }
+
+  /**
+   * Clamps to {@code [min, max]}, preferring {@code min} when the two cross — which happens when the
+   * tooltip is larger than the space it has to sit in.
+   */
+  private static clamp(value: number, min: number, max: number): number {
+    return Math.max(min, Math.min(value, Math.max(max, min)));
   }
 
   private static createTooltipDiv(canvas: HTMLElement, threadTooltipName: string): HTMLElement {

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileThreadsTimeline.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileThreadsTimeline.vue
@@ -9,66 +9,75 @@
     <TabBar v-model="activeTab" :tabs="tabs" class="mb-3" />
 
     <div v-show="activeTab === 'timeline'">
-    <div class="d-flex align-items-center mb-3">
-      <div class="input-group search-container me-3" style="max-width: 60%">
-        <span class="input-group-text"><i class="bi bi-search search-icon"></i></span>
-        <input
-          type="text"
-          class="form-control search-input"
-          placeholder="Filter threads..."
-          v-model="fulltextFilter"
-          @input="onFilterChange(($event.target as HTMLInputElement).value)"
-        />
+      <div class="d-flex align-items-center mb-3">
+        <div class="input-group search-container me-3" style="max-width: 60%">
+          <span class="input-group-text"><i class="bi bi-search search-icon"></i></span>
+          <input
+            type="text"
+            class="form-control search-input"
+            placeholder="Filter threads..."
+            v-model="fulltextFilter"
+            @input="onFilterChange(($event.target as HTMLInputElement).value)"
+          />
+          <button
+            v-if="fulltextFilter"
+            class="btn btn-outline-secondary clear-btn"
+            type="button"
+            @click="clearFilter"
+          >
+            <i class="bi bi-x-lg"></i>
+          </button>
+        </div>
+
+        <div class="btn-group btn-group-sm mini-sort-buttons">
+          <button
+            v-for="(option, index) in sortingTypes"
+            :key="index"
+            type="button"
+            class="btn compact-btn"
+            :class="[selectedSorting === option ? 'btn-primary active' : 'btn-outline-primary']"
+            @click="sortingChanged({ value: option })"
+            :title="`Sort by ${option}`"
+          >
+            {{ option }}
+          </button>
+        </div>
         <button
-          v-if="fulltextFilter"
-          class="btn btn-outline-secondary clear-btn"
           type="button"
-          @click="clearFilter"
+          class="btn icon-info-btn ms-2"
+          @click="infoDialogVisible = true"
+          title="Thread Information"
         >
-          <i class="bi bi-x-lg"></i>
+          <i class="bi bi-info-circle"></i>
         </button>
       </div>
 
-      <div class="btn-group btn-group-sm mini-sort-buttons">
-        <button
-          v-for="(option, index) in sortingTypes"
-          :key="index"
-          type="button"
-          class="btn compact-btn"
-          :class="[selectedSorting === option ? 'btn-primary active' : 'btn-outline-primary']"
-          @click="sortingChanged({ value: option })"
-          :title="`Sort by ${option}`"
-        >
-          {{ option }}
-        </button>
-      </div>
-      <button
-        type="button"
-        class="btn icon-info-btn ms-2"
-        @click="infoDialogVisible = true"
-        title="Thread Information"
-      >
-        <i class="bi bi-info-circle"></i>
-      </button>
-    </div>
+      <LoadingState v-if="loading" message="Reading thread activity from the recording…" />
+      <ErrorState v-else-if="error" :message="error" />
 
-    <div class="thread-components-container" :key="forceRenderThreads">
-      <div class="thread-row-wrapper" v-for="(threadRow, index) in threadRows" :key="index">
-        <ThreadComponent
-          v-if="threadRow.threadInfo.name.includes(fulltextFilterAfterTimeout)"
-          :index="index"
-          :project-id="projectId"
-          :primary-profile-id="profileId"
-          :thread-common="threadCommon as ThreadCommon"
-          :thread-row="threadRow"
+      <div v-else class="thread-components-container" :key="forceRenderThreads">
+        <div class="thread-row-wrapper" v-for="(threadRow, index) in threadRows" :key="index">
+          <ThreadComponent
+            v-if="threadRow.threadInfo.name.includes(fulltextFilterAfterTimeout)"
+            :index="index"
+            :project-id="projectId"
+            :primary-profile-id="profileId"
+            :thread-common="threadCommon as ThreadCommon"
+            :thread-row="threadRow"
+          />
+        </div>
+
+        <EmptyState
+          v-if="threadCount === 0"
+          icon="bi-clock-history"
+          title="No thread activity"
+          description="This recording contains no thread events to lay out on a timeline."
         />
+        <div v-else-if="filteredThreadCount === 0" class="no-threads-message">
+          <i class="bi bi-exclamation-circle"></i>
+          No threads match the current filter
+        </div>
       </div>
-
-      <div v-if="filteredThreadCount === 0" class="no-threads-message">
-        <i class="bi bi-exclamation-circle"></i>
-        No threads match the current filter
-      </div>
-    </div>
     </div>
 
     <!-- How It Works Tab -->
@@ -80,48 +89,56 @@
       >
         <AboutCallout variant="intro">
           <p>
-            Each row is one thread; the coloured bands along it show what that thread was doing at each
-            moment — running on CPU, blocked on a lock, parked, or doing socket/file I/O — laid out on a
-            shared wall-clock axis. It's reconstructed by bucketing JFR's per-thread events into time
-            slots, so you can see contention and idle periods across all threads at once.
+            Each row is one thread; the coloured bands along it show what that thread was doing at
+            each moment — running on CPU, blocked on a lock, parked, or doing socket/file I/O — laid
+            out on a shared wall-clock axis. It's reconstructed by bucketing JFR's per-thread events
+            into time slots, so you can see contention and idle periods across all threads at once.
           </p>
         </AboutCallout>
 
         <AboutSection icon="bi-bar-chart-steps" title="Reading the Timeline">
           <FeatureGrid>
             <FeatureCard icon="bi-list" variant="primary" title="Rows are threads">
-              One lane per thread, labelled by name. Filter and sort to bring the threads you care about
-              to the top.
+              One lane per thread, labelled by name. Filter and sort to bring the threads you care
+              about to the top.
             </FeatureCard>
             <FeatureCard icon="bi-palette" variant="info" title="Colours are activity">
-              Each colour is an event category (CPU sample, monitor block, park, socket/file I/O) — see
-              the legend in the info dialog. A solid band of one colour shows where time went.
+              Each colour is an event category (CPU sample, monitor block, park, socket/file I/O) —
+              see the legend in the info dialog. A solid band of one colour shows where time went.
             </FeatureCard>
             <FeatureCard icon="bi-dash" variant="neutral" title="Gaps are idle (or unsampled)">
-              Empty stretches mean the thread produced no events — genuinely idle, or active in a way the
-              recording didn't sample.
+              Empty stretches mean the thread produced no events — genuinely idle, or active in a
+              way the recording didn't sample.
             </FeatureCard>
             <FeatureCard icon="bi-zoom-in" variant="success" title="Patterns to spot">
-              Many threads blocked at the same instant = contention; one thread saturating CPU = a hot
-              path to profile; staircase start times = a warming thread pool.
+              Many threads blocked at the same instant = contention; one thread saturating CPU = a
+              hot path to profile; staircase start times = a warming thread pool.
             </FeatureCard>
           </FeatureGrid>
         </AboutSection>
 
         <AboutSection icon="bi-broadcast" title="How JFR Emits This">
           <p>
-            The lanes are assembled from several per-thread event streams, bucketed into time slots by
-            their <code>eventThread</code> and timestamp:
+            The lanes are assembled from several per-thread event streams, bucketed into time slots
+            by their <code>eventThread</code> and timestamp:
           </p>
           <ul>
-            <li><code>jdk.ThreadStart</code> / <code>jdk.ThreadEnd</code> — when each lane begins and ends.</li>
-            <li><code>jdk.ExecutionSample</code> — CPU activity (the thread was on-CPU when sampled).</li>
             <li>
-              <code>jdk.JavaMonitorEnter</code> / <code>jdk.ThreadPark</code> / <code>jdk.ThreadSleep</code>
+              <code>jdk.ThreadStart</code> / <code>jdk.ThreadEnd</code> — when each lane begins and
+              ends.
+            </li>
+            <li>
+              <code>jdk.ExecutionSample</code> — CPU activity (the thread was on-CPU when sampled).
+            </li>
+            <li>
+              <code>jdk.JavaMonitorEnter</code> / <code>jdk.ThreadPark</code> /
+              <code>jdk.ThreadSleep</code>
               — blocking bands.
             </li>
             <li>
-              <code>jdk.SocketRead</code>/<code>Write</code> and <code>jdk.FileRead</code>/<code>Write</code>
+              <code>jdk.SocketRead</code>/<code>Write</code> and <code>jdk.FileRead</code>/<code
+                >Write</code
+              >
               — I/O bands.
             </li>
           </ul>
@@ -270,6 +287,9 @@ import AboutSection from '@/components/about/AboutSection.vue';
 import FeatureGrid from '@/components/about/FeatureGrid.vue';
 import FeatureCard from '@/components/about/FeatureCard.vue';
 import DataTable from '@shared/components/table/DataTable.vue';
+import LoadingState from '@shared/components/LoadingState.vue';
+import ErrorState from '@shared/components/ErrorState.vue';
+import EmptyState from '@shared/components/EmptyState.vue';
 import type { PropType } from 'vue';
 import '@shared/styles/shared-components.css';
 
@@ -303,6 +323,8 @@ const profileId = route.params.profileId as string;
 
 const threadRows = ref<ThreadRowData[]>();
 const threadCommon = ref<ThreadCommon>();
+const loading = ref<boolean>(true);
+const error = ref<string | null>(null);
 
 const activeTab = ref('timeline');
 const tabs = [
@@ -318,8 +340,12 @@ const forceRenderThreads = ref<number>(0);
 
 const infoDialogVisible = ref<boolean>(false);
 
+const threadCount = computed(() => threadRows.value?.length ?? 0);
+
 const filteredThreadCount = computed(() => {
-  if (!threadRows.value) return 0;
+  if (!threadRows.value) {
+    return 0;
+  }
   return threadRows.value.filter(row =>
     row.threadInfo.name.includes(fulltextFilterAfterTimeout.value)
   ).length;
@@ -335,10 +361,20 @@ onBeforeMount(() => {
 
   threadService = new ProfileThreadClient(profileId);
 
-  threadService.list().then(response => {
-    threadRows.value = sortThreadRows(selectedSorting.value, response.rows);
-    threadCommon.value = response.common;
-  });
+  // A large recording takes a while to lay out, and until it lands there is nothing to show. Without
+  // the loading state, that wait was indistinguishable from a timeline with no threads in it.
+  threadService
+    .list()
+    .then(response => {
+      threadRows.value = sortThreadRows(selectedSorting.value, response.rows);
+      threadCommon.value = response.common;
+    })
+    .catch(e => {
+      error.value = e instanceof Error ? e.message : 'Failed to load the thread timeline';
+    })
+    .finally(() => {
+      loading.value = false;
+    });
 });
 
 function sortThreadRows(

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileThreadsTimeline.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileThreadsTimeline.vue
@@ -13,11 +13,11 @@
         <div class="input-group search-container me-3" style="max-width: 60%">
           <span class="input-group-text"><i class="bi bi-search search-icon"></i></span>
           <input
+            v-model="fulltextFilter"
             type="text"
             class="form-control search-input"
             placeholder="Filter threads..."
-            v-model="fulltextFilter"
-            @input="onFilterChange(($event.target as HTMLInputElement).value)"
+            @input="onFilterChange()"
           />
           <button
             v-if="fulltextFilter"
@@ -55,10 +55,9 @@
       <LoadingState v-if="loading" message="Reading thread activity from the recording…" />
       <ErrorState v-else-if="error" :message="error" />
 
-      <div v-else class="thread-components-container" :key="forceRenderThreads">
-        <div class="thread-row-wrapper" v-for="(threadRow, index) in threadRows" :key="index">
+      <div v-else :key="forceRenderThreads" class="thread-components-container">
+        <div v-for="(threadRow, index) in threadRows" :key="index" class="thread-row-wrapper">
           <ThreadComponent
-            v-if="threadRow.threadInfo.name.includes(fulltextFilterAfterTimeout)"
             :index="index"
             :project-id="projectId"
             :primary-profile-id="profileId"
@@ -68,14 +67,34 @@
         </div>
 
         <EmptyState
-          v-if="threadCount === 0"
+          v-if="loadedCount === 0 && isFiltered"
+          icon="bi-search"
+          title="No threads match the filter"
+          :description="`Nothing in this recording's ${totalCount.toLocaleString()} threads contains &quot;${fulltextFilter}&quot;.`"
+        />
+        <EmptyState
+          v-else-if="loadedCount === 0"
           icon="bi-clock-history"
           title="No thread activity"
           description="This recording contains no thread events to lay out on a timeline."
         />
-        <div v-else-if="filteredThreadCount === 0" class="no-threads-message">
-          <i class="bi bi-exclamation-circle"></i>
-          No threads match the current filter
+
+        <div v-else class="page-summary">
+          <span class="page-summary-text">{{ pageSummary }}</span>
+          <button
+            v-if="hasMore"
+            class="btn btn-sm btn-primary"
+            :disabled="loadingMore"
+            @click="loadMore"
+          >
+            <span
+              v-if="loadingMore"
+              class="spinner-border spinner-border-sm me-2"
+              role="status"
+            ></span>
+            {{ loadingMore ? 'Loading…' : `Show ${nextPageSize} more` }}
+          </button>
+          <span v-else class="page-summary-done">All loaded</span>
         </div>
       </div>
     </div>
@@ -113,6 +132,28 @@
             <FeatureCard icon="bi-zoom-in" variant="success" title="Patterns to spot">
               Many threads blocked at the same instant = contention; one thread saturating CPU = a
               hot path to profile; staircase start times = a warming thread pool.
+            </FeatureCard>
+          </FeatureGrid>
+        </AboutSection>
+
+        <AboutSection icon="bi-layers" title="Working with Large Recordings">
+          <FeatureGrid>
+            <FeatureCard icon="bi-sort-down" variant="primary" title="Busiest threads first">
+              A recording can hold thousands of threads, so the page loads 50 at a time in the order
+              you picked and appends the next 50 on request. The footer says how many of the
+              recording's threads you are looking at.
+            </FeatureCard>
+            <FeatureCard icon="bi-funnel" variant="info" title="Sort and filter search everything">
+              Both run against the whole recording, not the threads already on screen — a thread
+              that would have sorted onto the last page is still one search away.
+            </FeatureCard>
+            <FeatureCard icon="bi-bounding-box" variant="neutral" title="Bands, not events">
+              Events closer together than the timeline can draw apart are merged into one band. The
+              band remembers how many events it covers, so the counts stay honest.
+            </FeatureCard>
+            <FeatureCard icon="bi-cursor" variant="success" title="Details on hover">
+              A band carries no field values until you point at it — then the events behind that one
+              band are fetched, which is why the first tooltip on a lane takes a moment.
             </FeatureCard>
           </FeatureGrid>
         </AboutSection>
@@ -167,8 +208,11 @@
             represented by a single pixel.
           </li>
           <li>
-            One pixel of the timeline can keep multiple events of same type (the first one shows
-            details), or different types.
+            Events too close together to be drawn apart are merged into one band, which keeps count
+            of how many it covers. A single pixel can also hold bands of different types.
+          </li>
+          <li>
+            Pointing at a band fetches the events behind it and shows their fields in the tooltip.
           </li>
         </ul>
       </div>
@@ -276,6 +320,7 @@ import ProfileThreadClient from '@/services/api/ProfileThreadClient.ts';
 import ThreadComponent from '@/components/ThreadComponent.vue';
 import ThreadCommon from '@/services/api/model/ThreadCommon';
 import ThreadRowData from '@/services/api/model/ThreadRowData';
+import type { ThreadSort } from '@/services/api/model/ThreadResponse';
 import Konva from 'konva';
 import ThreadRow from '@/services/thread/ThreadRow';
 import PageHeader from '@shared/components/layout/PageHeader.vue';
@@ -312,19 +357,34 @@ const props = defineProps({
 const route = useRoute();
 const { projectId } = useNavigation();
 
-const EVENT_COUNT_COMPARATOR = (a: ThreadRowData, b: ThreadRowData) =>
-  b.eventsCount - a.eventsCount;
-const LIFESPAN_COMPARATOR = (a: ThreadRowData, b: ThreadRowData) =>
-  b.totalDuration - a.totalDuration;
-const ALPHABETICAL_COMPARATOR = (a: ThreadRowData, b: ThreadRowData) =>
-  a.threadInfo.name.localeCompare(b.threadInfo.name);
+/**
+ * How many threads a request asks for. Each row is a lane's worth of bands, so this is the knob
+ * that keeps the first paint quick on a recording with thousands of threads.
+ */
+const PAGE_SIZE = 50;
+
+const FILTER_DEBOUNCE_MS = 300;
+
+/**
+ * The sort buttons, paired with the order the server knows them by.
+ */
+const SORTINGS: { label: string; sort: ThreadSort }[] = [
+  { label: 'Event Count', sort: 'EVENT_COUNT' },
+  { label: 'Lifespan', sort: 'LIFESPAN' },
+  { label: 'Alphabetically', sort: 'NAME' }
+];
 
 const profileId = route.params.profileId as string;
 
 const threadRows = ref<ThreadRowData[]>();
 const threadCommon = ref<ThreadCommon>();
 const loading = ref<boolean>(true);
+const loadingMore = ref<boolean>(false);
 const error = ref<string | null>(null);
+
+/** Threads matching the current filter, and threads in the recording — both counted server-side. */
+const matchedCount = ref<number>(0);
+const totalCount = ref<number>(0);
 
 const activeTab = ref('timeline');
 const tabs = [
@@ -332,42 +392,62 @@ const tabs = [
   { id: 'about', label: 'How It Works', icon: 'book' }
 ];
 const fulltextFilter = ref<string>('');
-const fulltextFilterAfterTimeout = ref<string>('');
-const selectedSorting = ref<string>('Event Count');
-const sortingTypes = ref<string[]>(['Event Count', 'Lifespan', 'Alphabetically']);
+const selectedSorting = ref<string>(SORTINGS[0].label);
+const sortingTypes = ref<string[]>(SORTINGS.map(s => s.label));
 
 const forceRenderThreads = ref<number>(0);
 
 const infoDialogVisible = ref<boolean>(false);
 
-const threadCount = computed(() => threadRows.value?.length ?? 0);
+const loadedCount = computed(() => threadRows.value?.length ?? 0);
+const hasMore = computed(() => loadedCount.value < matchedCount.value);
+const isFiltered = computed(() => fulltextFilter.value.trim().length > 0);
 
-const filteredThreadCount = computed(() => {
-  if (!threadRows.value) {
-    return 0;
+/** The button promises exactly what is left, so the last page never says "show 50 more" for 7. */
+const nextPageSize = computed(() => Math.min(PAGE_SIZE, matchedCount.value - loadedCount.value));
+
+/** Reads as "Showing 50 of 1,204 threads", and says so about the filter when one is applied. */
+const pageSummary = computed(() => {
+  const shown = loadedCount.value.toLocaleString();
+  const matched = matchedCount.value.toLocaleString();
+  if (isFiltered.value) {
+    return `Showing ${shown} of ${matched} matching threads · ${totalCount.value.toLocaleString()} in the recording`;
   }
-  return threadRows.value.filter(row =>
-    row.threadInfo.name.includes(fulltextFilterAfterTimeout.value)
-  ).length;
+  return `Showing ${shown} of ${matched} threads`;
 });
 
 let filterTimeout: ReturnType<typeof setTimeout>;
 
-let threadService;
+let threadService: ProfileThreadClient;
 
 onBeforeMount(() => {
   // Too many layers, it spams the console
   Konva.showWarnings = false;
 
   threadService = new ProfileThreadClient(profileId);
+  loadFirstPage();
+});
 
-  // A large recording takes a while to lay out, and until it lands there is nothing to show. Without
-  // the loading state, that wait was indistinguishable from a timeline with no threads in it.
+function currentSort(): ThreadSort {
+  return SORTINGS.find(s => s.label === selectedSorting.value)?.sort ?? 'EVENT_COUNT';
+}
+
+/**
+ * Replaces what is on screen — used on first paint and whenever the sort or filter changes, since
+ * both reorder the whole recording and not just the threads already loaded.
+ */
+function loadFirstPage() {
+  loading.value = true;
+  error.value = null;
+
   threadService
-    .list()
+    .list({ sort: currentSort(), nameFilter: fulltextFilter.value, offset: 0, limit: PAGE_SIZE })
     .then(response => {
-      threadRows.value = sortThreadRows(selectedSorting.value, response.rows);
+      threadRows.value = response.rows;
       threadCommon.value = response.common;
+      matchedCount.value = response.matchedCount;
+      totalCount.value = response.totalCount;
+      forceRenderThreads.value++;
     })
     .catch(e => {
       error.value = e instanceof Error ? e.message : 'Failed to load the thread timeline';
@@ -375,53 +455,51 @@ onBeforeMount(() => {
     .finally(() => {
       loading.value = false;
     });
-});
+}
 
-function sortThreadRows(
-  sortingType: string,
-  threadRows: ThreadRowData[] | undefined
-): ThreadRowData[] | undefined {
-  if (!threadRows) return undefined;
+function loadMore() {
+  if (loadingMore.value || !hasMore.value) {
+    return;
+  }
+  loadingMore.value = true;
 
-  return [...threadRows].sort((a, b) => {
-    switch (sortingType) {
-      case 'Event Count':
-        return EVENT_COUNT_COMPARATOR(a, b);
-      case 'Lifespan':
-        return LIFESPAN_COMPARATOR(a, b);
-      case 'Alphabetically':
-        return ALPHABETICAL_COMPARATOR(a, b);
-      default:
-        return 0;
-    }
-  });
+  threadService
+    .list({
+      sort: currentSort(),
+      nameFilter: fulltextFilter.value,
+      offset: loadedCount.value,
+      limit: PAGE_SIZE
+    })
+    .then(response => {
+      threadRows.value = [...(threadRows.value ?? []), ...response.rows];
+      matchedCount.value = response.matchedCount;
+      totalCount.value = response.totalCount;
+    })
+    .catch(e => {
+      error.value = e instanceof Error ? e.message : 'Failed to load more threads';
+    })
+    .finally(() => {
+      loadingMore.value = false;
+    });
 }
 
 function sortingChanged(newSorting: { value: string }) {
-  selectedSorting.value = newSorting.value;
-  if (threadRows.value) {
-    threadRows.value = sortThreadRows(newSorting.value, threadRows.value);
-    forceRenderThreads.value++;
-  }
-}
-
-function onFilterChange(newFilter: string) {
-  fulltextFilterAfterTimeout.value = '';
-  clearTimeout(filterTimeout);
-
-  if (newFilter === '') {
-    fulltextFilterAfterTimeout.value = newFilter;
+  if (selectedSorting.value === newSorting.value) {
     return;
   }
+  selectedSorting.value = newSorting.value;
+  loadFirstPage();
+}
 
-  filterTimeout = setTimeout(() => {
-    fulltextFilterAfterTimeout.value = newFilter;
-  }, 300);
+function onFilterChange() {
+  clearTimeout(filterTimeout);
+  filterTimeout = setTimeout(loadFirstPage, FILTER_DEBOUNCE_MS);
 }
 
 function clearFilter() {
+  clearTimeout(filterTimeout);
   fulltextFilter.value = '';
-  fulltextFilterAfterTimeout.value = '';
+  loadFirstPage();
 }
 </script>
 
@@ -438,20 +516,29 @@ function clearFilter() {
   margin-bottom: 0.5rem;
 }
 
-.no-threads-message {
+/* Footer under the lanes: how much of the recording is on screen, and how to get the rest. */
+.page-summary {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 1.5rem;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-top: 0.5rem;
+  padding: 1rem 1.5rem;
   background-color: var(--color-light);
   border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.page-summary-text {
   font-size: 0.85rem;
   color: var(--color-text-muted);
 }
 
-.no-threads-message i {
-  margin-right: 0.5rem;
-  font-size: 1rem;
+.page-summary-done {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  opacity: 0.75;
 }
 
 /* Modal styles */

--- a/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/manager/thread/ThreadManager.java
+++ b/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/manager/thread/ThreadManager.java
@@ -27,6 +27,8 @@ import cafe.jeffrey.profile.manager.model.thread.dump.ParsedDump;
 import cafe.jeffrey.profile.manager.model.thread.dump.ThreadDumpAnalysis;
 import cafe.jeffrey.profile.thread.ThreadEventDetail;
 import cafe.jeffrey.profile.thread.ThreadEventsQuery;
+import cafe.jeffrey.profile.thread.ThreadPage;
+import cafe.jeffrey.profile.thread.ThreadPageQuery;
 import cafe.jeffrey.profile.thread.ThreadRoot;
 import cafe.jeffrey.provider.profile.api.AllocatingThread;
 import cafe.jeffrey.timeseries.SingleSerie;
@@ -50,7 +52,18 @@ public interface ThreadManager {
 
     ThreadCpuLoads threadCpuLoads(int limit);
 
+    /**
+     * The whole timeline. Used to warm the profile's cache after an import — the page itself asks
+     * for {@link #threadPage(ThreadPageQuery)} instead, so that a recording with a thousand threads
+     * does not have to cross the wire in one piece.
+     */
     ThreadRoot threadRows();
+
+    /**
+     * One ordered slice of the timeline, filtered and counted. Reads from the same cached timeline
+     * {@link #threadRows()} builds, so paging costs nothing after the first request.
+     */
+    ThreadPage threadPage(ThreadPageQuery query);
 
     /**
      * The events behind one band of {@link #threadRows()}, for the tooltip that opens when the

--- a/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/manager/thread/ThreadManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/manager/thread/ThreadManagerImpl.java
@@ -38,8 +38,11 @@ import cafe.jeffrey.profile.manager.model.thread.dump.ThreadDumpParser;
 import cafe.jeffrey.profile.thread.ThreadEventDetail;
 import cafe.jeffrey.profile.thread.ThreadEventsQuery;
 import cafe.jeffrey.profile.thread.ThreadInfoProvider;
+import cafe.jeffrey.profile.thread.ThreadPage;
+import cafe.jeffrey.profile.thread.ThreadPageQuery;
 import cafe.jeffrey.profile.thread.ThreadRecord;
 import cafe.jeffrey.profile.thread.ThreadRoot;
+import cafe.jeffrey.profile.thread.ThreadRow;
 import cafe.jeffrey.profile.thread.ThreadsRecordBuilder;
 import cafe.jeffrey.provider.profile.api.EventQueryConfigurer;
 import cafe.jeffrey.provider.profile.api.ProfileEventRepository;
@@ -51,7 +54,9 @@ import cafe.jeffrey.timeseries.SingleSerie;
 import java.time.Duration;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 public class ThreadManagerImpl implements ThreadManager {
 
@@ -148,6 +153,31 @@ public class ThreadManagerImpl implements ThreadManager {
     @Override
     public ThreadRoot threadRows() {
         return threadInfoProvider.get();
+    }
+
+    @Override
+    public ThreadPage threadPage(ThreadPageQuery query) {
+        ThreadRoot root = threadInfoProvider.get();
+
+        List<ThreadRow> matched = query.hasNameFilter()
+                ? root.rows().stream().filter(matchesName(query.nameFilter())).toList()
+                : root.rows();
+
+        List<ThreadRow> page = matched.stream()
+                .sorted(query.sort().comparator())
+                .skip(query.offset())
+                .limit(query.limit())
+                .toList();
+
+        return new ThreadPage(root.common(), page, query.offset(), matched.size(), root.rows().size());
+    }
+
+    private static Predicate<ThreadRow> matchesName(String nameFilter) {
+        String needle = nameFilter.toLowerCase(Locale.ROOT);
+        return row -> {
+            String name = row.threadInfo().name();
+            return name != null && name.toLowerCase(Locale.ROOT).contains(needle);
+        };
     }
 
     @Override

--- a/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/thread/ThreadPage.java
+++ b/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/thread/ThreadPage.java
@@ -1,0 +1,45 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.thread;
+
+import java.util.List;
+
+/**
+ * One slice of a profile's threads, plus what the page needs to describe the rest of them.
+ *
+ * <p>Kept separate from {@link ThreadRoot}: the root is the whole timeline as it is computed and
+ * cached, while this is the view of it that goes over the wire.
+ *
+ * @param common        the metadata every row is drawn against, unchanged between pages
+ * @param rows          the threads in this slice, already ordered
+ * @param offset        how many threads precede this slice
+ * @param matchedCount  threads matching the current filter — what "showing 50 of N" counts
+ * @param totalCount    threads in the recording, whether they matched the filter or not
+ */
+public record ThreadPage(
+        ThreadCommon common,
+        List<ThreadRow> rows,
+        int offset,
+        int matchedCount,
+        int totalCount) {
+
+    public boolean hasMore() {
+        return offset + rows.size() < matchedCount;
+    }
+}

--- a/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/thread/ThreadPageQuery.java
+++ b/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/thread/ThreadPageQuery.java
@@ -1,0 +1,51 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.thread;
+
+/**
+ * Which slice of the timeline to send.
+ *
+ * <p>The name filter is applied here rather than in the browser on purpose: with only a page of
+ * threads loaded, a filter that ran on the client would search the page instead of the recording,
+ * and a thread that matched would stay hidden simply because it sorted low.
+ *
+ * @param sort       the order threads are handed out in
+ * @param nameFilter case-insensitive substring the thread name must contain; blank matches everything
+ * @param offset     how many threads to skip
+ * @param limit      how many threads to send
+ */
+public record ThreadPageQuery(ThreadSort sort, String nameFilter, int offset, int limit) {
+
+    public ThreadPageQuery {
+        if (sort == null) {
+            throw new IllegalArgumentException("Sort must be specified");
+        }
+        if (offset < 0) {
+            throw new IllegalArgumentException("Offset must not be negative: " + offset);
+        }
+        if (limit < 1) {
+            throw new IllegalArgumentException("Limit must be positive: " + limit);
+        }
+        nameFilter = nameFilter == null ? "" : nameFilter.trim();
+    }
+
+    public boolean hasNameFilter() {
+        return !nameFilter.isEmpty();
+    }
+}

--- a/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/thread/ThreadSort.java
+++ b/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/thread/ThreadSort.java
@@ -1,0 +1,52 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.thread;
+
+import java.util.Comparator;
+
+/**
+ * The order the timeline hands threads out in. Ordering belongs on this side now that only the first
+ * page is sent: whichever threads sort first are the ones that arrive, so "busiest" has to mean the
+ * same thing here as it did when the page sorted the whole set itself.
+ */
+public enum ThreadSort {
+
+    EVENT_COUNT(Comparator.comparingLong(ThreadRow::eventsCount).reversed()),
+    LIFESPAN(Comparator.comparingLong(ThreadRow::totalDuration).reversed()),
+    NAME(Comparator.comparing(row -> row.threadInfo().name(), Comparator.nullsLast(String::compareTo)));
+
+    /**
+     * Threads that tie on the chosen key are broken by name, so paging stays stable: without a total
+     * order, two requests for the same page could return different threads.
+     */
+    private static final Comparator<ThreadRow> TIE_BREAK =
+            Comparator.comparing((ThreadRow row) -> row.threadInfo().name(), Comparator.nullsLast(String::compareTo))
+                    .thenComparingLong(row -> row.threadInfo().javaId())
+                    .thenComparingLong(row -> row.threadInfo().osId());
+
+    private final Comparator<ThreadRow> comparator;
+
+    ThreadSort(Comparator<ThreadRow> comparator) {
+        this.comparator = comparator;
+    }
+
+    public Comparator<ThreadRow> comparator() {
+        return comparator.thenComparing(TIE_BREAK);
+    }
+}

--- a/jeffrey-microscope/profiles/profile-threads/src/test/java/cafe/jeffrey/profile/manager/thread/ThreadPagingTest.java
+++ b/jeffrey-microscope/profiles/profile-threads/src/test/java/cafe/jeffrey/profile/manager/thread/ThreadPagingTest.java
@@ -1,0 +1,213 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.thread;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import cafe.jeffrey.profile.thread.ThreadCommon;
+import cafe.jeffrey.profile.thread.ThreadInfoProvider;
+import cafe.jeffrey.profile.thread.ThreadPage;
+import cafe.jeffrey.profile.thread.ThreadPageQuery;
+import cafe.jeffrey.profile.thread.ThreadRoot;
+import cafe.jeffrey.profile.thread.ThreadRow;
+import cafe.jeffrey.profile.thread.ThreadSort;
+import cafe.jeffrey.provider.profile.api.ProfileEventRepository;
+import cafe.jeffrey.provider.profile.api.ProfileEventStreamRepository;
+import cafe.jeffrey.provider.profile.api.ProfileEventTypeRepository;
+import cafe.jeffrey.shared.common.model.ProfileInfo;
+import cafe.jeffrey.shared.common.model.ThreadInfo;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The timeline hands out one page at a time, so the order and the filter have to be decided here —
+ * a browser holding fifty threads can only sort and filter those fifty.
+ */
+@ExtendWith(MockitoExtension.class)
+class ThreadPagingTest {
+
+    @Mock
+    ProfileInfo profileInfo;
+
+    @Mock
+    ProfileEventRepository eventRepository;
+
+    @Mock
+    ProfileEventStreamRepository eventStreamRepository;
+
+    @Mock
+    ProfileEventTypeRepository eventTypeRepository;
+
+    private static ThreadRow row(String name, long javaId, long events, long duration) {
+        return new ThreadRow(
+                duration,
+                events,
+                new ThreadInfo(javaId + 1000, javaId, name),
+                List.of(), List.of(), List.of(), List.of(), List.of(), List.of(), List.of(), List.of(), List.of());
+    }
+
+    /**
+     * Two pools plus a couple of singletons — the shape of the recording that motivated paging.
+     */
+    private static final List<ThreadRow> ROWS = List.of(
+            row("main", 1, 9_401, 60_000),
+            row("http-nio-8080-exec-17", 2, 58_204, 59_000),
+            row("http-nio-8080-exec-3", 3, 51_880, 58_000),
+            row("oracleApp:connection-adder-118", 4, 9_412, 12_000),
+            row("oracleApp:connection-adder-42", 5, 9_110, 11_000),
+            row("Keep-Alive-Timer-6", 6, 4_002, 57_000));
+
+    private ThreadManager manager(List<ThreadRow> rows) {
+        ThreadInfoProvider provider = () -> new ThreadRoot(new ThreadCommon(60_000, false, null), rows);
+        return new ThreadManagerImpl(
+                profileInfo, eventRepository, eventStreamRepository, eventTypeRepository, provider);
+    }
+
+    private ThreadPage page(ThreadSort sort, String filter, int offset, int limit) {
+        return manager(ROWS).threadPage(new ThreadPageQuery(sort, filter, offset, limit));
+    }
+
+    private static List<String> names(ThreadPage page) {
+        return page.rows().stream().map(row -> row.threadInfo().name()).toList();
+    }
+
+    @Nested
+    class Ordering {
+
+        @Test
+        void putsTheBusiestThreadsOnTheFirstPage() {
+            assertEquals(
+                    List.of("http-nio-8080-exec-17", "http-nio-8080-exec-3"),
+                    names(page(ThreadSort.EVENT_COUNT, null, 0, 2)));
+        }
+
+        @Test
+        void ordersByLifespanWhenAsked() {
+            assertEquals("main", names(page(ThreadSort.LIFESPAN, null, 0, 1)).getFirst());
+        }
+
+        @Test
+        void ordersByNameWhenAsked() {
+            assertEquals(
+                    List.of("Keep-Alive-Timer-6", "http-nio-8080-exec-17"),
+                    names(page(ThreadSort.NAME, null, 0, 2)));
+        }
+
+        /**
+         * Threads that tie on the sort key must not swap places between requests, or paging would
+         * show one of them twice and skip the other.
+         */
+        @Test
+        void breaksTiesTheSameWayEveryTime() {
+            List<ThreadRow> tied = IntStream.range(0, 40)
+                    .mapToObj(i -> row("oracleApp:connection-adder-" + i, i, 500, 1_000))
+                    .toList();
+            ThreadManager manager = manager(tied);
+
+            ThreadPage first = manager.threadPage(new ThreadPageQuery(ThreadSort.EVENT_COUNT, null, 0, 10));
+            ThreadPage again = manager.threadPage(new ThreadPageQuery(ThreadSort.EVENT_COUNT, null, 0, 10));
+            ThreadPage second = manager.threadPage(new ThreadPageQuery(ThreadSort.EVENT_COUNT, null, 10, 10));
+
+            assertEquals(names(first), names(again));
+            assertTrue(names(first).stream().noneMatch(names(second)::contains),
+                    "Consecutive pages must not overlap");
+        }
+    }
+
+    @Nested
+    class Filtering {
+
+        @Test
+        void matchesASubstringOfTheThreadName() {
+            ThreadPage page = page(ThreadSort.EVENT_COUNT, "connection-adder", 0, 50);
+
+            assertEquals(2, page.rows().size());
+            assertEquals(2, page.matchedCount());
+        }
+
+        @Test
+        void ignoresCase() {
+            assertEquals(2, page(ThreadSort.EVENT_COUNT, "CONNECTION-ADDER", 0, 50).matchedCount());
+        }
+
+        /**
+         * The footer reads "showing 2 of 2 matching threads · 6 in the recording", so the two counts
+         * have to mean different things.
+         */
+        @Test
+        void narrowsTheMatchedCountButNotTheTotal() {
+            ThreadPage page = page(ThreadSort.EVENT_COUNT, "connection-adder", 0, 50);
+
+            assertEquals(2, page.matchedCount());
+            assertEquals(6, page.totalCount());
+        }
+
+        @Test
+        void treatsABlankFilterAsNoFilter() {
+            assertEquals(6, page(ThreadSort.EVENT_COUNT, "   ", 0, 50).matchedCount());
+        }
+    }
+
+    @Nested
+    class Slicing {
+
+        @Test
+        void reportsMoreUntilTheLastPageIsReached() {
+            assertTrue(page(ThreadSort.EVENT_COUNT, null, 0, 2).hasMore());
+            assertFalse(page(ThreadSort.EVENT_COUNT, null, 4, 2).hasMore());
+        }
+
+        @Test
+        void returnsAnEmptyPagePastTheEnd() {
+            ThreadPage page = page(ThreadSort.EVENT_COUNT, null, 500, 50);
+
+            assertTrue(page.rows().isEmpty());
+            assertEquals(6, page.matchedCount());
+            assertFalse(page.hasMore());
+        }
+
+        @Test
+        void carriesTheOffsetBackSoThePageKnowsWhereItIs() {
+            assertEquals(2, page(ThreadSort.EVENT_COUNT, null, 2, 2).offset());
+        }
+    }
+
+    @Nested
+    class Validation {
+
+        @Test
+        void rejectsAnUnusableQuery() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> new ThreadPageQuery(null, null, 0, 50));
+            assertThrows(IllegalArgumentException.class,
+                    () -> new ThreadPageQuery(ThreadSort.EVENT_COUNT, null, -1, 50));
+            assertThrows(IllegalArgumentException.class,
+                    () -> new ThreadPageQuery(ThreadSort.EVENT_COUNT, null, 0, 0));
+        }
+    }
+}

--- a/jeffrey-microscope/profiles/profile-threads/src/test/java/cafe/jeffrey/profile/thread/DbBasedThreadProviderTest.java
+++ b/jeffrey-microscope/profiles/profile-threads/src/test/java/cafe/jeffrey/profile/thread/DbBasedThreadProviderTest.java
@@ -1,0 +1,164 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.thread;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import cafe.jeffrey.jfrparser.api.type.JfrThreadImpl;
+import cafe.jeffrey.provider.profile.api.EventQueryConfigurer;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.provider.profile.api.ProfileEventRepository;
+import cafe.jeffrey.provider.profile.api.ProfileEventStreamRepository;
+import cafe.jeffrey.provider.profile.api.RecordBuilder;
+import cafe.jeffrey.shared.common.model.ProfileInfo;
+import cafe.jeffrey.shared.common.model.RecordingEventSource;
+import cafe.jeffrey.shared.common.model.Type;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DbBasedThreadProviderTest {
+
+    private static final Instant RECORDING_START = Instant.parse("2026-01-01T00:00:00Z");
+    private static final Duration RECORDING_LENGTH = Duration.ofSeconds(4);
+
+    @Mock
+    ProfileEventRepository eventRepository;
+
+    @Mock
+    ProfileEventStreamRepository eventStreamRepository;
+
+    /**
+     * Drives the record builder with the given events, the way the streaming repository drives it
+     * with rows from the database.
+     */
+    private void streams(List<GenericRecord> events) {
+        when(eventStreamRepository.genericStreaming(any(EventQueryConfigurer.class), any()))
+                .thenAnswer(invocation -> {
+                    RecordBuilder<GenericRecord, ?> builder = invocation.getArgument(1);
+                    events.forEach(builder::onRecord);
+                    return builder.build();
+                });
+    }
+
+    private static GenericRecord event(Type type, long javaId, Duration start, Duration duration) {
+        return new GenericRecord(
+                type,
+                null,
+                RECORDING_START.plus(start),
+                start,
+                duration,
+                new JfrThreadImpl(javaId + 1000, javaId, "worker-" + javaId, false),
+                null,
+                1,
+                0,
+                null);
+    }
+
+    private ThreadRoot rootOf(List<GenericRecord> events) {
+        streams(events);
+        ProfileInfo profileInfo = new ProfileInfo(
+                "p-1",
+                "project-1",
+                "workspace-1",
+                "recording",
+                RecordingEventSource.JDK,
+                RECORDING_START,
+                RECORDING_START.plus(RECORDING_LENGTH),
+                RECORDING_START,
+                true,
+                false,
+                "rec-1");
+
+        return new DbBasedThreadProvider(profileInfo, eventRepository, eventStreamRepository).get();
+    }
+
+    @Nested
+    class ThreadRows {
+
+        /**
+         * The timeline query no longer asks for JSON fields, so the rows have to be reconstructed
+         * from the event's own columns alone. An empty timeline is what a regression here looks like.
+         */
+        @Test
+        void areBuiltFromEventsWithoutJsonFields() {
+            ThreadRoot root = rootOf(List.of(
+                    event(Type.THREAD_START, 1, Duration.ZERO, null),
+                    event(Type.FILE_WRITE, 1, Duration.ofMillis(100), Duration.ofMillis(2)),
+                    event(Type.FILE_WRITE, 1, Duration.ofMillis(2000), Duration.ofMillis(2)),
+                    event(Type.JAVA_MONITOR_ENTER, 2, Duration.ofMillis(500), Duration.ofMillis(5))));
+
+            assertEquals(2, root.rows().size(), "Both threads must produce a row");
+
+            ThreadRow writer = rowOf(root, 1);
+            assertEquals(2, writer.eventsCount(), "Event count reports events, not bands");
+            assertEquals(2, writer.fileWrite().size(), "Two writes two seconds apart stay two bands");
+            assertTrue(writer.lifespan().size() >= 1, "A started thread has a lifespan");
+
+            ThreadRow blocked = rowOf(root, 2);
+            assertEquals(1, blocked.blocked().size());
+            assertEquals(1, blocked.blocked().getFirst().eventCount());
+        }
+
+        /**
+         * Instantaneous events carry no duration; reading one as if it had a length would fail the
+         * whole request, and the timeline would come back empty.
+         */
+        @Test
+        void surviveEventsWithoutADuration() {
+            ThreadRoot root = rootOf(List.of(
+                    event(Type.THREAD_START, 1, Duration.ZERO, null),
+                    event(Type.THREAD_END, 1, Duration.ofMillis(50), null)));
+
+            ThreadRow row = rowOf(root, 1);
+            assertEquals(1, row.lifespan().size());
+            assertEquals(0, row.eventsCount());
+        }
+
+        @Test
+        void mergeABurstIntoASingleBand() {
+            List<GenericRecord> burst = java.util.stream.IntStream.range(0, 500)
+                    .mapToObj(i -> event(Type.FILE_WRITE, 1, Duration.ofNanos(i * 1_000L), Duration.ofNanos(500)))
+                    .toList();
+
+            ThreadRow row = rowOf(rootOf(burst), 1);
+
+            assertEquals(1, row.fileWrite().size(), "A burst is a single rectangle on screen");
+            assertEquals(500, row.fileWrite().getFirst().eventCount());
+            assertEquals(500, row.eventsCount());
+        }
+
+        private ThreadRow rowOf(ThreadRoot root, long javaId) {
+            return root.rows().stream()
+                    .filter(row -> row.threadInfo().javaId() == javaId)
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("No row for thread: " + javaId));
+        }
+    }
+}

--- a/jeffrey-microscope/profiles/profile-threads/src/test/java/cafe/jeffrey/profile/thread/ThreadPeriodSerdeTest.java
+++ b/jeffrey-microscope/profiles/profile-threads/src/test/java/cafe/jeffrey/profile/thread/ThreadPeriodSerdeTest.java
@@ -1,0 +1,45 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.thread;
+
+import org.junit.jupiter.api.Test;
+import cafe.jeffrey.shared.common.Json;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class ThreadPeriodSerdeTest {
+
+    /**
+     * The timeline is cached as JSON in the profile database and read back on every later request,
+     * so a band has to survive a round-trip. A derived accessor leaking into the output would be
+     * written but not accepted back, and the timeline would fail to load from cache.
+     */
+    @Test
+    void survivesTheCacheRoundTrip() {
+        ThreadPeriod band = new ThreadPeriod(1_000, 500, 7);
+
+        String json = Json.toString(band);
+
+        assertFalse(json.contains("endOffset"), "Only the band's own components belong on the wire: " + json);
+
+        ThreadPeriod read = Json.read(json, ThreadPeriod.class);
+        assertEquals(band, read);
+    }
+}


### PR DESCRIPTION
Follow-up to #128, which merged before these two commits were pushed. Both are rebased onto current master and contain no already-merged work.

## Why

Two problems remained after #128 bounded the timeline response:

1. **A loading timeline looked like an empty one.** The view had no loading and no error state, so until the response landed `threadRows` was undefined, `filteredThreadCount` fell through to zero, and the page rendered *"No threads match the current filter"*. On a recording with many threads that wait is long — and a failed request looked identical, permanently.

2. **Every thread still crossed the wire at once.** A recording with 351 `oracleApp:connection-adder` and 250 `Keep-Alive-Timer` threads renders 601 near-identical lanes before showing anything useful.

## What changed

**Three-state view** (`eed9ef5`) — `LoadingState` while the page loads, `ErrorState` with the real message if it fails, and the two zero cases separated: an `EmptyState` for a recording with no thread events, and the filter message only when a filter actually excluded something.

**Paging** (`af2c8b0`) — `GET /thread` takes `sort` / `nameFilter` / `offset` / `limit` (capped at 250) and returns a `ThreadPage` with `matchedCount` and `totalCount`. The page loads 50 threads and appends the next 50 on request, with a footer reading *"Showing 50 of 1,204 threads"*.

Sorting and filtering move server-side as a consequence, not a bonus: a browser holding one page can only sort and filter that page, so a thread that matched but sorted low would have stayed invisible. Threads that tie on the sort key are ordered by name and id — without a total order, two requests for the same page can return one thread twice and skip another.

Paging slices the timeline already cached per profile, so only the first request pays for building it.

The How It Works tab gains a *"Working with Large Recordings"* section in the existing `AboutPanel` / `AboutSection` / `FeatureGrid` structure, and the info dialog no longer claims a tooltip shows the first event of a pixel — it shows the events actually behind the band being pointed at.

The per-thread flamegraph button and the thread info dialog are unchanged.

## Tests

- `ThreadPagingTest` — 12 cases: ordering per sort, tie stability across repeated requests, non-overlapping consecutive pages, case-insensitive filtering, `matchedCount` vs `totalCount`, offset past the end.
- `ThreadControllerTest$ThreadPaging` — 10 cases: defaults, page-size cap, parameter passthrough, 400 on a negative offset.
- `DbBasedThreadProviderTest` and `ThreadPeriodSerdeTest` — added with the first commit to prove the band work in #128 did not empty the timeline: rows are still built from events without JSON fields, instantaneous events without a duration do not fail the request, and a band survives the cache round-trip.

Full backend build passes on this base; frontend build, lint and 210 tests pass.

## Known limitation

Paging bounds the response and the browser render — the two things actually hit — but the *first* request for a profile still computes every thread before caching it. Pushing `limit`/`offset` into SQL would need a separate aggregate query to pick the top-N threads before streaming their events; that is a larger change and is not included here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPkEqcM735YP1x82KLoZgw)_