### PR TITLE
Rename Advisor "Findings" to "Recommendations"

### DIFF
--- a/shared/ui/common/src/services/severityDisplay.ts
+++ b/shared/ui/common/src/services/severityDisplay.ts
@@ -21,7 +21,7 @@ export type Severity = "CRITICAL" | "HIGH" | "MEDIUM" | "LOW";
 
 /**
  * Presentation helpers for severity. Keeps the severity → look mapping in one place so every screen
- * that ranks findings reads the same way.
+ * that ranks recommendations reads the same way.
  */
 
 const BADGE_VARIANT: Record<Severity, string> = {
@@ -36,7 +36,7 @@ export function severityVariant(severity: Severity): string {
 }
 
 /**
- * Worst first. Kept here rather than in a view so every screen that orders findings agrees on what
+ * Worst first. Kept here rather than in a view so every screen that orders recommendations agrees on what
  * "worse" means — an unknown severity sorts last rather than jumping the queue.
  */
 const RANK: Record<Severity, number> = {


### PR DESCRIPTION
## Summary
Rename the Advisor feature's "Findings" terminology to "Recommendations" throughout the codebase for improved clarity and consistency with the feature's purpose.

## Key Changes
- **Route and component renaming**: Updated route path from `advisor/findings` to `advisor/recommendations` and renamed `AdvisorFindings.vue` to `AdvisorRecommendations.vue`
- **UI labels and messaging**: Changed all user-facing text from "Findings" to "Recommendations" in:
  - Page headers and titles
  - Loading and empty states
  - Navigation menu items
  - Button labels and descriptions
- **Internal references**: Updated variable names (`findingsPath` → `recommendationsPath`) and comments throughout advisor-related components
- **Documentation**: Updated references in profile advisor documentation page and code comments across Java backend modules
- **Consistency**: Updated severity display service comments and test assertions to use "recommendations" terminology

## Implementation Details
- The change is primarily a terminology update with no functional behavior changes
- All route references and component imports have been updated to maintain consistency
- Comments in Java backend modules (AdvisorRunner, AdvisorRun, BatchAdvisorRun, SeverityCalculator, etc.) were updated to reflect the new terminology
- Navigation configuration updated to display "Recommendations" in the profile sidebar menu

https://claude.ai/code/session_01M4Kjv8pJTA9DLX1v7UKAAe