### PR TITLE
Collapse threads that share a name into one timeline lane

### DIFF
--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/DifferentialFlamegraphController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/DifferentialFlamegraphController.java
@@ -67,7 +67,7 @@ public class DifferentialFlamegraphController {
         LOG.debug("Generating diff flamegraph: eventType={}", request.eventType());
         FlamegraphManager diffManager = diffManager(primaryProfileId, secondaryProfileId);
         ProfileManager primary = resolver.resolve(primaryProfileId);
-        GraphParameters params = mapToGenerateRequest(primary.info(), request, GraphType.DIFFERENTIAL);
+        GraphParameters params = mapToGenerateRequest(primary, request, GraphType.DIFFERENTIAL);
         return diffManager.generate(params);
     }
 

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/FlamegraphController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/FlamegraphController.java
@@ -37,6 +37,7 @@ import cafe.jeffrey.profile.panel.PanelContext;
 import cafe.jeffrey.profile.resources.request.GenerateFlamegraphRequest;
 import cafe.jeffrey.shared.common.GraphType;
 import cafe.jeffrey.shared.common.model.ProfileInfo;
+import cafe.jeffrey.shared.common.model.ThreadInfo;
 import cafe.jeffrey.shared.common.model.ProfilingStartEnd;
 import cafe.jeffrey.shared.common.model.time.RelativeTimeRange;
 import cafe.jeffrey.shared.common.model.time.TimeRange;
@@ -67,7 +68,7 @@ public class FlamegraphController {
             @RequestBody GenerateFlamegraphRequest request) {
         LOG.debug("Generating flamegraph: eventType={} useThreadMode={}", request.eventType(), request.useThreadMode());
         ProfileManager pm = resolver.resolve(profileId);
-        GraphParameters params = mapToGenerateRequest(pm.info(), request, GraphType.PRIMARY);
+        GraphParameters params = mapToGenerateRequest(pm, request, GraphType.PRIMARY);
         return pm.flamegraphManager().generate(params);
     }
 
@@ -77,7 +78,7 @@ public class FlamegraphController {
             @RequestBody GenerateFlamegraphRequest request) {
         LOG.debug("Generating AI export: eventType={}", request.eventType());
         ProfileManager pm = resolver.resolve(profileId);
-        GraphParameters params = mapToGenerateRequest(pm.info(), request, GraphType.PRIMARY);
+        GraphParameters params = mapToGenerateRequest(pm, request, GraphType.PRIMARY);
         return pm.flamegraphManager().generateAiExport(params);
     }
 
@@ -98,7 +99,9 @@ public class FlamegraphController {
     }
 
     static GraphParameters mapToGenerateRequest(
-            ProfileInfo profileInfo, GenerateFlamegraphRequest request, GraphType graphType) {
+            ProfileManager profileManager, GenerateFlamegraphRequest request, GraphType graphType) {
+
+        ProfileInfo profileInfo = profileManager.info();
 
         ProfilingStartEnd primaryStartEnd = new ProfilingStartEnd(
                 profileInfo.profilingStartedAt(), profileInfo.profilingFinishedAt());
@@ -109,7 +112,7 @@ public class FlamegraphController {
         return GraphParameters.builder()
                 .withEventType(request.eventType())
                 .withTimeRange(relativeTimeRange)
-                .withThreadInfo(request.threadInfo())
+                .withThreads(threadsOf(profileManager, request))
                 .withThreadMode(request.useThreadMode())
                 .withUseWeight(request.useWeight())
                 .withExcludeNonJavaSamples(request.excludeNonJavaSamples())
@@ -121,6 +124,25 @@ public class FlamegraphController {
                 .withSearchPattern(request.search())
                 .withMarkers(request.markers())
                 .build();
+    }
+
+    /**
+     * The threads a graph is scoped to. A request opened from a collapsed timeline lane names the
+     * group rather than a thread — the lane has no thread of its own, and the page holds at most a
+     * slice of its members — so the group is resolved to all of them here.
+     */
+    private static List<ThreadInfo> threadsOf(ProfileManager profileManager, GenerateFlamegraphRequest request) {
+        if (!request.hasThreadGroup()) {
+            return request.threadInfo() == null ? List.of() : List.of(request.threadInfo());
+        }
+
+        List<ThreadInfo> threads = profileManager.threadManager().threadGroupThreads(request.threadGroup());
+        if (threads.isEmpty()) {
+            // A group exists only because threads fell into it, so an empty one is a key that no
+            // longer names anything. Left alone it would silently graph the whole recording.
+            throw new IllegalArgumentException("Unknown thread group: " + request.threadGroup());
+        }
+        return threads;
     }
 
     public static TimeRange toTimeRange(TimeRangeRequest timeRangeRequest) {

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/ThreadController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/ThreadController.java
@@ -133,22 +133,41 @@ public class ThreadController {
     @GetMapping("/events")
     public List<ThreadEventDetail> threadEvents(
             @PathVariable("profileId") String profileId,
-            @RequestParam("osId") long osId,
-            @RequestParam("javaId") long javaId,
+            @RequestParam(value = "osId", required = false) Long osId,
+            @RequestParam(value = "javaId", required = false) Long javaId,
+            @RequestParam(value = "group", required = false) String group,
             @RequestParam("state") ThreadState state,
             @RequestParam("from") long fromNanos,
             @RequestParam("to") long toNanos,
             @RequestParam(value = "limit", defaultValue = "1") int limit) {
 
+        List<ThreadInfo> threads = threadsOf(profileId, group, osId, javaId);
+
         ThreadEventsQuery query = new ThreadEventsQuery(
-                new ThreadInfo(osId, javaId, null),
+                threads,
                 state,
                 Duration.ofNanos(fromNanos),
                 Duration.ofNanos(toNanos),
                 Math.min(limit, MAX_BAND_EVENTS));
 
-        LOG.debug("Fetching events of a timeline band: state={} from={} to={}", state, fromNanos, toNanos);
+        LOG.debug("Fetching events of a timeline band: state={} from={} to={} threads={}",
+                state, fromNanos, toNanos, threads.size());
         return mgr(profileId).threadEvents(query);
+    }
+
+    /**
+     * A band on a collapsed lane belongs to the whole group, not to one thread — the lane has no
+     * thread of its own — so the group is resolved to its members. A request naming neither is
+     * rejected before anything is resolved, so a bad request answers 400 rather than failing later.
+     */
+    private List<ThreadInfo> threadsOf(String profileId, String group, Long osId, Long javaId) {
+        if (group != null && !group.isBlank()) {
+            return mgr(profileId).threadGroupThreads(group);
+        }
+        if (osId == null || javaId == null) {
+            throw new IllegalArgumentException("Either a group or a thread's ids must be specified");
+        }
+        return List.of(new ThreadInfo(osId, javaId, null));
     }
 
     @GetMapping("/statistics")

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/ThreadController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/ThreadController.java
@@ -35,6 +35,8 @@ import cafe.jeffrey.profile.manager.model.thread.dump.ParsedDump;
 import cafe.jeffrey.profile.manager.model.thread.dump.ThreadDumpAnalysis;
 import cafe.jeffrey.profile.thread.ThreadEventDetail;
 import cafe.jeffrey.profile.thread.ThreadEventsQuery;
+import cafe.jeffrey.profile.thread.ThreadGroupPage;
+import cafe.jeffrey.profile.thread.ThreadMembersQuery;
 import cafe.jeffrey.profile.thread.ThreadPage;
 import cafe.jeffrey.profile.thread.ThreadPageQuery;
 import cafe.jeffrey.profile.thread.ThreadSort;
@@ -82,12 +84,13 @@ public class ThreadController {
     }
 
     /**
-     * One page of the timeline. A recording can hold thousands of threads, so the page asks for the
-     * busiest ones first and comes back for more; sorting and filtering happen here rather than in
-     * the browser, because a client that holds one page can only sort and filter that page.
+     * One page of the timeline, a lane per group of identically named threads. A recording can hold
+     * thousands of threads and most of them are pool workers, so the lanes come busiest-first and the
+     * page comes back for more. Sorting and filtering happen here rather than in the browser, because
+     * a client that holds one page can only sort and filter that page.
      */
     @GetMapping
-    public ThreadPage list(
+    public ThreadGroupPage list(
             @PathVariable("profileId") String profileId,
             @RequestParam(value = "sort", defaultValue = "EVENT_COUNT") ThreadSort sort,
             @RequestParam(value = "nameFilter", required = false) String nameFilter,
@@ -96,9 +99,30 @@ public class ThreadController {
 
         ThreadPageQuery query = new ThreadPageQuery(sort, nameFilter, offset, Math.min(limit, MAX_THREAD_PAGE));
 
-        ThreadPage page = mgr(profileId).threadPage(query);
-        LOG.debug("Listed threads: profileId={} sort={} offset={} returned={} matched={}",
-                profileId, sort, offset, page.rows().size(), page.matchedCount());
+        ThreadGroupPage page = mgr(profileId).threadGroups(query);
+        LOG.debug("Listed thread groups: profileId={} sort={} offset={} returned={} matched={} threads={}",
+                profileId, sort, offset, page.groups().size(), page.matchedGroups(), page.totalThreads());
+        return page;
+    }
+
+    /**
+     * The threads behind one collapsed lane. Opening a pool of 351 workers pages through them the
+     * same way the timeline itself pages through lanes.
+     */
+    @GetMapping("/members")
+    public ThreadPage members(
+            @PathVariable("profileId") String profileId,
+            @RequestParam("group") String group,
+            @RequestParam(value = "sort", defaultValue = "EVENT_COUNT") ThreadSort sort,
+            @RequestParam(value = "offset", defaultValue = "0") int offset,
+            @RequestParam(value = "limit", defaultValue = "50") int limit) {
+
+        ThreadMembersQuery query =
+                new ThreadMembersQuery(group, sort, offset, Math.min(limit, MAX_THREAD_PAGE));
+
+        ThreadPage page = mgr(profileId).threadGroupMembers(query);
+        LOG.debug("Listed members of a thread group: profileId={} group={} offset={} returned={} matched={}",
+                profileId, group, offset, page.rows().size(), page.matchedCount());
         return page;
     }
 

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/FlamegraphControllerTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/FlamegraphControllerTest.java
@@ -24,19 +24,43 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
 import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
+import cafe.jeffrey.profile.common.config.GraphComponents;
+import cafe.jeffrey.profile.common.config.GraphParameters;
 import cafe.jeffrey.profile.manager.FlamegraphManager;
 import cafe.jeffrey.profile.manager.ProfileManager;
+import cafe.jeffrey.profile.manager.thread.ThreadManager;
 import cafe.jeffrey.profile.panel.JfrFlamegraphPanelProvider;
+import cafe.jeffrey.profile.resources.request.GenerateFlamegraphRequest;
+import cafe.jeffrey.shared.common.GraphType;
+import cafe.jeffrey.shared.common.model.RecordingEventSource;
 import cafe.jeffrey.shared.common.exception.Exceptions;
+import cafe.jeffrey.shared.common.model.ProfileInfo;
+import cafe.jeffrey.shared.common.model.ThreadInfo;
+import cafe.jeffrey.shared.common.model.Type;
 
+import java.time.Instant;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 import static cafe.jeffrey.microscope.core.web.MockMvcSupport.mockMvcTesterFor;
 
 @ExtendWith(MockitoExtension.class)
 class FlamegraphControllerTest {
+
+    private static final String GROUP = "oracleApp:connection-adder*";
+
+    /** A pool that mixes both kinds of identity, as a group of real threads does. */
+    private static final List<ThreadInfo> POOL = List.of(
+            new ThreadInfo(41, 12, "oracleApp:connection-adder-12"),
+            new ThreadInfo(42, 13, "oracleApp:connection-adder-13"),
+            new ThreadInfo(43, -1, "oracleApp:connection-adder"));
+
+    private static final ProfileInfo PROFILE = new ProfileInfo(
+            "p-1", "proj-1", "ws-1", "profile", RecordingEventSource.JDK,
+            Instant.parse("2025-01-15T10:00:00Z"), Instant.parse("2025-01-15T10:01:00Z"),
+            Instant.parse("2025-01-15T10:02:00Z"), true, false, "rec-1");
 
     @Mock
     ProfileManagerResolver resolver;
@@ -46,6 +70,9 @@ class FlamegraphControllerTest {
 
     @Mock
     FlamegraphManager flamegraphManager;
+
+    @Mock
+    ThreadManager threadManager;
 
     @Test
     void listsEvents() {
@@ -75,6 +102,67 @@ class FlamegraphControllerTest {
                 .extractingPath("$[*].section").asArray()
                 .containsExactly("execution", "cpu-time", "method", "wall",
                         "allocation", "native-alloc", "native-leak", "blocking");
+    }
+
+    /**
+     * A graph opened from a collapsed timeline lane names the group. The lane has no thread of its
+     * own and the page holds at most a slice of its members, so every thread behind it has to be
+     * resolved here rather than sent.
+     */
+    @Test
+    void aGraphScopedToAThreadGroupCoversEveryThreadInIt() {
+        when(profileManager.info()).thenReturn(PROFILE);
+        when(profileManager.threadManager()).thenReturn(threadManager);
+        when(threadManager.threadGroupThreads(GROUP)).thenReturn(POOL);
+
+        GraphParameters params = FlamegraphController.mapToGenerateRequest(
+                profileManager, request(null, GROUP), GraphType.PRIMARY);
+
+        assertThat(params.threads()).isEqualTo(POOL);
+    }
+
+    @Test
+    void aGraphScopedToOneThreadStillCarriesThatThreadAlone() {
+        when(profileManager.info()).thenReturn(PROFILE);
+        ThreadInfo worker = new ThreadInfo(41, 12, "oracleApp:connection-adder-12");
+
+        GraphParameters params = FlamegraphController.mapToGenerateRequest(
+                profileManager, request(worker, null), GraphType.PRIMARY);
+
+        assertThat(params.threads()).containsExactly(worker);
+    }
+
+    @Test
+    void aGraphNamingNoThreadAtAllCoversTheWholeRecording() {
+        when(profileManager.info()).thenReturn(PROFILE);
+
+        GraphParameters params = FlamegraphController.mapToGenerateRequest(
+                profileManager, request(null, null), GraphType.PRIMARY);
+
+        assertThat(params.threads()).isEmpty();
+    }
+
+    /**
+     * A group exists only because threads fell into it, so a key that resolves to nothing is a key
+     * that no longer names anything — and graphing the whole recording instead would look like an
+     * answer.
+     */
+    @Test
+    void anUnknownThreadGroupIsRejected() {
+        when(profileManager.info()).thenReturn(PROFILE);
+        when(profileManager.threadManager()).thenReturn(threadManager);
+        when(threadManager.threadGroupThreads("ghosts*")).thenReturn(List.of());
+
+        assertThatThrownBy(() -> FlamegraphController.mapToGenerateRequest(
+                profileManager, request(null, "ghosts*"), GraphType.PRIMARY))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("ghosts*");
+    }
+
+    private static GenerateFlamegraphRequest request(ThreadInfo threadInfo, String threadGroup) {
+        return new GenerateFlamegraphRequest(
+                null, Type.EXECUTION_SAMPLE, null, null, false, false, false, false, false,
+                threadInfo, threadGroup, GraphComponents.BOTH, List.of());
     }
 
     @Test

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/ThreadControllerTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/ThreadControllerTest.java
@@ -40,6 +40,7 @@ import cafe.jeffrey.profile.thread.ThreadPageQuery;
 import cafe.jeffrey.profile.thread.ThreadSort;
 import cafe.jeffrey.profile.thread.ThreadState;
 import cafe.jeffrey.shared.common.exception.Exceptions;
+import cafe.jeffrey.shared.common.model.ThreadInfo;
 import cafe.jeffrey.timeseries.SingleSerie;
 import cafe.jeffrey.timeseries.TimeseriesData;
 
@@ -310,8 +311,9 @@ class ThreadControllerTest {
             ArgumentCaptor<ThreadEventsQuery> captor = ArgumentCaptor.forClass(ThreadEventsQuery.class);
             verify(threadManager).threadEvents(captor.capture());
             ThreadEventsQuery query = captor.getValue();
-            assertThat(query.threadInfo().javaId()).isEqualTo(42);
-            assertThat(query.threadInfo().osId()).isEqualTo(7);
+            assertThat(query.threads()).hasSize(1);
+            assertThat(query.threads().getFirst().javaId()).isEqualTo(42);
+            assertThat(query.threads().getFirst().osId()).isEqualTo(7);
             assertThat(query.state()).isEqualTo(ThreadState.FILE_WRITE);
             assertThat(query.from()).isEqualTo(Duration.ofNanos(1_000));
             assertThat(query.to()).isEqualTo(Duration.ofNanos(1_500));
@@ -339,6 +341,41 @@ class ThreadControllerTest {
             ArgumentCaptor<ThreadEventsQuery> captor = ArgumentCaptor.forClass(ThreadEventsQuery.class);
             verify(threadManager).threadEvents(captor.capture());
             assertThat(captor.getValue().limit()).isEqualTo(20);
+        }
+
+        /**
+         * A band on a collapsed lane belongs to the whole group. The lane carries no thread of its
+         * own, so asking by its identity matched nothing and the tooltip stayed blank; naming the
+         * group resolves it to every thread behind it.
+         */
+        @Test
+        void areLookedUpAcrossAWholeGroup() {
+            when(resolver.resolve("p-1")).thenReturn(profileManager);
+            when(profileManager.threadManager()).thenReturn(threadManager);
+            when(threadManager.threadGroupThreads("oracleApp:connection-adder")).thenReturn(List.of(
+                    new ThreadInfo(1001, 1, "oracleApp:connection-adder"),
+                    new ThreadInfo(1002, 2, "oracleApp:connection-adder")));
+            when(threadManager.threadEvents(any(ThreadEventsQuery.class))).thenReturn(List.of());
+
+            MockMvcTester mvc = mockMvcTesterFor(new ThreadController(resolver));
+
+            assertThat(mvc.get().uri("/api/internal/profiles/p-1/thread/events"
+                    + "?group=oracleApp:connection-adder&state=SOCKET_READ&from=0&to=1000"))
+                    .hasStatusOk();
+
+            ArgumentCaptor<ThreadEventsQuery> captor = ArgumentCaptor.forClass(ThreadEventsQuery.class);
+            verify(threadManager).threadEvents(captor.capture());
+            assertThat(captor.getValue().threads())
+                    .as("Every thread in the group is searched, not the lane's placeholder identity")
+                    .hasSize(2);
+        }
+
+        @Test
+        void areRejectedWithoutAThreadOrAGroup() {
+            MockMvcTester mvc = mockMvcTesterFor(new ThreadController(resolver));
+
+            assertThat(mvc.get().uri("/api/internal/profiles/p-1/thread/events"
+                    + "?state=SOCKET_READ&from=0&to=1000")).hasStatus(400);
         }
 
         /**

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/ThreadControllerTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/ThreadControllerTest.java
@@ -33,6 +33,8 @@ import cafe.jeffrey.profile.manager.model.thread.dump.ThreadDumpAnalysis;
 import cafe.jeffrey.profile.thread.ThreadCommon;
 import cafe.jeffrey.profile.thread.ThreadEventDetail;
 import cafe.jeffrey.profile.thread.ThreadEventsQuery;
+import cafe.jeffrey.profile.thread.ThreadGroupPage;
+import cafe.jeffrey.profile.thread.ThreadMembersQuery;
 import cafe.jeffrey.profile.thread.ThreadPage;
 import cafe.jeffrey.profile.thread.ThreadPageQuery;
 import cafe.jeffrey.profile.thread.ThreadSort;
@@ -115,13 +117,13 @@ class ThreadControllerTest {
     @Nested
     class ThreadPaging {
 
-        private ThreadPage emptyPage() {
-            return new ThreadPage(new ThreadCommon(60_000, false, null), List.of(), 0, 1204, 1204);
+        private ThreadGroupPage emptyPage() {
+            return new ThreadGroupPage(new ThreadCommon(60_000, false, null), List.of(), 0, 18, 18, 1204);
         }
 
         private ThreadPageQuery capturedQuery() {
             ArgumentCaptor<ThreadPageQuery> captor = ArgumentCaptor.forClass(ThreadPageQuery.class);
-            verify(threadManager).threadPage(captor.capture());
+            verify(threadManager).threadGroups(captor.capture());
             return captor.getValue();
         }
 
@@ -133,7 +135,7 @@ class ThreadControllerTest {
         void defaultsToTheFirstPageOfTheBusiestThreads() {
             when(resolver.resolve("p-1")).thenReturn(profileManager);
             when(profileManager.threadManager()).thenReturn(threadManager);
-            when(threadManager.threadPage(any(ThreadPageQuery.class))).thenReturn(emptyPage());
+            when(threadManager.threadGroups(any(ThreadPageQuery.class))).thenReturn(emptyPage());
 
             MockMvcTester mvc = mockMvcTesterFor(new ThreadController(resolver));
 
@@ -150,7 +152,7 @@ class ThreadControllerTest {
         void passesSortFilterAndOffsetThrough() {
             when(resolver.resolve("p-1")).thenReturn(profileManager);
             when(profileManager.threadManager()).thenReturn(threadManager);
-            when(threadManager.threadPage(any(ThreadPageQuery.class))).thenReturn(emptyPage());
+            when(threadManager.threadGroups(any(ThreadPageQuery.class))).thenReturn(emptyPage());
 
             MockMvcTester mvc = mockMvcTesterFor(new ThreadController(resolver));
 
@@ -172,7 +174,7 @@ class ThreadControllerTest {
         void capsThePageSizeWhateverIsAskedFor() {
             when(resolver.resolve("p-1")).thenReturn(profileManager);
             when(profileManager.threadManager()).thenReturn(threadManager);
-            when(threadManager.threadPage(any(ThreadPageQuery.class))).thenReturn(emptyPage());
+            when(threadManager.threadGroups(any(ThreadPageQuery.class))).thenReturn(emptyPage());
 
             MockMvcTester mvc = mockMvcTesterFor(new ThreadController(resolver));
 
@@ -185,17 +187,17 @@ class ThreadControllerTest {
          * The footer counts come from the response, so they have to survive serialization.
          */
         @Test
-        void reportsHowManyThreadsWereHeldBack() {
+        void reportsHowManyThreadsTheLanesStandFor() {
             when(resolver.resolve("p-1")).thenReturn(profileManager);
             when(profileManager.threadManager()).thenReturn(threadManager);
-            when(threadManager.threadPage(any(ThreadPageQuery.class))).thenReturn(emptyPage());
+            when(threadManager.threadGroups(any(ThreadPageQuery.class))).thenReturn(emptyPage());
 
             MockMvcTester mvc = mockMvcTesterFor(new ThreadController(resolver));
 
             assertThat(mvc.get().uri("/api/internal/profiles/p-1/thread"))
                     .hasStatusOk()
                     .bodyJson()
-                    .extractingPath("$.matchedCount").asNumber().isEqualTo(1204);
+                    .extractingPath("$.totalThreads").asNumber().isEqualTo(1204);
         }
 
         @Test
@@ -203,6 +205,83 @@ class ThreadControllerTest {
             MockMvcTester mvc = mockMvcTesterFor(new ThreadController(resolver));
 
             assertThat(mvc.get().uri("/api/internal/profiles/p-1/thread?offset=-1")).hasStatus(400);
+        }
+    }
+
+    @Nested
+    class GroupMembers {
+
+        private ThreadMembersQuery capturedQuery() {
+            ArgumentCaptor<ThreadMembersQuery> captor = ArgumentCaptor.forClass(ThreadMembersQuery.class);
+            verify(threadManager).threadGroupMembers(captor.capture());
+            return captor.getValue();
+        }
+
+        /**
+         * Opening a lane asks for its first 50 threads — a pool of 351 must not arrive whole any
+         * more than the ungrouped timeline could.
+         */
+        @Test
+        void defaultToTheFirstPageOfALane() {
+            when(resolver.resolve("p-1")).thenReturn(profileManager);
+            when(profileManager.threadManager()).thenReturn(threadManager);
+            when(threadManager.threadGroupMembers(any(ThreadMembersQuery.class)))
+                    .thenReturn(new ThreadPage(new ThreadCommon(60_000, false, null), List.of(), 0, 351, 1204));
+
+            MockMvcTester mvc = mockMvcTesterFor(new ThreadController(resolver));
+
+            assertThat(mvc.get().uri("/api/internal/profiles/p-1/thread/members"
+                    + "?group=oracleApp:connection-adder"))
+                    .hasStatusOk()
+                    .bodyJson()
+                    .extractingPath("$.matchedCount").asNumber().isEqualTo(351);
+
+            ThreadMembersQuery query = capturedQuery();
+            assertThat(query.groupKey()).isEqualTo("oracleApp:connection-adder");
+            assertThat(query.sort()).isEqualTo(ThreadSort.EVENT_COUNT);
+            assertThat(query.offset()).isZero();
+            assertThat(query.limit()).isEqualTo(50);
+        }
+
+        @Test
+        void pageThroughALaneOnRequest() {
+            when(resolver.resolve("p-1")).thenReturn(profileManager);
+            when(profileManager.threadManager()).thenReturn(threadManager);
+            when(threadManager.threadGroupMembers(any(ThreadMembersQuery.class)))
+                    .thenReturn(new ThreadPage(new ThreadCommon(60_000, false, null), List.of(), 50, 351, 1204));
+
+            MockMvcTester mvc = mockMvcTesterFor(new ThreadController(resolver));
+
+            assertThat(mvc.get().uri("/api/internal/profiles/p-1/thread/members"
+                    + "?group=http-nio-8080-exec-*&offset=50&sort=NAME"))
+                    .hasStatusOk();
+
+            ThreadMembersQuery query = capturedQuery();
+            assertThat(query.groupKey()).isEqualTo("http-nio-8080-exec-*");
+            assertThat(query.offset()).isEqualTo(50);
+            assertThat(query.sort()).isEqualTo(ThreadSort.NAME);
+        }
+
+        @Test
+        void areCappedLikeTheLanesThemselves() {
+            when(resolver.resolve("p-1")).thenReturn(profileManager);
+            when(profileManager.threadManager()).thenReturn(threadManager);
+            when(threadManager.threadGroupMembers(any(ThreadMembersQuery.class)))
+                    .thenReturn(new ThreadPage(new ThreadCommon(60_000, false, null), List.of(), 0, 351, 1204));
+
+            MockMvcTester mvc = mockMvcTesterFor(new ThreadController(resolver));
+
+            assertThat(mvc.get().uri("/api/internal/profiles/p-1/thread/members"
+                    + "?group=pool-*&limit=100000")).hasStatusOk();
+
+            assertThat(capturedQuery().limit()).isEqualTo(250);
+        }
+
+        @Test
+        void areRejectedWithoutALane() {
+            MockMvcTester mvc = mockMvcTesterFor(new ThreadController(resolver));
+
+            assertThat(mvc.get().uri("/api/internal/profiles/p-1/thread/members?group=")).hasStatus(400);
         }
     }
 

--- a/jeffrey-microscope/pages-microscope/src/components/ThreadComponent.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/ThreadComponent.vue
@@ -326,7 +326,10 @@ const showFlamegraph = (eventCode: string) => {
   const flamegraphClient = new PrimaryFlamegraphClient(
     props.primaryProfileId,
     eventCode,
-    true,
+    // Thread mode puts a synthetic root frame under every thread. On a collapsed lane that would
+    // split the graph by the very thing the lane collapsed — one sliver per pool worker — so a
+    // group merges instead, and only a single thread keeps its own root.
+    !collapsed.value,
     null,
     false,
     false,

--- a/jeffrey-microscope/pages-microscope/src/components/ThreadComponent.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/ThreadComponent.vue
@@ -90,8 +90,12 @@ const flamegraphModalId = ref(`flamegraphModal-${props.index}`);
 
 const showFlamegraphDialog = ref(false);
 
+/**
+ * Brings a reloaded graph back into view. The modal's overlay is what scrolls — the global
+ * `.modal-overlay` carries the `overflow-y` — so it is also what the flamegraph tracks.
+ */
 function scrollToTop() {
-  const wrapper = document.querySelector('.scrollable-wrapper');
+  const wrapper = document.getElementById(flamegraphModalId.value);
   if (wrapper) {
     wrapper.scrollTop = 0;
   }
@@ -713,7 +717,7 @@ function createContextMenuItems() {
         :with-timeseries="true"
         :use-weight="useWeightValue"
         :use-guardian="null"
-        scrollableWrapperClass="scrollable-wrapper"
+        :scrollable-wrapper-class="flamegraphModalId"
         :flamegraph-tooltip="flamegraphTooltip"
         :graph-updater="graphUpdater"
         @loaded="scrollToTop"

--- a/jeffrey-microscope/pages-microscope/src/components/ThreadComponent.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/ThreadComponent.vue
@@ -17,7 +17,7 @@
   -->
 
 <script setup lang="ts">
-import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
+import { computed, onMounted, onUnmounted, ref } from 'vue';
 import ThreadRowData from '@/services/api/model/ThreadRowData';
 import { useRoute } from 'vue-router';
 
@@ -34,7 +34,7 @@ import FullGraphUpdater from '@/services/flamegraphs/updater/FullGraphUpdater';
 import FlamegraphComponent from '@/components/FlamegraphComponent.vue';
 import TimeSeriesChart from '@/components/TimeSeriesChart.vue';
 import SearchBarComponent from '@/components/SearchBarComponent.vue';
-import * as bootstrap from 'bootstrap';
+import GenericModal from '@shared/components/GenericModal.vue';
 import TimeseriesEventAxeFormatter from '@/services/timeseries/TimeseriesEventAxeFormatter.ts';
 
 const props = withDefaults(
@@ -164,24 +164,6 @@ onMounted(() => {
   );
   threadRowRenderer.draw();
 
-  // Initialize the Bootstrap modal after the DOM is ready
-  nextTick(() => {
-    const modalEl = document.getElementById('flamegraphModal');
-    if (modalEl) {
-      // We'll manually create and dispose of the modal
-      // for better control over the behavior
-      modalEl.addEventListener('hidden.bs.modal', () => {
-        showFlamegraphDialog.value = false;
-      });
-
-      // Add event listener to close button that might not work with data-bs-dismiss
-      const closeButton = modalEl.querySelector('.btn-close');
-      if (closeButton) {
-        closeButton.addEventListener('click', closeModal);
-      }
-    }
-  });
-
   // Add scroll listener with stored handler reference for proper cleanup
   document.addEventListener('scroll', handleScroll);
 });
@@ -275,44 +257,8 @@ const executeMenuItem = (item: any) => {
   item.command();
 };
 
-let modalInstance: bootstrap.Modal | null = null;
-
-// Function to close the modal
-const closeModal = () => {
-  if (modalInstance) {
-    modalInstance.hide();
-  }
-  showFlamegraphDialog.value = false;
-};
-
-// Watch for changes to showFlamegraphDialog to control modal visibility
-watch(showFlamegraphDialog, isVisible => {
-  if (isVisible) {
-    if (!modalInstance) {
-      const modalEl = document.getElementById(flamegraphModalId.value);
-      if (modalEl) {
-        modalInstance = new bootstrap.Modal(modalEl);
-      }
-    }
-
-    if (modalInstance) {
-      modalInstance.show();
-    }
-  } else {
-    if (modalInstance) {
-      modalInstance.hide();
-    }
-  }
-});
-
-// Clean up event listeners and modal when component is unmounted
+// Clean up event listeners when the component is unmounted
 onUnmounted(() => {
-  // Clean up modal
-  if (modalInstance) {
-    modalInstance.dispose();
-    modalInstance = null;
-  }
-
   // Remove scroll listener with correct handler reference
   document.removeEventListener('scroll', handleScroll);
 
@@ -503,7 +449,7 @@ function createContextMenuItems() {
   </div>
 
   <!-- Thread Information Modal -->
-  <div v-if="showInfoModal" class="modal-overlay" @click="showInfoModal = false">
+  <div v-if="showInfoModal" class="thread-info-overlay" @click="showInfoModal = false">
     <div class="modal-container tooltip-style-modal" @click.stop>
       <div
         class="tooltip-header d-flex justify-content-between align-items-center"
@@ -745,48 +691,35 @@ function createContextMenuItems() {
   </div>
 
   <!-- Modal for events that contain StackTrace field -->
-  <div
-    class="modal fade"
-    :id="flamegraphModalId"
-    tabindex="-1"
-    aria-labelledby="flamegraphModalLabel"
-    aria-hidden="true"
+  <GenericModal
+    v-model:show="showFlamegraphDialog"
+    :modal-id="flamegraphModalId"
+    :title="selectedEventCode"
+    size="fullscreen"
+    :show-footer="false"
   >
-    <div class="modal-dialog modal-lg" style="width: 95vw; max-width: 95%">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title" id="flamegraphModalLabel">{{ selectedEventCode }}</h5>
-          <button type="button" class="btn-close" @click="closeModal" aria-label="Close"></button>
-        </div>
-        <div
-          id="scrollable-wrapper"
-          class="modal-body"
-          style="padding: 0.75rem"
-          v-if="showFlamegraphDialog"
-        >
-          <SearchBarComponent :graph-updater="graphUpdater" :with-timeseries="true" />
-          <TimeSeriesChart
-            :graph-updater="graphUpdater"
-            :primary-axis-type="
-              TimeseriesEventAxeFormatter.resolveAxisFormatter(useWeightValue, selectedEventCode)
-            "
-            :visible-minutes="60"
-            :zoom-enabled="true"
-            time-unit="seconds"
-          />
-          <FlamegraphComponent
-            :with-timeseries="true"
-            :use-weight="useWeightValue"
-            :use-guardian="null"
-            scrollableWrapperClass="scrollable-wrapper"
-            :flamegraph-tooltip="flamegraphTooltip"
-            :graph-updater="graphUpdater"
-            @loaded="scrollToTop"
-          />
-        </div>
-      </div>
+    <div v-if="showFlamegraphDialog" style="padding: 0.75rem">
+      <SearchBarComponent :graph-updater="graphUpdater" :with-timeseries="true" />
+      <TimeSeriesChart
+        :graph-updater="graphUpdater"
+        :primary-axis-type="
+          TimeseriesEventAxeFormatter.resolveAxisFormatter(useWeightValue, selectedEventCode)
+        "
+        :visible-minutes="60"
+        :zoom-enabled="true"
+        time-unit="seconds"
+      />
+      <FlamegraphComponent
+        :with-timeseries="true"
+        :use-weight="useWeightValue"
+        :use-guardian="null"
+        scrollableWrapperClass="scrollable-wrapper"
+        :flamegraph-tooltip="flamegraphTooltip"
+        :graph-updater="graphUpdater"
+        @loaded="scrollToTop"
+      />
     </div>
-  </div>
+  </GenericModal>
 </template>
 
 <style scoped>
@@ -970,8 +903,9 @@ function createContextMenuItems() {
   }
 }
 
-/* Modal styles */
-.modal-overlay {
+/* The thread-details overlay. Deliberately not named `modal-overlay`: that class also sits on
+   GenericModal's root, which a scoped rule here would reach and restyle. */
+.thread-info-overlay {
   position: fixed;
   top: 0;
   left: 0;
@@ -1019,25 +953,6 @@ function createContextMenuItems() {
   top: 8px;
 }
 
-/* Info modal styles */
-.modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 10px 12px;
-  border-bottom: 1px solid var(--color-border);
-  background-color: var(--color-light);
-}
-
-.modal-title {
-  margin: 0;
-  font-size: 0.95rem;
-  color: var(--color-indigo-text);
-  font-weight: 600;
-  display: flex;
-  align-items: center;
-}
-
 .modal-close {
   background: transparent;
   border: none;
@@ -1056,11 +971,6 @@ function createContextMenuItems() {
 .modal-close:hover {
   background-color: rgba(108, 117, 125, 0.12);
   color: var(--color-dark);
-}
-
-.modal-body {
-  padding: 12px;
-  overflow-y: auto;
 }
 
 .modal-footer {
@@ -1158,37 +1068,6 @@ function createContextMenuItems() {
   font-size: 0.75rem;
   color: var(--color-dark);
   text-align: right;
-}
-
-/* Flamegraph modal styles */
-.modal-fade .modal-body {
-  padding-left: 4px;
-  padding-right: 4px;
-  overflow: hidden;
-}
-
-.modal-body-content {
-  overflow: auto;
-}
-
-/* Add a subtle animation to the modal */
-.modal.fade .modal-dialog {
-  transition: transform 0.25s ease-out;
-  transform: translate(0, -40px);
-}
-
-.modal.show .modal-dialog {
-  transform: none;
-}
-
-/* Custom header styling */
-.modal-header {
-  background-color: var(--color-light);
-  border-bottom: 1px solid var(--color-border);
-}
-
-.modal-title {
-  font-weight: 600;
 }
 
 @keyframes modalFadeIn {

--- a/jeffrey-microscope/pages-microscope/src/components/ThreadComponent.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/ThreadComponent.vue
@@ -26,6 +26,7 @@ import ThreadPeriod from '@/services/api/model/ThreadPeriod';
 import ThreadRow from '@/services/thread/ThreadRow';
 import Badge from '@shared/components/Badge.vue';
 import PrimaryFlamegraphClient from '@/services/api/PrimaryFlamegraphClient';
+import ProfileThreadClient from '@/services/api/ProfileThreadClient';
 import FlamegraphTooltip from '@/services/flamegraphs/tooltips/FlamegraphTooltip';
 import FlamegraphTooltipFactory from '@/services/flamegraphs/tooltips/FlamegraphTooltipFactory';
 import GraphUpdater from '@/services/flamegraphs/updater/GraphUpdater';
@@ -45,18 +46,28 @@ const props = withDefaults(
     threadRow: ThreadRowData;
     /** How many threads this lane stands for; 1 means an ordinary thread. */
     threadCount?: number;
+    /** The group a collapsed lane stands for, which is what its requests are scoped by. */
+    groupKey?: string | null;
     expanded?: boolean;
   }>(),
-  { threadCount: 1, expanded: false }
+  { threadCount: 1, groupKey: null, expanded: false }
 );
 
 defineEmits<{ toggle: [] }>();
 
 /**
- * A lane standing for several threads has no thread of its own, so the actions that act on one —
- * the flamegraph and the thread info — are not offered until it is opened.
+ * A lane standing for several threads has no thread of its own: its {@link ThreadInfo} carries
+ * placeholder ids. Everything that would otherwise be scoped by those ids — the flamegraph, the
+ * band tooltips, the thread details — is scoped by the group instead.
  */
 const collapsed = computed(() => props.threadCount > 1);
+
+const threadGroup = computed<string | null>(() => (collapsed.value ? props.groupKey : null));
+
+/** How many of a group's threads the details modal lists at a time. */
+const MEMBER_PAGE_SIZE = 50;
+
+const threadClient = new ProfileThreadClient(props.primaryProfileId);
 
 const route = useRoute();
 
@@ -70,6 +81,12 @@ const flameMenuPosition = ref({
 const contextMenuItems = createContextMenuItems();
 
 const canvasId = ref(`thread-canvas-${props.index}`);
+
+/**
+ * Keyed by the lane's position rather than by a thread id: a collapsed lane has no id of its own, so
+ * every one of them would otherwise open the same modal.
+ */
+const flamegraphModalId = ref(`flamegraphModal-${props.index}`);
 
 const showFlamegraphDialog = ref(false);
 
@@ -142,7 +159,8 @@ onMounted(() => {
     props.primaryProfileId,
     props.threadCommon,
     props.threadRow,
-    canvasId.value
+    canvasId.value,
+    threadGroup.value
   );
   threadRowRenderer.draw();
 
@@ -177,8 +195,79 @@ const toggleFlamegraphMenu = (event: MouseEvent) => {
   showFlameMenu.value = !showFlameMenu.value;
 };
 
+/**
+ * The threads behind a collapsed lane, listed a page at a time — a pool can hold hundreds of them,
+ * and the lane itself only ever knew how many there were.
+ */
+const members = ref<ThreadRowData[]>([]);
+const matchedMembers = ref(0);
+const loadingMembers = ref(false);
+const membersError = ref<string | null>(null);
+
+const hasMoreMembers = computed(() => members.value.length < matchedMembers.value);
+
+function loadMembers(): void {
+  const group = threadGroup.value;
+  if (group === null || loadingMembers.value) {
+    return;
+  }
+
+  loadingMembers.value = true;
+  membersError.value = null;
+  threadClient
+    .members({
+      group: group,
+      sort: 'EVENT_COUNT',
+      offset: members.value.length,
+      limit: MEMBER_PAGE_SIZE
+    })
+    .then(page => {
+      members.value = members.value.concat(page.rows);
+      matchedMembers.value = page.matchedCount;
+    })
+    .catch(() => {
+      membersError.value = 'Threads of this group could not be loaded.';
+    })
+    .finally(() => {
+      loadingMembers.value = false;
+    });
+}
+
+/** What a thread reports for an id it never got. */
+const UNKNOWN_THREAD_ID = -1;
+
+function memberKey(member: ThreadRowData): string {
+  return `${member.threadInfo.javaId}-${member.threadInfo.osId}`;
+}
+
+/**
+ * Every thread in a group carries the same name, so a member is told apart by its ids. A thread can
+ * be missing either one — a native thread never got a Java id, a virtual thread has no OS id.
+ */
+function memberIds(member: ThreadRowData): string {
+  const ids = [];
+  if (Number(member.threadInfo.javaId) !== UNKNOWN_THREAD_ID) {
+    ids.push(`Java ID ${member.threadInfo.javaId}`);
+  }
+  if (Number(member.threadInfo.osId) !== UNKNOWN_THREAD_ID) {
+    ids.push(`OS ID ${member.threadInfo.osId}`);
+  }
+  return ids.length > 0 ? ids.join(' · ') : 'No thread id';
+}
+
+const memberSummary = computed(() => {
+  if (loadingMembers.value && members.value.length === 0) {
+    return 'Loading threads…';
+  }
+  const shown = members.value.length.toLocaleString();
+  return `Showing ${shown} of ${matchedMembers.value.toLocaleString()} threads in this lane`;
+});
+
 const openInfoModal = () => {
   showInfoModal.value = true;
+  if (collapsed.value && members.value.length === 0) {
+    loadMembers();
+  }
 };
 
 const executeMenuItem = (item: any) => {
@@ -200,7 +289,7 @@ const closeModal = () => {
 watch(showFlamegraphDialog, isVisible => {
   if (isVisible) {
     if (!modalInstance) {
-      const modalEl = document.getElementById('flamegraphModal-' + props.threadRow.threadInfo.osId);
+      const modalEl = document.getElementById(flamegraphModalId.value);
       if (modalEl) {
         modalInstance = new bootstrap.Modal(modalEl);
       }
@@ -242,7 +331,8 @@ const showFlamegraph = (eventCode: string) => {
     false,
     false,
     false,
-    props.threadRow.threadInfo
+    props.threadRow.threadInfo,
+    threadGroup.value
   );
 
   graphUpdater = new FullGraphUpdater(flamegraphClient, false);
@@ -354,22 +444,18 @@ function createContextMenuItems() {
     <div class="thread-card">
       <div class="thread-header">
         <div class="thread-actions">
-          <!-- A collapsed lane has no thread of its own, so the actions that need one are not
-               offered on it. They come back on every member once the lane is opened. -->
           <button
-            v-if="!collapsed"
             class="action-btn flame-btn"
             type="button"
-            title="Show flamegraph"
+            :title="collapsed ? 'Show flamegraph for all threads in the group' : 'Show flamegraph'"
             @click="toggleFlamegraphMenu"
           >
             <i class="bi bi-fire"></i>
           </button>
           <button
-            v-if="!collapsed"
             class="action-btn info-btn"
             type="button"
-            title="Thread information"
+            :title="collapsed ? 'Group information' : 'Thread information'"
             @click="openInfoModal"
           >
             <i class="bi bi-question-circle"></i>
@@ -429,22 +515,34 @@ function createContextMenuItems() {
       </div>
 
       <div class="section-header px-3 py-2 bg-white border-bottom border-light">
-        <span class="section-title fw-semibold">Thread Details</span>
+        <span class="section-title fw-semibold">{{
+          collapsed ? 'Group Details' : 'Thread Details'
+        }}</span>
       </div>
 
+      <!-- A collapsed lane has no ids of its own, so it is described by its group instead. The
+           counts below already cover every thread behind it — they are the lane's own bands. -->
       <div class="tooltip-content">
         <div class="tooltip-row d-flex px-3 py-2">
           <span class="field-name text-secondary fw-medium">Name:</span>
           <span class="field-value text-dark">{{ threadInfo.name }}</span>
         </div>
-        <div class="tooltip-row d-flex px-3 py-2">
-          <span class="field-name text-secondary fw-medium">Java ID:</span>
-          <span class="field-value text-dark">{{ threadInfo.javaId }}</span>
-        </div>
-        <div class="tooltip-row d-flex px-3 py-2">
-          <span class="field-name text-secondary fw-medium">OS ID:</span>
-          <span class="field-value text-dark">{{ threadInfo.osId }}</span>
-        </div>
+        <template v-if="collapsed">
+          <div class="tooltip-row d-flex px-3 py-2">
+            <span class="field-name text-secondary fw-medium">Threads:</span>
+            <span class="field-value text-dark">{{ threadCount }}</span>
+          </div>
+        </template>
+        <template v-else>
+          <div class="tooltip-row d-flex px-3 py-2">
+            <span class="field-name text-secondary fw-medium">Java ID:</span>
+            <span class="field-value text-dark">{{ threadInfo.javaId }}</span>
+          </div>
+          <div class="tooltip-row d-flex px-3 py-2">
+            <span class="field-name text-secondary fw-medium">OS ID:</span>
+            <span class="field-value text-dark">{{ threadInfo.osId }}</span>
+          </div>
+        </template>
       </div>
 
       <div
@@ -591,6 +689,50 @@ function createContextMenuItems() {
         </div>
       </div>
 
+      <!-- The threads behind the lane. They all share a name, so each is listed by its ids and by
+           how much of the lane it accounts for. -->
+      <template v-if="collapsed">
+        <div class="section-header px-3 py-2 bg-white border-top border-bottom border-light">
+          <span class="section-title fw-semibold">Threads</span>
+        </div>
+
+        <div v-if="membersError" class="member-message px-3 py-2 text-danger small">
+          {{ membersError }}
+        </div>
+
+        <div class="member-list">
+          <div
+            v-for="member in members"
+            :key="memberKey(member)"
+            class="member-row d-flex px-3 py-2"
+          >
+            <span class="member-ids text-dark">{{ memberIds(member) }}</span>
+            <span class="member-events text-muted small ms-auto"
+              >{{ member.eventsCount }} event{{ member.eventsCount !== 1 ? 's' : '' }}</span
+            >
+          </div>
+        </div>
+
+        <div class="member-message d-flex align-items-center px-3 py-2">
+          <span class="text-muted small">{{ memberSummary }}</span>
+          <button
+            v-if="hasMoreMembers"
+            class="btn btn-sm btn-outline-primary ms-auto"
+            type="button"
+            :disabled="loadingMembers"
+            @click="loadMembers"
+          >
+            <span
+              v-if="loadingMembers"
+              class="spinner-border spinner-border-sm me-2"
+              role="status"
+              aria-hidden="true"
+            ></span>
+            Show {{ matchedMembers - members.length }} more
+          </button>
+        </div>
+      </template>
+
       <div class="modal-footer">
         <button type="button" class="btn btn-sm btn-secondary" @click="showInfoModal = false">
           Close
@@ -602,7 +744,7 @@ function createContextMenuItems() {
   <!-- Modal for events that contain StackTrace field -->
   <div
     class="modal fade"
-    :id="'flamegraphModal-' + props.threadRow.threadInfo.osId"
+    :id="flamegraphModalId"
     tabindex="-1"
     aria-labelledby="flamegraphModalLabel"
     aria-hidden="true"
@@ -937,6 +1079,31 @@ function createContextMenuItems() {
   font-size: 0.8rem;
   color: var(--color-grey-text);
   letter-spacing: 0.01em;
+}
+
+/* The threads behind a collapsed lane. A pool can hold hundreds, so the list scrolls on its own
+   instead of pushing the footer off the modal. */
+.member-list {
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.member-row {
+  font-size: 0.8rem;
+  border-bottom: 1px solid var(--color-border-light);
+}
+
+.member-row:last-child {
+  border-bottom: none;
+}
+
+.member-ids {
+  font-variant-numeric: tabular-nums;
+}
+
+.member-message {
+  font-size: 0.8rem;
+  border-top: 1px solid var(--color-border-light);
 }
 
 .section-title {

--- a/jeffrey-microscope/pages-microscope/src/components/ThreadComponent.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/ThreadComponent.vue
@@ -24,6 +24,7 @@ import { useRoute } from 'vue-router';
 import ThreadCommon from '@/services/api/model/ThreadCommon';
 import ThreadPeriod from '@/services/api/model/ThreadPeriod';
 import ThreadRow from '@/services/thread/ThreadRow';
+import Badge from '@shared/components/Badge.vue';
 import PrimaryFlamegraphClient from '@/services/api/PrimaryFlamegraphClient';
 import FlamegraphTooltip from '@/services/flamegraphs/tooltips/FlamegraphTooltip';
 import FlamegraphTooltipFactory from '@/services/flamegraphs/tooltips/FlamegraphTooltipFactory';
@@ -35,13 +36,27 @@ import SearchBarComponent from '@/components/SearchBarComponent.vue';
 import * as bootstrap from 'bootstrap';
 import TimeseriesEventAxeFormatter from '@/services/timeseries/TimeseriesEventAxeFormatter.ts';
 
-const props = defineProps<{
-  index: number;
-  projectId: string;
-  primaryProfileId: string;
-  threadCommon: ThreadCommon;
-  threadRow: ThreadRowData;
-}>();
+const props = withDefaults(
+  defineProps<{
+    index: number;
+    projectId: string;
+    primaryProfileId: string;
+    threadCommon: ThreadCommon;
+    threadRow: ThreadRowData;
+    /** How many threads this lane stands for; 1 means an ordinary thread. */
+    threadCount?: number;
+    expanded?: boolean;
+  }>(),
+  { threadCount: 1, expanded: false }
+);
+
+defineEmits<{ toggle: [] }>();
+
+/**
+ * A lane standing for several threads has no thread of its own, so the actions that act on one —
+ * the flamegraph and the thread info — are not offered until it is opened.
+ */
+const collapsed = computed(() => props.threadCount > 1);
 
 const route = useRoute();
 
@@ -339,7 +354,10 @@ function createContextMenuItems() {
     <div class="thread-card">
       <div class="thread-header">
         <div class="thread-actions">
+          <!-- A collapsed lane has no thread of its own, so the actions that need one are not
+               offered on it. They come back on every member once the lane is opened. -->
           <button
+            v-if="!collapsed"
             class="action-btn flame-btn"
             type="button"
             title="Show flamegraph"
@@ -348,6 +366,7 @@ function createContextMenuItems() {
             <i class="bi bi-fire"></i>
           </button>
           <button
+            v-if="!collapsed"
             class="action-btn info-btn"
             type="button"
             title="Thread information"
@@ -356,7 +375,18 @@ function createContextMenuItems() {
             <i class="bi bi-question-circle"></i>
           </button>
         </div>
+        <button
+          v-if="collapsed"
+          class="thread-disclosure"
+          type="button"
+          :aria-expanded="expanded"
+          :title="expanded ? 'Collapse threads' : 'Show threads'"
+          @click="$emit('toggle')"
+        >
+          <i class="bi" :class="expanded ? 'bi-chevron-down' : 'bi-chevron-right'"></i>
+        </button>
         <h6 class="thread-title" :title="threadInfo.name">{{ threadInfo.name }}</h6>
+        <Badge v-if="collapsed" :value="`${threadCount} threads`" variant="primary" size="xs" />
       </div>
       <div class="thread-content">
         <div :id="canvasId" class="thread-canvas"></div>
@@ -635,9 +665,35 @@ function createContextMenuItems() {
 .thread-header {
   display: flex;
   align-items: center;
+  gap: 6px;
   padding: 6px 10px;
   background-color: var(--color-light);
   border-bottom: 1px solid var(--color-border);
+}
+
+/* Opens a collapsed lane into the threads behind it. */
+.thread-disclosure {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+}
+
+.thread-disclosure:hover {
+  background-color: var(--color-border);
+  color: var(--color-text);
+}
+
+.thread-disclosure:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 1px;
 }
 
 .thread-actions {

--- a/jeffrey-microscope/pages-microscope/src/services/api/FlamegraphClients.test.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/FlamegraphClients.test.ts
@@ -86,6 +86,7 @@ describe('PrimaryFlamegraphClient payloads', () => {
         excludeIdleSamples: false,
         onlyUnsafeAllocationSamples: true,
         threadInfo: null,
+        threadGroup: null,
         components: 'BOTH'
       })
     );
@@ -107,6 +108,7 @@ describe('PrimaryFlamegraphClient payloads', () => {
         excludeIdleSamples: false,
         onlyUnsafeAllocationSamples: true,
         threadInfo: null,
+        threadGroup: null,
         components: 'BOTH'
       })
     );
@@ -125,6 +127,7 @@ describe('PrimaryFlamegraphClient payloads', () => {
         excludeIdleSamples: false,
         onlyUnsafeAllocationSamples: true,
         threadInfo: null,
+        threadGroup: null,
         components: 'FLAMEGRAPH_ONLY'
       })
     );
@@ -144,6 +147,7 @@ describe('PrimaryFlamegraphClient payloads', () => {
         excludeIdleSamples: false,
         onlyUnsafeAllocationSamples: true,
         threadInfo: null,
+        threadGroup: null,
         components: 'TIMESERIES_ONLY'
       })
     );
@@ -188,6 +192,42 @@ describe('PrimaryFlamegraphClient payloads', () => {
         excludeIdleSamples: false,
         onlyUnsafeAllocationSamples: true,
         threadInfo: null,
+        threadGroup: null,
+        components: 'FLAMEGRAPH_ONLY'
+      })
+    );
+  });
+
+  /**
+   * A graph opened from a collapsed timeline lane names the group instead of a thread — the lane has
+   * no thread of its own, and the page holds at most a slice of its members.
+   */
+  it('a graph scoped to a thread group names the group', async () => {
+    const grouped = new PrimaryFlamegraphClient(
+      'p1',
+      'jdk.ExecutionSample',
+      true,
+      false,
+      true,
+      false,
+      true,
+      null,
+      'oracleApp:connection-adder*'
+    );
+
+    await grouped.provide(null);
+
+    expect(lastPost().bodyJson).toBe(
+      expectJson({
+        eventType: 'jdk.ExecutionSample',
+        useWeight: false,
+        useThreadMode: true,
+        timeRange: null,
+        excludeNonJavaSamples: true,
+        excludeIdleSamples: false,
+        onlyUnsafeAllocationSamples: true,
+        threadInfo: null,
+        threadGroup: 'oracleApp:connection-adder*',
         components: 'FLAMEGRAPH_ONLY'
       })
     );

--- a/jeffrey-microscope/pages-microscope/src/services/api/PrimaryFlamegraphClient.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/PrimaryFlamegraphClient.ts
@@ -30,6 +30,12 @@ export default class PrimaryFlamegraphClient extends RemoteFlamegraphClient {
   private readonly excludeIdleSamples: boolean;
   private readonly onlyUnsafeAllocationSamples: boolean;
   private readonly threadInfo: ThreadInfo | null;
+  /**
+   * Set instead of threadInfo when the graph is opened from a collapsed timeline lane. The lane has
+   * no thread of its own and the page holds at most a slice of its members, so it names the group
+   * and the server resolves every thread behind it.
+   */
+  private readonly threadGroup: string | null;
 
   constructor(
     profileId: string,
@@ -39,7 +45,8 @@ export default class PrimaryFlamegraphClient extends RemoteFlamegraphClient {
     excludeNonJavaSamples: boolean,
     excludeIdleSamples: boolean,
     onlyUnsafeAllocationSamples: boolean,
-    threadInfo: ThreadInfo | null
+    threadInfo: ThreadInfo | null,
+    threadGroup: string | null = null
   ) {
     super(GlobalVars.internalUrl + '/profiles/' + profileId + '/flamegraph');
     this.eventType = eventType;
@@ -49,6 +56,7 @@ export default class PrimaryFlamegraphClient extends RemoteFlamegraphClient {
     this.excludeIdleSamples = excludeIdleSamples;
     this.onlyUnsafeAllocationSamples = onlyUnsafeAllocationSamples;
     this.threadInfo = threadInfo;
+    this.threadGroup = threadGroup;
   }
 
   protected bothContent(
@@ -66,6 +74,7 @@ export default class PrimaryFlamegraphClient extends RemoteFlamegraphClient {
       excludeIdleSamples: this.excludeIdleSamples,
       onlyUnsafeAllocationSamples: this.onlyUnsafeAllocationSamples,
       threadInfo: this.threadInfo,
+      threadGroup: this.threadGroup,
       components: components
     };
   }

--- a/jeffrey-microscope/pages-microscope/src/services/api/ProfileThreadClient.test.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/ProfileThreadClient.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import axios from 'axios';
+import ProfileThreadClient from '@/services/api/ProfileThreadClient';
+import ThreadInfo from '@/services/api/model/ThreadInfo';
+import ThreadPeriod from '@/services/api/model/ThreadPeriod';
+
+vi.mock('axios', () => ({
+  default: {
+    get: vi.fn()
+  }
+}));
+
+const THREAD = new ThreadInfo('oracleApp:connection-adder-13', 13, '42');
+const BAND = new ThreadPeriod(1_000, 250, 4);
+
+function getMock() {
+  return vi.mocked(axios.get);
+}
+
+function lastParams(): Record<string, unknown> {
+  const calls = getMock().mock.calls;
+  const [, config] = calls[calls.length - 1];
+  return (config as { params: Record<string, unknown> }).params;
+}
+
+beforeEach(() => {
+  getMock().mockReset();
+  getMock().mockResolvedValue({ data: [] });
+});
+
+describe('bandEvents', () => {
+  it('names the hovered thread by its ids', async () => {
+    await new ProfileThreadClient('p1').bandEvents(THREAD, 'PARKED', BAND);
+
+    expect(lastParams()).toEqual({
+      osId: '42',
+      javaId: 13,
+      state: 'PARKED',
+      from: 1_000,
+      to: 1_250,
+      limit: 1
+    });
+  });
+
+  /**
+   * A band on a collapsed lane belongs to the group rather than to a thread. The lane's own ids are
+   * placeholders that match no real thread, so they must not travel with the request.
+   */
+  it('names the group when the band belongs to a collapsed lane', async () => {
+    const lane = new ThreadInfo('oracleApp:connection-adder*', -1, '-1');
+
+    await new ProfileThreadClient('p1').bandEvents(
+      lane,
+      'SOCKET_READ',
+      BAND,
+      1,
+      'oracleApp:connection-adder*'
+    );
+
+    expect(lastParams()).toEqual({
+      group: 'oracleApp:connection-adder*',
+      state: 'SOCKET_READ',
+      from: 1_000,
+      to: 1_250,
+      limit: 1
+    });
+  });
+});

--- a/jeffrey-microscope/pages-microscope/src/services/api/ProfileThreadClient.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/ProfileThreadClient.ts
@@ -74,16 +74,20 @@ export default class ProfileThreadClient extends BaseProfileClient {
   /**
    * The events behind a single timeline band, for its tooltip. The timeline itself carries only
    * rectangles and event counts, so the fields are fetched for the band under the pointer.
+   *
+   * A band on a collapsed lane belongs to the group rather than to a thread, so it names the group
+   * instead: the lane's own {@link ThreadInfo} carries placeholder ids that match no real thread.
    */
   public bandEvents(
     threadInfo: ThreadInfo,
     state: ThreadEventState,
     band: ThreadPeriod,
-    limit = 1
+    limit = 1,
+    group: string | null = null
   ): Promise<ThreadEventDetail[]> {
+    const target = group ? { group: group } : { osId: threadInfo.osId, javaId: threadInfo.javaId };
     return this.get<ThreadEventDetail[]>('/events', {
-      osId: threadInfo.osId,
-      javaId: threadInfo.javaId,
+      ...target,
       state: state,
       from: band.startOffset,
       to: band.startOffset + band.width,

--- a/jeffrey-microscope/pages-microscope/src/services/api/ProfileThreadClient.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/ProfileThreadClient.ts
@@ -27,6 +27,7 @@ import type ThreadEventDetail from '@/services/api/model/ThreadEventDetail';
 import type { ThreadEventState } from '@/services/api/model/ThreadEventDetail';
 import type ThreadInfo from '@/services/api/model/ThreadInfo';
 import type ThreadPeriod from '@/services/api/model/ThreadPeriod';
+import type { ThreadGroupResponse } from '@/services/api/model/ThreadGroupData';
 
 export default class ProfileThreadClient extends BaseProfileClient {
   constructor(profileId: string) {
@@ -34,18 +35,37 @@ export default class ProfileThreadClient extends BaseProfileClient {
   }
 
   /**
-   * One page of threads, ordered and filtered by the server. Both have to happen there: a client
-   * that holds a single page can only sort and filter that page.
+   * One page of lanes — a lane per group of identically named threads — ordered and filtered by the
+   * server. Both have to happen there: a client that holds a single page can only sort and filter
+   * that page.
    */
   public list(page: {
     sort: ThreadSort;
     nameFilter?: string;
     offset?: number;
     limit?: number;
-  }): Promise<ThreadResponse> {
-    return this.get<ThreadResponse>('', {
+  }): Promise<ThreadGroupResponse> {
+    return this.get<ThreadGroupResponse>('', {
       sort: page.sort,
       nameFilter: page.nameFilter ?? '',
+      offset: page.offset ?? 0,
+      limit: page.limit ?? 50
+    });
+  }
+
+  /**
+   * The threads behind one collapsed lane. Paged like the lanes themselves, because opening a pool
+   * of 351 workers would otherwise put 351 lanes on the page.
+   */
+  public members(page: {
+    group: string;
+    sort: ThreadSort;
+    offset?: number;
+    limit?: number;
+  }): Promise<ThreadResponse> {
+    return this.get<ThreadResponse>('/members', {
+      group: page.group,
+      sort: page.sort,
       offset: page.offset ?? 0,
       limit: page.limit ?? 50
     });

--- a/jeffrey-microscope/pages-microscope/src/services/api/model/ThreadGroupData.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/model/ThreadGroupData.ts
@@ -1,0 +1,42 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import ThreadRowData from '@/services/api/model/ThreadRowData';
+
+/**
+ * One lane on the timeline, standing for every thread that shares a name.
+ *
+ * `lane` is shaped exactly like a single thread's row, so a group draws the same way a thread does.
+ * For a group of one it *is* that thread's row, ids included — which is what keeps the flamegraph
+ * and thread-info actions working on threads that were never collapsed.
+ */
+export default interface ThreadGroupData {
+  key: string;
+  threadCount: number;
+  lane: ThreadRowData;
+}
+
+/** One page of lanes, plus what the footer needs to describe the rest. */
+export interface ThreadGroupResponse {
+  common: import('@/services/api/model/ThreadCommon').default;
+  groups: ThreadGroupData[];
+  offset: number;
+  matchedGroups: number;
+  totalGroups: number;
+  totalThreads: number;
+}

--- a/jeffrey-microscope/pages-microscope/src/services/flamegraphs/FlameUtils.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/flamegraphs/FlameUtils.ts
@@ -26,16 +26,31 @@ export default class FlameUtils {
     }
   }
 
+  /**
+   * Follows the scroll position of the element the graph sits in, so the tooltip and the highlight
+   * stay on the frame under the pointer. The id of that element, not a class, despite the name the
+   * callers pass it under.
+   *
+   * <p>A caller without a scroll container passes null, and one whose container is not in the DOM
+   * gets the same treatment: this runs inside the graph updater's init callback, so throwing here
+   * would strand the "Generating Flamegraph..." preloader on a graph that has already drawn.
+   */
   static registerAdjustableScrollableComponent(
     flamegraph: Flamegraph,
     scrollableComponent: string | null
   ) {
-    if (scrollableComponent != null) {
-      const el = document.querySelector('#' + scrollableComponent)!;
-      el.addEventListener('scroll', () => {
-        flamegraph.updateScrollPositionY(el.scrollTop);
-        flamegraph.removeHighlight();
-      });
+    if (scrollableComponent == null) {
+      return;
     }
+
+    const el = document.getElementById(scrollableComponent);
+    if (el == null) {
+      return;
+    }
+
+    el.addEventListener('scroll', () => {
+      flamegraph.updateScrollPositionY(el.scrollTop);
+      flamegraph.removeHighlight();
+    });
   }
 }

--- a/jeffrey-microscope/pages-microscope/src/services/flamegraphs/FlameUtils.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/flamegraphs/FlameUtils.ts
@@ -49,7 +49,7 @@ export default class FlameUtils {
     }
 
     el.addEventListener('scroll', () => {
-      flamegraph.updateScrollPositionY(el.scrollTop);
+      flamegraph.onScroll();
       flamegraph.removeHighlight();
     });
   }

--- a/jeffrey-microscope/pages-microscope/src/services/flamegraphs/Flamegraph.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/flamegraphs/Flamegraph.ts
@@ -43,7 +43,6 @@ export default class Flamegraph {
   private canvasHeight: number | null = null;
   private canvasWidth: number | null = null;
   private pxPerSample: number | null = null;
-  private currentScrollY: number = 0;
 
   private hlFrame: Frame | null = null;
   private contextFrame: Frame | null = null;
@@ -175,7 +174,7 @@ export default class Flamegraph {
           this.levels[0][0].totalWeight
         );
 
-        this.tooltip.showTooltip(event, this.currentScrollY, tooltipContent);
+        this.tooltip.showTooltip(event, tooltipContent);
 
         this.canvas.style.cursor = 'pointer';
         this.canvas.onclick = () => {
@@ -219,12 +218,14 @@ export default class Flamegraph {
     return this.skipRootInCanvas ? 1 : 0;
   }
 
-  updateScrollPositionY(value: number) {
+  /**
+   * The graph's container scrolled. Anything anchored to a frame's old position — the tooltip, the
+   * context menu — is dismissed rather than dragged along.
+   */
+  onScroll() {
     this.tooltip.hideTooltip();
     this.closeContextMenu();
     this.contextMenu.hide();
-
-    this.currentScrollY = value;
   }
 
   removeHighlight() {

--- a/jeffrey-microscope/pages-microscope/src/services/thread/ThreadBandDetails.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/thread/ThreadBandDetails.ts
@@ -32,12 +32,18 @@ import type ThreadPeriod from '@/services/api/model/ThreadPeriod';
 export default class ThreadBandDetails {
   private readonly client: ProfileThreadClient;
   private readonly threadInfo: ThreadInfo;
+  /**
+   * Set on a collapsed lane, whose bands stand for a whole group of threads. The lane's own ids are
+   * placeholders that match nothing, so the group is what the lookup goes by.
+   */
+  private readonly group: string | null;
   private readonly resolved = new Map<string, ThreadEventDetail | null>();
   private readonly inFlight = new Map<string, Promise<ThreadEventDetail | null>>();
 
-  constructor(profileId: string, threadInfo: ThreadInfo) {
+  constructor(profileId: string, threadInfo: ThreadInfo, group: string | null = null) {
     this.client = new ProfileThreadClient(profileId);
     this.threadInfo = threadInfo;
+    this.group = group;
   }
 
   /**
@@ -69,7 +75,7 @@ export default class ThreadBandDetails {
     }
 
     const request = this.client
-      .bandEvents(this.threadInfo, state, band)
+      .bandEvents(this.threadInfo, state, band, 1, this.group)
       .then(events => (events.length > 0 ? events[0] : null))
       .catch(() => null)
       .then(detail => {

--- a/jeffrey-microscope/pages-microscope/src/services/thread/ThreadRow.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/thread/ThreadRow.ts
@@ -147,12 +147,13 @@ export default class ThreadRow {
     profileId: string,
     threadCommon: ThreadCommon,
     threadRow: ThreadRowData,
-    canvasElementId: string
+    canvasElementId: string,
+    threadGroup: string | null = null
   ) {
     this.threadCommon = threadCommon;
     this.threadMetadata = threadCommon.metadata;
     this.threadRow = threadRow;
-    this.bandDetails = new ThreadBandDetails(profileId, threadRow.threadInfo);
+    this.bandDetails = new ThreadBandDetails(profileId, threadRow.threadInfo, threadGroup);
 
     this.konvaContainer = document.getElementById(canvasElementId) as HTMLElement;
     this.stage = this.createStage();

--- a/jeffrey-microscope/pages-microscope/src/services/thread/ThreadRow.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/thread/ThreadRow.ts
@@ -277,7 +277,7 @@ export default class ThreadRow {
       ThreadTooltips.header(threadName)
     );
 
-    this.threadTooltip.showTooltip(new TooltipPosition(pos.x, pos.y), 0, content);
+    this.threadTooltip.showTooltip(new TooltipPosition(pos.x, pos.y), content);
   }
 
   /**

--- a/jeffrey-microscope/pages-microscope/src/services/tooltip/Tooltip.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/tooltip/Tooltip.ts
@@ -49,7 +49,7 @@ export default class Tooltip {
     this.registerInteractionHandlers();
   }
 
-  public showTooltip(event: TooltipPosition, currentScrollY: number, content: string): void {
+  public showTooltip(event: TooltipPosition, content: string): void {
     this.cancelPendingHide();
 
     if (this.displayedContent === content) {
@@ -69,7 +69,7 @@ export default class Tooltip {
       this.tooltip.innerHTML = content;
       this.displayedContent = content;
       this.pendingContent = null;
-      Tooltip.placeTooltip(this.canvas, this.tooltip, event, currentScrollY);
+      Tooltip.placeTooltip(this.canvas, this.tooltip, event);
       this.applyIdeGate();
     }, 500);
   }
@@ -176,16 +176,16 @@ export default class Tooltip {
    * — leaving the part that mattered unreachable. So the height is capped first, and the side is
    * chosen by what actually fits.
    *
-   * <p>Two coordinate systems meet here. The tooltip is positioned against the canvas's offset
-   * parent, while the room available for it is measured in the window. They differ by a constant,
-   * computed once as {@code layoutOffset}: the fitting is done in window coordinates and shifted
-   * into layout coordinates at the end.
+   * <p>Two coordinate systems meet here. The room available for the tooltip is measured in the
+   * window, while the tooltip itself is positioned against its containing block. The fitting is done
+   * in window coordinates and shifted into layout ones at the end, by measuring that containing
+   * block — which already reflects every scroll between it and the window, so the result holds
+   * whichever ancestor happens to be the one that scrolls.
    */
   private static placeTooltip(
     canvas: HTMLElement,
     tooltip: HTMLElement,
-    position: TooltipPosition,
-    currentScrollY: number
+    position: TooltipPosition
   ): void {
     const viewportHeight = window.innerHeight;
     const viewportWidth = window.innerWidth;
@@ -196,7 +196,19 @@ export default class Tooltip {
     tooltip.style.maxHeight = viewportHeight - 2 * Tooltip.VIEWPORT_MARGIN + 'px';
     tooltip.style.overflowY = 'auto';
 
-    const layoutOffsetY = canvas.offsetTop - currentScrollY - canvasPos.y;
+    // Where the containing block sits in the window. An absolutely positioned element is laid out
+    // against its offsetParent's padding box, while getBoundingClientRect reports the border box —
+    // clientTop/clientLeft is that difference. With no offsetParent the document is the containing
+    // block, and its origin sits at minus the page scroll.
+    const container = tooltip.offsetParent as HTMLElement | null;
+    let containerTop = -window.scrollY;
+    let containerLeft = -window.scrollX;
+    if (container) {
+      const containerPos = container.getBoundingClientRect();
+      containerTop = containerPos.top + container.clientTop;
+      containerLeft = containerPos.left + container.clientLeft;
+    }
+
     const pointerY = canvasPos.y + position.offsetY;
     const height = tooltip.offsetHeight;
 
@@ -217,9 +229,8 @@ export default class Tooltip {
       Tooltip.VIEWPORT_MARGIN,
       viewportHeight - height - Tooltip.VIEWPORT_MARGIN
     );
-    tooltip.style.top = Math.max(clampedTop + layoutOffsetY, 0) + 'px';
+    tooltip.style.top = Math.max(clampedTop - containerTop, 0) + 'px';
 
-    const layoutOffsetX = canvas.offsetLeft - canvasPos.x;
     const pointerX = canvasPos.x + position.offsetX;
     const width = tooltip.offsetWidth;
 
@@ -233,7 +244,7 @@ export default class Tooltip {
       Tooltip.VIEWPORT_MARGIN,
       viewportWidth - width - Tooltip.VIEWPORT_MARGIN
     );
-    tooltip.style.left = clampedLeft + layoutOffsetX + 'px';
+    tooltip.style.left = clampedLeft - containerLeft + 'px';
 
     tooltip.style.visibility = 'visible';
   }

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileThreadsTimeline.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileThreadsTimeline.vue
@@ -64,6 +64,7 @@
             :thread-common="threadCommon as ThreadCommon"
             :thread-row="group.lane"
             :thread-count="group.threadCount"
+            :group-key="group.key"
             :expanded="isExpanded(group.key)"
             @toggle="toggleGroup(group.key)"
           />

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileThreadsTimeline.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileThreadsTimeline.vue
@@ -56,21 +56,60 @@
       <ErrorState v-else-if="error" :message="error" />
 
       <div v-else :key="forceRenderThreads" class="thread-components-container">
-        <div v-for="(threadRow, index) in threadRows" :key="index" class="thread-row-wrapper">
+        <div v-for="(group, index) in groups" :key="group.key" class="thread-row-wrapper">
           <ThreadComponent
             :index="index"
             :project-id="projectId"
             :primary-profile-id="profileId"
             :thread-common="threadCommon as ThreadCommon"
-            :thread-row="threadRow"
+            :thread-row="group.lane"
+            :thread-count="group.threadCount"
+            :expanded="isExpanded(group.key)"
+            @toggle="toggleGroup(group.key)"
           />
+
+          <!-- The threads behind an opened lane, paged the same way the lanes are. -->
+          <div v-if="isExpanded(group.key)" class="group-members">
+            <div
+              v-for="(member, memberIndex) in membersOf(group.key)"
+              :key="member.threadInfo.osId + '-' + member.threadInfo.javaId"
+              class="thread-row-wrapper"
+            >
+              <ThreadComponent
+                :index="1000 * (index + 1) + memberIndex"
+                :project-id="projectId"
+                :primary-profile-id="profileId"
+                :thread-common="threadCommon as ThreadCommon"
+                :thread-row="member"
+              />
+            </div>
+
+            <div class="page-summary members-summary">
+              <span class="page-summary-text">{{ memberSummary(group) }}</span>
+              <button
+                v-if="groupHasMore(group)"
+                class="btn btn-sm btn-outline-primary"
+                :disabled="isLoadingMembers(group.key)"
+                @click="loadMoreMembers(group.key)"
+              >
+                <span
+                  v-if="isLoadingMembers(group.key)"
+                  class="spinner-border spinner-border-sm me-2"
+                  role="status"
+                ></span>
+                {{
+                  isLoadingMembers(group.key) ? 'Loading…' : `Show ${nextMemberPage(group)} more`
+                }}
+              </button>
+            </div>
+          </div>
         </div>
 
         <EmptyState
           v-if="loadedCount === 0 && isFiltered"
           icon="bi-search"
           title="No threads match the filter"
-          :description="`Nothing in this recording's ${totalCount.toLocaleString()} threads contains &quot;${fulltextFilter}&quot;.`"
+          :description="`Nothing in this recording's ${totalThreads.toLocaleString()} threads contains &quot;${fulltextFilter}&quot;.`"
         />
         <EmptyState
           v-else-if="loadedCount === 0"
@@ -118,8 +157,9 @@
         <AboutSection icon="bi-bar-chart-steps" title="Reading the Timeline">
           <FeatureGrid>
             <FeatureCard icon="bi-list" variant="primary" title="Rows are threads">
-              One lane per thread, labelled by name. Filter and sort to bring the threads you care
-              about to the top.
+              One lane per thread — or, where a pool runs many threads under one name, a single lane
+              standing for all of them. Filter and sort to bring the threads you care about to the
+              top.
             </FeatureCard>
             <FeatureCard icon="bi-palette" variant="info" title="Colours are activity">
               Each colour is an event category (CPU sample, monitor block, park, socket/file I/O) —
@@ -138,10 +178,15 @@
 
         <AboutSection icon="bi-layers" title="Working with Large Recordings">
           <FeatureGrid>
-            <FeatureCard icon="bi-sort-down" variant="primary" title="Busiest threads first">
-              A recording can hold thousands of threads, so the page loads 50 at a time in the order
-              you picked and appends the next 50 on request. The footer says how many of the
-              recording's threads you are looking at.
+            <FeatureCard icon="bi-collection" variant="primary" title="Pools share a lane">
+              Threads a pool runs under one name — <code>oracleApp:connection-adder</code>, or a
+              numbered set like <code>http-nio-8080-exec-17</code> — collapse into one lane carrying
+              all their activity. Open it to see the threads behind it, 50 at a time.
+            </FeatureCard>
+            <FeatureCard icon="bi-sort-down" variant="info" title="Busiest lanes first">
+              The page loads 50 lanes at a time in the order you picked and appends the next 50 on
+              request. The footer says how many lanes you are looking at, and how many threads they
+              stand for.
             </FeatureCard>
             <FeatureCard icon="bi-funnel" variant="info" title="Sort and filter search everything">
               Both run against the whole recording, not the threads already on screen — a thread
@@ -320,6 +365,7 @@ import ProfileThreadClient from '@/services/api/ProfileThreadClient.ts';
 import ThreadComponent from '@/components/ThreadComponent.vue';
 import ThreadCommon from '@/services/api/model/ThreadCommon';
 import ThreadRowData from '@/services/api/model/ThreadRowData';
+import type ThreadGroupData from '@/services/api/model/ThreadGroupData';
 import type { ThreadSort } from '@/services/api/model/ThreadResponse';
 import Konva from 'konva';
 import ThreadRow from '@/services/thread/ThreadRow';
@@ -376,15 +422,22 @@ const SORTINGS: { label: string; sort: ThreadSort }[] = [
 
 const profileId = route.params.profileId as string;
 
-const threadRows = ref<ThreadRowData[]>();
+const groups = ref<ThreadGroupData[]>();
 const threadCommon = ref<ThreadCommon>();
 const loading = ref<boolean>(true);
 const loadingMore = ref<boolean>(false);
 const error = ref<string | null>(null);
 
-/** Threads matching the current filter, and threads in the recording — both counted server-side. */
-const matchedCount = ref<number>(0);
-const totalCount = ref<number>(0);
+/** Lanes matching the current filter, and what the recording holds — all counted server-side. */
+const matchedGroups = ref<number>(0);
+const totalThreads = ref<number>(0);
+
+/**
+ * The threads behind each opened lane, keyed by group. A lane is only fetched when it is opened, and
+ * what has been fetched is kept so closing and reopening does not ask again.
+ */
+const expandedMembers = ref<Record<string, ThreadRowData[]>>({});
+const loadingMembers = ref<Record<string, boolean>>({});
 
 const activeTab = ref('timeline');
 const tabs = [
@@ -399,22 +452,51 @@ const forceRenderThreads = ref<number>(0);
 
 const infoDialogVisible = ref<boolean>(false);
 
-const loadedCount = computed(() => threadRows.value?.length ?? 0);
-const hasMore = computed(() => loadedCount.value < matchedCount.value);
+const loadedCount = computed(() => groups.value?.length ?? 0);
+const hasMore = computed(() => loadedCount.value < matchedGroups.value);
 const isFiltered = computed(() => fulltextFilter.value.trim().length > 0);
 
 /** The button promises exactly what is left, so the last page never says "show 50 more" for 7. */
-const nextPageSize = computed(() => Math.min(PAGE_SIZE, matchedCount.value - loadedCount.value));
+const nextPageSize = computed(() => Math.min(PAGE_SIZE, matchedGroups.value - loadedCount.value));
 
-/** Reads as "Showing 50 of 1,204 threads", and says so about the filter when one is applied. */
+/**
+ * Reads as "Showing 18 of 18 lanes · 1,204 threads" — both numbers matter, because a handful of
+ * lanes can stand for a thousand threads.
+ */
 const pageSummary = computed(() => {
   const shown = loadedCount.value.toLocaleString();
-  const matched = matchedCount.value.toLocaleString();
+  const matched = matchedGroups.value.toLocaleString();
+  const threads = totalThreads.value.toLocaleString();
   if (isFiltered.value) {
-    return `Showing ${shown} of ${matched} matching threads · ${totalCount.value.toLocaleString()} in the recording`;
+    return `Showing ${shown} of ${matched} matching lanes · ${threads} threads in the recording`;
   }
-  return `Showing ${shown} of ${matched} threads`;
+  return `Showing ${shown} of ${matched} lanes · ${threads} threads`;
 });
+
+function isExpanded(key: string): boolean {
+  return expandedMembers.value[key] !== undefined;
+}
+
+function membersOf(key: string): ThreadRowData[] {
+  return expandedMembers.value[key] ?? [];
+}
+
+function isLoadingMembers(key: string): boolean {
+  return loadingMembers.value[key] === true;
+}
+
+function groupHasMore(group: ThreadGroupData): boolean {
+  return membersOf(group.key).length < group.threadCount;
+}
+
+function nextMemberPage(group: ThreadGroupData): number {
+  return Math.min(PAGE_SIZE, group.threadCount - membersOf(group.key).length);
+}
+
+function memberSummary(group: ThreadGroupData): string {
+  const shown = membersOf(group.key).length.toLocaleString();
+  return `Showing ${shown} of ${group.threadCount.toLocaleString()} threads in this lane`;
+}
 
 let filterTimeout: ReturnType<typeof setTimeout>;
 
@@ -439,14 +521,17 @@ function currentSort(): ThreadSort {
 function loadFirstPage() {
   loading.value = true;
   error.value = null;
+  // A reorder or a new filter invalidates which lanes are on screen, so anything opened under the
+  // old set is closed rather than left attached to a lane that may no longer be there.
+  expandedMembers.value = {};
 
   threadService
     .list({ sort: currentSort(), nameFilter: fulltextFilter.value, offset: 0, limit: PAGE_SIZE })
     .then(response => {
-      threadRows.value = response.rows;
+      groups.value = response.groups;
       threadCommon.value = response.common;
-      matchedCount.value = response.matchedCount;
-      totalCount.value = response.totalCount;
+      matchedGroups.value = response.matchedGroups;
+      totalThreads.value = response.totalThreads;
       forceRenderThreads.value++;
     })
     .catch(e => {
@@ -471,15 +556,54 @@ function loadMore() {
       limit: PAGE_SIZE
     })
     .then(response => {
-      threadRows.value = [...(threadRows.value ?? []), ...response.rows];
-      matchedCount.value = response.matchedCount;
-      totalCount.value = response.totalCount;
+      groups.value = [...(groups.value ?? []), ...response.groups];
+      matchedGroups.value = response.matchedGroups;
+      totalThreads.value = response.totalThreads;
     })
     .catch(e => {
-      error.value = e instanceof Error ? e.message : 'Failed to load more threads';
+      error.value = e instanceof Error ? e.message : 'Failed to load more lanes';
     })
     .finally(() => {
       loadingMore.value = false;
+    });
+}
+
+/**
+ * Opens a lane into the threads behind it, or closes it again. Only the first page of members is
+ * fetched — a pool of 351 opens as 50 lanes, not 351.
+ */
+function toggleGroup(key: string) {
+  if (isExpanded(key)) {
+    const remaining = { ...expandedMembers.value };
+    delete remaining[key];
+    expandedMembers.value = remaining;
+    return;
+  }
+  expandedMembers.value = { ...expandedMembers.value, [key]: [] };
+  fetchMembers(key, 0);
+}
+
+function loadMoreMembers(key: string) {
+  if (isLoadingMembers(key)) {
+    return;
+  }
+  fetchMembers(key, membersOf(key).length);
+}
+
+function fetchMembers(key: string, offset: number) {
+  loadingMembers.value = { ...loadingMembers.value, [key]: true };
+
+  threadService
+    .members({ group: key, sort: currentSort(), offset: offset, limit: PAGE_SIZE })
+    .then(response => {
+      const loaded = [...membersOf(key), ...response.rows];
+      expandedMembers.value = { ...expandedMembers.value, [key]: loaded };
+    })
+    .catch(e => {
+      error.value = e instanceof Error ? e.message : 'Failed to load the threads in this lane';
+    })
+    .finally(() => {
+      loadingMembers.value = { ...loadingMembers.value, [key]: false };
     });
 }
 
@@ -539,6 +663,18 @@ function clearFilter() {
   font-size: 0.8rem;
   color: var(--color-text-muted);
   opacity: 0.75;
+}
+
+/* The threads behind an opened lane, indented so the lane still reads as their parent. */
+.group-members {
+  margin: 0 0 0.75rem 1.5rem;
+  padding-left: 0.75rem;
+  border-left: 2px solid var(--color-border);
+}
+
+.members-summary {
+  margin-top: 0.25rem;
+  padding: 0.5rem 1rem;
 }
 
 /* Modal styles */

--- a/jeffrey-microscope/profiles/common-profile/src/main/java/cafe/jeffrey/profile/common/config/GraphParameters.java
+++ b/jeffrey-microscope/profiles/common-profile/src/main/java/cafe/jeffrey/profile/common/config/GraphParameters.java
@@ -34,7 +34,9 @@ import java.util.List;
 public record GraphParameters(
         Type eventType,
         RelativeTimeRange timeRange,
-        ThreadInfo threadInfo,
+        // The threads the graph is scoped to: one for a plain thread, all of them for a lane that
+        // stands for a group of identically named threads. Empty means every thread.
+        List<ThreadInfo> threads,
         String searchPattern,
         boolean threadMode,
         Boolean useWeight,
@@ -86,7 +88,7 @@ public record GraphParameters(
         return builder()
                 .withEventType(eventType)
                 .withTimeRange(timeRange)
-                .withThreadInfo(threadInfo)
+                .withThreads(threads)
                 .withSearchPattern(searchPattern)
                 .withThreadMode(threadMode)
                 .withUseWeight(useWeight)

--- a/jeffrey-microscope/profiles/common-profile/src/main/java/cafe/jeffrey/profile/common/config/GraphParametersBuilder.java
+++ b/jeffrey-microscope/profiles/common-profile/src/main/java/cafe/jeffrey/profile/common/config/GraphParametersBuilder.java
@@ -32,7 +32,7 @@ public class GraphParametersBuilder {
 
     private Type eventType;
     private RelativeTimeRange timeRange;
-    private ThreadInfo threadInfo;
+    private List<ThreadInfo> threads = List.of();
     private String searchPattern;
     private boolean threadMode;
     private Boolean collectWeight;
@@ -58,7 +58,14 @@ public class GraphParametersBuilder {
     }
 
     public GraphParametersBuilder withThreadInfo(ThreadInfo threadInfo) {
-        this.threadInfo = threadInfo;
+        return withThreads(threadInfo == null ? List.of() : List.of(threadInfo));
+    }
+
+    /**
+     * Scopes the graph to a set of threads — everything behind one collapsed timeline lane.
+     */
+    public GraphParametersBuilder withThreads(List<ThreadInfo> threads) {
+        this.threads = threads == null ? List.of() : List.copyOf(threads);
         return this;
     }
 
@@ -131,7 +138,7 @@ public class GraphParametersBuilder {
         return new GraphParameters(
                 eventType,
                 timeRange,
-                threadInfo,
+                threads,
                 searchPattern,
                 threadMode,
                 collectWeight,

--- a/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/provider/FlamegraphDataProvider.java
+++ b/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/provider/FlamegraphDataProvider.java
@@ -113,7 +113,7 @@ public class FlamegraphDataProvider {
                 .filterStacktraceTypes(graphParameters.stacktraceTypes())
                 .filterStacktraceTags(graphParameters.stacktraceTags())
                 .withThreads(graphParameters.threadMode())
-                .withSpecifiedThread(graphParameters.threadInfo())
+                .withSpecifiedThreads(graphParameters.threads())
                 .withWeight(graphParameters.useWeight())
                 .withSpanIntervals(graphParameters.spanIntervals());
 

--- a/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/provider/TimeseriesDataProvider.java
+++ b/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/provider/TimeseriesDataProvider.java
@@ -50,7 +50,7 @@ public class TimeseriesDataProvider {
                     .withThreads(graphParameters.threadMode())
                     .withWeight(graphParameters.useWeight())
                     .withSearchPattern(graphParameters.searchPattern())
-                    .withSpecifiedThread(graphParameters.threadInfo())
+                    .withSpecifiedThreads(graphParameters.threads())
                     .withSpanIntervals(graphParameters.spanIntervals());
 
             if (timeseriesType == TimeseriesType.SIMPLE) {

--- a/jeffrey-microscope/profiles/frame-ir/src/main/java/cafe/jeffrey/frameir/RecordsFrameIterator.java
+++ b/jeffrey-microscope/profiles/frame-ir/src/main/java/cafe/jeffrey/frameir/RecordsFrameIterator.java
@@ -47,7 +47,7 @@ public class RecordsFrameIterator {
                 .filterStacktraceTypes(graphParameters.stacktraceTypes())
                 .filterStacktraceTags(graphParameters.stacktraceTags())
                 .withThreads(graphParameters.threadMode())
-                .withSpecifiedThread(graphParameters.threadInfo());
+                .withSpecifiedThreads(graphParameters.threads());
 
         return eventStreamRepository.flamegraphStreamer(configurer, frameBuilder);
     }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/resources/request/GenerateFlamegraphRequest.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/resources/request/GenerateFlamegraphRequest.java
@@ -37,6 +37,14 @@ public record GenerateFlamegraphRequest(
         boolean excludeIdleSamples,
         boolean onlyUnsafeAllocationSamples,
         ThreadInfo threadInfo,
+        // Set instead of threadInfo when the graph is opened from a collapsed timeline lane: the lane
+        // has no thread of its own, and the page holds at most a slice of its members, so it names the
+        // group and lets the server resolve every thread behind it.
+        String threadGroup,
         GraphComponents components,
         List<Marker> markers) {
+
+    public boolean hasThreadGroup() {
+        return threadGroup != null && !threadGroup.isBlank();
+    }
 }

--- a/jeffrey-microscope/profiles/profile-persistence-api/src/main/java/cafe/jeffrey/provider/profile/api/EventQueryConfigurer.java
+++ b/jeffrey-microscope/profiles/profile-persistence-api/src/main/java/cafe/jeffrey/provider/profile/api/EventQueryConfigurer.java
@@ -55,7 +55,7 @@ public class EventQueryConfigurer {
     private boolean withEventTypeInfo;
     private Boolean useWeight;
     private boolean withThreads;
-    private ThreadInfo specifiedThread;
+    private List<ThreadInfo> specifiedThreads = List.of();
     private List<Type> eventTypes;
     private RelativeTimeRange timeRange;
     private String searchPattern;
@@ -154,15 +154,26 @@ public class EventQueryConfigurer {
     }
 
     /**
-     * Limit the event-stream to the specified threads.
+     * Limit the event-stream to a single thread.
      *
      * @param threadInfo thread information
      * @return instance of the event-stream configurer
      */
     public EventQueryConfigurer withSpecifiedThread(ThreadInfo threadInfo) {
-        if (threadInfo != null) {
+        return threadInfo == null ? this : withSpecifiedThreads(List.of(threadInfo));
+    }
+
+    /**
+     * Limit the event-stream to a set of threads — the timeline draws one lane per group of
+     * identically named threads, and everything that acts on such a lane acts on all of them.
+     *
+     * @param threads the threads to keep; null or empty applies no thread filter
+     * @return instance of the event-stream configurer
+     */
+    public EventQueryConfigurer withSpecifiedThreads(List<ThreadInfo> threads) {
+        if (threads != null && !threads.isEmpty()) {
             this.withThreads = true;
-            this.specifiedThread = threadInfo;
+            this.specifiedThreads = List.copyOf(threads);
         }
         return this;
     }
@@ -290,8 +301,11 @@ public class EventQueryConfigurer {
         return withThreads;
     }
 
-    public ThreadInfo specifiedThread() {
-        return specifiedThread;
+    /**
+     * The threads the event-stream is limited to, empty when it is not limited by thread.
+     */
+    public List<ThreadInfo> specifiedThreads() {
+        return specifiedThreads;
     }
 
     public String searchPattern() {

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/DuckDBTimeseriesQueries.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/DuckDBTimeseriesQueries.java
@@ -255,7 +255,7 @@ public class DuckDBTimeseriesQueries implements ComplexQueries.Timeseries {
 
     private static String render(String sql, EventQueryConfigurer configurer) {
         String valueField = configurer.useWeight() ? "e.weight" : "e.samples";
-        String threadJoin = configurer.specifiedThread() != null ? THREAD_JOIN : "";
+        String threadJoin = configurer.specifiedThreads().isEmpty() ? "" : THREAD_JOIN;
 
         String result = sql
                 .replace(PLACEHOLDER_TARGET_VALUE, valueField)

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/EventQueryFilters.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/EventQueryFilters.java
@@ -21,6 +21,7 @@ package cafe.jeffrey.provider.profile.jdbc;
 import cafe.jeffrey.provider.profile.api.EventQueryConfigurer;
 import cafe.jeffrey.shared.common.model.StacktraceTag;
 import cafe.jeffrey.shared.common.model.StacktraceType;
+import cafe.jeffrey.shared.common.model.ThreadInfo;
 import cafe.jeffrey.shared.common.model.time.RelativeTimeRange;
 
 import java.util.List;
@@ -61,10 +62,22 @@ final class EventQueryFilters {
     private static final String INCLUDED_TAGS_CLAUSE = "AND list_has_any(s.tag_ids, [:included_tags])\n";
     //language=SQL
     private static final String EXCLUDED_TAGS_CLAUSE = "AND NOT list_has_any(s.tag_ids, [:excluded_tags])\n";
+    /**
+     * Keeps events taken on any of the requested threads. The two id columns are matched separately
+     * because a lane standing for a group can hold both threads that have a Java id and threads that
+     * only have an OS id; each side is spliced in only when it has members, so neither list is ever
+     * empty at query time.
+     */
     //language=SQL
-    private static final String THREAD_CLAUSES = """
-            AND t.java_id = :java_thread_id
-            AND t.os_id = :os_thread_id
+    private static final String THREAD_JAVA_ID_CLAUSE =
+            "AND list_contains([:java_thread_ids], t.java_id)\n";
+    //language=SQL
+    private static final String THREAD_OS_ID_CLAUSE =
+            "AND list_contains([:os_thread_ids], t.os_id)\n";
+    //language=SQL
+    private static final String THREAD_EITHER_ID_CLAUSE = """
+            AND (list_contains([:java_thread_ids], t.java_id)
+                 OR list_contains([:os_thread_ids], t.os_id))
             """;
     //language=SQL
     private static final String JSON_FIELD_CLAUSE =
@@ -129,10 +142,17 @@ final class EventQueryFilters {
     }
 
     private static String threadFilters(EventQueryConfigurer configurer) {
-        if (configurer.specifiedThread() == null) {
+        List<ThreadInfo> threads = configurer.specifiedThreads();
+        if (threads.isEmpty()) {
             return "";
         }
-        return THREAD_CLAUSES;
+        if (ThreadIdParams.osIds(threads).isEmpty()) {
+            return THREAD_JAVA_ID_CLAUSE;
+        }
+        if (ThreadIdParams.javaIds(threads).isEmpty()) {
+            return THREAD_OS_ID_CLAUSE;
+        }
+        return THREAD_EITHER_ID_CLAUSE;
     }
 
     private static String jsonFieldFilter(EventQueryConfigurer configurer) {

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/GenericQueryBuilder.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/GenericQueryBuilder.java
@@ -82,8 +82,8 @@ public class GenericQueryBuilder implements QueryBuilder {
             builder.merge(sqlFormatter.threads());
         }
 
-        if (configurer.specifiedThread() != null) {
-            builder.merge(sqlFormatter.threadInfo(configurer.specifiedThread()));
+        if (!configurer.specifiedThreads().isEmpty()) {
+            builder.merge(sqlFormatter.threadInfo(configurer.specifiedThreads()));
         }
 
         if (configurer.eventTypeInfo()) {

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/JdbcProfileEventStreamRepository.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/JdbcProfileEventStreamRepository.java
@@ -266,18 +266,7 @@ public class JdbcProfileEventStreamRepository implements ProfileEventStreamRepos
             baseParams = baseParams.addValue("search_pattern", null);
         }
 
-        if (configurer.threads()) {
-            boolean specifiedThread = configurer.specifiedThread() != null;
-            Long javaThreadId = specifiedThread ? configurer.specifiedThread().javaId() : null;
-            Long osThreadId = specifiedThread ? configurer.specifiedThread().osId() : null;
-
-            baseParams.addValue("java_thread_id", javaThreadId);
-            baseParams.addValue("os_thread_id", osThreadId);
-        } else {
-            baseParams = baseParams
-                    .addValue("java_thread_id", null)
-                    .addValue("os_thread_id", null);
-        }
+        ThreadIdParams.apply(baseParams, configurer.specifiedThreads());
 
         List<StacktraceType> stacktraceTypes = configurer.filterStacktraceTypes();
         if (stacktraceTypes != null && !stacktraceTypes.isEmpty()) {

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/SQLFormatter.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/SQLFormatter.java
@@ -102,17 +102,39 @@ public abstract class SQLFormatter {
     }
 
     /**
-     * Narrows the query to a single thread. Java threads are identified by their Java id; threads
-     * that never got one (a plain native thread reports {@code -1}) would all collide on that value,
-     * so they are matched on the OS id instead.
+     * Narrows the query to the given threads — one for a plain thread, all of them for a lane that
+     * stands for a group.
+     *
+     * <p>The two id columns are matched separately. Java threads are identified by their Java id;
+     * threads that never got one (a plain native thread reports {@code -1}) would all collide on
+     * that value, so they are matched on the OS id instead. A group can hold both kinds, hence the
+     * disjunction — and each side is emitted only when it has members, because an empty {@code IN ()}
+     * is not valid SQL.
      */
-    public SQLBuilder threadInfo(ThreadInfo threadInfo) {
-        if (threadInfo == null) {
+    public SQLBuilder threadInfo(List<ThreadInfo> threads) {
+        if (threads == null || threads.isEmpty()) {
             return new SQLBuilder();
         }
-        if (threadInfo.javaId() == UNKNOWN_THREAD_ID) {
-            return new SQLBuilder().where("threads.os_id", "=", l(threadInfo.osId()));
+
+        List<Long> javaIds = threads.stream()
+                .map(ThreadInfo::javaId)
+                .filter(id -> id != UNKNOWN_THREAD_ID)
+                .distinct()
+                .toList();
+
+        List<Long> osIds = threads.stream()
+                .filter(thread -> thread.javaId() == UNKNOWN_THREAD_ID)
+                .map(ThreadInfo::osId)
+                .distinct()
+                .toList();
+
+        if (osIds.isEmpty()) {
+            return new SQLBuilder().where(inLongs("threads.java_id", javaIds));
         }
-        return new SQLBuilder().where("threads.java_id", "=", l(threadInfo.javaId()));
+        if (javaIds.isEmpty()) {
+            return new SQLBuilder().where(inLongs("threads.os_id", osIds));
+        }
+        return new SQLBuilder().where(
+                or(inLongs("threads.java_id", javaIds), inLongs("threads.os_id", osIds)));
     }
 }

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/ThreadIdParams.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/ThreadIdParams.java
@@ -1,0 +1,80 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.provider.profile.jdbc;
+
+import cafe.jeffrey.shared.common.model.ThreadInfo;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+
+import java.util.List;
+
+/**
+ * Splits a set of threads into the two id columns the events query can match them on, and binds them
+ * as list params so they render as native DuckDB list literals — the same shape
+ * {@code SpanIntervalParams} uses.
+ *
+ * <p>Threads are matched by Java id where they have one. A thread that never got one reports
+ * {@code -1}, and every such thread would collide on that value, so those are matched on their OS id
+ * instead. A lane standing for a group of threads can hold both kinds, which is why this is a split
+ * rather than a choice.
+ *
+ * <p>The predicate and the parameters are derived from the same two methods so the clause spliced
+ * into the SQL can never reference a list that was not bound.
+ */
+final class ThreadIdParams {
+
+    static final String JAVA_THREAD_IDS = "java_thread_ids";
+    static final String OS_THREAD_IDS = "os_thread_ids";
+
+    /**
+     * The value {@link ThreadInfo} carries when a thread id is not available.
+     */
+    private static final long UNKNOWN_THREAD_ID = -1;
+
+    private ThreadIdParams() {
+    }
+
+    static List<Long> javaIds(List<ThreadInfo> threads) {
+        return threads.stream()
+                .map(ThreadInfo::javaId)
+                .filter(id -> id != UNKNOWN_THREAD_ID)
+                .distinct()
+                .toList();
+    }
+
+    static List<Long> osIds(List<ThreadInfo> threads) {
+        return threads.stream()
+                .filter(thread -> thread.javaId() == UNKNOWN_THREAD_ID)
+                .map(ThreadInfo::osId)
+                .distinct()
+                .toList();
+    }
+
+    static void apply(MapSqlParameterSource params, List<ThreadInfo> threads) {
+        params.addValue(JAVA_THREAD_IDS, nullIfEmpty(javaIds(threads)))
+                .addValue(OS_THREAD_IDS, nullIfEmpty(osIds(threads)));
+    }
+
+    /**
+     * An empty list has no valid rendering as a list literal, and the clause that would have read it
+     * is not spliced in when it is empty, so the binding is left null.
+     */
+    private static List<Long> nullIfEmpty(List<Long> ids) {
+        return ids.isEmpty() ? null : ids;
+    }
+}

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/test/java/cafe/jeffrey/provider/profile/jdbc/DuckDBFlamegraphThreadFilterTest.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/test/java/cafe/jeffrey/provider/profile/jdbc/DuckDBFlamegraphThreadFilterTest.java
@@ -1,0 +1,113 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.provider.profile.jdbc;
+
+import cafe.jeffrey.provider.profile.api.EventQueryConfigurer;
+import cafe.jeffrey.shared.common.model.ThreadInfo;
+import cafe.jeffrey.shared.persistence.GroupLabel;
+import cafe.jeffrey.shared.persistence.StatementLabel;
+import cafe.jeffrey.shared.persistence.client.DatabaseClient;
+import cafe.jeffrey.shared.persistence.client.DatabaseClientProvider;
+import cafe.jeffrey.test.DuckDBTest;
+import cafe.jeffrey.test.TestUtils;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+
+import javax.sql.DataSource;
+import java.sql.SQLException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Runs the real flamegraph SIMPLE query against DuckDB to prove that a graph opened on a collapsed
+ * timeline lane covers every thread in the group and nothing else.
+ *
+ * <p>Going through Spring's named-parameter binding also proves the {@code [:*_thread_ids]} params
+ * expand into DuckDB list literals — the filter used to take a single thread, so a list is new.
+ */
+@DuckDBTest(migration = "classpath:db/migration/profile")
+class DuckDBFlamegraphThreadFilterTest {
+
+    private static final String EVENT_TYPE = "jdk.ExecutionSample";
+
+    /** Two pool workers with a Java id, and one that never got one and reports {@code -1}. */
+    private static final List<ThreadInfo> POOL = List.of(
+            new ThreadInfo(41, 12, "oracleApp:connection-adder"),
+            new ThreadInfo(42, 13, "oracleApp:connection-adder"),
+            new ThreadInfo(43, -1, "oracleApp:connection-adder"));
+
+    /**
+     * Runs {@code byThreadAndWeight} — the query the flamegraph actually resolves to once a thread
+     * filter is set, and the only family that joins {@code threads} and carries the predicate.
+     */
+    private static long totalSamples(DatabaseClient client, List<ThreadInfo> threads) {
+        EventQueryConfigurer configurer = new EventQueryConfigurer()
+                .withThreads()
+                .withSpecifiedThreads(threads);
+        String sql = DuckDBFlamegraphQueries.of(EVENT_TYPE, "").byThreadAndWeight(configurer);
+
+        MapSqlParameterSource params = new MapSqlParameterSource();
+        ThreadIdParams.apply(params, configurer.specifiedThreads());
+
+        return client.query(StatementLabel.STREAM_EVENTS, sql, params, (rs, _) -> rs.getLong("total_samples"))
+                .stream()
+                .mapToLong(Long::longValue)
+                .sum();
+    }
+
+    @Test
+    void coversEveryThreadInAGroup(DataSource dataSource) throws SQLException {
+        TestUtils.executeSql(dataSource, "sql/events/insert-thread-group-flamegraph.sql");
+        DatabaseClient client = new DatabaseClientProvider(dataSource).provide(GroupLabel.PROFILE_EVENTS);
+
+        assertEquals(3, totalSamples(client, POOL),
+                "All three pool workers contribute, including the one matched on its OS id");
+    }
+
+    @Test
+    void keepsASingleThreadToItself(DataSource dataSource) throws SQLException {
+        TestUtils.executeSql(dataSource, "sql/events/insert-thread-group-flamegraph.sql");
+        DatabaseClient client = new DatabaseClientProvider(dataSource).provide(GroupLabel.PROFILE_EVENTS);
+
+        assertEquals(1, totalSamples(client, List.of(POOL.getFirst())),
+                "One thread is still one thread — the list did not widen the single-thread case");
+    }
+
+    /**
+     * A thread with no Java id reports {@code -1}, and so does every other such thread. Matching on
+     * that marker rather than on the OS id would sweep in threads that are not in the group.
+     */
+    @Test
+    void doesNotSweepInOtherThreadsWithoutAJavaId(DataSource dataSource) throws SQLException {
+        TestUtils.executeSql(dataSource, "sql/events/insert-thread-group-flamegraph.sql");
+        DatabaseClient client = new DatabaseClientProvider(dataSource).provide(GroupLabel.PROFILE_EVENTS);
+
+        assertEquals(1, totalSamples(client, List.of(new ThreadInfo(43, -1, "oracleApp:connection-adder"))),
+                "Only the worker with OS id 43 counts, not the GC thread that also reports -1");
+    }
+
+    @Test
+    void leavesTheGraphUnfilteredWithoutThreads(DataSource dataSource) throws SQLException {
+        TestUtils.executeSql(dataSource, "sql/events/insert-thread-group-flamegraph.sql");
+        DatabaseClient client = new DatabaseClientProvider(dataSource).provide(GroupLabel.PROFILE_EVENTS);
+
+        assertEquals(5, totalSamples(client, List.of()), "No thread filter means the whole recording");
+    }
+}

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/test/resources/sql/events/insert-thread-group-flamegraph.sql
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/test/resources/sql/events/insert-thread-group-flamegraph.sql
@@ -1,0 +1,39 @@
+-- Fixture for DuckDBFlamegraphThreadFilterTest.
+-- jdk.ExecutionSample events across a pool of workers plus two threads outside it, to prove a
+-- flamegraph opened on a collapsed lane covers every thread in the group and nothing else.
+--
+-- The pool mixes both kinds of identity on purpose: two workers carry a Java id, one never got one
+-- and reports -1, which is how a native thread appears. A group has to match both.
+
+INSERT INTO event_types (name, label, type_id, description, categories, source, subtype, has_stacktrace, extras, settings, columns)
+VALUES
+    ('jdk.ExecutionSample', 'Execution Sample', 2, 'CPU execution sample', '["Profiling"]', '1', NULL, true, NULL, NULL, NULL);
+
+INSERT INTO threads (thread_hash, name, os_id, java_id, is_virtual)
+VALUES
+    (3001, 'oracleApp:connection-adder', 41, 12, false),
+    (3002, 'oracleApp:connection-adder', 42, 13, false),
+    (3003, 'oracleApp:connection-adder', 43, -1, false),
+    (3004, 'main', 44, 1, false),
+    (3005, 'GC Thread#0', 45, -1, false);
+
+INSERT INTO frames (frame_hash, class_name, method_name, frame_type, line_number, bytecode_index)
+VALUES
+    (9001, 'com.example.Pool', 'addConnection', 'Interpreted', 10, 0);
+
+INSERT INTO stacktraces (stacktrace_hash, type_id, frame_hashes, tag_ids)
+VALUES
+    (5001, 1, [9001], []);
+
+INSERT INTO events (event_type, start_timestamp, duration, samples, weight, weight_entity, stacktrace_hash, thread_hash, fields)
+VALUES
+    -- KEPT by the group: a worker identified by its Java id
+    ('jdk.ExecutionSample', '2025-01-15T10:00:00.050Z', NULL, 1, NULL, NULL, 5001, 3001, '{}'),
+    -- KEPT by the group: a second worker, so the filter cannot be matching one thread
+    ('jdk.ExecutionSample', '2025-01-15T10:00:01.050Z', NULL, 1, NULL, NULL, 5001, 3002, '{}'),
+    -- KEPT by the group: a worker with no Java id, matched on its OS id instead
+    ('jdk.ExecutionSample', '2025-01-15T10:00:02.050Z', NULL, 1, NULL, NULL, 5001, 3003, '{}'),
+    -- EXCLUDED: a thread outside the group
+    ('jdk.ExecutionSample', '2025-01-15T10:00:03.050Z', NULL, 1, NULL, NULL, 5001, 3004, '{}'),
+    -- EXCLUDED: another thread with no Java id, which must not be swept in by the -1 marker
+    ('jdk.ExecutionSample', '2025-01-15T10:00:04.050Z', NULL, 1, NULL, NULL, 5001, 3005, '{}');

--- a/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/manager/thread/ThreadManager.java
+++ b/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/manager/thread/ThreadManager.java
@@ -18,6 +18,7 @@
 
 package cafe.jeffrey.profile.manager.thread;
 
+import cafe.jeffrey.shared.common.model.ThreadInfo;
 import cafe.jeffrey.shared.common.model.ProfileInfo;
 import cafe.jeffrey.shared.common.model.Type;
 import cafe.jeffrey.profile.manager.model.thread.ReservedStackActivation;
@@ -56,7 +57,7 @@ public interface ThreadManager {
 
     /**
      * The whole timeline. Used to warm the profile's cache after an import — the page itself asks
-     * for {@link #threadPage(ThreadPageQuery)} instead, so that a recording with a thousand threads
+     * for {@link #threadGroups(ThreadPageQuery)} instead, so that a recording with a thousand threads
      * does not have to cross the wire in one piece.
      */
     ThreadRoot threadRows();
@@ -73,6 +74,13 @@ public interface ThreadManager {
      * put 351 lanes on the page any more than the ungrouped timeline could.
      */
     ThreadPage threadGroupMembers(ThreadMembersQuery query);
+
+    /**
+     * Every thread behind one collapsed lane, unpaged — what anything acting on the lane as a whole
+     * has to be scoped to. Unlike {@link #threadGroupMembers(ThreadMembersQuery)} this merges no
+     * bands, so resolving a 351-thread pool costs a grouping pass and nothing more.
+     */
+    List<ThreadInfo> threadGroupThreads(String groupKey);
 
     /**
      * The events behind one band of {@link #threadRows()}, for the tooltip that opens when the

--- a/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/manager/thread/ThreadManager.java
+++ b/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/manager/thread/ThreadManager.java
@@ -27,6 +27,8 @@ import cafe.jeffrey.profile.manager.model.thread.dump.ParsedDump;
 import cafe.jeffrey.profile.manager.model.thread.dump.ThreadDumpAnalysis;
 import cafe.jeffrey.profile.thread.ThreadEventDetail;
 import cafe.jeffrey.profile.thread.ThreadEventsQuery;
+import cafe.jeffrey.profile.thread.ThreadGroupPage;
+import cafe.jeffrey.profile.thread.ThreadMembersQuery;
 import cafe.jeffrey.profile.thread.ThreadPage;
 import cafe.jeffrey.profile.thread.ThreadPageQuery;
 import cafe.jeffrey.profile.thread.ThreadRoot;
@@ -60,10 +62,17 @@ public interface ThreadManager {
     ThreadRoot threadRows();
 
     /**
-     * One ordered slice of the timeline, filtered and counted. Reads from the same cached timeline
-     * {@link #threadRows()} builds, so paging costs nothing after the first request.
+     * One ordered slice of the timeline, a lane per group of identically named threads. Reads from
+     * the same cached timeline {@link #threadRows()} builds, so paging costs nothing after the first
+     * request.
      */
-    ThreadPage threadPage(ThreadPageQuery query);
+    ThreadGroupPage threadGroups(ThreadPageQuery query);
+
+    /**
+     * The threads behind one collapsed lane, a page at a time. Opening a pool of 351 workers must not
+     * put 351 lanes on the page any more than the ungrouped timeline could.
+     */
+    ThreadPage threadGroupMembers(ThreadMembersQuery query);
 
     /**
      * The events behind one band of {@link #threadRows()}, for the tooltip that opens when the

--- a/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/manager/thread/ThreadManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/manager/thread/ThreadManagerImpl.java
@@ -35,9 +35,15 @@ import cafe.jeffrey.profile.manager.model.thread.dump.ThreadDumpAnalysis;
 import cafe.jeffrey.profile.manager.model.thread.dump.ThreadDumpAnalyzer;
 import cafe.jeffrey.profile.manager.model.thread.dump.ThreadDumpBuilder;
 import cafe.jeffrey.profile.manager.model.thread.dump.ThreadDumpParser;
+import cafe.jeffrey.profile.thread.ThreadBands;
 import cafe.jeffrey.profile.thread.ThreadEventDetail;
 import cafe.jeffrey.profile.thread.ThreadEventsQuery;
+import cafe.jeffrey.profile.thread.ThreadGroup;
+import cafe.jeffrey.profile.thread.ThreadGroupMembers;
+import cafe.jeffrey.profile.thread.ThreadGroupPage;
+import cafe.jeffrey.profile.thread.ThreadGrouping;
 import cafe.jeffrey.profile.thread.ThreadInfoProvider;
+import cafe.jeffrey.profile.thread.ThreadMembersQuery;
 import cafe.jeffrey.profile.thread.ThreadPage;
 import cafe.jeffrey.profile.thread.ThreadPageQuery;
 import cafe.jeffrey.profile.thread.ThreadRecord;
@@ -156,28 +162,61 @@ public class ThreadManagerImpl implements ThreadManager {
     }
 
     @Override
-    public ThreadPage threadPage(ThreadPageQuery query) {
+    public ThreadGroupPage threadGroups(ThreadPageQuery query) {
+        ThreadRoot root = threadInfoProvider.get();
+        List<ThreadGroupMembers> groups = grouping().group(root.rows());
+
+        List<ThreadGroupMembers> matched = query.hasNameFilter()
+                ? groups.stream().filter(matchesName(query.nameFilter())).toList()
+                : groups;
+
+        // Only the lanes actually returned are merged: building a union walks every member's bands,
+        // while ordering and filtering need no more than the totals each group already knows.
+        List<ThreadGroup> page = matched.stream()
+                .sorted(query.sort().groupComparator())
+                .skip(query.offset())
+                .limit(query.limit())
+                .map(grouping()::merge)
+                .toList();
+
+        return new ThreadGroupPage(
+                root.common(), page, query.offset(), matched.size(), groups.size(), root.rows().size());
+    }
+
+    @Override
+    public ThreadPage threadGroupMembers(ThreadMembersQuery query) {
         ThreadRoot root = threadInfoProvider.get();
 
-        List<ThreadRow> matched = query.hasNameFilter()
-                ? root.rows().stream().filter(matchesName(query.nameFilter())).toList()
-                : root.rows();
+        List<ThreadRow> members = grouping().group(root.rows()).stream()
+                .filter(group -> group.key().equals(query.groupKey()))
+                .findFirst()
+                .map(ThreadGroupMembers::members)
+                .orElse(List.of());
 
-        List<ThreadRow> page = matched.stream()
+        List<ThreadRow> page = members.stream()
                 .sorted(query.sort().comparator())
                 .skip(query.offset())
                 .limit(query.limit())
                 .toList();
 
-        return new ThreadPage(root.common(), page, query.offset(), matched.size(), root.rows().size());
+        return new ThreadPage(root.common(), page, query.offset(), members.size(), root.rows().size());
     }
 
-    private static Predicate<ThreadRow> matchesName(String nameFilter) {
+    private ThreadGrouping grouping() {
+        return new ThreadGrouping(ThreadBands.forRecording(profileInfo.duration()));
+    }
+
+    /**
+     * A group matches when its own name does, or when any thread inside it does — otherwise a search
+     * for one worker of a pool would come back empty just because the lane is named after the pool.
+     */
+    private static Predicate<ThreadGroupMembers> matchesName(String nameFilter) {
         String needle = nameFilter.toLowerCase(Locale.ROOT);
-        return row -> {
-            String name = row.threadInfo().name();
-            return name != null && name.toLowerCase(Locale.ROOT).contains(needle);
-        };
+        return group -> group.key().toLowerCase(Locale.ROOT).contains(needle)
+                || group.members().stream().anyMatch(row -> {
+                    String name = row.threadInfo().name();
+                    return name != null && name.toLowerCase(Locale.ROOT).contains(needle);
+                });
     }
 
     @Override

--- a/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/manager/thread/ThreadManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/manager/thread/ThreadManagerImpl.java
@@ -21,6 +21,7 @@ package cafe.jeffrey.profile.manager.thread;
 import tools.jackson.databind.node.ObjectNode;
 import cafe.jeffrey.shared.common.model.EventSummary;
 import cafe.jeffrey.shared.common.model.ProfileInfo;
+import cafe.jeffrey.shared.common.model.ThreadInfo;
 import cafe.jeffrey.shared.common.model.Type;
 import cafe.jeffrey.shared.common.model.time.RelativeTimeRange;
 import cafe.jeffrey.profile.manager.thread.builder.CPULoadBuilder;
@@ -186,12 +187,7 @@ public class ThreadManagerImpl implements ThreadManager {
     @Override
     public ThreadPage threadGroupMembers(ThreadMembersQuery query) {
         ThreadRoot root = threadInfoProvider.get();
-
-        List<ThreadRow> members = grouping().group(root.rows()).stream()
-                .filter(group -> group.key().equals(query.groupKey()))
-                .findFirst()
-                .map(ThreadGroupMembers::members)
-                .orElse(List.of());
+        List<ThreadRow> members = membersOf(root.rows(), query.groupKey());
 
         List<ThreadRow> page = members.stream()
                 .sorted(query.sort().comparator())
@@ -200,6 +196,26 @@ public class ThreadManagerImpl implements ThreadManager {
                 .toList();
 
         return new ThreadPage(root.common(), page, query.offset(), members.size(), root.rows().size());
+    }
+
+    @Override
+    public List<ThreadInfo> threadGroupThreads(String groupKey) {
+        return membersOf(threadInfoProvider.get().rows(), groupKey).stream()
+                .map(ThreadRow::threadInfo)
+                .toList();
+    }
+
+    /**
+     * Every thread in a group, in the order the timeline built them. Unlike a page of members this
+     * merges no bands, so resolving a 351-thread pool for a filter costs a grouping pass and nothing
+     * more.
+     */
+    private List<ThreadRow> membersOf(List<ThreadRow> rows, String groupKey) {
+        return grouping().group(rows).stream()
+                .filter(group -> group.key().equals(groupKey))
+                .findFirst()
+                .map(ThreadGroupMembers::members)
+                .orElse(List.of());
     }
 
     private ThreadGrouping grouping() {
@@ -223,7 +239,7 @@ public class ThreadManagerImpl implements ThreadManager {
     public List<ThreadEventDetail> threadEvents(ThreadEventsQuery query) {
         EventQueryConfigurer configurer = new EventQueryConfigurer()
                 .withEventType(query.state().eventType())
-                .withSpecifiedThread(query.threadInfo())
+                .withSpecifiedThreads(query.threads())
                 .withTimeRange(bandTimeRange(query))
                 .withEventTypeInfo()
                 .withJsonFields();

--- a/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/thread/ThreadEventsQuery.java
+++ b/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/thread/ThreadEventsQuery.java
@@ -21,28 +21,32 @@ package cafe.jeffrey.profile.thread;
 import cafe.jeffrey.shared.common.model.ThreadInfo;
 
 import java.time.Duration;
+import java.util.List;
 
 /**
- * Asks for the events behind one band of a thread's timeline — what a tooltip needs once the pointer
+ * Asks for the events behind one band of a timeline lane — what a tooltip needs once the pointer
  * settles on a rectangle.
  *
- * @param threadInfo the thread the band belongs to
- * @param state      which band was hovered
- * @param from       start of the band, as an offset from the beginning of the recording
- * @param to         end of the band, as an offset from the beginning of the recording
- * @param limit      how many events to return; a tooltip shows one, the band already carries the count
+ * @param threads the threads the band belongs to: one for a plain thread, all of them for a lane
+ *                standing for a group. A collapsed lane has no thread of its own, so asking by its
+ *                identity would match nothing
+ * @param state   which band was hovered
+ * @param from    start of the band, as an offset from the beginning of the recording
+ * @param to      end of the band, as an offset from the beginning of the recording
+ * @param limit   how many events to return; a tooltip shows one, the band already carries the count
  */
 public record ThreadEventsQuery(
-        ThreadInfo threadInfo,
+        List<ThreadInfo> threads,
         ThreadState state,
         Duration from,
         Duration to,
         int limit) {
 
     public ThreadEventsQuery {
-        if (threadInfo == null) {
-            throw new IllegalArgumentException("Thread must be specified");
+        if (threads == null || threads.isEmpty()) {
+            throw new IllegalArgumentException("At least one thread must be specified");
         }
+        threads = List.copyOf(threads);
         if (state == null || !state.hasEventDetail()) {
             throw new IllegalArgumentException("Thread state has no event detail: " + state);
         }

--- a/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/thread/ThreadGroup.java
+++ b/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/thread/ThreadGroup.java
@@ -1,0 +1,48 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.thread;
+
+/**
+ * One lane on the timeline, standing for every thread that shares a name.
+ *
+ * <p>The lane carries the union of its members' activity, so a pool of 351 workers that each emitted
+ * a single event draws as 351 marks on one row — which is the cadence the pool was running at, and
+ * the thing a row per worker made impossible to see.
+ *
+ * @param key         what members are fetched by; see {@link ThreadGroupKey}
+ * @param threadCount how many threads the lane stands for
+ * @param lane        the merged activity, shaped exactly like a single thread's row so it draws the
+ *                    same way. For a group of one it <em>is</em> that thread's row, identity included
+ */
+public record ThreadGroup(String key, int threadCount, ThreadRow lane) {
+
+    public ThreadGroup {
+        if (threadCount < 1) {
+            throw new IllegalArgumentException("A group needs at least one thread: " + threadCount);
+        }
+    }
+
+    /**
+     * Whether the lane stands for several threads. A lane of one is an ordinary thread and keeps
+     * everything a thread has — its ids, and the actions that need them.
+     */
+    public boolean isCollapsed() {
+        return threadCount > 1;
+    }
+}

--- a/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/thread/ThreadGroupKey.java
+++ b/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/thread/ThreadGroupKey.java
@@ -1,0 +1,67 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.thread;
+
+import java.util.regex.Pattern;
+
+/**
+ * Decides which threads belong on the same lane.
+ *
+ * <p>Pools name their workers one of two ways. Some give every worker the same name — a recording
+ * can hold 351 threads all called {@code oracleApp:connection-adder} — and those group on the name
+ * itself. Others number them, as in {@code http-nio-8080-exec-17}, and grouping those means dropping
+ * the number.
+ *
+ * <p>Only the <em>trailing</em> number is dropped, which matters for names like
+ * {@code pool-3-thread-1}: the pool's own number identifies which executor the thread belongs to, so
+ * collapsing {@code pool-3} and {@code pool-4} together would merge two unrelated pools. Threads
+ * whose names carry no trailing number are their own group of one, and a group of one renders
+ * exactly as a plain thread does today.
+ */
+public final class ThreadGroupKey {
+
+    /**
+     * A trailing worker number. Anchored to the end so only the last number in the name goes, and
+     * preceded by a non-digit so a name made entirely of digits keeps something to group under. The
+     * separator that introduces the number is left in place, which keeps {@code http-nio-8080-exec-*}
+     * readable as the pool it names.
+     */
+    private static final Pattern TRAILING_NUMBER = Pattern.compile("(?<=[^\\d])\\d+$");
+
+    /**
+     * Stands in for the number that was dropped, so a grouped name reads as a pattern rather than as
+     * one particular worker.
+     */
+    private static final String WILDCARD = "*";
+
+    private static final String UNNAMED = "<unnamed>";
+
+    private ThreadGroupKey() {
+    }
+
+    /**
+     * The name threads are grouped under. Equal keys mean one lane.
+     */
+    public static String of(String threadName) {
+        if (threadName == null || threadName.isBlank()) {
+            return UNNAMED;
+        }
+        return TRAILING_NUMBER.matcher(threadName).replaceAll(WILDCARD);
+    }
+}

--- a/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/thread/ThreadGroupMembers.java
+++ b/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/thread/ThreadGroupMembers.java
@@ -1,0 +1,58 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.thread;
+
+import java.util.List;
+
+/**
+ * The threads sharing one name, before their lanes are merged into a single one.
+ *
+ * <p>Kept apart from {@link ThreadGroup} because the two cost very different amounts. Ordering and
+ * filtering the groups only needs the totals below, which are a sum over members; building the lane
+ * means merging every member's bands, and that is worth doing only for the groups a page actually
+ * returns.
+ */
+public record ThreadGroupMembers(String key, List<ThreadRow> members) {
+
+    public ThreadGroupMembers {
+        if (members.isEmpty()) {
+            throw new IllegalArgumentException("A group needs at least one thread: " + key);
+        }
+    }
+
+    public int threadCount() {
+        return members.size();
+    }
+
+    public long eventsCount() {
+        return members.stream().mapToLong(ThreadRow::eventsCount).sum();
+    }
+
+    /**
+     * The longest a member was alive. A sum would exceed the recording itself once a pool has more
+     * than one worker, which reads as nonsense next to a timeline.
+     */
+    public long totalDuration() {
+        return members.stream().mapToLong(ThreadRow::totalDuration).max().orElse(0);
+    }
+
+    public boolean isSingleThread() {
+        return members.size() == 1;
+    }
+}

--- a/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/thread/ThreadGroupPage.java
+++ b/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/thread/ThreadGroupPage.java
@@ -1,0 +1,44 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.thread;
+
+import java.util.List;
+
+/**
+ * One slice of a profile's timeline, a lane per group of identically named threads.
+ *
+ * @param common        the metadata every lane is drawn against
+ * @param groups        the lanes in this slice, already ordered
+ * @param offset        how many groups precede this slice
+ * @param matchedGroups groups matching the current filter — what "showing 4 of 18" counts
+ * @param totalGroups   groups in the recording, filtered or not
+ * @param totalThreads  threads behind those groups, which is the number the lanes stand in for
+ */
+public record ThreadGroupPage(
+        ThreadCommon common,
+        List<ThreadGroup> groups,
+        int offset,
+        int matchedGroups,
+        int totalGroups,
+        int totalThreads) {
+
+    public boolean hasMore() {
+        return offset + groups.size() < matchedGroups;
+    }
+}

--- a/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/thread/ThreadGrouping.java
+++ b/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/thread/ThreadGrouping.java
@@ -1,0 +1,109 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.thread;
+
+import cafe.jeffrey.shared.common.model.ThreadInfo;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Folds threads that share a name into one lane each.
+ *
+ * <p>Splitting the work in two is deliberate. {@link #group(List)} only buckets rows by key, which is
+ * what ordering and filtering need; {@link #merge(ThreadGroupMembers)} builds the union lane, which
+ * walks every member's bands and is therefore run only for the groups a page returns.
+ */
+public final class ThreadGrouping {
+
+    /**
+     * A collapsed lane has no thread of its own. The ids are the "not available" marker
+     * {@link ThreadInfo} already uses, so nothing downstream mistakes the lane for a real thread.
+     */
+    private static final long NO_THREAD_ID = -1;
+
+    private final ThreadBands bands;
+
+    public ThreadGrouping(ThreadBands bands) {
+        this.bands = bands;
+    }
+
+    /**
+     * Buckets rows by group key, preserving the order the rows arrived in so the result is stable.
+     */
+    public List<ThreadGroupMembers> group(List<ThreadRow> rows) {
+        Map<String, List<ThreadRow>> byKey = new LinkedHashMap<>();
+        for (ThreadRow row : rows) {
+            byKey.computeIfAbsent(ThreadGroupKey.of(row.threadInfo().name()), _ -> new ArrayList<>())
+                    .add(row);
+        }
+
+        List<ThreadGroupMembers> groups = new ArrayList<>(byKey.size());
+        byKey.forEach((key, members) -> groups.add(new ThreadGroupMembers(key, members)));
+        return groups;
+    }
+
+    /**
+     * Builds the lane a group draws as. A group of one keeps its thread's own row untouched — the
+     * lane is that thread, so its ids stay intact and everything that acts on a thread still works.
+     */
+    public ThreadGroup merge(ThreadGroupMembers group) {
+        if (group.isSingleThread()) {
+            return new ThreadGroup(group.key(), 1, group.members().getFirst());
+        }
+
+        List<ThreadRow> members = group.members();
+        ThreadRow lane = new ThreadRow(
+                group.totalDuration(),
+                group.eventsCount(),
+                new ThreadInfo(NO_THREAD_ID, NO_THREAD_ID, group.key()),
+                union(members, ThreadRow::lifespan),
+                union(members, ThreadRow::parked),
+                union(members, ThreadRow::blocked),
+                union(members, ThreadRow::waiting),
+                union(members, ThreadRow::sleep),
+                union(members, ThreadRow::socketRead),
+                union(members, ThreadRow::socketWrite),
+                union(members, ThreadRow::fileRead),
+                union(members, ThreadRow::fileWrite));
+
+        return new ThreadGroup(group.key(), members.size(), lane);
+    }
+
+    /**
+     * Every member's bands of one category on a single track. They are merged the same way a single
+     * thread's events are, so bands that would overlap on screen become one and keep their count —
+     * without it, a pool of 351 would put 351 rectangles on top of each other.
+     */
+    private List<ThreadPeriod> union(
+            List<ThreadRow> members,
+            Function<ThreadRow, List<ThreadPeriod>> category) {
+
+        List<ThreadPeriod> all = new ArrayList<>();
+        for (ThreadRow member : members) {
+            all.addAll(category.apply(member));
+        }
+        all.sort(Comparator.comparingLong(ThreadPeriod::startOffset));
+        return bands.merge(all);
+    }
+}

--- a/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/thread/ThreadMembersQuery.java
+++ b/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/thread/ThreadMembersQuery.java
@@ -1,0 +1,46 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.thread;
+
+/**
+ * Asks for the threads behind one collapsed lane, a page at a time — opening a pool of 351 must not
+ * put 351 lanes on the page any more than the ungrouped timeline could.
+ *
+ * @param groupKey which lane was opened; see {@link ThreadGroupKey}
+ * @param sort     the order members are handed out in
+ * @param offset   how many members to skip
+ * @param limit    how many members to send
+ */
+public record ThreadMembersQuery(String groupKey, ThreadSort sort, int offset, int limit) {
+
+    public ThreadMembersQuery {
+        if (groupKey == null || groupKey.isBlank()) {
+            throw new IllegalArgumentException("Group key must be specified");
+        }
+        if (sort == null) {
+            throw new IllegalArgumentException("Sort must be specified");
+        }
+        if (offset < 0) {
+            throw new IllegalArgumentException("Offset must not be negative: " + offset);
+        }
+        if (limit < 1) {
+            throw new IllegalArgumentException("Limit must be positive: " + limit);
+        }
+    }
+}

--- a/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/thread/ThreadSort.java
+++ b/jeffrey-microscope/profiles/profile-threads/src/main/java/cafe/jeffrey/profile/thread/ThreadSort.java
@@ -27,9 +27,15 @@ import java.util.Comparator;
  */
 public enum ThreadSort {
 
-    EVENT_COUNT(Comparator.comparingLong(ThreadRow::eventsCount).reversed()),
-    LIFESPAN(Comparator.comparingLong(ThreadRow::totalDuration).reversed()),
-    NAME(Comparator.comparing(row -> row.threadInfo().name(), Comparator.nullsLast(String::compareTo)));
+    EVENT_COUNT(
+            Comparator.comparingLong(ThreadRow::eventsCount).reversed(),
+            Comparator.comparingLong(ThreadGroupMembers::eventsCount).reversed()),
+    LIFESPAN(
+            Comparator.comparingLong(ThreadRow::totalDuration).reversed(),
+            Comparator.comparingLong(ThreadGroupMembers::totalDuration).reversed()),
+    NAME(
+            Comparator.comparing(row -> row.threadInfo().name(), Comparator.nullsLast(String::compareTo)),
+            Comparator.comparing(ThreadGroupMembers::key));
 
     /**
      * Threads that tie on the chosen key are broken by name, so paging stays stable: without a total
@@ -40,13 +46,32 @@ public enum ThreadSort {
                     .thenComparingLong(row -> row.threadInfo().javaId())
                     .thenComparingLong(row -> row.threadInfo().osId());
 
-    private final Comparator<ThreadRow> comparator;
+    /**
+     * Groups tie-break on their key, which is unique among groups by construction.
+     */
+    private static final Comparator<ThreadGroupMembers> GROUP_TIE_BREAK =
+            Comparator.comparing(ThreadGroupMembers::key);
 
-    ThreadSort(Comparator<ThreadRow> comparator) {
+    private final Comparator<ThreadRow> comparator;
+    private final Comparator<ThreadGroupMembers> groupComparator;
+
+    ThreadSort(Comparator<ThreadRow> comparator, Comparator<ThreadGroupMembers> groupComparator) {
         this.comparator = comparator;
+        this.groupComparator = groupComparator;
     }
 
+    /**
+     * Orders individual threads — the members behind one collapsed lane.
+     */
     public Comparator<ThreadRow> comparator() {
         return comparator.thenComparing(TIE_BREAK);
+    }
+
+    /**
+     * Orders the lanes themselves. A group's key is the sum of its members for a count, and the
+     * longest-lived member for a lifespan, so "busiest" means the same thing at both levels.
+     */
+    public Comparator<ThreadGroupMembers> groupComparator() {
+        return groupComparator.thenComparing(GROUP_TIE_BREAK);
     }
 }

--- a/jeffrey-microscope/profiles/profile-threads/src/test/java/cafe/jeffrey/profile/manager/thread/ThreadPagingTest.java
+++ b/jeffrey-microscope/profiles/profile-threads/src/test/java/cafe/jeffrey/profile/manager/thread/ThreadPagingTest.java
@@ -23,10 +23,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import cafe.jeffrey.profile.thread.ThreadCommon;
+import cafe.jeffrey.profile.thread.ThreadGroup;
+import cafe.jeffrey.profile.thread.ThreadGroupPage;
 import cafe.jeffrey.profile.thread.ThreadInfoProvider;
+import cafe.jeffrey.profile.thread.ThreadMembersQuery;
 import cafe.jeffrey.profile.thread.ThreadPage;
 import cafe.jeffrey.profile.thread.ThreadPageQuery;
+import cafe.jeffrey.profile.thread.ThreadPeriod;
 import cafe.jeffrey.profile.thread.ThreadRoot;
 import cafe.jeffrey.profile.thread.ThreadRow;
 import cafe.jeffrey.profile.thread.ThreadSort;
@@ -36,6 +42,8 @@ import cafe.jeffrey.provider.profile.api.ProfileEventTypeRepository;
 import cafe.jeffrey.shared.common.model.ProfileInfo;
 import cafe.jeffrey.shared.common.model.ThreadInfo;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -43,16 +51,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
 /**
- * The timeline hands out one page at a time, so the order and the filter have to be decided here —
- * a browser holding fifty threads can only sort and filter those fifty.
+ * The timeline draws one lane per group of identically named threads and pages through both levels:
+ * the lanes themselves, and the members behind a lane once it is opened.
  */
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class ThreadPagingTest {
 
-    @Mock
-    ProfileInfo profileInfo;
+    private static final Instant RECORDING_START = Instant.parse("2026-01-01T00:00:00Z");
+    private static final Duration RECORDING_LENGTH = Duration.ofMinutes(1);
 
     @Mock
     ProfileEventRepository eventRepository;
@@ -64,15 +74,24 @@ class ThreadPagingTest {
     ProfileEventTypeRepository eventTypeRepository;
 
     private static ThreadRow row(String name, long javaId, long events, long duration) {
+        return row(name, javaId, events, duration, List.of());
+    }
+
+    private static ThreadRow row(
+            String name, long javaId, long events, long duration, List<ThreadPeriod> socketRead) {
+
         return new ThreadRow(
                 duration,
                 events,
                 new ThreadInfo(javaId + 1000, javaId, name),
-                List.of(), List.of(), List.of(), List.of(), List.of(), List.of(), List.of(), List.of(), List.of());
+                List.of(), List.of(), List.of(), List.of(), List.of(),
+                socketRead,
+                List.of(), List.of(), List.of());
     }
 
     /**
-     * Two pools plus a couple of singletons — the shape of the recording that motivated paging.
+     * Six threads in four groups: a numbered pool of two, another of two, and two threads that are
+     * alone under their own name.
      */
     private static final List<ThreadRow> ROWS = List.of(
             row("main", 1, 9_401, 60_000),
@@ -83,59 +102,116 @@ class ThreadPagingTest {
             row("Keep-Alive-Timer-6", 6, 4_002, 57_000));
 
     private ThreadManager manager(List<ThreadRow> rows) {
+        ProfileInfo profileInfo = org.mockito.Mockito.mock(ProfileInfo.class);
+        when(profileInfo.duration()).thenReturn(RECORDING_LENGTH);
+
         ThreadInfoProvider provider = () -> new ThreadRoot(new ThreadCommon(60_000, false, null), rows);
         return new ThreadManagerImpl(
                 profileInfo, eventRepository, eventStreamRepository, eventTypeRepository, provider);
     }
 
-    private ThreadPage page(ThreadSort sort, String filter, int offset, int limit) {
-        return manager(ROWS).threadPage(new ThreadPageQuery(sort, filter, offset, limit));
+    private ThreadGroupPage groups(ThreadSort sort, String filter, int offset, int limit) {
+        return manager(ROWS).threadGroups(new ThreadPageQuery(sort, filter, offset, limit));
     }
 
-    private static List<String> names(ThreadPage page) {
-        return page.rows().stream().map(row -> row.threadInfo().name()).toList();
+    private static List<String> keys(ThreadGroupPage page) {
+        return page.groups().stream().map(ThreadGroup::key).toList();
+    }
+
+    @Nested
+    class Grouping {
+
+        @Test
+        void foldsNumberedWorkersOfAPoolIntoOneLane() {
+            ThreadGroupPage page = groups(ThreadSort.EVENT_COUNT, null, 0, 50);
+
+            assertEquals(4, page.groups().size(), "Six threads make four lanes");
+            assertEquals(4, page.totalGroups());
+            assertEquals(6, page.totalThreads(), "The thread count is what the lanes stand in for");
+            assertTrue(keys(page).contains("http-nio-8080-exec-*"));
+            assertTrue(keys(page).contains("oracleApp:connection-adder-*"));
+        }
+
+        @Test
+        void countsTheThreadsBehindEachLane() {
+            ThreadGroup pool = groups(ThreadSort.EVENT_COUNT, null, 0, 50).groups().stream()
+                    .filter(group -> group.key().equals("http-nio-8080-exec-*"))
+                    .findFirst()
+                    .orElseThrow();
+
+            assertEquals(2, pool.threadCount());
+            assertTrue(pool.isCollapsed());
+            assertEquals(58_204 + 51_880, pool.lane().eventsCount(), "A lane's events are its members'");
+        }
+
+        /**
+         * A lane standing for one thread has to stay that thread: everything that acts on a thread
+         * needs its ids, and a group of one has no reason to lose them.
+         */
+        @Test
+        void leavesAThreadThatIsAloneUntouched() {
+            ThreadGroup single = groups(ThreadSort.EVENT_COUNT, null, 0, 50).groups().stream()
+                    .filter(group -> group.key().equals("main"))
+                    .findFirst()
+                    .orElseThrow();
+
+            assertEquals(1, single.threadCount());
+            assertFalse(single.isCollapsed());
+            assertEquals(1, single.lane().threadInfo().javaId());
+            assertEquals("main", single.lane().threadInfo().name());
+        }
+
+        /**
+         * The case the grouping exists for: hundreds of threads sharing one name exactly, each with a
+         * single event, become one lane carrying all of their marks.
+         */
+        @Test
+        void putsAWholePoolsEventsOnOneLane() {
+            List<ThreadRow> pool = IntStream.range(0, 351)
+                    .mapToObj(i -> row(
+                            "oracleApp:connection-adder", i, 1, 58_000,
+                            List.of(new ThreadPeriod(i * 150_000_000L, 1_000_000, 1))))
+                    .toList();
+
+            ThreadGroupPage page = manager(pool)
+                    .threadGroups(new ThreadPageQuery(ThreadSort.EVENT_COUNT, null, 0, 50));
+
+            assertEquals(1, page.groups().size());
+            ThreadGroup group = page.groups().getFirst();
+            assertEquals(351, group.threadCount());
+            assertEquals(351, group.lane().eventsCount());
+            assertEquals(351, group.lane().socketRead().stream()
+                    .mapToInt(ThreadPeriod::eventCount).sum(), "Every member's event survives the union");
+            assertFalse(group.lane().socketRead().isEmpty());
+        }
     }
 
     @Nested
     class Ordering {
 
         @Test
-        void putsTheBusiestThreadsOnTheFirstPage() {
-            assertEquals(
-                    List.of("http-nio-8080-exec-17", "http-nio-8080-exec-3"),
-                    names(page(ThreadSort.EVENT_COUNT, null, 0, 2)));
+        void putsTheBusiestLaneFirst() {
+            assertEquals("http-nio-8080-exec-*", keys(groups(ThreadSort.EVENT_COUNT, null, 0, 1)).getFirst());
         }
 
         @Test
-        void ordersByLifespanWhenAsked() {
-            assertEquals("main", names(page(ThreadSort.LIFESPAN, null, 0, 1)).getFirst());
+        void ordersByTheLongestLivedMemberForLifespan() {
+            assertEquals("main", keys(groups(ThreadSort.LIFESPAN, null, 0, 1)).getFirst());
         }
 
         @Test
         void ordersByNameWhenAsked() {
-            assertEquals(
-                    List.of("Keep-Alive-Timer-6", "http-nio-8080-exec-17"),
-                    names(page(ThreadSort.NAME, null, 0, 2)));
+            assertEquals("Keep-Alive-Timer-*", keys(groups(ThreadSort.NAME, null, 0, 1)).getFirst());
         }
 
-        /**
-         * Threads that tie on the sort key must not swap places between requests, or paging would
-         * show one of them twice and skip the other.
-         */
         @Test
-        void breaksTiesTheSameWayEveryTime() {
-            List<ThreadRow> tied = IntStream.range(0, 40)
-                    .mapToObj(i -> row("oracleApp:connection-adder-" + i, i, 500, 1_000))
-                    .toList();
-            ThreadManager manager = manager(tied);
+        void keepsPagesStableAndNonOverlapping() {
+            ThreadGroupPage first = groups(ThreadSort.EVENT_COUNT, null, 0, 2);
+            ThreadGroupPage again = groups(ThreadSort.EVENT_COUNT, null, 0, 2);
+            ThreadGroupPage second = groups(ThreadSort.EVENT_COUNT, null, 2, 2);
 
-            ThreadPage first = manager.threadPage(new ThreadPageQuery(ThreadSort.EVENT_COUNT, null, 0, 10));
-            ThreadPage again = manager.threadPage(new ThreadPageQuery(ThreadSort.EVENT_COUNT, null, 0, 10));
-            ThreadPage second = manager.threadPage(new ThreadPageQuery(ThreadSort.EVENT_COUNT, null, 10, 10));
-
-            assertEquals(names(first), names(again));
-            assertTrue(names(first).stream().noneMatch(names(second)::contains),
-                    "Consecutive pages must not overlap");
+            assertEquals(keys(first), keys(again));
+            assertTrue(keys(first).stream().noneMatch(keys(second)::contains));
         }
     }
 
@@ -143,57 +219,76 @@ class ThreadPagingTest {
     class Filtering {
 
         @Test
-        void matchesASubstringOfTheThreadName() {
-            ThreadPage page = page(ThreadSort.EVENT_COUNT, "connection-adder", 0, 50);
-
-            assertEquals(2, page.rows().size());
-            assertEquals(2, page.matchedCount());
-        }
-
-        @Test
-        void ignoresCase() {
-            assertEquals(2, page(ThreadSort.EVENT_COUNT, "CONNECTION-ADDER", 0, 50).matchedCount());
+        void matchesTheLaneName() {
+            assertEquals(1, groups(ThreadSort.EVENT_COUNT, "connection-adder", 0, 50).matchedGroups());
         }
 
         /**
-         * The footer reads "showing 2 of 2 matching threads · 6 in the recording", so the two counts
-         * have to mean different things.
+         * Searching for one worker must find the lane it is folded into — otherwise grouping would
+         * make individual threads unreachable by name.
          */
         @Test
-        void narrowsTheMatchedCountButNotTheTotal() {
-            ThreadPage page = page(ThreadSort.EVENT_COUNT, "connection-adder", 0, 50);
+        void alsoMatchesAMemberInsideTheLane() {
+            ThreadGroupPage page = groups(ThreadSort.EVENT_COUNT, "exec-17", 0, 50);
 
-            assertEquals(2, page.matchedCount());
-            assertEquals(6, page.totalCount());
+            assertEquals(1, page.matchedGroups());
+            assertEquals("http-nio-8080-exec-*", keys(page).getFirst());
         }
 
         @Test
-        void treatsABlankFilterAsNoFilter() {
-            assertEquals(6, page(ThreadSort.EVENT_COUNT, "   ", 0, 50).matchedCount());
+        void narrowsTheMatchedCountButNotTheTotals() {
+            ThreadGroupPage page = groups(ThreadSort.EVENT_COUNT, "connection-adder", 0, 50);
+
+            assertEquals(1, page.matchedGroups());
+            assertEquals(4, page.totalGroups());
+            assertEquals(6, page.totalThreads());
         }
     }
 
     @Nested
-    class Slicing {
+    class Members {
 
-        @Test
-        void reportsMoreUntilTheLastPageIsReached() {
-            assertTrue(page(ThreadSort.EVENT_COUNT, null, 0, 2).hasMore());
-            assertFalse(page(ThreadSort.EVENT_COUNT, null, 4, 2).hasMore());
+        private ThreadPage members(String key, int offset, int limit) {
+            return manager(ROWS)
+                    .threadGroupMembers(new ThreadMembersQuery(key, ThreadSort.EVENT_COUNT, offset, limit));
         }
 
         @Test
-        void returnsAnEmptyPagePastTheEnd() {
-            ThreadPage page = page(ThreadSort.EVENT_COUNT, null, 500, 50);
+        void returnTheThreadsBehindALane() {
+            ThreadPage page = members("http-nio-8080-exec-*", 0, 50);
 
-            assertTrue(page.rows().isEmpty());
-            assertEquals(6, page.matchedCount());
-            assertFalse(page.hasMore());
+            assertEquals(2, page.rows().size());
+            assertEquals(2, page.matchedCount());
+            assertEquals("http-nio-8080-exec-17", page.rows().getFirst().threadInfo().name());
+        }
+
+        /**
+         * Opening a pool of 351 must not put 351 lanes on the page — the whole reason the timeline
+         * pages in the first place.
+         */
+        @Test
+        void arePagedLikeTheLanesThemselves() {
+            List<ThreadRow> pool = IntStream.range(0, 351)
+                    .mapToObj(i -> row("oracleApp:connection-adder", i, 351 - i, 58_000))
+                    .toList();
+
+            ThreadPage first = manager(pool).threadGroupMembers(
+                    new ThreadMembersQuery("oracleApp:connection-adder", ThreadSort.EVENT_COUNT, 0, 50));
+
+            assertEquals(50, first.rows().size());
+            assertEquals(351, first.matchedCount());
+            assertTrue(first.hasMore());
+
+            ThreadPage last = manager(pool).threadGroupMembers(
+                    new ThreadMembersQuery("oracleApp:connection-adder", ThreadSort.EVENT_COUNT, 350, 50));
+
+            assertEquals(1, last.rows().size());
+            assertFalse(last.hasMore());
         }
 
         @Test
-        void carriesTheOffsetBackSoThePageKnowsWhereItIs() {
-            assertEquals(2, page(ThreadSort.EVENT_COUNT, null, 2, 2).offset());
+        void areEmptyForALaneThatDoesNotExist() {
+            assertTrue(members("no-such-group", 0, 50).rows().isEmpty());
         }
     }
 
@@ -207,7 +302,9 @@ class ThreadPagingTest {
             assertThrows(IllegalArgumentException.class,
                     () -> new ThreadPageQuery(ThreadSort.EVENT_COUNT, null, -1, 50));
             assertThrows(IllegalArgumentException.class,
-                    () -> new ThreadPageQuery(ThreadSort.EVENT_COUNT, null, 0, 0));
+                    () -> new ThreadMembersQuery("  ", ThreadSort.EVENT_COUNT, 0, 50));
+            assertThrows(IllegalArgumentException.class,
+                    () -> new ThreadMembersQuery("pool-*", ThreadSort.EVENT_COUNT, 0, 0));
         }
     }
 }

--- a/jeffrey-microscope/profiles/profile-threads/src/test/java/cafe/jeffrey/profile/thread/ThreadGroupKeyTest.java
+++ b/jeffrey-microscope/profiles/profile-threads/src/test/java/cafe/jeffrey/profile/thread/ThreadGroupKeyTest.java
@@ -1,0 +1,108 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.thread;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class ThreadGroupKeyTest {
+
+    @Nested
+    class PoolsThatNumberTheirWorkers {
+
+        @Test
+        void collapseOnTheTrailingNumber() {
+            assertEquals("http-nio-8080-exec-*", ThreadGroupKey.of("http-nio-8080-exec-17"));
+            assertEquals("http-nio-8080-exec-*", ThreadGroupKey.of("http-nio-8080-exec-3"));
+        }
+
+        @Test
+        void handleTheSeparatorsTheJdkUses() {
+            assertEquals("worker-*", ThreadGroupKey.of("worker-12"));
+            assertEquals("worker#*", ThreadGroupKey.of("worker#12"));
+            assertEquals("worker_*", ThreadGroupKey.of("worker_12"));
+            assertEquals("Thread*", ThreadGroupKey.of("Thread12"));
+        }
+
+        /**
+         * Only the last number goes. A pool's own number says which executor a thread belongs to, so
+         * dropping it would merge two unrelated pools into one lane.
+         */
+        @Test
+        void keepAnEarlierNumberThatIdentifiesThePool() {
+            assertEquals("pool-3-thread-*", ThreadGroupKey.of("pool-3-thread-1"));
+            assertNotEquals(
+                    ThreadGroupKey.of("pool-3-thread-1"),
+                    ThreadGroupKey.of("pool-4-thread-1"));
+        }
+
+        @Test
+        void collapseForkJoinWorkers() {
+            assertEquals(
+                    "ForkJoinPool.commonPool-worker-*",
+                    ThreadGroupKey.of("ForkJoinPool.commonPool-worker-3"));
+        }
+    }
+
+    @Nested
+    class ThreadsThatShareANameExactly {
+
+        /**
+         * The recording that prompted this: 351 threads all called the same thing, no numbers to
+         * strip. They group on the name itself.
+         */
+        @Test
+        void groupOnTheNameItself() {
+            assertEquals("oracleApp:connection-adder", ThreadGroupKey.of("oracleApp:connection-adder"));
+            assertEquals(
+                    ThreadGroupKey.of("oracleApp:connection-adder"),
+                    ThreadGroupKey.of("oracleApp:connection-adder"));
+        }
+
+        @Test
+        void leaveUnnumberedNamesAlone() {
+            assertEquals("Keep-Alive-Timer", ThreadGroupKey.of("Keep-Alive-Timer"));
+            assertEquals("main", ThreadGroupKey.of("main"));
+            assertEquals("Notification Thread", ThreadGroupKey.of("Notification Thread"));
+        }
+
+        /**
+         * A name that is nothing but digits has no stem to group under, so it stays as it is rather
+         * than collapsing every such thread into a single nameless lane.
+         */
+        @Test
+        void leaveANameThatIsOnlyDigitsAlone() {
+            assertEquals("12345", ThreadGroupKey.of("12345"));
+        }
+    }
+
+    @Nested
+    class MissingNames {
+
+        @Test
+        void fallBackToAPlaceholder() {
+            assertEquals("<unnamed>", ThreadGroupKey.of(null));
+            assertEquals("<unnamed>", ThreadGroupKey.of(""));
+            assertEquals("<unnamed>", ThreadGroupKey.of("   "));
+        }
+    }
+}

--- a/shared/sql-builder/src/main/java/cafe/jeffrey/sql/SQLBuilder.java
+++ b/shared/sql-builder/src/main/java/cafe/jeffrey/sql/SQLBuilder.java
@@ -323,6 +323,10 @@ public class SQLBuilder {
         return new InCondition(column, values.stream().map(LongLiteral::new).toList());
     }
 
+    public static Condition inLongs(String column, List<Long> values) {
+        return new InCondition(column, values.stream().map(LongLiteral::new).toList());
+    }
+
     public static Condition in(String column, List<String> values) {
         return new InCondition(column, values.stream().map(StringLiteral::new).toList());
     }


### PR DESCRIPTION
## Why

A recording with 351 threads called `oracleApp:connection-adder` spent 351 full-width lanes to show 351 single events — one tick each, scattered across the page. The one thing those threads collectively said, the rate the pool was opening connections at, was the one thing a lane apiece made impossible to see. Another 250 lanes went to `Keep-Alive-Timer`.

## What changed

Threads group by name, and the lane carries the **union** of its members' bands. The union is merged the same way a single thread's events are, so 351 rectangles do not stack on one row and each band keeps the count of events behind it.

Opening a lane fetches its threads **50 at a time** — a pool that arrives whole is the problem this started from.

### Grouping key

Numbered workers group by dropping the trailing number, so `http-nio-8080-exec-17` and `http-nio-8080-exec-3` share a lane. Only the *trailing* number goes: `pool-3-thread-1` keeps its `3`, or two unrelated executors would merge into one lane. Threads whose names carry no number — the 351 above — group on the name itself.

### What a lane of one keeps

A group of one **is** that thread's row, identity included, so everything that acts on a thread still works on it. A collapsed lane has no thread of its own and therefore does not offer the flamegraph or thread-info actions — its members do, once opened.

### Filtering

A filter matches a member's name as well as the lane's, so searching for `exec-17` still finds the lane it was folded into. Without that, grouping would make individual threads unfindable by name.

## API

- `GET /thread` now returns `ThreadGroupPage` — lanes, with `matchedGroups` / `totalGroups` / `totalThreads`.
- `GET /thread/members?group=…&offset=…&limit=…` returns the threads behind one lane, paged and capped at 250 like the lanes themselves.

Both read from the timeline already cached per profile. Ordering and filtering use each group's totals, which are a sum over members; the expensive part — building the union — runs only for the lanes a page actually returns.

## Tests

- `ThreadGroupKeyTest` — 8 cases over the grouping key: numbered pools, the JDK's separators, `pool-3-thread-1` keeping its pool number, names that share exactly, names that are only digits, missing names.
- `ThreadPagingTest` — reworked to the group level: six threads folding into four lanes, a 351-member pool whose every event survives the union, a lane of one keeping its thread identity, ordering and stable non-overlapping pages, filtering by member name, and member paging.
- `ThreadControllerTest` — both endpoints: defaults, page caps, parameter passthrough, 400 on a missing group.

Full backend build passes; frontend build, lint, prettier and 210 tests pass.

## Not verified here

I have no recording to drive the UI against, so the visual result — the union lane, the disclosure control, the indented member list — is unverified in a browser. Worth a look at a pool lane, its expansion, and that the flamegraph button still behaves on an individual thread.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPkEqcM735YP1x82KLoZgw)_