### PR TITLE
Hub: add a read-only Storage tab with per-project disk usage

### DIFF
--- a/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/configuration/StorageConfiguration.java
+++ b/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/configuration/StorageConfiguration.java
@@ -1,0 +1,35 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.hub.core.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import cafe.jeffrey.hub.core.HubJeffreyDirs;
+import cafe.jeffrey.hub.core.manager.storage.StorageManager;
+import cafe.jeffrey.hub.core.manager.storage.StorageManagerImpl;
+import cafe.jeffrey.hub.core.manager.workspace.WorkspacesManager;
+
+@Configuration
+public class StorageConfiguration {
+
+    @Bean
+    public StorageManager storageManager(WorkspacesManager workspacesManager, HubJeffreyDirs jeffreyDirs) {
+        return new StorageManagerImpl(workspacesManager, jeffreyDirs);
+    }
+}

--- a/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/manager/storage/StorageManager.java
+++ b/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/manager/storage/StorageManager.java
@@ -1,0 +1,29 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.hub.core.manager.storage;
+
+public interface StorageManager {
+
+    /**
+     * Computes the current storage usage across all workspaces and projects, plus the
+     * hub's infrastructure directories and the capacity of the underlying volume.
+     * Walks every project's session tree, so the cost grows with the repository size.
+     */
+    StorageOverview overview();
+}

--- a/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/manager/storage/StorageManagerImpl.java
+++ b/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/manager/storage/StorageManagerImpl.java
@@ -1,0 +1,119 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.hub.core.manager.storage;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import cafe.jeffrey.hub.core.HubJeffreyDirs;
+import cafe.jeffrey.hub.core.manager.project.ProjectManager;
+import cafe.jeffrey.hub.core.manager.storage.StorageOverview.DiskSpace;
+import cafe.jeffrey.hub.core.manager.storage.StorageOverview.InfrastructureUsage;
+import cafe.jeffrey.hub.core.manager.storage.StorageOverview.ProjectStorage;
+import cafe.jeffrey.hub.core.manager.workspace.WorkspaceManager;
+import cafe.jeffrey.hub.core.manager.workspace.WorkspacesManager;
+import cafe.jeffrey.shared.common.filesystem.FileSystemUtils;
+import cafe.jeffrey.shared.common.model.ProjectInfo;
+import cafe.jeffrey.shared.common.model.repository.RepositoryStatistics;
+import cafe.jeffrey.shared.common.model.workspace.WorkspaceInfo;
+
+import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class StorageManagerImpl implements StorageManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StorageManagerImpl.class);
+
+    /**
+     * Default database files inside the hub's home directory. A custom
+     * {@code jeffrey.hub.persistence.database.url} pointing elsewhere is not measured.
+     */
+    private static final String DATABASE_FILE_NAME = "jeffrey-data.db";
+    private static final String DATABASE_WAL_FILE_NAME = "jeffrey-data.db.wal";
+
+    private final WorkspacesManager workspacesManager;
+    private final HubJeffreyDirs jeffreyDirs;
+
+    public StorageManagerImpl(WorkspacesManager workspacesManager, HubJeffreyDirs jeffreyDirs) {
+        this.workspacesManager = workspacesManager;
+        this.jeffreyDirs = jeffreyDirs;
+    }
+
+    @Override
+    public StorageOverview overview() {
+        return new StorageOverview(diskSpace(), infrastructureUsage(), collectProjects());
+    }
+
+    private List<ProjectStorage> collectProjects() {
+        List<ProjectStorage> result = new ArrayList<>();
+        for (WorkspaceManager workspaceManager : workspacesManager.findAll()) {
+            WorkspaceInfo workspaceInfo = workspaceManager.localInfo();
+            for (ProjectManager projectManager : workspaceManager.projectsManager().findAll()) {
+                result.add(toProjectStorage(workspaceInfo, projectManager));
+            }
+        }
+        return result;
+    }
+
+    private static ProjectStorage toProjectStorage(WorkspaceInfo workspaceInfo, ProjectManager projectManager) {
+        ProjectInfo projectInfo = projectManager.info();
+        RepositoryStatistics stats = projectManager.repositoryManager().calculateRepositoryStatistics();
+        long logSize = stats.log().size() + stats.appLog().size() + stats.errorLog().size();
+        return new ProjectStorage(
+                workspaceInfo.id(),
+                workspaceInfo.name(),
+                projectInfo.id(),
+                projectInfo.name(),
+                projectInfo.label(),
+                stats.totalSizeBytes(),
+                stats.totalFiles(),
+                stats.jfr().size(),
+                stats.heapDump().size(),
+                logSize,
+                stats.other().size());
+    }
+
+    private InfrastructureUsage infrastructureUsage() {
+        long databaseBytes = fileSizeIfExists(jeffreyDirs.homeDir().resolve(DATABASE_FILE_NAME))
+                + fileSizeIfExists(jeffreyDirs.homeDir().resolve(DATABASE_WAL_FILE_NAME));
+        long queueBytes = FileSystemUtils.directorySize(jeffreyDirs.workspaceEvents());
+        long tempBytes = FileSystemUtils.directorySize(jeffreyDirs.temp());
+        return new InfrastructureUsage(databaseBytes, queueBytes, tempBytes);
+    }
+
+    private DiskSpace diskSpace() {
+        try {
+            FileStore fileStore = Files.getFileStore(jeffreyDirs.homeDir());
+            return new DiskSpace(fileStore.getTotalSpace(), fileStore.getUsableSpace());
+        } catch (IOException e) {
+            LOG.warn("Cannot resolve disk space of the home directory: home_dir={}", jeffreyDirs.homeDir());
+            return DiskSpace.UNKNOWN;
+        }
+    }
+
+    private static long fileSizeIfExists(Path file) {
+        if (!Files.isRegularFile(file)) {
+            return 0L;
+        }
+        return FileSystemUtils.size(file);
+    }
+}

--- a/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/manager/storage/StorageOverview.java
+++ b/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/manager/storage/StorageOverview.java
@@ -1,0 +1,63 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.hub.core.manager.storage;
+
+import java.util.List;
+
+/**
+ * Snapshot of the hub's on-disk storage usage. All byte figures are computed from
+ * the filesystem at the time of the call — the hub database stores no size columns.
+ */
+public record StorageOverview(
+        DiskSpace disk,
+        InfrastructureUsage infrastructure,
+        List<ProjectStorage> projects) {
+
+    /**
+     * Capacity of the volume holding the hub's home directory.
+     */
+    public record DiskSpace(long totalBytes, long usableBytes) {
+
+        public static final DiskSpace UNKNOWN = new DiskSpace(0L, 0L);
+    }
+
+    /**
+     * Storage used by the hub itself, outside of project repositories.
+     */
+    public record InfrastructureUsage(long databaseBytes, long queueBytes, long tempBytes) {
+    }
+
+    /**
+     * Storage used by a single project's recording repository, broken down by file category.
+     * Log bytes aggregate JVM, application, and error logs.
+     */
+    public record ProjectStorage(
+            String workspaceId,
+            String workspaceName,
+            String projectId,
+            String projectName,
+            String projectLabel,
+            long totalSizeBytes,
+            int totalFiles,
+            long jfrSizeBytes,
+            long heapDumpSizeBytes,
+            long logSizeBytes,
+            long otherSizeBytes) {
+    }
+}

--- a/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/resources/response/StorageOverviewResponse.java
+++ b/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/resources/response/StorageOverviewResponse.java
@@ -1,0 +1,75 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.hub.core.resources.response;
+
+import cafe.jeffrey.hub.core.manager.storage.StorageOverview;
+
+import java.util.List;
+
+public record StorageOverviewResponse(
+        long diskTotalBytes,
+        long diskUsableBytes,
+        long databaseSizeBytes,
+        long queueSizeBytes,
+        long tempSizeBytes,
+        List<ProjectStorageResponse> projects) {
+
+    public static StorageOverviewResponse from(StorageOverview overview) {
+        List<ProjectStorageResponse> projects = overview.projects().stream()
+                .map(ProjectStorageResponse::from)
+                .toList();
+
+        return new StorageOverviewResponse(
+                overview.disk().totalBytes(),
+                overview.disk().usableBytes(),
+                overview.infrastructure().databaseBytes(),
+                overview.infrastructure().queueBytes(),
+                overview.infrastructure().tempBytes(),
+                projects);
+    }
+
+    public record ProjectStorageResponse(
+            String workspaceId,
+            String workspaceName,
+            String projectId,
+            String projectName,
+            String projectLabel,
+            long totalSizeBytes,
+            int totalFiles,
+            long jfrSizeBytes,
+            long heapDumpSizeBytes,
+            long logSizeBytes,
+            long otherSizeBytes) {
+
+        public static ProjectStorageResponse from(StorageOverview.ProjectStorage project) {
+            return new ProjectStorageResponse(
+                    project.workspaceId(),
+                    project.workspaceName(),
+                    project.projectId(),
+                    project.projectName(),
+                    project.projectLabel(),
+                    project.totalSizeBytes(),
+                    project.totalFiles(),
+                    project.jfrSizeBytes(),
+                    project.heapDumpSizeBytes(),
+                    project.logSizeBytes(),
+                    project.otherSizeBytes());
+        }
+    }
+}

--- a/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/web/controllers/StorageController.java
+++ b/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/web/controllers/StorageController.java
@@ -1,0 +1,55 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.hub.core.web.controllers;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import cafe.jeffrey.hub.core.manager.storage.StorageManager;
+import cafe.jeffrey.hub.core.manager.storage.StorageOverview;
+import cafe.jeffrey.hub.core.resources.response.StorageOverviewResponse;
+import cafe.jeffrey.shared.common.measure.Elapsed;
+import cafe.jeffrey.shared.common.measure.Measuring;
+
+/**
+ * Read-only view of the hub's on-disk storage usage. Sizes are computed from the
+ * filesystem on every request; there is no cached or persisted state behind this endpoint.
+ */
+@RestController
+@RequestMapping("/api/internal/storage")
+public class StorageController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StorageController.class);
+
+    private final StorageManager storageManager;
+
+    public StorageController(StorageManager storageManager) {
+        this.storageManager = storageManager;
+    }
+
+    @GetMapping
+    public StorageOverviewResponse overview() {
+        Elapsed<StorageOverview> overview = Measuring.s(storageManager::overview);
+        LOG.debug("Computed storage overview: projects={} duration_ms={}",
+                overview.entity().projects().size(), overview.duration().toMillis());
+        return StorageOverviewResponse.from(overview.entity());
+    }
+}

--- a/jeffrey-hub/core-hub/src/test/java/cafe/jeffrey/hub/core/manager/storage/StorageManagerImplTest.java
+++ b/jeffrey-hub/core-hub/src/test/java/cafe/jeffrey/hub/core/manager/storage/StorageManagerImplTest.java
@@ -1,0 +1,172 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.hub.core.manager.storage;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import cafe.jeffrey.hub.core.HubJeffreyDirs;
+import cafe.jeffrey.hub.core.manager.RepositoryManager;
+import cafe.jeffrey.hub.core.manager.project.ProjectManager;
+import cafe.jeffrey.hub.core.manager.project.ProjectsManager;
+import cafe.jeffrey.hub.core.manager.storage.StorageOverview.ProjectStorage;
+import cafe.jeffrey.hub.core.manager.workspace.WorkspaceManager;
+import cafe.jeffrey.hub.core.manager.workspace.WorkspacesManager;
+import cafe.jeffrey.shared.common.model.ProjectInfo;
+import cafe.jeffrey.shared.common.model.repository.RecordingStatus;
+import cafe.jeffrey.shared.common.model.repository.RepositoryStatistics;
+import cafe.jeffrey.shared.common.model.repository.RepositoryStatistics.FileTypeStats;
+import cafe.jeffrey.shared.common.model.workspace.WorkspaceInfo;
+import cafe.jeffrey.shared.common.model.workspace.WorkspaceStatus;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StorageManagerImplTest {
+
+    private static final Instant CREATED_AT = Instant.parse("2026-04-01T10:00:00Z");
+
+    @TempDir
+    Path homeDir;
+
+    @Mock
+    WorkspacesManager workspacesManager;
+
+    @Mock
+    WorkspaceManager workspaceManager;
+
+    @Mock
+    ProjectsManager projectsManager;
+
+    @Mock
+    ProjectManager projectManager;
+
+    @Mock
+    RepositoryManager repositoryManager;
+
+    StorageManagerImpl storageManager;
+
+    @BeforeEach
+    void setUp() {
+        storageManager = new StorageManagerImpl(workspacesManager, new HubJeffreyDirs(homeDir));
+    }
+
+    @Nested
+    class InfrastructureSizes {
+
+        @Test
+        void measuresDatabaseQueueAndTempDirectories() throws IOException {
+            Files.write(homeDir.resolve("jeffrey-data.db"), new byte[100]);
+            Files.write(homeDir.resolve("jeffrey-data.db.wal"), new byte[20]);
+            Path events = Files.createDirectories(homeDir.resolve("workspaces").resolve(".events"));
+            Files.write(events.resolve("event.json"), new byte[30]);
+            Path temp = Files.createDirectories(homeDir.resolve("tmp"));
+            Files.write(temp.resolve("scratch.bin"), new byte[40]);
+            when(workspacesManager.findAll()).thenReturn(List.of());
+
+            StorageOverview overview = storageManager.overview();
+
+            assertThat(overview.infrastructure().databaseBytes()).isEqualTo(120L);
+            assertThat(overview.infrastructure().queueBytes()).isEqualTo(30L);
+            assertThat(overview.infrastructure().tempBytes()).isEqualTo(40L);
+        }
+
+        @Test
+        void reportsZeroesWhenNothingExistsOnDisk() {
+            when(workspacesManager.findAll()).thenReturn(List.of());
+
+            StorageOverview overview = storageManager.overview();
+
+            assertThat(overview.infrastructure().databaseBytes()).isZero();
+            assertThat(overview.infrastructure().queueBytes()).isZero();
+            assertThat(overview.infrastructure().tempBytes()).isZero();
+            assertThat(overview.projects()).isEmpty();
+        }
+
+        @Test
+        void resolvesDiskSpaceOfTheHomeDirectoryVolume() {
+            when(workspacesManager.findAll()).thenReturn(List.of());
+
+            StorageOverview overview = storageManager.overview();
+
+            assertThat(overview.disk().totalBytes()).isPositive();
+        }
+    }
+
+    @Nested
+    class ProjectAggregation {
+
+        @Test
+        void collectsPerProjectStatisticsAcrossWorkspaces() {
+            WorkspaceInfo workspaceInfo = new WorkspaceInfo(
+                    "ws-1", "ws-1", "repo-1", "production",
+                    null, null, CREATED_AT, WorkspaceStatus.AVAILABLE, 1);
+            ProjectInfo projectInfo = new ProjectInfo(
+                    "prj-1", "origin-1", "order-service", "Order Service", "default",
+                    "ws-1", CREATED_AT, CREATED_AT, Map.of(), null);
+
+            RepositoryStatistics stats = RepositoryStatistics.fromCategoryMap(
+                    2, RecordingStatus.ACTIVE, CREATED_AT.toEpochMilli(), 1000L, 12, 600L,
+                    Map.of(
+                            RepositoryStatistics.StatsCategory.JFR, new FileTypeStats(6, 700L),
+                            RepositoryStatistics.StatsCategory.HEAP_DUMP, new FileTypeStats(1, 200L),
+                            RepositoryStatistics.StatsCategory.LOG, new FileTypeStats(2, 40L),
+                            RepositoryStatistics.StatsCategory.APP_LOG, new FileTypeStats(1, 30L),
+                            RepositoryStatistics.StatsCategory.ERROR_LOG, new FileTypeStats(1, 20L),
+                            RepositoryStatistics.StatsCategory.OTHER, new FileTypeStats(1, 10L)));
+
+            doReturn(List.of(workspaceManager)).when(workspacesManager).findAll();
+            when(workspaceManager.localInfo()).thenReturn(workspaceInfo);
+            when(workspaceManager.projectsManager()).thenReturn(projectsManager);
+            doReturn(List.of(projectManager)).when(projectsManager).findAll();
+            when(projectManager.info()).thenReturn(projectInfo);
+            when(projectManager.repositoryManager()).thenReturn(repositoryManager);
+            when(repositoryManager.calculateRepositoryStatistics()).thenReturn(stats);
+
+            StorageOverview overview = storageManager.overview();
+
+            assertThat(overview.projects()).hasSize(1);
+            ProjectStorage project = overview.projects().getFirst();
+            assertThat(project.workspaceId()).isEqualTo("ws-1");
+            assertThat(project.workspaceName()).isEqualTo("production");
+            assertThat(project.projectId()).isEqualTo("prj-1");
+            assertThat(project.projectName()).isEqualTo("order-service");
+            assertThat(project.projectLabel()).isEqualTo("Order Service");
+            assertThat(project.totalSizeBytes()).isEqualTo(1000L);
+            assertThat(project.totalFiles()).isEqualTo(12);
+            assertThat(project.jfrSizeBytes()).isEqualTo(700L);
+            assertThat(project.heapDumpSizeBytes()).isEqualTo(200L);
+            assertThat(project.logSizeBytes()).isEqualTo(90L);
+            assertThat(project.otherSizeBytes()).isEqualTo(10L);
+        }
+    }
+}

--- a/jeffrey-hub/core-hub/src/test/java/cafe/jeffrey/hub/core/web/controllers/StorageControllerTest.java
+++ b/jeffrey-hub/core-hub/src/test/java/cafe/jeffrey/hub/core/web/controllers/StorageControllerTest.java
@@ -1,0 +1,89 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.hub.core.web.controllers;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import cafe.jeffrey.hub.core.manager.storage.StorageManager;
+import cafe.jeffrey.hub.core.manager.storage.StorageOverview;
+import cafe.jeffrey.hub.core.manager.storage.StorageOverview.DiskSpace;
+import cafe.jeffrey.hub.core.manager.storage.StorageOverview.InfrastructureUsage;
+import cafe.jeffrey.hub.core.manager.storage.StorageOverview.ProjectStorage;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static cafe.jeffrey.hub.core.web.MockMvcSupport.mockMvcTesterFor;
+
+@ExtendWith(MockitoExtension.class)
+class StorageControllerTest {
+
+    @Mock
+    StorageManager storageManager;
+
+    @Test
+    void returnsStorageOverview() {
+        StorageOverview overview = new StorageOverview(
+                new DiskSpace(512_000_000_000L, 387_000_000_000L),
+                new InfrastructureUsage(2_900_000_000L, 214_000_000L, 1_300_000_000L),
+                List.of(new ProjectStorage(
+                        "ws-1", "production",
+                        "prj-1", "order-service", null,
+                        27_100_000_000L, 342,
+                        20_000_000_000L, 5_000_000_000L, 1_600_000_000L, 500_000_000L)));
+        when(storageManager.overview()).thenReturn(overview);
+
+        MockMvcTester mvc = mockMvcTesterFor(new StorageController(storageManager));
+
+        assertThat(mvc.get().uri("/api/internal/storage"))
+                .hasStatusOk()
+                .bodyJson()
+                .hasPathSatisfying("$.diskTotalBytes", v -> assertThat(v).asNumber().isEqualTo(512_000_000_000L))
+                .hasPathSatisfying("$.diskUsableBytes", v -> assertThat(v).asNumber().isEqualTo(387_000_000_000L))
+                .hasPathSatisfying("$.databaseSizeBytes", v -> assertThat(v).asNumber().isEqualTo(2_900_000_000L))
+                .hasPathSatisfying("$.queueSizeBytes", v -> assertThat(v).asNumber().isEqualTo(214_000_000))
+                .hasPathSatisfying("$.tempSizeBytes", v -> assertThat(v).asNumber().isEqualTo(1_300_000_000))
+                .hasPathSatisfying("$.projects[0].workspaceName", v -> assertThat(v).asString().isEqualTo("production"))
+                .hasPathSatisfying("$.projects[0].projectName", v -> assertThat(v).asString().isEqualTo("order-service"))
+                .hasPathSatisfying("$.projects[0].totalSizeBytes", v -> assertThat(v).asNumber().isEqualTo(27_100_000_000L))
+                .hasPathSatisfying("$.projects[0].totalFiles", v -> assertThat(v).asNumber().isEqualTo(342))
+                .hasPathSatisfying("$.projects[0].jfrSizeBytes", v -> assertThat(v).asNumber().isEqualTo(20_000_000_000L));
+    }
+
+    @Test
+    void returnsEmptyProjectsWhenNothingIsStored() {
+        StorageOverview overview = new StorageOverview(
+                DiskSpace.UNKNOWN,
+                new InfrastructureUsage(0L, 0L, 0L),
+                List.of());
+        when(storageManager.overview()).thenReturn(overview);
+
+        MockMvcTester mvc = mockMvcTesterFor(new StorageController(storageManager));
+
+        assertThat(mvc.get().uri("/api/internal/storage"))
+                .hasStatusOk()
+                .bodyJson()
+                .hasPathSatisfying("$.diskTotalBytes", v -> assertThat(v).asNumber().isEqualTo(0))
+                .hasPathSatisfying("$.projects", v -> assertThat(v).asList().isEmpty());
+    }
+}

--- a/jeffrey-hub/pages-hub/src/router/index.ts
+++ b/jeffrey-hub/pages-hub/src/router/index.ts
@@ -19,6 +19,7 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import ServerDashboard from '@/views/server/ServerDashboard.vue';
 import SchedulerView from '@/views/server/SchedulerView.vue';
+import StorageView from '@/views/server/StorageView.vue';
 import GrpcApiDocs from '@/views/server/GrpcApiDocs.vue';
 
 const router = createRouter({
@@ -33,6 +34,11 @@ const router = createRouter({
             path: '/scheduler',
             name: 'scheduler',
             component: SchedulerView
+        },
+        {
+            path: '/storage',
+            name: 'storage',
+            component: StorageView
         },
         {
             path: '/api-docs',

--- a/jeffrey-hub/pages-hub/src/services/api/StorageClient.ts
+++ b/jeffrey-hub/pages-hub/src/services/api/StorageClient.ts
@@ -1,0 +1,30 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import BasePlatformClient from '@shared/services/api/BasePlatformClient';
+import type { StorageOverview } from '@/services/api/model/StorageOverview';
+
+export default class StorageClient extends BasePlatformClient {
+    constructor() {
+        super('/storage');
+    }
+
+    overview(): Promise<StorageOverview> {
+        return this.get<StorageOverview>();
+    }
+}

--- a/jeffrey-hub/pages-hub/src/services/api/model/StorageOverview.ts
+++ b/jeffrey-hub/pages-hub/src/services/api/model/StorageOverview.ts
@@ -1,0 +1,40 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export interface ProjectStorage {
+    workspaceId: string;
+    workspaceName: string;
+    projectId: string;
+    projectName: string;
+    projectLabel: string | null;
+    totalSizeBytes: number;
+    totalFiles: number;
+    jfrSizeBytes: number;
+    heapDumpSizeBytes: number;
+    logSizeBytes: number;
+    otherSizeBytes: number;
+}
+
+export interface StorageOverview {
+    diskTotalBytes: number;
+    diskUsableBytes: number;
+    databaseSizeBytes: number;
+    queueSizeBytes: number;
+    tempSizeBytes: number;
+    projects: ProjectStorage[];
+}

--- a/jeffrey-hub/pages-hub/src/views/server/GrpcApiDocs.vue
+++ b/jeffrey-hub/pages-hub/src/views/server/GrpcApiDocs.vue
@@ -28,6 +28,7 @@
       <nav class="header-nav">
         <router-link to="/" class="nav-tab">Workspaces</router-link>
         <router-link to="/scheduler" class="nav-tab">Scheduler</router-link>
+        <router-link to="/storage" class="nav-tab">Storage</router-link>
         <router-link to="/api-docs" class="nav-tab">API Documentation</router-link>
       </nav>
     </div>

--- a/jeffrey-hub/pages-hub/src/views/server/SchedulerView.vue
+++ b/jeffrey-hub/pages-hub/src/views/server/SchedulerView.vue
@@ -27,6 +27,7 @@
             <nav class="header-nav">
                 <router-link to="/" class="nav-tab">Workspaces</router-link>
                 <router-link to="/scheduler" class="nav-tab">Scheduler</router-link>
+                <router-link to="/storage" class="nav-tab">Storage</router-link>
                 <router-link to="/api-docs" class="nav-tab">API Documentation</router-link>
             </nav>
         </div>

--- a/jeffrey-hub/pages-hub/src/views/server/ServerDashboard.vue
+++ b/jeffrey-hub/pages-hub/src/views/server/ServerDashboard.vue
@@ -28,6 +28,7 @@
       <nav class="header-nav">
         <router-link to="/" class="nav-tab">Workspaces</router-link>
         <router-link to="/scheduler" class="nav-tab">Scheduler</router-link>
+        <router-link to="/storage" class="nav-tab">Storage</router-link>
         <router-link to="/api-docs" class="nav-tab">API Documentation</router-link>
       </nav>
     </div>

--- a/jeffrey-hub/pages-hub/src/views/server/StorageView.vue
+++ b/jeffrey-hub/pages-hub/src/views/server/StorageView.vue
@@ -1,0 +1,589 @@
+<!--
+  - Jeffrey
+  - Copyright (C) 2026 Petr Bouda
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as published by
+  - the Free Software Foundation, either version 3 of the License, or
+  - (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<template>
+    <div class="storage-view">
+        <div class="page-header">
+            <div class="header-left">
+                <img src="/jeffrey-icon.svg" alt="Jeffrey" class="header-logo">
+                <h4>Jeffrey Hub</h4>
+                <span v-if="version" class="version-badge">{{ version }}</span>
+            </div>
+            <nav class="header-nav">
+                <router-link to="/" class="nav-tab">Workspaces</router-link>
+                <router-link to="/scheduler" class="nav-tab">Scheduler</router-link>
+                <router-link to="/storage" class="nav-tab">Storage</router-link>
+                <router-link to="/api-docs" class="nav-tab">API Documentation</router-link>
+            </nav>
+        </div>
+
+        <div v-if="loading" class="loading-state">
+            <div class="spinner-border spinner-border-sm text-secondary" role="status"></div>
+            <span>Computing storage usage...</span>
+        </div>
+
+        <div v-else-if="error" class="empty-state">
+            <i class="bi bi-exclamation-triangle"></i>
+            <span>Failed to load storage usage</span>
+            <span class="empty-hint">{{ error }}</span>
+        </div>
+
+        <template v-else-if="overview">
+            <div class="section-card summary-strip">
+                <div class="summary-kv">
+                    <div class="summary-key">Total used</div>
+                    <div class="summary-value">{{ formatBytes(totalUsedBytes) }}</div>
+                </div>
+                <div class="summary-kv">
+                    <div class="summary-key">Projects</div>
+                    <div class="summary-value">{{ overview.projects.length }}</div>
+                </div>
+                <div class="summary-kv">
+                    <div class="summary-key">Files</div>
+                    <div class="summary-value">{{ totalFiles.toLocaleString() }}</div>
+                </div>
+                <div v-if="overview.diskTotalBytes > 0" class="volume-meter">
+                    <div class="volume-label">
+                        <span>Volume usage</span>
+                        <span class="volume-figures">
+                            {{ formatBytes(volumeUsedBytes) }} / {{ formatBytes(overview.diskTotalBytes) }}
+                            · {{ formatBytes(overview.diskUsableBytes) }} free
+                        </span>
+                    </div>
+                    <div class="volume-bar">
+                        <div class="volume-jeffrey" :style="{ width: volumeJeffreyPct + '%' }"></div>
+                        <div class="volume-others" :style="{ width: volumeOthersPct + '%' }"></div>
+                    </div>
+                </div>
+            </div>
+
+            <div v-if="overview.projects.length === 0" class="empty-state">
+                <i class="bi bi-hdd"></i>
+                <span>No project data stored yet</span>
+                <span class="empty-hint">Repositories fill up as connected applications record sessions</span>
+            </div>
+
+            <div v-else class="section-card">
+                <table class="storage-table">
+                    <thead>
+                    <tr>
+                        <th class="sortable" @click="sortBy('workspace')">
+                            Workspace <span class="sort-arrow">{{ sortArrow('workspace') }}</span>
+                        </th>
+                        <th class="sortable" @click="sortBy('project')">
+                            Project <span class="sort-arrow">{{ sortArrow('project') }}</span>
+                        </th>
+                        <th class="sortable text-end" @click="sortBy('size')">
+                            Size <span class="sort-arrow">{{ sortArrow('size') }}</span>
+                        </th>
+                        <th class="sortable text-end" @click="sortBy('files')">
+                            Files <span class="sort-arrow">{{ sortArrow('files') }}</span>
+                        </th>
+                        <th>Categories</th>
+                        <th class="text-end">% of total</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr v-for="row in sortedProjects" :key="row.projectId">
+                        <td>
+                            <span class="workspace-cell">
+                                <span class="workspace-dot" :style="{ background: workspaceColor(row.workspaceId) }"></span>
+                                {{ row.workspaceName }}
+                            </span>
+                        </td>
+                        <td class="project-cell">{{ displayName(row) }}</td>
+                        <td class="text-end size-cell">{{ formatBytes(row.totalSizeBytes) }}</td>
+                        <td class="text-end files-cell">{{ row.totalFiles.toLocaleString() }}</td>
+                        <td>
+                            <span class="category-bar">
+                                <span
+                                    v-for="segment in categorySegments(row)"
+                                    :key="segment.key"
+                                    :style="{ width: segment.width + '%', background: segment.color }"
+                                ></span>
+                            </span>
+                        </td>
+                        <td>
+                            <span class="share-cell">
+                                <span class="share-track">
+                                    <span class="share-fill" :style="{ width: shareOfLargestPct(row) + '%' }"></span>
+                                </span>
+                                <span class="share-value">{{ shareOfProjectsPct(row) }}</span>
+                            </span>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="category-legend">
+                <span v-for="category in CATEGORIES" :key="category.key" class="legend-item">
+                    <span class="workspace-dot" :style="{ background: category.color }"></span>{{ category.label }}
+                </span>
+                <span class="legend-spacer"></span>
+                <span class="infra-note">
+                    Infrastructure (outside projects):
+                    database {{ formatBytes(overview.databaseSizeBytes) }}
+                    · folder queue {{ formatBytes(overview.queueSizeBytes) }}
+                    · temp {{ formatBytes(overview.tempSizeBytes) }}
+                </span>
+            </div>
+        </template>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import FormattingService from '@shared/services/FormattingService';
+import StorageClient from '@/services/api/StorageClient';
+import VersionClient from '@/services/api/VersionClient';
+import type { ProjectStorage, StorageOverview } from '@/services/api/model/StorageOverview';
+
+type SortColumn = 'workspace' | 'project' | 'size' | 'files';
+type SortDirection = 'asc' | 'desc';
+
+const CATEGORIES = [
+    { key: 'jfr', label: 'JFR recordings', color: 'var(--color-primary)' },
+    { key: 'heapDump', label: 'Heap dumps', color: 'var(--color-orange)' },
+    { key: 'log', label: 'Logs', color: 'var(--color-teal)' },
+    { key: 'other', label: 'Other files', color: 'var(--color-amber)' }
+] as const;
+
+// Fixed palette assigned to workspaces in order of first appearance
+const WORKSPACE_COLORS = [
+    'var(--color-primary)',
+    'var(--color-orange)',
+    'var(--color-teal)',
+    'var(--color-purple)',
+    'var(--color-amber)',
+    'var(--color-danger)'
+];
+
+const storageClient = new StorageClient();
+const versionClient = new VersionClient();
+
+const loading = ref(true);
+const error = ref<string | null>(null);
+const overview = ref<StorageOverview | null>(null);
+const version = ref<string>('');
+const sortColumn = ref<SortColumn>('size');
+const sortDirection = ref<SortDirection>('desc');
+
+const formatBytes = (bytes: number) => FormattingService.formatBytesShort(bytes);
+
+const displayName = (row: ProjectStorage) => {
+    return row.projectLabel?.trim() ? row.projectLabel : row.projectName;
+};
+
+const projectsTotalBytes = computed(() => {
+    if (!overview.value) {
+        return 0;
+    }
+    return overview.value.projects.reduce((sum, p) => sum + p.totalSizeBytes, 0);
+});
+
+const totalUsedBytes = computed(() => {
+    if (!overview.value) {
+        return 0;
+    }
+    return projectsTotalBytes.value
+        + overview.value.databaseSizeBytes
+        + overview.value.queueSizeBytes
+        + overview.value.tempSizeBytes;
+});
+
+const totalFiles = computed(() => {
+    if (!overview.value) {
+        return 0;
+    }
+    return overview.value.projects.reduce((sum, p) => sum + p.totalFiles, 0);
+});
+
+const maxProjectBytes = computed(() => {
+    if (!overview.value) {
+        return 0;
+    }
+    return overview.value.projects.reduce((max, p) => Math.max(max, p.totalSizeBytes), 0);
+});
+
+const volumeUsedBytes = computed(() => {
+    if (!overview.value) {
+        return 0;
+    }
+    return Math.max(0, overview.value.diskTotalBytes - overview.value.diskUsableBytes);
+});
+
+const volumeJeffreyPct = computed(() => {
+    if (!overview.value || overview.value.diskTotalBytes === 0) {
+        return 0;
+    }
+    return (totalUsedBytes.value / overview.value.diskTotalBytes) * 100;
+});
+
+const volumeOthersPct = computed(() => {
+    if (!overview.value || overview.value.diskTotalBytes === 0) {
+        return 0;
+    }
+    const othersBytes = Math.max(0, volumeUsedBytes.value - totalUsedBytes.value);
+    return (othersBytes / overview.value.diskTotalBytes) * 100;
+});
+
+const workspaceColorIndex = computed(() => {
+    const indexByWorkspace = new Map<string, number>();
+    if (!overview.value) {
+        return indexByWorkspace;
+    }
+    for (const project of overview.value.projects) {
+        if (!indexByWorkspace.has(project.workspaceId)) {
+            indexByWorkspace.set(project.workspaceId, indexByWorkspace.size);
+        }
+    }
+    return indexByWorkspace;
+});
+
+const workspaceColor = (workspaceId: string) => {
+    const index = workspaceColorIndex.value.get(workspaceId) ?? 0;
+    return WORKSPACE_COLORS[index % WORKSPACE_COLORS.length];
+};
+
+const sortedProjects = computed(() => {
+    if (!overview.value) {
+        return [];
+    }
+    const direction = sortDirection.value === 'asc' ? 1 : -1;
+    return [...overview.value.projects].sort((a, b) => {
+        switch (sortColumn.value) {
+            case 'workspace':
+                return direction * a.workspaceName.localeCompare(b.workspaceName);
+            case 'project':
+                return direction * displayName(a).localeCompare(displayName(b));
+            case 'files':
+                return direction * (a.totalFiles - b.totalFiles);
+            default:
+                return direction * (a.totalSizeBytes - b.totalSizeBytes);
+        }
+    });
+});
+
+const sortBy = (column: SortColumn) => {
+    if (sortColumn.value === column) {
+        sortDirection.value = sortDirection.value === 'asc' ? 'desc' : 'asc';
+    } else {
+        sortColumn.value = column;
+        sortDirection.value = column === 'workspace' || column === 'project' ? 'asc' : 'desc';
+    }
+};
+
+const sortArrow = (column: SortColumn) => {
+    if (sortColumn.value !== column) {
+        return '';
+    }
+    return sortDirection.value === 'asc' ? '▲' : '▼';
+};
+
+const categorySegments = (row: ProjectStorage) => {
+    if (row.totalSizeBytes === 0) {
+        return [];
+    }
+    const sizes: Record<(typeof CATEGORIES)[number]['key'], number> = {
+        jfr: row.jfrSizeBytes,
+        heapDump: row.heapDumpSizeBytes,
+        log: row.logSizeBytes,
+        other: row.otherSizeBytes
+    };
+    return CATEGORIES
+        .filter(category => sizes[category.key] > 0)
+        .map(category => ({
+            key: category.key,
+            color: category.color,
+            width: (sizes[category.key] / row.totalSizeBytes) * 100
+        }));
+};
+
+const shareOfLargestPct = (row: ProjectStorage) => {
+    if (maxProjectBytes.value === 0) {
+        return 0;
+    }
+    return (row.totalSizeBytes / maxProjectBytes.value) * 100;
+};
+
+const shareOfProjectsPct = (row: ProjectStorage) => {
+    if (projectsTotalBytes.value === 0) {
+        return FormattingService.formatPercentValue(0);
+    }
+    return FormattingService.formatPercentValue((row.totalSizeBytes / projectsTotalBytes.value) * 100);
+};
+
+const loadStorage = async () => {
+    try {
+        overview.value = await storageClient.overview();
+        error.value = null;
+    } catch (e) {
+        console.error('Failed to load storage overview:', e);
+        error.value = e instanceof Error ? e.message : 'Unexpected error while loading storage usage';
+    } finally {
+        loading.value = false;
+    }
+};
+
+onMounted(() => {
+    loadStorage();
+    versionClient.getVersion()
+        .then(v => { version.value = v; })
+        .catch(err => console.error('Failed to load version:', err));
+});
+</script>
+
+<style scoped>
+.storage-view {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 32px 24px;
+}
+
+/* Header (shared style with the other hub views) */
+.page-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 28px;
+}
+.header-left {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+.header-logo { width: 32px; height: 32px; }
+.header-left h4 {
+    margin: 0;
+    font-weight: 600;
+    color: var(--color-heading-dark);
+}
+.version-badge {
+    font-size: 0.72rem;
+    font-weight: 500;
+    color: var(--color-slate-muted);
+    background: var(--color-grey-bg);
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-variant-numeric: tabular-nums;
+}
+.header-nav {
+    display: flex;
+    gap: 2px;
+    background: var(--color-grey-bg);
+    border-radius: 8px;
+    padding: 3px;
+}
+.nav-tab {
+    padding: 6px 14px;
+    border-radius: 6px;
+    font-size: 0.78rem;
+    font-weight: 500;
+    color: var(--color-slate-muted);
+    text-decoration: none;
+    transition: all 0.15s ease;
+}
+.nav-tab:hover { color: var(--color-slate-text); }
+.nav-tab.router-link-active {
+    background: white;
+    color: var(--color-primary);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.loading-state, .empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    padding: 60px 20px;
+    color: var(--color-text-light);
+}
+.empty-state i { font-size: 3rem; }
+.empty-hint {
+    font-size: 0.8rem;
+    color: var(--color-muted-separator);
+}
+
+.section-card {
+    background: white;
+    border: 1px solid var(--color-border);
+    border-radius: 10px;
+    overflow: hidden;
+}
+
+/* Summary strip */
+.summary-strip {
+    display: flex;
+    align-items: center;
+    gap: 28px;
+    padding: 14px 18px;
+    margin-bottom: 16px;
+    flex-wrap: wrap;
+}
+.summary-key {
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-text-light);
+}
+.summary-value {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--color-heading-dark);
+    font-variant-numeric: tabular-nums;
+}
+.volume-meter {
+    flex: 1;
+    min-width: 240px;
+}
+.volume-label {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.72rem;
+    color: var(--color-slate-muted);
+    margin-bottom: 5px;
+}
+.volume-figures { font-variant-numeric: tabular-nums; }
+.volume-bar {
+    display: flex;
+    gap: 2px;
+    height: 10px;
+    border-radius: 4px;
+    overflow: hidden;
+    background: var(--color-grey-bg);
+}
+.volume-jeffrey { background: var(--color-primary); }
+.volume-others { background: var(--color-slate-light); }
+
+/* Table */
+.storage-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+.storage-table thead th {
+    text-align: left;
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-text-light);
+    padding: 10px 18px;
+    background: var(--color-light);
+    border-bottom: 1px solid var(--color-grey-bg);
+    white-space: nowrap;
+}
+.storage-table thead th.sortable {
+    cursor: pointer;
+    user-select: none;
+}
+.sort-arrow {
+    color: var(--color-primary);
+    font-size: 0.6rem;
+}
+.storage-table tbody td {
+    padding: 11px 18px;
+    border-bottom: 1px solid var(--color-grey-bg);
+    font-size: 0.82rem;
+    color: var(--color-heading-dark);
+    vertical-align: middle;
+}
+.storage-table tbody tr:last-child td { border-bottom: none; }
+.storage-table tbody tr:hover { background: var(--color-light); }
+
+.workspace-cell {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    color: var(--color-slate-muted);
+    font-size: 0.78rem;
+}
+.workspace-dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 3px;
+    flex: none;
+    display: inline-block;
+}
+.project-cell { font-weight: 600; }
+.size-cell {
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+}
+.files-cell {
+    color: var(--color-slate-muted);
+    font-variant-numeric: tabular-nums;
+}
+
+.category-bar {
+    display: flex;
+    gap: 1px;
+    width: 130px;
+    height: 8px;
+    border-radius: 3px;
+    overflow: hidden;
+    background: var(--color-grey-bg);
+}
+
+.share-cell {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    justify-content: flex-end;
+}
+.share-track {
+    width: 70px;
+    height: 6px;
+    border-radius: 3px;
+    background: var(--color-grey-bg);
+    overflow: hidden;
+    display: inline-block;
+}
+.share-fill {
+    display: block;
+    height: 100%;
+    border-radius: 3px;
+    background: var(--color-primary);
+}
+.share-value {
+    color: var(--color-slate-muted);
+    font-size: 0.78rem;
+    font-variant-numeric: tabular-nums;
+    min-width: 44px;
+    text-align: right;
+}
+
+/* Legend + infrastructure footnote */
+.category-legend {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    flex-wrap: wrap;
+    margin: 10px 4px 0;
+    font-size: 0.74rem;
+    color: var(--color-slate-muted);
+}
+.legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+.legend-spacer { flex: 1; }
+.infra-note { font-variant-numeric: tabular-nums; }
+</style>


### PR DESCRIPTION
New /api/internal/storage endpoint aggregates repository statistics across
all workspaces and projects (size, file count, per-category breakdown),
measures the infrastructure directories (database, folder queue, temp) with
FileSystemUtils, and reports the home-directory volume's capacity via
FileStore. Sizes are computed from the filesystem on every request — the
hub database stores no size columns.

The new Storage tab in pages-hub renders a sortable dense table (workspace,
project, size, files, category mini-bar, share of total) with a summary
strip showing total usage and a volume meter, plus an infrastructure
footnote.

Claude-Session: https://claude.ai/code/session_01Nn7djnxiQ9UTk93Wcak12h