### PR TITLE
Handle port conflicts gracefully in recovery web server

### DIFF
--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/recovery/MicroscopeStartupGuard.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/recovery/MicroscopeStartupGuard.java
@@ -61,12 +61,20 @@ public final class MicroscopeStartupGuard {
             ================================================================================
             """;
 
-    private static final String PORT_BANNER = """
+    private static final String FALLBACK_PORT_BANNER = """
+            ================================================================================
+             Note: port %d is already in use, so the recovery page is served on a fallback
+             port (see the address above). Jeffrey itself still needs port %d after the
+             recovery completes — free it, or restart with --server.port=<port>.
+            ================================================================================
+            """;
+
+    private static final String SERVER_FAILED_BANNER = """
             ================================================================================
              Jeffrey cannot start: the data folder was created by an older version, and the
-             recovery page cannot be served because port %d is already in use.
+             recovery page cannot be served: %s
 
-             Free the port (or start with --server.port=<port>) and try again.
+             Resolve the error and try again, or fix the data folder manually.
             ================================================================================
             """;
 
@@ -98,7 +106,6 @@ public final class MicroscopeStartupGuard {
     private static Path recover(Path homeDir, int port, SchemaValidationResult result) {
         LOG.warn("Existing database is incompatible with this Jeffrey version: home_dir={} detail={}",
                 homeDir, describe(result));
-        System.out.printf(BANNER, homeDir, port);
 
         Path currentHome = homeDir;
         try (RecoveryWebServer server = new RecoveryWebServer(
@@ -107,12 +114,17 @@ public final class MicroscopeStartupGuard {
                 () -> RecoveryActions.startFresh(currentHome),
                 rawPath -> RecoveryActions.switchHome(currentHome, rawPath))) {
 
+            System.out.printf(BANNER, homeDir, server.port());
+            if (server.usesFallbackPort()) {
+                System.out.printf(FALLBACK_PORT_BANNER, port, port);
+            }
+
             Path newHome = server.awaitAction();
             LOG.info("Recovery action completed, continuing startup: home_dir={}", newHome);
             return newHome;
         } catch (IOException e) {
             LOG.error("Cannot start the recovery web server: port={} message={}", port, e.getMessage());
-            System.out.printf(PORT_BANNER, port);
+            System.out.printf(SERVER_FAILED_BANNER, e.getMessage());
             System.exit(1);
             return homeDir;
         }

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/recovery/RecoveryWebServer.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/recovery/RecoveryWebServer.java
@@ -28,6 +28,7 @@ import tools.jackson.databind.json.JsonMapper;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.BindException;
 import java.net.InetSocketAddress;
 import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
@@ -38,9 +39,12 @@ import java.util.function.Supplier;
 
 /**
  * Minimal web server (JDK built-in {@link HttpServer}, no Spring, no Tomcat) that serves the
- * recovery page on Jeffrey's regular HTTP port while the application cannot start. Once the
- * user completes one of the recovery actions the server is stopped, the port is released and
- * the same JVM continues into the normal Spring Boot startup.
+ * recovery page on Jeffrey's regular HTTP port while the application cannot start. When the
+ * regular port is already taken by another process, the server falls back to an ephemeral
+ * port instead of failing — the recovery page works on any port, only the later Spring Boot
+ * startup needs the regular one. Once the user completes one of the recovery actions the
+ * server is stopped, the port is released and the same JVM continues into the normal Spring
+ * Boot startup.
  */
 public final class RecoveryWebServer implements AutoCloseable {
 
@@ -62,6 +66,7 @@ public final class RecoveryWebServer implements AutoCloseable {
     private static final String CONTENT_TYPE_JSON = "application/json";
 
     private static final int SERVER_STOP_GRACE_SECONDS = 1;
+    private static final int EPHEMERAL_PORT = 0;
 
     private static final JsonMapper JSON = JsonMapper.builder().build();
 
@@ -75,6 +80,7 @@ public final class RecoveryWebServer implements AutoCloseable {
     }
 
     private final HttpServer server;
+    private final boolean usesFallbackPort;
     private final ExecutorService executor;
     private final Path currentHome;
     private final Supplier<Path> startFreshAction;
@@ -91,7 +97,19 @@ public final class RecoveryWebServer implements AutoCloseable {
         this.startFreshAction = startFreshAction;
         this.switchHomeAction = switchHomeAction;
 
-        this.server = HttpServer.create(new InetSocketAddress(port), 0);
+        HttpServer boundServer;
+        boolean fallbackPort;
+        try {
+            boundServer = HttpServer.create(new InetSocketAddress(port), 0);
+            fallbackPort = false;
+        } catch (BindException e) {
+            LOG.warn("Configured port is already in use, serving the recovery page on a fallback port: " +
+                    "configured_port={} message={}", port, e.getMessage());
+            boundServer = HttpServer.create(new InetSocketAddress(EPHEMERAL_PORT), 0);
+            fallbackPort = true;
+        }
+        this.server = boundServer;
+        this.usesFallbackPort = fallbackPort;
         this.executor = Executors.newVirtualThreadPerTaskExecutor();
         server.createContext(ROOT_PATH, this::handlePage);
         server.createContext(STATUS_PATH, this::handleStatus);
@@ -104,6 +122,14 @@ public final class RecoveryWebServer implements AutoCloseable {
 
     public int port() {
         return server.getAddress().getPort();
+    }
+
+    /**
+     * Returns {@code true} when the configured port was already taken and the server had to
+     * bind an ephemeral fallback port instead.
+     */
+    public boolean usesFallbackPort() {
+        return usesFallbackPort;
     }
 
     /**

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/recovery/RecoveryWebServerTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/recovery/RecoveryWebServerTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.net.ServerSocket;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -29,6 +30,8 @@ import java.net.http.HttpResponse;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RecoveryWebServerTest {
@@ -89,6 +92,36 @@ class RecoveryWebServerTest {
         assertTrue(root.body().contains("jeffrey-recovery"));
         assertEquals(200, deepLink.statusCode());
         assertTrue(deepLink.body().contains("jeffrey-recovery"));
+    }
+
+    @Test
+    void bindsConfiguredPortWithoutFallbackWhenFree() {
+        assertFalse(server.usesFallbackPort());
+    }
+
+    @Test
+    void fallsBackToEphemeralPortWhenConfiguredPortIsTaken() throws Exception {
+        try (ServerSocket portBlocker = new ServerSocket(0)) {
+            int takenPort = portBlocker.getLocalPort();
+
+            try (RecoveryWebServer fallbackServer = new RecoveryWebServer(
+                    takenPort,
+                    CURRENT_HOME,
+                    () -> FRESH_HOME,
+                    rawPath -> SWITCHED_HOME)) {
+
+                assertTrue(fallbackServer.usesFallbackPort());
+                assertNotEquals(takenPort, fallbackServer.port());
+
+                HttpResponse<String> root = client.send(
+                        HttpRequest.newBuilder(URI.create("http://localhost:" + fallbackServer.port() + "/"))
+                                .GET()
+                                .build(),
+                        HttpResponse.BodyHandlers.ofString());
+                assertEquals(200, root.statusCode());
+                assertTrue(root.body().contains("jeffrey-recovery"));
+            }
+        }
     }
 
     @Test

--- a/jeffrey-pages/src/views/docs/microscope/MicroscopeStoragePage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/MicroscopeStoragePage.vue
@@ -222,7 +222,7 @@ onMounted(() => {
       </DocsCallout>
 
       <h2 id="upgrades-recovery">Upgrades &amp; Recovery Mode</h2>
-      <p>After an update, the data in your home folder may have been created by an older Jeffrey version and can no longer be used. Microscope detects this at startup and, instead of failing, serves a recovery page on its regular port (default <code>http://localhost:8080</code>) with two options:</p>
+      <p>After an update, the data in your home folder may have been created by an older Jeffrey version and can no longer be used. Microscope detects this at startup and, instead of failing, serves a recovery page on its regular port (default <code>http://localhost:8080</code>) with two options. If the regular port is already taken by another process, the recovery page is served on a fallback port instead — the console banner prints the exact address to open. The regular port still has to be freed (or changed with <code>--server.port</code>) before Jeffrey itself can start after the recovery completes.</p>
       <ul>
         <li><strong>Start fresh</strong> — permanently removes the current data folder and starts again with empty data.</li>
         <li><strong>Use another folder</strong> — keeps the current folder untouched and points Jeffrey at a new home folder for this start. To make the change permanent, launch Jeffrey with <code>jeffrey.microscope.home.dir</code> pointing at the new folder — otherwise the recovery page appears again on the next start.</li>


### PR DESCRIPTION
## Summary
When the recovery web server cannot bind to the configured port because it's already in use, the server now falls back to an ephemeral port instead of failing. This allows the recovery page to be served on any available port, while the regular port can be freed before Jeffrey's normal startup completes.

## Key Changes
- **RecoveryWebServer**: Added fallback logic to catch `BindException` and bind to an ephemeral port (port 0) when the configured port is unavailable
  - New field `usesFallbackPort` tracks whether a fallback port was used
  - New public method `usesFallbackPort()` exposes this state
  - Added constant `EPHEMERAL_PORT = 0` for clarity
  
- **MicroscopeStartupGuard**: Updated startup banners to inform users when a fallback port is in use
  - New `FALLBACK_PORT_BANNER` explains the situation and reminds users to free the regular port before Jeffrey startup completes
  - Renamed `PORT_BANNER` to `SERVER_FAILED_BANNER` for clarity (now used only for actual server startup failures)
  - Moved banner printing to after server creation so the actual bound port is displayed
  - Improved error messaging for server startup failures
  
- **RecoveryWebServerTest**: Added comprehensive test coverage
  - `bindsConfiguredPortWithoutFallbackWhenFree()` verifies normal operation
  - `fallsBackToEphemeralPortWhenConfiguredPortIsTaken()` verifies fallback behavior by blocking the configured port with a `ServerSocket`
  
- **MicroscopeStoragePage.vue**: Updated documentation to explain the fallback port behavior

## Implementation Details
The fallback mechanism uses a try-catch block around `HttpServer.create()` to detect `BindException`. When caught, the server is created with port 0, which tells the OS to assign any available ephemeral port. The actual bound port is then retrieved via `server.getAddress().getPort()` and displayed to the user in the startup banner.

https://claude.ai/code/session_01PTy7zT5TJ8Ta6rnuGQ7wUw