### PR TITLE
Refactor Advisor docket into reusable component with unified layout

### DIFF
--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/AdvisorController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/AdvisorController.java
@@ -30,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
 import cafe.jeffrey.profile.advisor.prompt.AdvisorPrompt;
 import cafe.jeffrey.profile.advisor.prompt.AdvisorPromptManagerFactory;
+import cafe.jeffrey.profile.advisor.prompt.AdvisorPromptType;
 import cafe.jeffrey.profile.advisor.run.AdvisorRunResult;
 import cafe.jeffrey.profile.advisor.run.AdvisorRunner;
 import cafe.jeffrey.profile.advisor.run.AdvisorStages;
@@ -66,7 +67,13 @@ public class AdvisorController {
      * the Advisor's Prompt page renders.
      */
     public record PromptResponse(
-            String eventType, String label, long samples, String prompt, long generatedAt) {
+            String eventType,
+            String label,
+            long samples,
+            String prompt,
+            double dominantSelfPct,
+            String dominantMethod,
+            long generatedAt) {
 
         static PromptResponse from(AdvisorPrompt prompt) {
             return new PromptResponse(
@@ -74,14 +81,19 @@ public class AdvisorController {
                     prompt.label(),
                     prompt.samples(),
                     prompt.prompt(),
+                    prompt.dominantSelfPct(),
+                    prompt.dominantMethod(),
                     prompt.generatedAt().toEpochMilli());
         }
     }
 
     /**
-     * A profile group the Advisor can analyze for this profile, so the UI offers only tabs that exist.
+     * A profile group the Advisor knows about. Every group is listed, including those this recording
+     * carries no samples for: the pages show all four in a fixed order and mark the missing ones, so a
+     * docket reads the same whatever a recording happens to contain. {@code available} is what separates
+     * the two — only an available type can be analyzed.
      */
-    public record EventTypeResponse(String eventType, String label) {
+    public record EventTypeResponse(String eventType, String label, boolean available) {
     }
 
     /**
@@ -94,6 +106,7 @@ public class AdvisorController {
             String eventType,
             String severity,
             double dominantSelfPct,
+            String dominantMethod,
             String report,
             String patch,
             String sourceRef,
@@ -134,11 +147,19 @@ public class AdvisorController {
         this.persistenceProvider = persistenceProvider;
     }
 
+    /**
+     * Every profile group the Advisor knows about, in its declared order, each marked with whether this
+     * recording carries samples for it. The pages list all of them so a type keeps its place whatever a
+     * recording contains; only the available ones can be run.
+     */
     @GetMapping("/event-types")
     public List<EventTypeResponse> eventTypes(@PathVariable("profileId") String profileId) {
         ProfileInfo profile = resolver.resolve(profileId).info();
-        return promptManagerFactory.apply(profile).availableTypes().stream()
-                .map(type -> new EventTypeResponse(type.primaryEventType().code(), type.label()))
+        List<AdvisorPromptType> available = promptManagerFactory.apply(profile).availableTypes();
+
+        return List.of(AdvisorPromptType.values()).stream()
+                .map(type -> new EventTypeResponse(
+                        type.primaryEventType().code(), type.label(), available.contains(type)))
                 .toList();
     }
 
@@ -277,6 +298,7 @@ public class AdvisorController {
                 row.eventType(),
                 row.severity(),
                 row.dominantSelfPct(),
+                row.dominantMethod(),
                 row.report(),
                 row.patch(),
                 row.sourceRef(),

--- a/jeffrey-microscope/pages-microscope/src/composables/useAdvisor.ts
+++ b/jeffrey-microscope/pages-microscope/src/composables/useAdvisor.ts
@@ -18,6 +18,7 @@
 
 import { computed, onUnmounted, ref } from 'vue';
 import AdvisorClient from '@/services/api/AdvisorClient';
+import { compareEventTypes } from '@/views/profiles/detail/advisor/eventTypeStyle';
 import type {
   AdvisorEventType,
   AdvisorRecommendation,
@@ -94,12 +95,21 @@ export function useAdvisor(profileId: string) {
     }
   };
 
+  /**
+   * Lands on the first analysed type in the docket's own order, so the page opens where the docket
+   * points. Failing that, the first type the recording actually carries — never one it has no samples
+   * for, which would open the page on an explanation of an absence.
+   */
   const pickSelected = (): void => {
-    selectedEventType.value =
-      recommendations.value[0]?.eventType ??
-      selectedEventType.value ??
-      eventTypes.value[0]?.eventType ??
-      null;
+    const analysed = [...recommendations.value].sort((left, right) =>
+      compareEventTypes(left.eventType, right.eventType)
+    )[0]?.eventType;
+
+    const recorded = [...eventTypes.value]
+      .sort((left, right) => compareEventTypes(left.eventType, right.eventType))
+      .find(type => type.available)?.eventType;
+
+    selectedEventType.value = analysed ?? selectedEventType.value ?? recorded ?? null;
   };
 
   /**

--- a/jeffrey-microscope/pages-microscope/src/services/api/model/Advisor.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/model/Advisor.ts
@@ -18,10 +18,15 @@
 
 import type { Severity } from '@shared/services/severityDisplay';
 
-/** A profile group the Advisor can analyze, as reported by the backend. */
+/**
+ * A profile group the Advisor knows about. Every group is reported, including the ones this recording
+ * carries no samples for — {@link available} is what separates them. The pages list all of them so a
+ * type keeps its place whatever a recording contains.
+ */
 export interface AdvisorEventType {
   eventType: string;
   label: string;
+  available: boolean;
 }
 
 /**
@@ -33,6 +38,10 @@ export interface AdvisorPrompt {
   label: string;
   samples: number;
   prompt: string;
+  /** The measured self share of the profile's heaviest method, as of when the prompt was built. */
+  dominantSelfPct: number;
+  /** The name of that method, or an empty string when the profile had no samples. */
+  dominantMethod: string;
   generatedAt: number;
 }
 
@@ -41,6 +50,8 @@ export interface AdvisorRecommendation {
   severity: Severity;
   /** The measured self share of the profile's heaviest method — the number severity was graded from. */
   dominantSelfPct: number;
+  /** The name of that method, or an empty string when it is not known. */
+  dominantMethod: string;
   /** The recommendations markdown the model wrote. */
   report: string;
   /** The proposed unified diff, or null when the model proposed no code edit. */

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/advisor/AdvisorDocket.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/advisor/AdvisorDocket.vue
@@ -1,0 +1,213 @@
+<!--
+  - Jeffrey
+  - Copyright (C) 2026 Petr Bouda
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as published by
+  - the Free Software Foundation, either version 3 of the License, or
+  - (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<!--
+  The docket the three Advisor artifact pages open with: every event type the Advisor knows about, in
+  one fixed order, each card carrying that type's own figures. What those figures are is the page's
+  business — Prompts has no diff and Patches has no prompt size — so the rows come in through a slot
+  and this component owns only the card, its states and the selection.
+-->
+<template>
+  <div class="docket">
+    <div class="docket-list">
+      <button
+        v-for="item in items"
+        :key="item.eventType"
+        type="button"
+        class="docket-item"
+        :class="{ selected: item.eventType === selected, unavailable: !item.available }"
+        :style="eventTypeVars(item.eventType)"
+        :title="item.available ? undefined : `This recording carries no ${item.label} samples`"
+        @click="emit('update:selected', item.eventType)"
+      >
+        <span class="docket-head">
+          <span class="docket-name">
+            <i class="bi" :class="eventTypeStyle(item.eventType).icon"></i>
+            {{ item.label }}
+          </span>
+          <Badge
+            v-if="item.badge"
+            :value="item.badge.value"
+            :variant="item.badge.variant"
+            size="xxs"
+          />
+          <span v-else-if="!item.available" class="docket-missing">Not recorded</span>
+        </span>
+
+        <span v-if="item.available" class="docket-rows">
+          <slot name="rows" :item="item"></slot>
+        </span>
+
+        <!-- A missing type still says something: the flag that would have captured it. -->
+        <span v-else class="docket-note">
+          No samples here. Captured by <code>{{ eventTypeCaptureFlag(item.eventType) }}</code
+          >.
+        </span>
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Badge from '@shared/components/Badge.vue';
+import {
+  eventTypeCaptureFlag,
+  eventTypeStyle,
+  eventTypeVars
+} from '@/views/profiles/detail/advisor/eventTypeStyle';
+import type { DocketItem } from '@/views/profiles/detail/advisor/advisorDocket';
+
+defineProps<{
+  items: DocketItem[];
+  selected: string | null;
+}>();
+
+const emit = defineEmits<{
+  'update:selected': [eventType: string];
+}>();
+</script>
+
+<style scoped>
+.docket {
+  margin-bottom: 1.1rem;
+}
+
+.docket-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(212px, 1fr));
+  gap: 0.5rem;
+}
+
+/* The left spine is the type's own accent — the same device the Overview's manifest uses, so the
+   Advisor's pages read as one family. Selection tints the card rather than flooding it, which keeps a
+   red type (Blocking) from reading as an error the moment you pick it. */
+.docket-item {
+  appearance: none;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+  border: 1px solid var(--color-border);
+  border-left: 3px solid var(--et);
+  border-radius: var(--radius-base);
+  background: var(--color-bg-card);
+  padding: 0.6rem 0.72rem 0.65rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  transition:
+    background 0.16s,
+    border-color 0.16s;
+}
+
+.docket-item:hover {
+  background: var(--color-light);
+}
+
+.docket-item.selected {
+  background: var(--et-light);
+  border-color: var(--et);
+}
+
+.docket-head {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.docket-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  min-width: 0;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--color-heading-dark);
+}
+
+.docket-name i {
+  color: var(--et);
+}
+
+.docket-head :deep(.badge) {
+  margin-left: auto;
+  flex: none;
+}
+
+.docket-rows {
+  display: flex;
+  flex-direction: column;
+}
+
+/* A type the recording has no samples for: ruled out with a hatch, still selectable — its page
+   explains what is missing and how to record it. Selection reads as a neutral ring rather than the
+   type's colour, which would imply there is data behind the card. */
+.docket-item.unavailable {
+  border-left-color: var(--color-border-input);
+  background-color: var(--color-bg-card);
+  background-image: repeating-linear-gradient(-45deg, var(--hatch-line) 0 1px, transparent 1px 7px);
+}
+
+.docket-item.unavailable .docket-name,
+.docket-item.unavailable .docket-name i {
+  color: var(--color-text-muted);
+}
+
+.docket-item.unavailable:hover {
+  background-color: var(--color-light);
+}
+
+.docket-item.unavailable.selected {
+  background-color: var(--color-lighter);
+  border-color: var(--color-border-input);
+  border-left-color: var(--color-border-input);
+}
+
+.docket-item.unavailable.selected .docket-name {
+  color: var(--color-heading-dark);
+}
+
+.docket-missing {
+  margin-left: auto;
+  flex: none;
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  background: var(--color-light);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  padding: 0.06rem 0.4rem;
+}
+
+.docket-note {
+  font-size: 0.68rem;
+  line-height: 1.5;
+  color: var(--color-text-muted);
+}
+
+.docket-note code {
+  font-family: var(--font-family-monospace);
+  font-size: 0.68rem;
+  color: var(--color-heading-dark);
+  background: var(--color-light);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 0.02rem 0.24rem;
+}
+</style>

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/advisor/AdvisorDocketRow.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/advisor/AdvisorDocketRow.vue
@@ -1,0 +1,78 @@
+<!--
+  - Jeffrey
+  - Copyright (C) 2026 Petr Bouda
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as published by
+  - the Free Software Foundation, either version 3 of the License, or
+  - (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<template>
+  <span class="docket-row">
+    <span class="docket-key">{{ label }}</span>
+    <span class="docket-value" :class="{ mono }" :title="title">
+      <slot></slot>
+    </span>
+  </span>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  label: string;
+  /** Frame names and other code identifiers read better — and truncate more honestly — in monospace. */
+  mono?: boolean;
+  /** The unabbreviated value, for the values a card has to shorten. */
+  title?: string;
+}>();
+</script>
+
+<style scoped>
+/* Everything here is inline-level: these rows live inside the docket's <button>. */
+.docket-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.22rem 0;
+  font-size: 0.71rem;
+}
+
+.docket-row + .docket-row {
+  border-top: 1px solid var(--color-border-row);
+}
+
+.docket-key {
+  flex: none;
+  font-size: 0.6rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+.docket-value {
+  margin-left: auto;
+  min-width: 0;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--color-heading-dark);
+}
+
+.docket-value.mono {
+  font-family: var(--font-family-monospace);
+  font-size: 0.67rem;
+  font-weight: 500;
+}
+</style>

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/advisor/AdvisorMissingType.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/advisor/AdvisorMissingType.vue
@@ -1,0 +1,184 @@
+<!--
+  - Jeffrey
+  - Copyright (C) 2026 Petr Bouda
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as published by
+  - the Free Software Foundation, either version 3 of the License, or
+  - (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<!--
+  What an Advisor page shows when you pick a type this recording carries no samples for. "No samples"
+  on its own is a dead end, so the card answers the question it provokes: the profiler command that
+  captures this type, with the missing flag as the only highlighted thing on it.
+-->
+<template>
+  <MainCard>
+    <template #header>
+      <MainCardHeader :icon="eventTypeStyle(eventType).icon" :title="label">
+        <template #actions>
+          <Badge value="Not recorded" variant="grey" size="xs" />
+        </template>
+      </MainCardHeader>
+    </template>
+
+    <div class="missing">
+      <p>
+        This recording carries no <b>{{ label }}</b> samples, so there is no {{ missingArtifact }}.
+        <template v-if="description">{{ label }} measures {{ description }}.</template>
+      </p>
+
+      <span class="missing-label">Add it to the profiler command</span>
+      <code class="missing-command"
+        ><span>{{ commandPrefix }}</span
+        ><mark>{{ captureFlag }}</mark
+        ><span>{{ COMMAND_SUFFIX }}</span></code
+      >
+
+      <button type="button" class="copy-btn" @click="copy">
+        <i class="bi" :class="copied ? 'bi-check-lg' : 'bi-clipboard'"></i>
+        {{ copied ? 'Copied' : 'Copy command' }}
+      </button>
+    </div>
+  </MainCard>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import MainCard from '@shared/components/MainCard.vue';
+import MainCardHeader from '@shared/components/MainCardHeader.vue';
+import Badge from '@shared/components/Badge.vue';
+import ToastService from '@shared/services/ToastService';
+import {
+  eventTypeCaptureFlag,
+  eventTypeDescription,
+  eventTypeStyle
+} from '@/views/profiles/detail/advisor/eventTypeStyle';
+
+const props = defineProps<{
+  eventType: string;
+  label: string;
+  /** What this page would have held for the type — "the prompt", "a report", "a diff". */
+  missingArtifact: string;
+}>();
+
+const COPIED_FEEDBACK_MS = 1500;
+
+// The command the Profiler Settings page builds, with this type's flag spliced into it.
+const COMMAND_PREFIX = '-agentpath:/path/to/libasyncProfiler.so=start,event=ctimer,';
+const COMMAND_SUFFIX = ',loop=15m,file=profile.jfr';
+
+const captureFlag = computed(() => eventTypeCaptureFlag(props.eventType));
+const description = computed(() => eventTypeDescription(props.eventType));
+
+/**
+ * CPU is captured by the engine the command already names, so its flag is the prefix's own — showing
+ * `event=ctimer` twice would read as a command that does not work.
+ */
+const commandPrefix = computed(() =>
+  COMMAND_PREFIX.endsWith(captureFlag.value + ',')
+    ? COMMAND_PREFIX.slice(0, -(captureFlag.value.length + 1))
+    : COMMAND_PREFIX
+);
+
+const command = computed(() => commandPrefix.value + captureFlag.value + COMMAND_SUFFIX);
+
+const copied = ref(false);
+
+async function copy(): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(command.value);
+    copied.value = true;
+    setTimeout(() => {
+      copied.value = false;
+    }, COPIED_FEEDBACK_MS);
+  } catch {
+    ToastService.error('Profiler command', 'The browser blocked access to the clipboard');
+  }
+}
+</script>
+
+<style scoped>
+.missing {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.missing p {
+  margin: 0 0 0.9rem;
+  font-size: 0.85rem;
+  line-height: 1.6;
+  color: var(--color-text-muted);
+}
+
+.missing p b {
+  color: var(--color-heading-dark);
+  font-weight: 600;
+}
+
+.missing-label {
+  display: block;
+  font-size: 0.64rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  margin-bottom: 0.4rem;
+}
+
+.missing-command {
+  display: block;
+  align-self: stretch;
+  font-family: var(--font-family-monospace);
+  font-size: 0.72rem;
+  line-height: 1.7;
+  color: var(--color-heading-dark);
+  background: var(--color-light);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-base);
+  padding: 0.6rem 0.7rem;
+  overflow-x: auto;
+  white-space: pre;
+}
+
+.missing-command mark {
+  background: var(--color-primary-light);
+  color: var(--color-primary);
+  font-weight: 600;
+  border-radius: var(--radius-sm);
+  padding: 0.05rem 0.2rem;
+}
+
+.copy-btn {
+  appearance: none;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.74rem;
+  font-weight: 600;
+  border-radius: var(--radius-base);
+  border: 1px solid var(--color-primary-border-light);
+  background: transparent;
+  color: var(--color-primary);
+  padding: 0.32rem 0.65rem;
+  margin-top: 0.9rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.32rem;
+  transition: background 0.15s;
+}
+
+.copy-btn:hover {
+  background: var(--color-primary-light);
+}
+</style>

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/advisor/AdvisorPatches.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/advisor/AdvisorPatches.vue
@@ -30,35 +30,44 @@
     <AiDisabledFeatureAlert v-if="aiDisabled" />
 
     <template v-else-if="hasResults">
-      <!-- Every analyzed type is listed, including those the model proposed nothing for: a type that
-           produced no diff is a result, and hiding it would read as a type that was never analyzed. -->
-      <div class="docket">
-        <div class="docket-list">
-          <button
-            v-for="rec in orderedRecommendations"
-            :key="rec.eventType"
-            type="button"
-            class="docket-item"
-            :class="{ selected: selectedType === rec.eventType, empty: !hasPatch(rec) }"
-            :style="eventTypeVars(rec.eventType)"
-            @click="selectedType = rec.eventType"
-          >
-            <span class="docket-name">
-              <i class="bi" :class="eventTypeStyle(rec.eventType).icon"></i>
-              {{ labelFor(rec.eventType) }}
-            </span>
-            <span class="docket-verdict">
-              {{ severityLabel(rec.severity) }} · {{ costOf(rec) }}
-            </span>
-          </button>
-        </div>
-      </div>
+      <!-- Every type is listed, including those the model proposed nothing for: a type that produced
+           no diff is a result, and hiding it would read as a type that was never analyzed. -->
+      <AdvisorDocket v-model:selected="selectedType" :items="items">
+        <template #rows="{ item }">
+          <template v-if="recommendationFor(item.eventType)">
+            <AdvisorDocketRow label="Diff">
+              <template v-if="hasPatch(recommendationFor(item.eventType)!.patch)">
+                <span class="added">+{{ statsFor(item.eventType).added }}</span>
+                <span class="removed">−{{ statsFor(item.eventType).removed }}</span>
+              </template>
+              <template v-else>none</template>
+            </AdvisorDocketRow>
+            <AdvisorDocketRow label="Files">{{ filesLabel(item.eventType) }}</AdvisorDocketRow>
+            <AdvisorDocketRow
+              label="Top method"
+              mono
+              :title="recommendationFor(item.eventType)!.dominantMethod"
+            >
+              {{ topMethod(recommendationFor(item.eventType)!.dominantMethod) }}
+            </AdvisorDocketRow>
+          </template>
+          <AdvisorDocketRow v-else label="Patch">not analysed yet</AdvisorDocketRow>
+        </template>
+      </AdvisorDocket>
+
+      <!-- A type this recording has no samples for: what is missing, and how to record it. -->
+      <AdvisorMissingType
+        v-if="selectedMissing"
+        :event-type="selectedMissing.eventType"
+        :label="selectedMissing.label"
+        missing-artifact="diff to apply"
+      />
 
       <!-- The diff carries its own frame — file, cost, counts and actions are all on its header bar —
            so it stands on its own rather than inside a card that would repeat the type's name. -->
-      <template v-if="selected">
+      <template v-else-if="selected">
         <DiffViewer
-          v-if="hasPatch(selected)"
+          v-if="hasPatch(selected.patch)"
           :patch="selected.patch as string"
           :file-name="patchFileName"
         />
@@ -78,6 +87,14 @@
           </template>
         </EmptyState>
       </template>
+
+      <!-- Recorded, but this run never analysed it. -->
+      <EmptyState
+        v-else
+        icon="bi-file-earmark-diff"
+        :title="`No ${selectedLabel} patch yet`"
+        description="The Advisor analyses this type on its next run."
+      />
     </template>
 
     <!-- The Advisor has not produced anything yet for this profile. -->
@@ -110,16 +127,19 @@ import ErrorState from '@shared/components/ErrorState.vue';
 import PageHeader from '@shared/components/layout/PageHeader.vue';
 import EmptyState from '@shared/components/EmptyState.vue';
 import DiffViewer from '@shared/components/DiffViewer.vue';
-import FormattingService from '@shared/services/FormattingService';
-import { severityLabel } from '@shared/services/severityDisplay';
+import { severityLabel, severityVariant } from '@shared/services/severityDisplay';
 import type { AdvisorRecommendation } from '@/services/api/model/Advisor';
 import AiDisabledFeatureAlert from '@/components/alerts/AiDisabledFeatureAlert.vue';
+import AdvisorDocket from '@/views/profiles/detail/advisor/AdvisorDocket.vue';
+import AdvisorDocketRow from '@/views/profiles/detail/advisor/AdvisorDocketRow.vue';
+import AdvisorMissingType from '@/views/profiles/detail/advisor/AdvisorMissingType.vue';
 import {
-  compareEventTypes,
-  eventTypeCostLabel,
-  eventTypeStyle,
-  eventTypeVars
-} from '@/views/profiles/detail/advisor/eventTypeStyle';
+  docketItems,
+  hasPatch,
+  patchStats,
+  type PatchStats
+} from '@/views/profiles/detail/advisor/advisorDocket';
+import { shortMethodName } from '@/views/profiles/detail/advisor/eventTypeStyle';
 import { useAdvisor } from '@/composables/useAdvisor';
 import FeatureType from '@/services/api/model/FeatureType';
 
@@ -147,37 +167,62 @@ const recommendationsPath = computed(() => `/profiles/${profileId}/advisor/recom
 const labelFor = (code: string): string =>
   eventTypes.value.find(type => type.eventType === code)?.label ?? code;
 
-const hasPatch = (recommendation: AdvisorRecommendation): boolean =>
-  recommendation.patch !== null && recommendation.patch.trim() !== '';
+const recommendationFor = (eventType: string): AdvisorRecommendation | undefined =>
+  recommendations.value.find(item => item.eventType === eventType);
 
-/** What a type's card says under its name: the price of its patch, or that there isn't one. */
-const costOf = (recommendation: AdvisorRecommendation): string => {
-  if (!hasPatch(recommendation)) {
-    return 'no patch';
-  }
-  return `${FormattingService.formatPercentValue(recommendation.dominantSelfPct)} ${eventTypeCostLabel(recommendation.eventType)}`;
+const statsFor = (eventType: string): PatchStats =>
+  patchStats(recommendationFor(eventType)?.patch ?? null);
+
+const filesLabel = (eventType: string): string => {
+  const files = statsFor(eventType).files;
+  return files === 0 ? '\u2014' : String(files);
 };
+
+const topMethod = (method: string): string => (method === '' ? 'unknown' : shortMethodName(method));
 
 /**
  * CPU, Wall-Clock, Allocation, Blocking — the Advisor's canonical order, the same one Prompts and
  * Recommendations use, so a type sits in the same place on all three pages. Whether a type produced a
  * patch is said on its card rather than by moving it.
  */
-const orderedRecommendations = computed(() =>
-  [...recommendations.value].sort((left, right) =>
-    compareEventTypes(left.eventType, right.eventType)
-  )
+const items = computed(() =>
+  docketItems(eventTypes.value, eventType => {
+    const recommendation = recommendationFor(eventType);
+    if (recommendation === undefined) {
+      return undefined;
+    }
+    return {
+      value: severityLabel(recommendation.severity),
+      variant: severityVariant(recommendation.severity)
+    };
+  })
 );
 
 /**
- * Opens on the first type that actually has a patch, so the page lands on something to read rather than
- * on an explanation of an absence — the docket order itself no longer guarantees that.
+ * Opens on the first type that actually has a patch, so the page lands on something to read rather
+ * than on an explanation of an absence — the docket order itself does not guarantee that.
  */
-const selected = computed(
+const firstWithPatch = computed(
   () =>
-    orderedRecommendations.value.find(rec => rec.eventType === selectedType.value) ??
-    orderedRecommendations.value.find(hasPatch) ??
-    orderedRecommendations.value[0]
+    items.value.find(item => hasPatch(recommendationFor(item.eventType)?.patch ?? null))
+      ?.eventType ?? null
+);
+
+const selectedItem = computed(
+  () =>
+    items.value.find(item => item.eventType === selectedType.value) ??
+    items.value.find(item => item.eventType === firstWithPatch.value)
+);
+
+const selectedLabel = computed(() => selectedItem.value?.label ?? '');
+
+/** Set only when the selected type is one this recording carries no samples for. */
+const selectedMissing = computed(() =>
+  selectedItem.value?.available === false ? selectedItem.value : undefined
+);
+
+const selected = computed(() =>
+  selectedItem.value ? recommendationFor(selectedItem.value.eventType) : undefined
 );
 
 const patchFileName = computed(() => {
@@ -189,84 +234,14 @@ onMounted(load);
 </script>
 
 <style scoped>
-/* The docket: the patches ranked by what each one is worth. */
-.docket {
-  margin-bottom: 1.1rem;
+/* The docket's own styling lives in AdvisorDocket; only the diff counts are this page's. */
+.added {
+  color: var(--color-success-dark);
 }
 
-.docket-list {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
-  gap: 0.5rem;
-}
-
-/* The left spine is the type's own accent — the same device the Recommendations docket uses, so the Advisor's
-   pages read as one family. Selection tints the card rather than flooding it, which keeps a red type
-   (Blocking) from reading as an error the moment you pick it. */
-.docket-item {
-  appearance: none;
-  font-family: inherit;
-  text-align: left;
-  cursor: pointer;
-  border: 1px solid var(--color-border);
-  border-left: 3px solid var(--et);
-  border-radius: var(--radius-base);
-  background: var(--color-bg-card);
-  padding: 0.5rem 0.7rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.1rem;
-  transition: background 0.16s, border-color 0.16s;
-}
-
-.docket-item:hover {
-  background: var(--color-light);
-}
-
-.docket-item.selected {
-  background: var(--et-light);
-  border-color: var(--et);
-}
-
-.docket-name {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  font-size: 0.82rem;
-  font-weight: 600;
-  color: var(--color-heading-dark);
-}
-
-.docket-name i {
-  color: var(--et);
-}
-
-.docket-verdict {
-  font-size: 0.68rem;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--color-text-muted);
-}
-
-.docket-item.selected .docket-verdict {
-  color: var(--et);
-}
-
-/* Analyzed but with nothing to apply: still listed, still selectable, just visibly not the reason you
-   came to this page. The accent stays so the type keeps its identity across the Advisor's pages. */
-.docket-item.empty .docket-name {
-  color: var(--color-text-muted);
-}
-
-.docket-item.empty .docket-name i {
-  opacity: 0.55;
-}
-
-.docket-item.empty .docket-verdict {
-  font-style: italic;
-  letter-spacing: 0.03em;
-  text-transform: none;
+.removed {
+  color: var(--color-danger);
+  margin-left: 0.3rem;
 }
 
 /* action button inside the EmptyState (nothing to apply) */

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/advisor/AdvisorPatches.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/advisor/AdvisorPatches.vue
@@ -35,7 +35,7 @@
       <div class="docket">
         <div class="docket-list">
           <button
-            v-for="rec in rankedRecommendations"
+            v-for="rec in orderedRecommendations"
             :key="rec.eventType"
             type="button"
             class="docket-item"
@@ -111,10 +111,11 @@ import PageHeader from '@shared/components/layout/PageHeader.vue';
 import EmptyState from '@shared/components/EmptyState.vue';
 import DiffViewer from '@shared/components/DiffViewer.vue';
 import FormattingService from '@shared/services/FormattingService';
-import { severityLabel, severityRank } from '@shared/services/severityDisplay';
+import { severityLabel } from '@shared/services/severityDisplay';
 import type { AdvisorRecommendation } from '@/services/api/model/Advisor';
 import AiDisabledFeatureAlert from '@/components/alerts/AiDisabledFeatureAlert.vue';
 import {
+  compareEventTypes,
   eventTypeCostLabel,
   eventTypeStyle,
   eventTypeVars
@@ -158,35 +159,25 @@ const costOf = (recommendation: AdvisorRecommendation): string => {
 };
 
 /**
- * Types with a patch first — this page exists to hand you a change, so the ones that have none belong
- * after the ones that do. Within each group the ranking is the Recommendations docket's: worst severity
- * first, then the most expensive frame, then alphabetically, so the order is stable across reloads.
+ * CPU, Wall-Clock, Allocation, Blocking — the Advisor's canonical order, the same one Prompts and
+ * Recommendations use, so a type sits in the same place on all three pages. Whether a type produced a
+ * patch is said on its card rather than by moving it.
  */
-const rankedRecommendations = computed(() =>
-  [...recommendations.value].sort((left, right) => {
-    if (hasPatch(left) !== hasPatch(right)) {
-      return hasPatch(left) ? -1 : 1;
-    }
-    const bySeverity = severityRank(left.severity) - severityRank(right.severity);
-    if (bySeverity !== 0) {
-      return bySeverity;
-    }
-    const byCost = right.dominantSelfPct - left.dominantSelfPct;
-    if (byCost !== 0) {
-      return byCost;
-    }
-    return labelFor(left.eventType).localeCompare(labelFor(right.eventType));
-  })
+const orderedRecommendations = computed(() =>
+  [...recommendations.value].sort((left, right) =>
+    compareEventTypes(left.eventType, right.eventType)
+  )
 );
 
 /**
- * Opens on the first type that actually has a patch — the ranking puts it first — so the page lands
- * on something to read rather than on an explanation of an absence.
+ * Opens on the first type that actually has a patch, so the page lands on something to read rather than
+ * on an explanation of an absence — the docket order itself no longer guarantees that.
  */
 const selected = computed(
   () =>
-    rankedRecommendations.value.find(rec => rec.eventType === selectedType.value) ??
-    rankedRecommendations.value[0]
+    orderedRecommendations.value.find(rec => rec.eventType === selectedType.value) ??
+    orderedRecommendations.value.find(hasPatch) ??
+    orderedRecommendations.value[0]
 );
 
 const patchFileName = computed(() => {

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/advisor/AdvisorPrompt.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/advisor/AdvisorPrompt.vue
@@ -23,7 +23,7 @@
 
   <PageHeader
     v-else
-    title="Prompt"
+    title="Prompts"
     description="The exact message the Advisor sends to the model for each event type"
     icon="bi-chat-square-text"
   >
@@ -33,7 +33,7 @@
       <div class="docket">
         <div class="docket-list">
           <button
-            v-for="prompt in prompts"
+            v-for="prompt in orderedPrompts"
             :key="prompt.eventType"
             type="button"
             class="docket-item"
@@ -109,7 +109,11 @@ import ToastService from '@shared/services/ToastService';
 import AdvisorClient from '@/services/api/AdvisorClient';
 import type { AdvisorPrompt } from '@/services/api/model/Advisor';
 import AiDisabledFeatureAlert from '@/components/alerts/AiDisabledFeatureAlert.vue';
-import { eventTypeStyle, eventTypeVars } from '@/views/profiles/detail/advisor/eventTypeStyle';
+import {
+  compareEventTypes,
+  eventTypeStyle,
+  eventTypeVars
+} from '@/views/profiles/detail/advisor/eventTypeStyle';
 import { useAdvisor } from '@/composables/useAdvisor';
 import FeatureType from '@/services/api/model/FeatureType';
 
@@ -143,9 +147,15 @@ const aiDisabled = computed(
 
 const overviewPath = computed(() => `/profiles/${profileId}/advisor`);
 
+/** CPU, Wall-Clock, Allocation, Blocking — the order Recommendations and Patches list them in too. */
+const orderedPrompts = computed(() =>
+  [...prompts.value].sort((left, right) => compareEventTypes(left.eventType, right.eventType))
+);
+
 const selected = computed(
   () =>
-    prompts.value.find(prompt => prompt.eventType === selectedType.value) ?? prompts.value[0]
+    orderedPrompts.value.find(prompt => prompt.eventType === selectedType.value) ??
+    orderedPrompts.value[0]
 );
 
 async function load(): Promise<void> {

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/advisor/AdvisorPrompt.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/advisor/AdvisorPrompt.vue
@@ -30,29 +30,37 @@
     <AiDisabledFeatureAlert v-if="aiDisabled" />
 
     <template v-else-if="prompts.length > 0">
-      <div class="docket">
-        <div class="docket-list">
-          <button
-            v-for="prompt in orderedPrompts"
-            :key="prompt.eventType"
-            type="button"
-            class="docket-item"
-            :class="{ selected: selected?.eventType === prompt.eventType }"
-            :style="eventTypeVars(prompt.eventType)"
-            @click="selectedType = prompt.eventType"
-          >
-            <span class="docket-name">
-              <i class="bi" :class="eventTypeStyle(prompt.eventType).icon"></i>
-              {{ prompt.label }}
-            </span>
-            <span class="docket-verdict">
-              {{ FormattingService.formatNumber(prompt.samples) }} samples
-            </span>
-          </button>
-        </div>
-      </div>
+      <AdvisorDocket v-model:selected="selectedType" :items="items">
+        <template #rows="{ item }">
+          <template v-if="promptFor(item.eventType)">
+            <AdvisorDocketRow label="Samples">
+              {{ FormattingService.formatNumber(promptFor(item.eventType)!.samples) }}
+            </AdvisorDocketRow>
+            <AdvisorDocketRow label="Prompt">
+              {{ FormattingService.formatBytesShort(promptFor(item.eventType)!.prompt.length) }}
+            </AdvisorDocketRow>
+            <AdvisorDocketRow
+              label="Top method"
+              mono
+              :title="promptFor(item.eventType)!.dominantMethod"
+            >
+              {{ topMethod(promptFor(item.eventType)!.dominantMethod) }}
+            </AdvisorDocketRow>
+          </template>
+          <AdvisorDocketRow v-else label="Prompt">not built yet</AdvisorDocketRow>
+        </template>
+      </AdvisorDocket>
 
-      <MainCard v-if="selected">
+      <!-- A type this recording has no samples for is still selectable: the page says what is missing
+           and how to record it, rather than leaving a dead card. -->
+      <AdvisorMissingType
+        v-if="selectedMissing"
+        :event-type="selectedMissing.eventType"
+        :label="selectedMissing.label"
+        missing-artifact="prompt to show"
+      />
+
+      <MainCard v-else-if="selected">
         <template #header>
           <MainCardHeader icon="bi-chat-square-text" :title="`${selected.label} prompt`">
             <template #actions>
@@ -71,6 +79,14 @@
              and a rendered call tree is no longer the text the model read. -->
         <pre class="prompt">{{ selected.prompt }}</pre>
       </MainCard>
+
+      <!-- Recorded, but this run never built its prompt. -->
+      <EmptyState
+        v-else
+        icon="bi-chat-square-text"
+        :title="`No ${selectedLabel} prompt yet`"
+        description="The Advisor builds a prompt for this type on its next run."
+      />
     </template>
 
     <!-- Nothing is cached until the Advisor has run at least once for this profile. -->
@@ -109,11 +125,11 @@ import ToastService from '@shared/services/ToastService';
 import AdvisorClient from '@/services/api/AdvisorClient';
 import type { AdvisorPrompt } from '@/services/api/model/Advisor';
 import AiDisabledFeatureAlert from '@/components/alerts/AiDisabledFeatureAlert.vue';
-import {
-  compareEventTypes,
-  eventTypeStyle,
-  eventTypeVars
-} from '@/views/profiles/detail/advisor/eventTypeStyle';
+import AdvisorDocket from '@/views/profiles/detail/advisor/AdvisorDocket.vue';
+import AdvisorDocketRow from '@/views/profiles/detail/advisor/AdvisorDocketRow.vue';
+import AdvisorMissingType from '@/views/profiles/detail/advisor/AdvisorMissingType.vue';
+import { docketItems } from '@/views/profiles/detail/advisor/advisorDocket';
+import { shortMethodName } from '@/views/profiles/detail/advisor/eventTypeStyle';
 import { useAdvisor } from '@/composables/useAdvisor';
 import FeatureType from '@/services/api/model/FeatureType';
 
@@ -131,7 +147,7 @@ const profileId = route.params.profileId as string;
  * composable is
  * still used for the run state, which is what tells an empty page whether to say "not yet" or "wait".
  */
-const { isRunning, load: loadRunState } = useAdvisor(profileId);
+const { eventTypes, isRunning, load: loadRunState } = useAdvisor(profileId);
 
 const client = new AdvisorClient(profileId);
 
@@ -147,15 +163,34 @@ const aiDisabled = computed(
 
 const overviewPath = computed(() => `/profiles/${profileId}/advisor`);
 
-/** CPU, Wall-Clock, Allocation, Blocking — the order Recommendations and Patches list them in too. */
-const orderedPrompts = computed(() =>
-  [...prompts.value].sort((left, right) => compareEventTypes(left.eventType, right.eventType))
+/** CPU, Wall-Clock, Allocation, Blocking — every type, in the order the other Advisor pages use. */
+const items = computed(() => docketItems(eventTypes.value, () => undefined));
+
+const promptFor = (eventType: string): AdvisorPrompt | undefined =>
+  prompts.value.find(prompt => prompt.eventType === eventType);
+
+const topMethod = (method: string): string => (method === '' ? 'unknown' : shortMethodName(method));
+
+/** Opens on the first type that has a prompt, so the page lands on something to read. */
+const firstWithPrompt = computed(
+  () => items.value.find(item => promptFor(item.eventType) !== undefined)?.eventType ?? null
 );
 
-const selected = computed(
+const selectedItem = computed(
   () =>
-    orderedPrompts.value.find(prompt => prompt.eventType === selectedType.value) ??
-    orderedPrompts.value[0]
+    items.value.find(item => item.eventType === selectedType.value) ??
+    items.value.find(item => item.eventType === firstWithPrompt.value)
+);
+
+const selectedLabel = computed(() => selectedItem.value?.label ?? '');
+
+/** Set only when the selected type is one this recording carries no samples for. */
+const selectedMissing = computed(() =>
+  selectedItem.value?.available === false ? selectedItem.value : undefined
+);
+
+const selected = computed(() =>
+  selectedItem.value ? promptFor(selectedItem.value.eventType) : undefined
 );
 
 async function load(): Promise<void> {
@@ -190,67 +225,6 @@ onMounted(load);
 </script>
 
 <style scoped>
-/* The docket mirrors Recommendations and Patches, so the three artifact pages read as one family. */
-.docket {
-  margin-bottom: 1.1rem;
-}
-
-.docket-list {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
-  gap: 0.5rem;
-}
-
-.docket-item {
-  appearance: none;
-  font-family: inherit;
-  text-align: left;
-  cursor: pointer;
-  border: 1px solid var(--color-border);
-  border-left: 3px solid var(--et);
-  border-radius: var(--radius-base);
-  background: var(--color-bg-card);
-  padding: 0.5rem 0.7rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.1rem;
-  transition: background 0.16s, border-color 0.16s;
-}
-
-.docket-item:hover {
-  background: var(--color-light);
-}
-
-.docket-item.selected {
-  background: var(--et-light);
-  border-color: var(--et);
-}
-
-.docket-name {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  font-size: 0.82rem;
-  font-weight: 600;
-  color: var(--color-heading-dark);
-}
-
-.docket-name i {
-  color: var(--et);
-}
-
-.docket-verdict {
-  font-size: 0.68rem;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--color-text-muted);
-}
-
-.docket-item.selected .docket-verdict {
-  color: var(--et);
-}
-
 .generated {
   font-size: 0.72rem;
   color: var(--color-text-muted);

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/advisor/AdvisorRecommendations.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/advisor/AdvisorRecommendations.vue
@@ -30,31 +30,42 @@
     <AiDisabledFeatureAlert v-if="aiDisabled" />
 
     <template v-else-if="hasResults">
-      <!-- The docket: every analyzed type in the Advisor's canonical order, so a type sits in the same
-           place here as on Prompts and Patches. -->
-      <div class="docket">
-        <div class="docket-list">
-          <button
-            v-for="rec in orderedRecommendations"
-            :key="rec.eventType"
-            type="button"
-            class="docket-item"
-            :class="{ selected: selectedEventType === rec.eventType }"
-            :style="eventTypeVars(rec.eventType)"
-            @click="selectedEventType = rec.eventType"
-          >
-            <span class="docket-name">
-              <i class="bi" :class="eventTypeStyle(rec.eventType).icon"></i>
-              {{ labelFor(rec.eventType) }}
-            </span>
-            <span class="docket-verdict">
-              {{ severityLabel(rec.severity) }} · {{ hotspotLabel(rec) }}
-            </span>
-          </button>
-        </div>
-      </div>
+      <!-- The docket: every type in the Advisor's canonical order, so a type sits in the same place
+           here as on Prompts and Patches, carrying the figures behind its grade. -->
+      <AdvisorDocket v-model:selected="selectedEventType" :items="items">
+        <template #rows="{ item }">
+          <template v-if="recommendationFor(item.eventType)">
+            <AdvisorDocketRow
+              label="Top method"
+              mono
+              :title="recommendationFor(item.eventType)!.dominantMethod"
+            >
+              {{ topMethod(recommendationFor(item.eventType)!.dominantMethod) }}
+            </AdvisorDocketRow>
+            <AdvisorDocketRow label="Its share">
+              {{
+                FormattingService.formatPercentValue(
+                  recommendationFor(item.eventType)!.dominantSelfPct
+                )
+              }}
+            </AdvisorDocketRow>
+            <AdvisorDocketRow label="Analysed in">
+              {{ analysedIn(item.eventType) }}
+            </AdvisorDocketRow>
+          </template>
+          <AdvisorDocketRow v-else label="Report">not analysed yet</AdvisorDocketRow>
+        </template>
+      </AdvisorDocket>
 
-      <MainCard v-if="selectedRecommendation">
+      <!-- A type this recording has no samples for: what is missing, and how to record it. -->
+      <AdvisorMissingType
+        v-if="selectedMissing"
+        :event-type="selectedMissing.eventType"
+        :label="selectedMissing.label"
+        missing-artifact="report to read"
+      />
+
+      <MainCard v-else-if="selectedRecommendation">
         <template #header>
           <MainCardHeader
             icon="bi-lightbulb"
@@ -82,6 +93,14 @@
         <!-- Sanitized in MarkdownRenderer: this markdown quotes source read off the user's disk. -->
         <div class="report" v-html="renderedReport"></div>
       </MainCard>
+
+      <!-- Recorded, but this run never analysed it. -->
+      <EmptyState
+        v-else
+        icon="bi-lightbulb"
+        :title="`No ${selectedLabel} report yet`"
+        description="The Advisor analyses this type on its next run."
+      />
     </template>
 
     <!-- Nothing recommended yet: send the user to the Overview to run the Advisor. -->
@@ -121,11 +140,11 @@ import { severityLabel, severityVariant } from '@shared/services/severityDisplay
 import type { AdvisorRecommendation } from '@/services/api/model/Advisor';
 import EmptyState from '@shared/components/EmptyState.vue';
 import AiDisabledFeatureAlert from '@/components/alerts/AiDisabledFeatureAlert.vue';
-import {
-  compareEventTypes,
-  eventTypeStyle,
-  eventTypeVars
-} from '@/views/profiles/detail/advisor/eventTypeStyle';
+import AdvisorDocket from '@/views/profiles/detail/advisor/AdvisorDocket.vue';
+import AdvisorDocketRow from '@/views/profiles/detail/advisor/AdvisorDocketRow.vue';
+import AdvisorMissingType from '@/views/profiles/detail/advisor/AdvisorMissingType.vue';
+import { analysisDurationMs, docketItems } from '@/views/profiles/detail/advisor/advisorDocket';
+import { shortMethodName } from '@/views/profiles/detail/advisor/eventTypeStyle';
 import { useAdvisor } from '@/composables/useAdvisor';
 import FeatureType from '@/services/api/model/FeatureType';
 
@@ -139,6 +158,7 @@ const {
   error,
   eventTypes,
   recommendations,
+  runResult,
   selectedEventType,
   selectedRecommendation,
   hasResults,
@@ -156,20 +176,45 @@ const patchesPath = computed(() => `/profiles/${profileId}/advisor/patches`);
 const labelFor = (code: string): string =>
   eventTypes.value.find(type => type.eventType === code)?.label ?? code;
 
+const recommendationFor = (eventType: string): AdvisorRecommendation | undefined =>
+  recommendations.value.find(item => item.eventType === eventType);
+
 /**
  * CPU, Wall-Clock, Allocation, Blocking — the Advisor's canonical order rather than a per-page ranking,
- * so the docket reads the same on Prompts, Recommendations and Patches. Each card still carries its
- * severity, which is where the "where to start" signal lives.
+ * so the docket reads the same on Prompts, Recommendations and Patches. The grade rides on the card,
+ * which is where the "where to start" signal lives.
  */
-const orderedRecommendations = computed(() =>
-  [...recommendations.value].sort((left, right) =>
-    compareEventTypes(left.eventType, right.eventType)
-  )
+const items = computed(() =>
+  docketItems(eventTypes.value, eventType => {
+    const recommendation = recommendationFor(eventType);
+    if (recommendation === undefined) {
+      return undefined;
+    }
+    return {
+      value: severityLabel(recommendation.severity),
+      variant: severityVariant(recommendation.severity)
+    };
+  })
 );
 
-/** What a type's card says under its name: the share of the profile its hottest method accounts for. */
-const hotspotLabel = (recommendation: AdvisorRecommendation): string =>
-  `${FormattingService.formatPercentValue(recommendation.dominantSelfPct)} in its hottest method`;
+const topMethod = (method: string): string => (method === '' ? 'unknown' : shortMethodName(method));
+
+/** How long the last run spent on this type — the same stored timings the Overview's timeline uses. */
+const analysedIn = (eventType: string): string => {
+  const durationMs = analysisDurationMs(runResult.value, eventType);
+  return durationMs === null ? '—' : FormattingService.formatDurationMillisCoarse(durationMs);
+};
+
+const selectedItem = computed(() =>
+  items.value.find(item => item.eventType === selectedEventType.value)
+);
+
+const selectedLabel = computed(() => selectedItem.value?.label ?? '');
+
+/** Set only when the selected type is one this recording carries no samples for. */
+const selectedMissing = computed(() =>
+  selectedItem.value?.available === false ? selectedItem.value : undefined
+);
 
 const renderedReport = computed(() =>
   MarkdownRenderer.render(selectedRecommendation.value?.report)
@@ -179,70 +224,6 @@ onMounted(load);
 </script>
 
 <style scoped>
-/* The docket: the reports ranked worst-first. */
-.docket {
-  margin-bottom: 1.1rem;
-}
-
-.docket-list {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
-  gap: 0.5rem;
-}
-
-/* The left spine is the type's own accent — the same device the Overview's manifest uses, so the two
-   Advisor pages read as one family. Selection tints the card rather than flooding it, which keeps a
-   red type (Blocking) from reading as an error the moment you pick it. */
-.docket-item {
-  appearance: none;
-  font-family: inherit;
-  text-align: left;
-  cursor: pointer;
-  border: 1px solid var(--color-border);
-  border-left: 3px solid var(--et);
-  border-radius: var(--radius-base);
-  background: var(--color-bg-card);
-  padding: 0.5rem 0.7rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.1rem;
-  transition: background 0.16s, border-color 0.16s;
-}
-
-.docket-item:hover {
-  background: var(--color-light);
-}
-
-.docket-item.selected {
-  background: var(--et-light);
-  border-color: var(--et);
-}
-
-.docket-name {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  font-size: 0.82rem;
-  font-weight: 600;
-  color: var(--color-heading-dark);
-}
-
-.docket-name i {
-  color: var(--et);
-}
-
-.docket-verdict {
-  font-size: 0.68rem;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--color-text-muted);
-}
-
-.docket-item.selected .docket-verdict {
-  color: var(--et);
-}
-
 /* The hand-off sits above the prose: you see that a change exists, then read why it is proposed. */
 .patch-link {
   display: flex;
@@ -254,7 +235,9 @@ onMounted(load);
   border-radius: var(--radius-base);
   background: var(--color-primary-lighter);
   text-decoration: none;
-  transition: background 0.16s, border-color 0.16s;
+  transition:
+    background 0.16s,
+    border-color 0.16s;
 }
 
 .patch-link:hover {

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/advisor/AdvisorRecommendations.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/advisor/AdvisorRecommendations.vue
@@ -30,11 +30,12 @@
     <AiDisabledFeatureAlert v-if="aiDisabled" />
 
     <template v-else-if="hasResults">
-      <!-- The docket: the reports ranked worst-first, so the page opens by saying where to start. -->
+      <!-- The docket: every analyzed type in the Advisor's canonical order, so a type sits in the same
+           place here as on Prompts and Patches. -->
       <div class="docket">
         <div class="docket-list">
           <button
-            v-for="rec in rankedRecommendations"
+            v-for="rec in orderedRecommendations"
             :key="rec.eventType"
             type="button"
             class="docket-item"
@@ -116,11 +117,15 @@ import PageHeader from '@shared/components/layout/PageHeader.vue';
 import Badge from '@shared/components/Badge.vue';
 import MarkdownRenderer from '@shared/services/MarkdownRenderer';
 import FormattingService from '@shared/services/FormattingService';
-import { severityLabel, severityRank, severityVariant } from '@shared/services/severityDisplay';
+import { severityLabel, severityVariant } from '@shared/services/severityDisplay';
 import type { AdvisorRecommendation } from '@/services/api/model/Advisor';
 import EmptyState from '@shared/components/EmptyState.vue';
 import AiDisabledFeatureAlert from '@/components/alerts/AiDisabledFeatureAlert.vue';
-import { eventTypeStyle, eventTypeVars } from '@/views/profiles/detail/advisor/eventTypeStyle';
+import {
+  compareEventTypes,
+  eventTypeStyle,
+  eventTypeVars
+} from '@/views/profiles/detail/advisor/eventTypeStyle';
 import { useAdvisor } from '@/composables/useAdvisor';
 import FeatureType from '@/services/api/model/FeatureType';
 
@@ -152,21 +157,14 @@ const labelFor = (code: string): string =>
   eventTypes.value.find(type => type.eventType === code)?.label ?? code;
 
 /**
- * Worst first, then by the measured cost behind the grade, then alphabetically — so the order is
- * stable across reloads and the report that earns your attention is the one you read first.
+ * CPU, Wall-Clock, Allocation, Blocking — the Advisor's canonical order rather than a per-page ranking,
+ * so the docket reads the same on Prompts, Recommendations and Patches. Each card still carries its
+ * severity, which is where the "where to start" signal lives.
  */
-const rankedRecommendations = computed(() =>
-  [...recommendations.value].sort((left, right) => {
-    const bySeverity = severityRank(left.severity) - severityRank(right.severity);
-    if (bySeverity !== 0) {
-      return bySeverity;
-    }
-    const byCost = right.dominantSelfPct - left.dominantSelfPct;
-    if (byCost !== 0) {
-      return byCost;
-    }
-    return labelFor(left.eventType).localeCompare(labelFor(right.eventType));
-  })
+const orderedRecommendations = computed(() =>
+  [...recommendations.value].sort((left, right) =>
+    compareEventTypes(left.eventType, right.eventType)
+  )
 );
 
 /** What a type's card says under its name: the share of the profile its hottest method accounts for. */

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/advisor/AdvisorRunOverview.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/advisor/AdvisorRunOverview.vue
@@ -139,7 +139,7 @@
       <p class="picker-cap">What it will analyze</p>
       <div class="ready-grid">
         <div
-          v-for="type in eventTypes"
+          v-for="type in analyzableTypes"
           :key="type.eventType"
           class="ready-card"
           :style="eventTypeVars(type.eventType)"
@@ -157,7 +157,7 @@
       </div>
 
       <EmptyState
-        v-if="eventTypes.length === 0"
+        v-if="analyzableTypes.length === 0"
         icon="bi-lightbulb"
         title="Nothing to analyze"
         description="This profile has no event types the Advisor can work with."
@@ -223,6 +223,13 @@ const recommendationsPath = computed(() => `/profiles/${profileId}/advisor/recom
 const labelFor = (code: string | null): string =>
   eventTypes.value.find(type => type.eventType === code)?.label ?? code ?? 'Unknown';
 
+/**
+ * The types a run would actually process. The endpoint lists every type the Advisor knows about, so
+ * the artifact pages can show a missing one in its place — but this page is about what is going to
+ * happen, and a type with no samples is not part of it.
+ */
+const analyzableTypes = computed(() => eventTypes.value.filter(type => type.available));
+
 const liveTypes = computed<TimelineType[]>(() =>
   (batch.value?.types ?? []).map(type => ({
     eventType: type.eventType ?? '',
@@ -278,7 +285,7 @@ const runTitle = computed(() =>
 );
 
 const analyzeCountLabel = computed(() => {
-  const count = eventTypes.value.length;
+  const count = analyzableTypes.value.length;
   return count === 1 ? '1 profile' : `all ${count} profiles`;
 });
 

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/advisor/advisorDocket.test.ts
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/advisor/advisorDocket.test.ts
@@ -1,0 +1,142 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  analysisDurationMs,
+  docketItems,
+  hasPatch,
+  patchStats
+} from '@/views/profiles/detail/advisor/advisorDocket';
+import { shortMethodName } from '@/views/profiles/detail/advisor/eventTypeStyle';
+import type { AdvisorEventType, AdvisorRunResult } from '@/services/api/model/Advisor';
+
+const CPU = 'jdk.ExecutionSample';
+const WALL = 'profiler.WallClockSample';
+const ALLOC = 'jdk.ObjectAllocationSample';
+const BLOCKING = 'jdk.JavaMonitorEnter';
+
+const type = (eventType: string, label: string, available: boolean): AdvisorEventType => ({
+  eventType,
+  label,
+  available
+});
+
+describe('docketItems', () => {
+  it('orders every type CPU, Wall-Clock, Allocation, Blocking whatever order the backend sends', () => {
+    const items = docketItems(
+      [
+        type(BLOCKING, 'Blocking', true),
+        type(ALLOC, 'Allocation', true),
+        type(WALL, 'Wall-Clock', true),
+        type(CPU, 'CPU', true)
+      ],
+      () => undefined
+    );
+
+    expect(items.map(item => item.label)).toEqual(['CPU', 'Wall-Clock', 'Allocation', 'Blocking']);
+  });
+
+  it('keeps a type the recording has no samples for in its own place', () => {
+    const items = docketItems(
+      [type(CPU, 'CPU', true), type(WALL, 'Wall-Clock', false), type(ALLOC, 'Allocation', true)],
+      () => undefined
+    );
+
+    // Dropping Wall-Clock — or pushing it to the end — is exactly what the docket must not do: a type
+    // sits in the same place on every profile so the three pages read alike.
+    expect(items.map(item => item.eventType)).toEqual([CPU, WALL, ALLOC]);
+    expect(items[1].available).toBe(false);
+  });
+
+  it('grades only the types the recording carries', () => {
+    const items = docketItems(
+      [type(CPU, 'CPU', true), type(WALL, 'Wall-Clock', false)],
+      () => ({ value: 'Critical', variant: 'danger' })
+    );
+
+    expect(items[0].badge?.value).toBe('Critical');
+    expect(items[1].badge).toBeUndefined();
+  });
+});
+
+describe('patchStats', () => {
+  const PATCH = `--- a/RateTable.java
++++ b/RateTable.java
+@@ -1,4 +1,5 @@
+ unchanged
+-slow
++fast
++extra
+--- a/Cache.java
++++ b/Cache.java
+@@ -9,1 +9,1 @@
+-old
++new
+`;
+
+  it('counts files and changed lines without counting the diff headers', () => {
+    // The headers start with the very prefixes an added and a removed line do; counting them would
+    // inflate every patch by one line of each per file.
+    expect(patchStats(PATCH)).toEqual({ files: 2, added: 3, removed: 2 });
+  });
+
+  it('reports nothing for a type the model proposed no edit for', () => {
+    expect(patchStats(null)).toEqual({ files: 0, added: 0, removed: 0 });
+    expect(hasPatch(null)).toBe(false);
+    expect(hasPatch('   ')).toBe(false);
+    expect(hasPatch(PATCH)).toBe(true);
+  });
+
+  it('does not count a deleted file as a file the patch writes', () => {
+    const deletion = '--- a/Gone.java\n+++ /dev/null\n@@ -1,1 +0,0 @@\n-gone\n';
+    expect(patchStats(deletion).files).toBe(0);
+  });
+});
+
+describe('shortMethodName', () => {
+  it('keeps the class and method and drops the package', () => {
+    expect(shortMethodName('com.acme.pricing.PricingEngine.applyRules')).toBe(
+      'PricingEngine.applyRules'
+    );
+  });
+
+  it('leaves a name with nothing to drop alone', () => {
+    expect(shortMethodName('socketRead0')).toBe('socketRead0');
+    expect(shortMethodName('Cache.lookup')).toBe('Cache.lookup');
+  });
+});
+
+describe('analysisDurationMs', () => {
+  const runResult: AdvisorRunResult = {
+    totalElapsedMs: 9_000,
+    completedTypes: 1,
+    totalTypes: 2,
+    completedAt: 1_754_000_000_000,
+    types: [{ eventType: CPU, status: 'COMPLETED', totalMs: 4_200, steps: [] }]
+  };
+
+  it('finds what the last run spent on a type', () => {
+    expect(analysisDurationMs(runResult, CPU)).toBe(4_200);
+  });
+
+  it('has nothing to report for a type that run never touched', () => {
+    expect(analysisDurationMs(runResult, WALL)).toBeNull();
+    expect(analysisDurationMs(null, CPU)).toBeNull();
+  });
+});

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/advisor/advisorDocket.ts
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/advisor/advisorDocket.ts
@@ -1,0 +1,118 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { Variant } from '@shared/types/ui';
+import type { AdvisorEventType, AdvisorRunResult } from '@/services/api/model/Advisor';
+import { compareEventTypes } from '@/views/profiles/detail/advisor/eventTypeStyle';
+
+/** The grade shown on a card, when the page has one to show. Prompts do not. */
+export interface DocketBadge {
+  value: string;
+  variant: Variant;
+}
+
+/** One card of the Advisor's docket: a type, whether the recording carries it, and its grade. */
+export interface DocketItem {
+  eventType: string;
+  label: string;
+  available: boolean;
+  badge?: DocketBadge;
+}
+
+/**
+ * Every type the Advisor knows about in the canonical order, so the docket reads the same on Prompts,
+ * Recommendations and Patches, and on every profile — a recording that carries no wall-clock samples
+ * still shows Wall-Clock in second place, marked as missing rather than silently dropped.
+ */
+export function docketItems(
+  eventTypes: AdvisorEventType[],
+  badgeFor: (eventType: string) => DocketBadge | undefined
+): DocketItem[] {
+  return [...eventTypes]
+    .sort((left, right) => compareEventTypes(left.eventType, right.eventType))
+    .map(type => ({
+      eventType: type.eventType,
+      label: type.label,
+      available: type.available,
+      badge: type.available ? badgeFor(type.eventType) : undefined
+    }));
+}
+
+/** The size of a proposed change, counted off the unified diff the page already holds. */
+export interface PatchStats {
+  files: number;
+  added: number;
+  removed: number;
+}
+
+const NO_PATCH_STATS: PatchStats = { files: 0, added: 0, removed: 0 };
+
+const NEW_FILE_HEADER_PREFIX = '+++ ';
+const OLD_FILE_HEADER_PREFIX = '--- ';
+const ADDED_LINE_PREFIX = '+';
+const REMOVED_LINE_PREFIX = '-';
+const NO_FILE_PATH = '/dev/null';
+const LINE_SEPARATOR = '\n';
+
+/**
+ * Counts the files and lines a unified diff touches. The two file headers are checked before the line
+ * prefixes because `+++` and `---` would otherwise be counted as an added and a removed line each,
+ * inflating every patch by one per file.
+ */
+export function patchStats(patch: string | null): PatchStats {
+  if (patch === null || patch.trim() === '') {
+    return NO_PATCH_STATS;
+  }
+
+  let files = 0;
+  let added = 0;
+  let removed = 0;
+
+  for (const line of patch.split(LINE_SEPARATOR)) {
+    if (line.startsWith(NEW_FILE_HEADER_PREFIX)) {
+      if (!line.endsWith(NO_FILE_PATH)) {
+        files += 1;
+      }
+    } else if (line.startsWith(OLD_FILE_HEADER_PREFIX)) {
+      continue;
+    } else if (line.startsWith(ADDED_LINE_PREFIX)) {
+      added += 1;
+    } else if (line.startsWith(REMOVED_LINE_PREFIX)) {
+      removed += 1;
+    }
+  }
+
+  return { files, added, removed };
+}
+
+export function hasPatch(patch: string | null): boolean {
+  return patch !== null && patch.trim() !== '';
+}
+
+/**
+ * How long the last run spent on one event type, or null when it did not run in it. Read from the
+ * stored run result rather than timed in the browser, so it survives a reload like the Overview's
+ * timeline does.
+ */
+export function analysisDurationMs(
+  runResult: AdvisorRunResult | null,
+  eventType: string
+): number | null {
+  const type = runResult?.types.find(candidate => candidate.eventType === eventType);
+  return type?.totalMs ?? null;
+}

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/advisor/eventTypeStyle.ts
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/advisor/eventTypeStyle.ts
@@ -61,6 +61,33 @@ const COST_LABELS: Record<string, string> = {
 
 const DEFAULT_COST_LABEL = 'of this profile';
 
+/**
+ * The order the Advisor lists its event types in — CPU, Wall-Clock, Allocation, Blocking — mirroring the
+ * backend's `AdvisorPromptType` declaration order. Prompts, Recommendations and Patches all sort by it, so
+ * a type keeps its position as you move between the three pages instead of shuffling per page.
+ */
+const CANONICAL_ORDER: string[] = [
+  'jdk.ExecutionSample',
+  'profiler.WallClockSample',
+  'jdk.ObjectAllocationSample',
+  'jdk.JavaMonitorEnter'
+];
+
+/** Unknown codes keep to the end rather than pushing a known type out of its place. */
+function orderIndex(eventTypeCode: string): number {
+  const index = CANONICAL_ORDER.indexOf(eventTypeCode);
+  return index === -1 ? CANONICAL_ORDER.length : index;
+}
+
+/** Comparator putting event types in the Advisor's canonical order; unknown ones last, alphabetically. */
+export function compareEventTypes(left: string, right: string): number {
+  const byOrder = orderIndex(left) - orderIndex(right);
+  if (byOrder !== 0) {
+    return byOrder;
+  }
+  return left.localeCompare(right);
+}
+
 export function eventTypeCostLabel(eventTypeCode: string): string {
   return COST_LABELS[eventTypeCode] ?? DEFAULT_COST_LABEL;
 }

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/advisor/eventTypeStyle.ts
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/advisor/eventTypeStyle.ts
@@ -48,18 +48,6 @@ const DESCRIPTIONS: Record<string, string> = {
   'jdk.JavaMonitorEnter': 'Time parked on locks'
 };
 
-/**
- * What a percentage of this profile actually measures. Shown next to a patch's headline figure, so
- * "62.6%" reads as "62.6% of blocked time" rather than as a bare number of unknown units.
- */
-const COST_LABELS: Record<string, string> = {
-  'jdk.ExecutionSample': 'of CPU time',
-  'profiler.WallClockSample': 'of wall-clock time',
-  'jdk.ObjectAllocationSample': 'of allocated bytes',
-  'jdk.JavaMonitorEnter': 'of blocked time'
-};
-
-const DEFAULT_COST_LABEL = 'of this profile';
 
 /**
  * The order the Advisor lists its event types in — CPU, Wall-Clock, Allocation, Blocking — mirroring the
@@ -88,8 +76,36 @@ export function compareEventTypes(left: string, right: string): number {
   return left.localeCompare(right);
 }
 
-export function eventTypeCostLabel(eventTypeCode: string): string {
-  return COST_LABELS[eventTypeCode] ?? DEFAULT_COST_LABEL;
+/**
+ * The profiler option that captures each type — the same flags the Profiler Settings command builder
+ * writes. A type missing from a recording is only a useful thing to say next to what would have
+ * produced it, which is what a card shows in place of its data.
+ */
+const CAPTURE_FLAGS: Record<string, string> = {
+  'jdk.ExecutionSample': 'event=ctimer',
+  'profiler.WallClockSample': 'wall=10ms',
+  'jdk.ObjectAllocationSample': 'alloc=512k',
+  'jdk.JavaMonitorEnter': 'lock=10ms'
+};
+
+export function eventTypeCaptureFlag(eventTypeCode: string): string {
+  return CAPTURE_FLAGS[eventTypeCode] ?? '';
+}
+
+/** How many trailing segments of a frame name a card shows before it stops being readable. */
+const METHOD_SEGMENTS_SHOWN = 2;
+
+/**
+ * A frame name shortened to its class and method — `com.acme.pricing.PricingEngine.applyRules` reads as
+ * `PricingEngine.applyRules`. Cards have room for the part that identifies the code and none for the
+ * package; the full name goes in the element's title.
+ */
+export function shortMethodName(method: string): string {
+  const segments = method.split('.');
+  if (segments.length <= METHOD_SEGMENTS_SHOWN) {
+    return method;
+  }
+  return segments.slice(-METHOD_SEGMENTS_SHOWN).join('.');
 }
 
 export function eventTypeStyle(eventTypeCode: string): EventTypeStyle {

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/navigation/profileNavConfig.ts
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/navigation/profileNavConfig.ts
@@ -447,7 +447,7 @@ export const profileNavSections: Record<
         // No AI highlight here: the whole Advisor mode is already an AI feature, so marking three of
         // its four pages would single them out for nothing.
         item('Overview', 'bi-play-circle', '/advisor'),
-        item('Prompt', 'bi-chat-square-text', '/advisor/prompt', {
+        item('Prompts', 'bi-chat-square-text', '/advisor/prompt', {
           disabledKeys: [AI_ANALYSIS_KEY]
         }),
         item('Recommendations', 'bi-lightbulb', '/advisor/recommendations', {

--- a/jeffrey-microscope/profiles/profile-advisor/src/main/java/cafe/jeffrey/profile/advisor/prompt/AdvisorPrompt.java
+++ b/jeffrey-microscope/profiles/profile-advisor/src/main/java/cafe/jeffrey/profile/advisor/prompt/AdvisorPrompt.java
@@ -33,6 +33,7 @@ import java.time.Instant;
  * @param samples         the profile's total sample count, for the chip beside the label
  * @param prompt          the full user message sent to the model
  * @param dominantSelfPct the heaviest method's self share of the profile, which severity is graded from
+ * @param dominantMethod  the name of that heaviest method, or "" when the profile has no samples
  * @param generatedAt     when this prompt was built from the profile
  */
 public record AdvisorPrompt(
@@ -41,5 +42,6 @@ public record AdvisorPrompt(
         long samples,
         String prompt,
         double dominantSelfPct,
+        String dominantMethod,
         Instant generatedAt) {
 }

--- a/jeffrey-microscope/profiles/profile-advisor/src/main/java/cafe/jeffrey/profile/advisor/prompt/AdvisorPromptManager.java
+++ b/jeffrey-microscope/profiles/profile-advisor/src/main/java/cafe/jeffrey/profile/advisor/prompt/AdvisorPromptManager.java
@@ -132,13 +132,15 @@ public class AdvisorPromptManager {
                 eventStreamRepository, pruneThresholdPct, new AiExportConfig(pruneThresholdPct));
 
         DbBasedFlamegraphGenerator.AiExport export = generator.generateAiExportWithFrames(parameters(eventType));
+        DominantMethod dominant = DominantSelfShare.of(export.root());
 
         AdvisorPrompt prompt = new AdvisorPrompt(
                 promptType.primaryEventType().code(),
                 promptType.label(),
                 export.root().totalSamples(),
                 AdvisorPrompts.userMessage(promptType.label(), export.markdown()),
-                DominantSelfShare.of(export.root()),
+                dominant.selfPct(),
+                dominant.method(),
                 clock.instant());
 
         advisorRepository.upsertPrompt(new AdvisorPromptRow(
@@ -147,10 +149,13 @@ public class AdvisorPromptManager {
                 prompt.samples(),
                 prompt.prompt(),
                 prompt.dominantSelfPct(),
+                prompt.dominantMethod(),
                 prompt.generatedAt()));
 
-        LOG.info("Generated advisor prompt: prompt_type={} event_type={} total_samples={} dominant_self_pct={}",
-                promptType.name(), eventType.code(), prompt.samples(), prompt.dominantSelfPct());
+        LOG.info("Generated advisor prompt: prompt_type={} event_type={} total_samples={} "
+                        + "dominant_self_pct={} dominant_method={}",
+                promptType.name(), eventType.code(), prompt.samples(), prompt.dominantSelfPct(),
+                prompt.dominantMethod());
         return Optional.of(prompt);
     }
 
@@ -197,6 +202,7 @@ public class AdvisorPromptManager {
                 row.samples(),
                 row.prompt(),
                 row.dominantSelfPct(),
+                row.dominantMethod(),
                 row.generatedAt());
     }
 }

--- a/jeffrey-microscope/profiles/profile-advisor/src/main/java/cafe/jeffrey/profile/advisor/prompt/DominantMethod.java
+++ b/jeffrey-microscope/profiles/profile-advisor/src/main/java/cafe/jeffrey/profile/advisor/prompt/DominantMethod.java
@@ -1,0 +1,41 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.advisor.prompt;
+
+/**
+ * The single heaviest method of a profile and its share of it. The share is what severity is graded
+ * from; the name is what makes the grade mean something to a person, so the two travel together rather
+ * than the name being recomputed — or, as it used to be, discarded.
+ *
+ * @param method  the fully qualified method name, or {@code ""} when the profile has no samples
+ * @param selfPct the method's self samples as a percentage of the profile's total
+ */
+public record DominantMethod(String method, double selfPct) {
+
+    private static final String NO_METHOD = "";
+
+    /** What an empty call tree produces: nothing is dominant, and nothing is graded. */
+    public static final DominantMethod NONE = new DominantMethod(NO_METHOD, 0.0);
+
+    public DominantMethod {
+        if (method == null) {
+            throw new IllegalArgumentException("method must not be null");
+        }
+    }
+}

--- a/jeffrey-microscope/profiles/profile-advisor/src/main/java/cafe/jeffrey/profile/advisor/prompt/DominantSelfShare.java
+++ b/jeffrey-microscope/profiles/profile-advisor/src/main/java/cafe/jeffrey/profile/advisor/prompt/DominantSelfShare.java
@@ -20,14 +20,15 @@ package cafe.jeffrey.profile.advisor.prompt;
 
 import cafe.jeffrey.frameir.Frame;
 
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 
 /**
- * The share of a profile spent in its single heaviest method, as a percentage of total samples. This is
- * the one number the Advisor keeps from the parsed call tree, and it is what severity is graded from —
- * so the ranking of a recording is arithmetic over what Jeffrey measured, never something the model was
- * asked to judge.
+ * The single heaviest method of a profile and its share of it, as a percentage of total samples. The
+ * share is what severity is graded from — so the ranking of a recording is arithmetic over what Jeffrey
+ * measured, never something the model was asked to judge — and the method's name is carried out with it,
+ * because a grade that names the frame it came from is one a reader can act on.
  *
  * <p>Two choices decide what the number means. <strong>Self samples are summed</strong> across every
  * call path a method appears on: self weight never nests inside itself, so summing it is exact even
@@ -38,26 +39,35 @@ import java.util.Map;
  */
 public final class DominantSelfShare {
 
+    /**
+     * Heaviest first, and on a tie the alphabetically first name — a walk over a hash map has no order
+     * of its own, so without a tie-break two equally hot methods would name whichever one the map
+     * happened to hand back.
+     */
+    private static final Comparator<Map.Entry<String, Long>> BY_WEIGHT_THEN_NAME =
+            Map.Entry.<String, Long>comparingByValue()
+                    .thenComparing(Map.Entry.<String, Long>comparingByKey(Comparator.reverseOrder()));
+
     private DominantSelfShare() {
     }
 
     /**
-     * The heaviest method's self share of {@code root}, or {@code 0.0} for a tree with no samples.
+     * The heaviest method of {@code root} and its self share, or {@link DominantMethod#NONE} for a tree
+     * with no samples. Ties are broken by method name so the same tree always names the same frame.
      */
-    public static double of(Frame root) {
+    public static DominantMethod of(Frame root) {
         long totalSamples = root.totalSamples();
         if (totalSamples <= 0) {
-            return 0.0;
+            return DominantMethod.NONE;
         }
 
         Map<String, Long> selfByName = new HashMap<>();
         collect(root, selfByName);
 
-        long dominant = selfByName.values().stream()
-                .mapToLong(Long::longValue)
-                .max()
-                .orElse(0L);
-        return 100.0 * dominant / totalSamples;
+        return selfByName.entrySet().stream()
+                .max(BY_WEIGHT_THEN_NAME)
+                .map(entry -> new DominantMethod(entry.getKey(), 100.0 * entry.getValue() / totalSamples))
+                .orElse(DominantMethod.NONE);
     }
 
     /**

--- a/jeffrey-microscope/profiles/profile-advisor/src/main/java/cafe/jeffrey/profile/advisor/run/AdvisorService.java
+++ b/jeffrey-microscope/profiles/profile-advisor/src/main/java/cafe/jeffrey/profile/advisor/run/AdvisorService.java
@@ -179,6 +179,7 @@ public final class AdvisorService {
                 target.eventType(),
                 result.severity().name(),
                 prompt.dominantSelfPct(),
+                prompt.dominantMethod(),
                 result.report(),
                 result.patch(),
                 sourceTree.resolvedRef(),

--- a/jeffrey-microscope/profiles/profile-advisor/src/test/java/cafe/jeffrey/profile/advisor/prompt/DominantSelfShareTest.java
+++ b/jeffrey-microscope/profiles/profile-advisor/src/test/java/cafe/jeffrey/profile/advisor/prompt/DominantSelfShareTest.java
@@ -64,7 +64,9 @@ class DominantSelfShareTest {
 
             // hot is reached two ways for 40 of 70 samples. Counting either path alone would put it
             // behind cold's 30 and grade the profile off the wrong method.
-            assertEquals(57.14, DominantSelfShare.of(root), PRECISION);
+            DominantMethod dominant = DominantSelfShare.of(root);
+            assertEquals("hot", dominant.method());
+            assertEquals(57.14, dominant.selfPct(), PRECISION);
         }
 
         @Test
@@ -75,7 +77,20 @@ class DominantSelfShareTest {
 
             // Self weight never nests inside itself, so the four nested occurrences contribute 40 once,
             // not 160. Summing subtree totals instead would put recurse above 100%.
-            assertEquals(60.0, DominantSelfShare.of(root), PRECISION);
+            DominantMethod dominant = DominantSelfShare.of(root);
+            assertEquals("flat", dominant.method());
+            assertEquals(60.0, dominant.selfPct(), PRECISION);
+        }
+
+        @Test
+        void namesTheAlphabeticallyFirstMethodWhenTwoAreEquallyHot() {
+            Frame root = emptyTree();
+            record(root, 50, "zebra");
+            record(root, 50, "alpha");
+
+            // The walk is over a hash map, so without a tie-break the name would depend on iteration
+            // order and the same recording could report either method between runs.
+            assertEquals("alpha", DominantSelfShare.of(root).method());
         }
     }
 
@@ -89,7 +104,9 @@ class DominantSelfShareTest {
             record(root, 40, "orchestrate", "leafB");
 
             // orchestrate carries 100% of the profile in its subtree but spends none of it itself.
-            assertEquals(60.0, DominantSelfShare.of(root), PRECISION);
+            DominantMethod dominant = DominantSelfShare.of(root);
+            assertEquals("leafA", dominant.method());
+            assertEquals(60.0, dominant.selfPct(), PRECISION);
         }
 
         @Test
@@ -98,7 +115,7 @@ class DominantSelfShareTest {
             root.increment(FrameType.JIT_COMPILED, 100, 100, true);
 
             // The root is the synthetic node the tree hangs from, not a method anyone can change.
-            assertEquals(0.0, DominantSelfShare.of(root), PRECISION);
+            assertEquals(DominantMethod.NONE, DominantSelfShare.of(root));
         }
     }
 
@@ -107,7 +124,7 @@ class DominantSelfShareTest {
 
         @Test
         void gradesAnUnsampledProfileAsZero() {
-            assertEquals(0.0, DominantSelfShare.of(emptyTree()), PRECISION);
+            assertEquals(DominantMethod.NONE, DominantSelfShare.of(emptyTree()));
         }
     }
 }

--- a/jeffrey-microscope/profiles/profile-persistence-api/src/main/java/cafe/jeffrey/provider/profile/api/AdvisorPromptRow.java
+++ b/jeffrey-microscope/profiles/profile-persistence-api/src/main/java/cafe/jeffrey/provider/profile/api/AdvisorPromptRow.java
@@ -29,6 +29,7 @@ import java.time.Instant;
  * @param samples         total samples the call tree was built from
  * @param prompt          the full user message sent to the model
  * @param dominantSelfPct the heaviest method's self share of the profile, as a percentage
+ * @param dominantMethod  the name of that heaviest method, or "" when it is not known
  * @param generatedAt     when the prompt was generated
  */
 public record AdvisorPromptRow(
@@ -37,5 +38,6 @@ public record AdvisorPromptRow(
         long samples,
         String prompt,
         double dominantSelfPct,
+        String dominantMethod,
         Instant generatedAt) {
 }

--- a/jeffrey-microscope/profiles/profile-persistence-api/src/main/java/cafe/jeffrey/provider/profile/api/AdvisorRecommendationRow.java
+++ b/jeffrey-microscope/profiles/profile-persistence-api/src/main/java/cafe/jeffrey/provider/profile/api/AdvisorRecommendationRow.java
@@ -27,6 +27,7 @@ import java.time.Instant;
  * @param eventType        the sample event type analyzed
  * @param severity         the computed severity name
  * @param dominantSelfPct  the measured self share the severity was computed from
+ * @param dominantMethod   the method holding that share, or "" when it is not known
  * @param report           the recommendations markdown
  * @param patch            the proposed unified diff, or null when the model proposed no code edit
  * @param sourceRef        the commit the source tree was on, or null when it was not a git checkout
@@ -36,6 +37,7 @@ public record AdvisorRecommendationRow(
         String eventType,
         String severity,
         double dominantSelfPct,
+        String dominantMethod,
         String report,
         String patch,
         String sourceRef,

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/JdbcProfileAdvisorRepository.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/JdbcProfileAdvisorRepository.java
@@ -41,44 +41,48 @@ public class JdbcProfileAdvisorRepository implements ProfileAdvisorRepository {
 
     //language=SQL
     private static final String FIND_PROMPTS = """
-            SELECT event_type, label, samples, prompt, dominant_self_pct, generated_at
+            SELECT event_type, label, samples, prompt, dominant_self_pct, dominant_method, generated_at
             FROM advisor_prompts
             ORDER BY event_type""";
 
     //language=SQL
     private static final String FIND_PROMPT = """
-            SELECT event_type, label, samples, prompt, dominant_self_pct, generated_at
+            SELECT event_type, label, samples, prompt, dominant_self_pct, dominant_method, generated_at
             FROM advisor_prompts
             WHERE event_type = :event_type""";
 
     //language=SQL
     private static final String UPSERT_PROMPT = """
             INSERT INTO advisor_prompts (event_type, label, samples, prompt, dominant_self_pct,
-                                         generated_at)
-            VALUES (:event_type, :label, :samples, :prompt, :dominant_self_pct, :generated_at)
+                                         dominant_method, generated_at)
+            VALUES (:event_type, :label, :samples, :prompt, :dominant_self_pct, :dominant_method,
+                    :generated_at)
             ON CONFLICT (event_type) DO UPDATE SET
                 label = EXCLUDED.label,
                 samples = EXCLUDED.samples,
                 prompt = EXCLUDED.prompt,
                 dominant_self_pct = EXCLUDED.dominant_self_pct,
+                dominant_method = EXCLUDED.dominant_method,
                 generated_at = EXCLUDED.generated_at""";
 
     //language=SQL
     private static final String FIND_RECOMMENDATIONS = """
-            SELECT event_type, severity, dominant_self_pct, report, patch, source_ref,
-                   generated_at
+            SELECT event_type, severity, dominant_self_pct, dominant_method, report, patch,
+                   source_ref, generated_at
             FROM advisor_recommendations
             ORDER BY event_type""";
 
     //language=SQL
     private static final String UPSERT_RECOMMENDATION = """
             INSERT INTO advisor_recommendations (event_type, severity, dominant_self_pct,
-                                                 report, patch, source_ref, generated_at)
-            VALUES (:event_type, :severity, :dominant_self_pct, :report, :patch,
+                                                 dominant_method, report, patch, source_ref,
+                                                 generated_at)
+            VALUES (:event_type, :severity, :dominant_self_pct, :dominant_method, :report, :patch,
                     :source_ref, :generated_at)
             ON CONFLICT (event_type) DO UPDATE SET
                 severity = EXCLUDED.severity,
                 dominant_self_pct = EXCLUDED.dominant_self_pct,
+                dominant_method = EXCLUDED.dominant_method,
                 report = EXCLUDED.report,
                 patch = EXCLUDED.patch,
                 source_ref = EXCLUDED.source_ref,
@@ -119,6 +123,7 @@ public class JdbcProfileAdvisorRepository implements ProfileAdvisorRepository {
                 .addValue("samples", prompt.samples())
                 .addValue("prompt", prompt.prompt())
                 .addValue("dominant_self_pct", prompt.dominantSelfPct())
+                .addValue("dominant_method", prompt.dominantMethod())
                 .addValue("generated_at", Timestamp.from(prompt.generatedAt()));
 
         databaseClient.insert(StatementLabel.UPSERT_ADVISOR_PROMPT, UPSERT_PROMPT, params);
@@ -136,6 +141,7 @@ public class JdbcProfileAdvisorRepository implements ProfileAdvisorRepository {
                 .addValue(PARAM_EVENT_TYPE, recommendation.eventType())
                 .addValue("severity", recommendation.severity())
                 .addValue("dominant_self_pct", recommendation.dominantSelfPct())
+                .addValue("dominant_method", recommendation.dominantMethod())
                 .addValue("report", recommendation.report())
                 .addValue("patch", recommendation.patch())
                 .addValue("source_ref", recommendation.sourceRef())
@@ -160,6 +166,7 @@ public class JdbcProfileAdvisorRepository implements ProfileAdvisorRepository {
                 rs.getLong("samples"),
                 rs.getString("prompt"),
                 rs.getDouble("dominant_self_pct"),
+                rs.getString("dominant_method"),
                 instant(rs, "generated_at"));
     }
 
@@ -168,6 +175,7 @@ public class JdbcProfileAdvisorRepository implements ProfileAdvisorRepository {
                 rs.getString(PARAM_EVENT_TYPE),
                 rs.getString("severity"),
                 rs.getDouble("dominant_self_pct"),
+                rs.getString("dominant_method"),
                 rs.getString("report"),
                 rs.getString("patch"),
                 rs.getString("source_ref"),

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/resources/db/migration/profile/V001__init.sql
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/resources/db/migration/profile/V001__init.sql
@@ -127,7 +127,8 @@ CREATE TABLE IF NOT EXISTS profile_info
 -- One AI prompt per sample event type. `prompt` is the complete user message as the model receives
 -- it, composed when the prompt is generated rather than at run time, so the run sends it verbatim and
 -- the Advisor's Prompt page shows exactly what was asked. `dominant_self_pct` is the heaviest
--- method's measured self share of the profile — the number severity is graded from.
+-- method's measured self share of the profile — the number severity is graded from — and
+-- `dominant_method` names the method holding it, so the share can be shown attached to its frame.
 --
 CREATE TABLE IF NOT EXISTS advisor_prompts
 (
@@ -136,6 +137,7 @@ CREATE TABLE IF NOT EXISTS advisor_prompts
     samples           BIGINT      NOT NULL,
     prompt            VARCHAR     NOT NULL,
     dominant_self_pct DOUBLE      NOT NULL DEFAULT 0,
+    dominant_method   VARCHAR     NOT NULL DEFAULT '',
     generated_at      TIMESTAMPTZ NOT NULL
 );
 
@@ -152,6 +154,7 @@ CREATE TABLE IF NOT EXISTS advisor_recommendations
     event_type        VARCHAR     NOT NULL PRIMARY KEY,
     severity          VARCHAR     NOT NULL DEFAULT 'LOW',
     dominant_self_pct DOUBLE      NOT NULL DEFAULT 0,
+    dominant_method   VARCHAR     NOT NULL DEFAULT '',
     report            VARCHAR     NOT NULL,
     patch             VARCHAR,
     source_ref        VARCHAR,

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/test/java/cafe/jeffrey/provider/profile/jdbc/JdbcProfileAdvisorRepositoryTest.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/test/java/cafe/jeffrey/provider/profile/jdbc/JdbcProfileAdvisorRepositoryTest.java
@@ -38,6 +38,7 @@ class JdbcProfileAdvisorRepositoryTest {
     private static final String CPU = "jdk.ExecutionSample";
     private static final String ALLOC = "jdk.ObjectAllocationSample";
     private static final Instant WHEN = Instant.parse("2026-08-01T06:00:14Z");
+    private static final String HOT_METHOD = "com.acme.rates.RateTable.lookup";
     private static final String PATCH = """
             --- a/RateTable.java
             +++ b/RateTable.java
@@ -52,11 +53,11 @@ class JdbcProfileAdvisorRepositoryTest {
 
     private static void seed(JdbcProfileAdvisorRepository repository) {
         repository.upsertPrompt(
-                new AdvisorPromptRow(CPU, "CPU", 1_000L, "the user message", 21.5, WHEN));
+                new AdvisorPromptRow(CPU, "CPU", 1_000L, "the user message", 21.5, HOT_METHOD, WHEN));
         repository.upsertPrompt(
-                new AdvisorPromptRow(ALLOC, "Allocation", 400L, "the user message", 12.0, WHEN));
+                new AdvisorPromptRow(ALLOC, "Allocation", 400L, "the user message", 12.0, HOT_METHOD, WHEN));
         repository.upsertRecommendation(
-                new AdvisorRecommendationRow(CPU, "HIGH", 21.5, "report", PATCH, "abc123", WHEN));
+                new AdvisorRecommendationRow(CPU, "HIGH", 21.5, HOT_METHOD, "report", PATCH, "abc123", WHEN));
     }
 
     @Nested
@@ -71,6 +72,8 @@ class JdbcProfileAdvisorRepositoryTest {
 
             assertEquals("the user message", row.prompt());
             assertEquals(21.5, row.dominantSelfPct());
+            assertEquals(HOT_METHOD, row.dominantMethod(),
+                    "the share is only readable next to the method holding it");
         }
     }
 
@@ -89,7 +92,7 @@ class JdbcProfileAdvisorRepositoryTest {
         void keepsAMissingPatchNullRatherThanEmpty(DataSource dataSource) {
             JdbcProfileAdvisorRepository repository = repository(dataSource);
             repository.upsertRecommendation(
-                    new AdvisorRecommendationRow(ALLOC, "LOW", 1.2, "report", null, "abc123", WHEN));
+                    new AdvisorRecommendationRow(ALLOC, "LOW", 1.2, HOT_METHOD, "report", null, "abc123", WHEN));
 
             assertNull(repository.findRecommendations().getFirst().patch());
         }
@@ -100,7 +103,8 @@ class JdbcProfileAdvisorRepositoryTest {
             seed(repository);
 
             repository.upsertRecommendation(
-                    new AdvisorRecommendationRow(CPU, "LOW", 21.5, "second report", null, "def456", WHEN));
+                    new AdvisorRecommendationRow(
+                            CPU, "LOW", 21.5, HOT_METHOD, "second report", null, "def456", WHEN));
 
             assertEquals(1, repository.findRecommendations().size());
             assertNull(repository.findRecommendations().getFirst().patch(),
@@ -150,7 +154,8 @@ class JdbcProfileAdvisorRepositoryTest {
 
             // Clearing must not leave anything behind that a re-run would collide with.
             repository.upsertPrompt(
-                    new AdvisorPromptRow(CPU, "CPU", 2_000L, "the rebuilt user message", 8.0, WHEN));
+                    new AdvisorPromptRow(
+                            CPU, "CPU", 2_000L, "the rebuilt user message", 8.0, HOT_METHOD, WHEN));
 
             assertEquals(1, repository.findPrompts().size());
             assertEquals(2_000L, repository.findPrompts().getFirst().samples());

--- a/jeffrey-pages/src/views/docs/microscope/profiles/ProfileAdvisorPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/profiles/ProfileAdvisorPage.vue
@@ -27,6 +27,7 @@ const { setHeadings } = useDocHeadings();
 
 const headings = [
   { id: 'overview', text: 'Overview', level: 2 },
+  { id: 'docket', text: 'The Docket', level: 2 },
   { id: 'setup', text: 'Setup', level: 2 },
   { id: 'how-a-run-works', text: 'How a Run Works', level: 2 },
   { id: 'severity', text: 'Severity', level: 2 },
@@ -64,7 +65,7 @@ onMounted(() => {
 
       <ul>
         <li><strong>Overview</strong> — the landing page: set the source folder inline, launch the run, and watch its phased, timed timeline. The finished timeline is kept and re-shown on return.</li>
-        <li><strong>Prompt</strong> — the exact message sent to the model for each event type, shown verbatim and copyable.</li>
+        <li><strong>Prompts</strong> — the exact message sent to the model for each event type, shown verbatim and copyable.</li>
         <li><strong>Recommendations</strong> — a separate page for the report the model wrote.</li>
         <li><strong>Patches</strong> — the proposed code changes, one per event type, each shown as a unified diff.</li>
       </ul>
@@ -80,6 +81,25 @@ onMounted(() => {
         <li><strong>Allocation</strong> — <code>jdk.ObjectAllocationSample</code>, or the older TLAB pair</li>
         <li><strong>Blocking</strong> — <code>jdk.JavaMonitorEnter</code>, <code>jdk.JavaMonitorWait</code>, <code>jdk.ThreadPark</code></li>
       </ul>
+
+      <h2 id="docket">The Docket</h2>
+
+      <p>
+        Prompts, Recommendations and Patches all open with the same row of cards, always in the order
+        CPU → Wall-Clock → Allocation → Blocking, so a group sits in the same place on every page and
+        every profile. Each card carries that group's own figures: on Prompts the sample count, the size
+        of the cached message and the method holding the largest share of the profile; on
+        Recommendations that method, its share and how long the last run spent analysing the group; on
+        Patches the size of the proposed diff in files and lines.
+      </p>
+
+      <p>
+        A group the recording carries no samples for keeps its place, ruled out with a hatch rather than
+        dropped from the row. It is still selectable: picking it explains what is missing and shows the
+        profiler flag that captures it — <code>event=ctimer</code>, <code>wall=10ms</code>,
+        <code>alloc=512k</code> or <code>lock=10ms</code>. Only the groups a recording actually carries
+        are analysed, and the Overview's "what it will analyze" list shows those alone.
+      </p>
 
       <h2 id="setup">Setup</h2>
 
@@ -179,9 +199,9 @@ onMounted(() => {
 
       <p>
         When the model proposes a concrete edit, it is stored as a unified diff and shown on the
-        <strong>Patches</strong> page — one patch per event type, ranked by severity and then by the
-        profile's dominant self share. Each is rendered as a unified diff with line numbers, and can be
-        copied or saved as a <code>.patch</code> file that <code>git apply -p1</code> accepts.
+        <strong>Patches</strong> page — one patch per event type, listed in the docket's fixed order with
+        the size of each diff on its card. Each is rendered as a unified diff with line numbers, and can
+        be copied or saved as a <code>.patch</code> file that <code>git apply -p1</code> accepts.
       </p>
 
       <p>

--- a/shared/ui/common/src/assets/design-tokens.css
+++ b/shared/ui/common/src/assets/design-tokens.css
@@ -293,6 +293,10 @@
   --color-border: #eaedf1;
   --color-border-light: #edf2f9;
   --color-border-input: #d8e2ef;
+
+  /* The stroke of the diagonal hatch that marks a surface as ruled out — present, but with nothing
+     in it (e.g. an Advisor event type this recording carries no samples for). */
+  --hatch-line: rgba(116, 129, 148, 0.09);
   
   /* Background Colors */
   --color-bg-body: #edf2f9;

--- a/shared/ui/common/src/services/severityDisplay.ts
+++ b/shared/ui/common/src/services/severityDisplay.ts
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import type { Variant } from "../types/ui";
+
 /** Severity as Jeffrey computes it from the measured profile — never graded by a model. */
 export type Severity = "CRITICAL" | "HIGH" | "MEDIUM" | "LOW";
 
@@ -24,14 +26,14 @@ export type Severity = "CRITICAL" | "HIGH" | "MEDIUM" | "LOW";
  * that ranks recommendations reads the same way.
  */
 
-const BADGE_VARIANT: Record<Severity, string> = {
+const BADGE_VARIANT: Record<Severity, Variant> = {
   CRITICAL: "danger",
   HIGH: "orange",
   MEDIUM: "warning",
   LOW: "grey",
 };
 
-export function severityVariant(severity: Severity): string {
+export function severityVariant(severity: Severity): Variant {
   return BADGE_VARIANT[severity] ?? "grey";
 }
 


### PR DESCRIPTION
## Summary
Extracts the Advisor's docket (the card grid showing event types) into a reusable `AdvisorDocket` component, unifying the layout and interaction patterns across Prompts, Recommendations, and Patches pages. All three pages now display types in the same canonical order (CPU, Wall-Clock, Allocation, Blocking) and handle missing types consistently.

## Key Changes

**New Components:**
- `AdvisorDocket.vue` — Reusable docket container with selection, styling, and badge support. Accepts items via slot for page-specific content.
- `AdvisorDocketRow.vue` — Lightweight row component for displaying key-value pairs within docket cards (label + value, with optional monospace and title).
- `AdvisorMissingType.vue` — Unified card for types the recording has no samples for, showing the profiler flag needed to capture them with copy-to-clipboard support.

**Utility Functions:**
- `advisorDocket.ts` — New module with:
  - `docketItems()` — Sorts event types in canonical order and builds `DocketItem` objects with availability and badge info
  - `patchStats()` — Counts files and changed lines from unified diff patches
  - `hasPatch()` — Checks if a patch is non-empty
  - `analysisDurationMs()` — Computes analysis duration from run result
  - `shortMethodName()` — Extracts class.method from fully qualified names
- `eventTypeStyle.ts` — Added:
  - `compareEventTypes()` — Comparator enforcing canonical order
  - `eventTypeCaptureFlag()` — Returns profiler flag for each type (e.g., `event=ctimer`)
  - `eventTypeDescription()` — Human-readable description of what each type measures

**Page Updates:**
- `AdvisorPatches.vue` — Replaced inline docket with `<AdvisorDocket>`, now shows diff stats (added/removed lines, files, top method) in rows. Handles missing types and recorded-but-unanalyzed states.
- `AdvisorRecommendations.vue` — Replaced inline docket with `<AdvisorDocket>`, shows top method, its share, and analysis duration. Consistent missing type handling.
- `AdvisorPrompt.vue` — Replaced inline docket with `<AdvisorDocket>`, displays sample count, prompt size, and top method. Title changed from "Prompt" to "Prompts".

**Backend Changes:**
- `DominantMethod.java` — New record holding method name and self percentage (extracted from `DominantSelfShare`).
- `DominantSelfShare.java` — Now returns `DominantMethod` instead of just percentage, carrying both values together.
- `AdvisorController.java` — Updated `PromptResponse` to include `dominantMethod` field.
- Database schema — Added `dominant_method` column to `advisor_prompts` table.
- `JdbcProfileAdvisorRepository` — Updated queries to fetch and map `dominant_method`.

**Styling & UX:**
- Docket cards now show a diagonal hatch pattern for unavailable types (no samples recorded).
- Selection uses a tinted background rather than border change, keeping red types (Blocking) from reading as errors.
- Unavailable types remain selectable, showing the missing-type card instead of empty state.
- Added `--hatch-line` CSS variable for the diagonal pattern.

**Testing:**
- `advisorDocket.test.ts` — Tests for canonical ordering, missing type handling, badge grading, and patch stat counting.
- Updated `DominantSelfShareTest.java` to verify both method name and percentage are returned.

## Notable Implementation Details

- **Canonical Order**: All three Advisor pages now sort types identically (CPU → Wall-Clock → Allocation → Blocking), so a type stays in the same position as users navigate between pages.
- **Missing Types**: Types the recording has no samples for are no longer hidden; they appear with a "Not recorded" badge and a card explaining how to capture them (with the profiler flag and copy button).
- **Recorded but

https://claude.ai/code/session_0127zjLSw5QTQWsLfdjRAeTk