### PR TITLE
Add per-instance session cap to ProjectInstanceSessionCleanerJob

### DIFF
--- a/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/scheduler/job/InstanceSessionUnits.java
+++ b/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/scheduler/job/InstanceSessionUnits.java
@@ -1,0 +1,85 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.hub.core.scheduler.job;
+
+import cafe.jeffrey.shared.common.model.repository.RecordingSession;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Logical retention units of one instance's sessions: a consecutive run of failed-empty
+ * sessions (a crash loop) collapses into a single unit, while every session that produced
+ * data — including the still-active one — forms a unit of its own and splits failed runs.
+ * This mirrors the collapsed crash-loop groups the UI renders (sessionGrouping.ts).
+ *
+ * <p>Units and the sessions inside them are ordered newest-first by {@code createdAt}.
+ * Failed-empty classification relies on {@link RecordingSession#isFailedEmpty()}, so the
+ * sessions must have been loaded WITH files.</p>
+ */
+final class InstanceSessionUnits {
+
+    private final List<List<RecordingSession>> units;
+
+    private InstanceSessionUnits(List<List<RecordingSession>> units) {
+        this.units = units;
+    }
+
+    static InstanceSessionUnits of(List<RecordingSession> sessions) {
+        List<RecordingSession> sorted = sessions.stream()
+                .sorted(Comparator.comparing(RecordingSession::createdAt).reversed())
+                .toList();
+
+        List<List<RecordingSession>> units = new ArrayList<>();
+        List<RecordingSession> currentFailedRun = new ArrayList<>();
+
+        for (RecordingSession session : sorted) {
+            if (session.isFailedEmpty()) {
+                currentFailedRun.add(session);
+            } else {
+                flushFailedRun(units, currentFailedRun);
+                units.add(List.of(session));
+            }
+        }
+        flushFailedRun(units, currentFailedRun);
+
+        return new InstanceSessionUnits(List.copyOf(units));
+    }
+
+    private static void flushFailedRun(List<List<RecordingSession>> units, List<RecordingSession> failedRun) {
+        if (failedRun.isEmpty()) {
+            return;
+        }
+        units.add(List.copyOf(failedRun));
+        failedRun.clear();
+    }
+
+    /** Logical units, newest-first; each unit's sessions are also newest-first. */
+    List<List<RecordingSession>> units() {
+        return units;
+    }
+
+    /** All sessions flattened, newest-first — the order the protection scan expects. */
+    List<RecordingSession> sessionsNewestFirst() {
+        return units.stream()
+                .flatMap(List::stream)
+                .toList();
+    }
+}

--- a/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/scheduler/job/ProjectInstanceSessionCleanerJob.java
+++ b/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/scheduler/job/ProjectInstanceSessionCleanerJob.java
@@ -76,15 +76,17 @@ public class ProjectInstanceSessionCleanerJob extends RepositoryProjectJob<Proje
         String projectName = manager.info().name();
         LOG.debug("Cleaning the project instance sessions: project='{}'", projectName);
         Duration duration = jobDescriptor.toDuration();
+        int maxSessions = jobDescriptor.maxSessions();
 
         Instant currentTime = clock.instant();
         ProjectInstanceRepository instanceRepo = platformRepositories.newProjectInstanceRepository(projectId);
 
-        // Group finished sessions by instance. Retained sessions are pinned evidence
-        // (a manual pin, or an auto-pin from a detected JVM crash) and never expire.
+        // Group ALL non-retained sessions by instance — the still-active session must occupy
+        // a slot of the max-sessions cap, so it stays in the list and is excluded only at
+        // deletion time. Retained sessions are pinned evidence (a manual pin, or an auto-pin
+        // from a detected JVM crash): they never expire and never consume a cap slot.
         // Files must be loaded (listSessions(true)) so isFailedEmpty() sees real sizes.
         Map<String, List<RecordingSession>> sessionsByInstance = repositoryStorage.listSessions(true).stream()
-                .filter(session -> session.finishedAt() != null)
                 .filter(session -> !session.retained())
                 .collect(Collectors.groupingBy(RecordingSession::instanceId));
 
@@ -92,38 +94,45 @@ public class ProjectInstanceSessionCleanerJob extends RepositoryProjectJob<Proje
 
         for (var entry : sessionsByInstance.entrySet()) {
             String instanceId = entry.getKey();
-            List<RecordingSession> sessions = entry.getValue().stream()
-                    .sorted(Comparator.comparing(RecordingSession::createdAt).reversed())
-                    .toList();
+            InstanceSessionUnits units = InstanceSessionUnits.of(entry.getValue());
 
             Optional<ProjectInstanceInfo> instanceOpt = instanceRepo.find(instanceId);
             boolean isFinished = instanceOpt.isPresent()
                     && instanceOpt.get().status() == ProjectInstanceStatus.FINISHED;
 
-            // Protection slot: the newest session that actually produced data. Failed/empty
-            // sessions (finished with zero bytes, e.g. a crash-looped container) never consume
-            // the keep-newest protection, so a real session followed by a burst of failed
-            // sessions stays protected.
-            int protectedIndex = -1;
-            for (int i = 0; i < sessions.size(); i++) {
-                if (!sessions.get(i).isFailedEmpty()) {
-                    protectedIndex = i;
-                    break;
-                }
-            }
+            // Protection slot: the newest FINISHED session that actually produced data.
+            // Failed/empty sessions (finished with zero bytes, e.g. a crash-looped container)
+            // never consume the keep-newest protection, and the active session must not claim
+            // it either — it is already safe, and letting it win would silently un-protect
+            // the newest real finished session.
+            String protectedSessionId = units.sessionsNewestFirst().stream()
+                    .filter(session -> session.finishedAt() != null)
+                    .filter(session -> !session.isFailedEmpty())
+                    .map(RecordingSession::id)
+                    .findFirst()
+                    .orElse(null);
 
-            for (int i = 0; i < sessions.size(); i++) {
-                RecordingSession session = sessions.get(i);
-                if (!currentTime.isAfter(session.createdAt().plus(duration))) {
-                    continue;
-                }
+            // Two independent rules in one pass: the age window, and the per-instance cap of
+            // logical sessions (a consecutive crash-loop run counts as one unit). Sessions in
+            // units beyond the cap are deleted even before their age window expires.
+            List<List<RecordingSession>> unitList = units.units();
+            for (int unitIndex = 0; unitIndex < unitList.size(); unitIndex++) {
+                boolean overCap = unitIndex >= maxSessions;
+                for (RecordingSession session : unitList.get(unitIndex)) {
+                    if (session.finishedAt() == null) {
+                        continue;
+                    }
 
-                // Keep the newest non-empty session for non-FINISHED instances
-                if (i == protectedIndex && !isFinished) {
-                    continue;
-                }
+                    // Keep the newest non-empty session for non-FINISHED instances
+                    if (!isFinished && session.id().equals(protectedSessionId)) {
+                        continue;
+                    }
 
-                candidatesForDeletion.add(session);
+                    boolean ageExpired = currentTime.isAfter(session.createdAt().plus(duration));
+                    if (ageExpired || overCap) {
+                        candidatesForDeletion.add(session);
+                    }
+                }
             }
         }
 

--- a/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/scheduler/job/descriptor/ProjectInstanceSessionCleanerJobDescriptor.java
+++ b/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/scheduler/job/descriptor/ProjectInstanceSessionCleanerJobDescriptor.java
@@ -1,6 +1,6 @@
 /*
  * Jeffrey
- * Copyright (C) 2025 Petr Bouda
+ * Copyright (C) 2026 Petr Bouda
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -24,19 +24,34 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
 
+/**
+ * Retention rules for finished instance sessions: an age window ({@code duration} +
+ * {@code timeUnit}) and a per-instance cap of {@code maxSessions} logical sessions.
+ * A logical session is either a single session that produced data or a consecutive
+ * run of failed-empty sessions (a crash loop), which counts as one.
+ */
 public record ProjectInstanceSessionCleanerJobDescriptor(
         long duration,
-        ChronoUnit timeUnit
+        ChronoUnit timeUnit,
+        int maxSessions
 ) implements JobDescriptor<ProjectInstanceSessionCleanerJobDescriptor> {
 
     private static final String PARAM_DURATION = "duration";
     private static final String PARAM_TIME_UNIT = "time-unit";
+    private static final String PARAM_MAX_SESSIONS = "max-sessions";
+
+    public ProjectInstanceSessionCleanerJobDescriptor {
+        if (maxSessions <= 0) {
+            throw new IllegalArgumentException(PARAM_MAX_SESSIONS + " must be positive: " + maxSessions);
+        }
+    }
 
     @Override
     public Map<String, String> params() {
         return Map.of(
                 PARAM_DURATION, String.valueOf(duration),
-                PARAM_TIME_UNIT, timeUnit.toString());
+                PARAM_TIME_UNIT, timeUnit.toString(),
+                PARAM_MAX_SESSIONS, Integer.toString(maxSessions));
     }
 
     @Override
@@ -51,6 +66,7 @@ public record ProjectInstanceSessionCleanerJobDescriptor(
     public static ProjectInstanceSessionCleanerJobDescriptor of(Map<String, String> params) {
         return new ProjectInstanceSessionCleanerJobDescriptor(
                 JobDescriptorUtils.resolveLong(params, PARAM_DURATION),
-                JobDescriptorUtils.resolveChronoUnit(params, PARAM_TIME_UNIT));
+                JobDescriptorUtils.resolveChronoUnit(params, PARAM_TIME_UNIT),
+                JobDescriptorUtils.resolveInt(params, PARAM_MAX_SESSIONS));
     }
 }

--- a/jeffrey-hub/core-hub/src/main/resources/scheduler-defaults.properties
+++ b/jeffrey-hub/core-hub/src/main/resources/scheduler-defaults.properties
@@ -68,10 +68,17 @@ jeffrey.hub.scheduler.jobs.profiler-settings-synchronizer.period=5m
 jeffrey.hub.scheduler.jobs.profiler-settings-synchronizer.params.max-versions=5
 
 # PROJECT — fan out across all projects in all workspaces
+#
+# Two independent retention rules per instance: an age window (duration + time-unit) and a
+# cap of max-sessions logical sessions. A consecutive run of failed sessions (finished with
+# zero bytes — a crash loop, collapsed in the UI) counts as ONE logical session; the live
+# session occupies a slot; retained (pinned) sessions neither occupy a slot nor expire.
+# Oldest logical sessions beyond the cap are deleted even before the age window expires.
 jeffrey.hub.scheduler.jobs.project-instance-session-cleaner.enabled=true
 jeffrey.hub.scheduler.jobs.project-instance-session-cleaner.period=1h
 jeffrey.hub.scheduler.jobs.project-instance-session-cleaner.params.duration=7
 jeffrey.hub.scheduler.jobs.project-instance-session-cleaner.params.time-unit=Days
+jeffrey.hub.scheduler.jobs.project-instance-session-cleaner.params.max-sessions=10
 
 jeffrey.hub.scheduler.jobs.project-instance-recording-cleaner.enabled=true
 jeffrey.hub.scheduler.jobs.project-instance-recording-cleaner.period=1h

--- a/jeffrey-hub/core-hub/src/test/java/cafe/jeffrey/hub/core/scheduler/job/InstanceSessionUnitsTest.java
+++ b/jeffrey-hub/core-hub/src/test/java/cafe/jeffrey/hub/core/scheduler/job/InstanceSessionUnitsTest.java
@@ -1,0 +1,147 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.hub.core.scheduler.job;
+
+import cafe.jeffrey.shared.common.model.repository.RecordingSession;
+import cafe.jeffrey.shared.common.model.repository.RecordingStatus;
+import cafe.jeffrey.shared.common.model.repository.RepositoryFile;
+import cafe.jeffrey.shared.common.model.repository.SupportedRecordingFile;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class InstanceSessionUnitsTest {
+
+    private static final Instant NOW = Instant.parse("2026-02-20T12:00:00Z");
+    private static final long MB = 1024L * 1024L;
+
+    @Test
+    void emptyInputProducesNoUnits() {
+        InstanceSessionUnits units = InstanceSessionUnits.of(List.of());
+
+        assertTrue(units.units().isEmpty());
+        assertTrue(units.sessionsNewestFirst().isEmpty());
+    }
+
+    @Test
+    void consecutiveFailedSessionsCollapseIntoOneUnit() {
+        InstanceSessionUnits units = InstanceSessionUnits.of(List.of(
+                real("real-1", 1),
+                failed("failed-1", 2),
+                failed("failed-2", 3),
+                real("real-2", 4)));
+
+        assertEquals(List.of(
+                        List.of("real-1"),
+                        List.of("failed-1", "failed-2"),
+                        List.of("real-2")),
+                unitIds(units));
+    }
+
+    @Test
+    void allFailedSessionsFormASingleUnit() {
+        InstanceSessionUnits units = InstanceSessionUnits.of(List.of(
+                failed("failed-1", 1),
+                failed("failed-2", 2),
+                failed("failed-3", 3)));
+
+        assertEquals(List.of(List.of("failed-1", "failed-2", "failed-3")), unitIds(units));
+    }
+
+    @Test
+    void realSessionSplitsFailedRuns() {
+        InstanceSessionUnits units = InstanceSessionUnits.of(List.of(
+                failed("failed-1", 1),
+                real("real-1", 2),
+                failed("failed-2", 3)));
+
+        assertEquals(List.of(
+                        List.of("failed-1"),
+                        List.of("real-1"),
+                        List.of("failed-2")),
+                unitIds(units));
+    }
+
+    @Test
+    void activeSessionSplitsFailedRuns() {
+        // An active session has no finishedAt, so it never counts as failed-empty
+        InstanceSessionUnits units = InstanceSessionUnits.of(List.of(
+                failed("failed-1", 1),
+                active("live", 2),
+                failed("failed-2", 3)));
+
+        assertEquals(List.of(
+                        List.of("failed-1"),
+                        List.of("live"),
+                        List.of("failed-2")),
+                unitIds(units));
+    }
+
+    @Test
+    void unsortedInputIsSortedNewestFirst() {
+        InstanceSessionUnits units = InstanceSessionUnits.of(List.of(
+                failed("failed-2", 3),
+                real("real-1", 2),
+                failed("failed-1", 1)));
+
+        assertEquals(List.of("failed-1", "real-1", "failed-2"), sessionIds(units.sessionsNewestFirst()));
+    }
+
+    private static List<List<String>> unitIds(InstanceSessionUnits units) {
+        return units.units().stream()
+                .map(InstanceSessionUnitsTest::sessionIds)
+                .toList();
+    }
+
+    private static List<String> sessionIds(List<RecordingSession> sessions) {
+        return sessions.stream()
+                .map(RecordingSession::id)
+                .toList();
+    }
+
+    private static RecordingSession real(String id, int hoursOld) {
+        Instant createdAt = NOW.minus(Duration.ofHours(hoursOld));
+        RepositoryFile file = new RepositoryFile(
+                id + "-file", id + "-file", createdAt, 10 * MB,
+                SupportedRecordingFile.JFR, RecordingStatus.FINISHED, null);
+        return session(id, createdAt, createdAt.plusSeconds(60), file);
+    }
+
+    private static RecordingSession failed(String id, int hoursOld) {
+        Instant createdAt = NOW.minus(Duration.ofHours(hoursOld));
+        return session(id, createdAt, createdAt.plusSeconds(5));
+    }
+
+    private static RecordingSession active(String id, int hoursOld) {
+        return session(id, NOW.minus(Duration.ofHours(hoursOld)), null);
+    }
+
+    private static RecordingSession session(
+            String id, Instant createdAt, Instant finishedAt, RepositoryFile... files) {
+
+        RecordingStatus status = finishedAt != null ? RecordingStatus.FINISHED : RecordingStatus.ACTIVE;
+        return new RecordingSession(
+                id, id, "inst-1", createdAt, finishedAt, status, null, null, List.of(files), false);
+    }
+}

--- a/jeffrey-hub/core-hub/src/test/java/cafe/jeffrey/hub/core/scheduler/job/ProjectInstanceSessionCleanerJobTest.java
+++ b/jeffrey-hub/core-hub/src/test/java/cafe/jeffrey/hub/core/scheduler/job/ProjectInstanceSessionCleanerJobTest.java
@@ -50,6 +50,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -73,6 +74,7 @@ class ProjectInstanceSessionCleanerJobTest {
     private static final Duration PAST_RETENTION = RETENTION.plus(Duration.ofDays(1));
     private static final long MB = 1024L * 1024L;
     private static final String INSTANCE_ID = "inst-1";
+    private static final int MAX_SESSIONS = 10;
 
     @Mock
     WorkspacesManager workspacesManager;
@@ -112,7 +114,7 @@ class ProjectInstanceSessionCleanerJobTest {
         when(instanceRepository.find(INSTANCE_ID)).thenReturn(Optional.of(instance(ProjectInstanceStatus.ACTIVE)));
 
         ProjectInstanceSessionCleanerJobDescriptor descriptor =
-                new ProjectInstanceSessionCleanerJobDescriptor(RETENTION.toDays(), ChronoUnit.DAYS);
+                new ProjectInstanceSessionCleanerJobDescriptor(RETENTION.toDays(), ChronoUnit.DAYS, MAX_SESSIONS);
 
         job = new ProjectInstanceSessionCleanerJob(
                 workspacesManager,
@@ -125,16 +127,24 @@ class ProjectInstanceSessionCleanerJobTest {
     }
 
     private void execute() {
+        execute(MAX_SESSIONS);
+    }
+
+    private void execute(int maxSessions) {
         job.executeOnRepository(
                 projectManager,
                 storage,
-                new ProjectInstanceSessionCleanerJobDescriptor(RETENTION.toDays(), ChronoUnit.DAYS),
+                new ProjectInstanceSessionCleanerJobDescriptor(RETENTION.toDays(), ChronoUnit.DAYS, maxSessions),
                 JobContext.EMPTY);
     }
 
     private static ProjectInstanceInfo instance(ProjectInstanceStatus status) {
+        return instance(INSTANCE_ID, status);
+    }
+
+    private static ProjectInstanceInfo instance(String instanceId, ProjectInstanceStatus status) {
         return new ProjectInstanceInfo(
-                INSTANCE_ID, "proj-1", "my-instance", status, NOW.minus(Duration.ofDays(30)),
+                instanceId, "proj-1", "my-instance", status, NOW.minus(Duration.ofDays(30)),
                 null, null, null, 3, null);
     }
 
@@ -154,12 +164,24 @@ class ProjectInstanceSessionCleanerJobTest {
         return session(id, createdAt, createdAt.plusSeconds(5), false);
     }
 
+    /** A still-running session — zero bytes so far, no finish timestamp. */
+    private static RecordingSession activeSession(String id, Instant createdAt) {
+        return session(id, createdAt, null, false);
+    }
+
     private static RecordingSession session(
             String id, Instant createdAt, Instant finishedAt, boolean retained, RepositoryFile... files) {
 
+        return session(id, INSTANCE_ID, createdAt, finishedAt, retained, files);
+    }
+
+    private static RecordingSession session(
+            String id, String instanceId, Instant createdAt, Instant finishedAt, boolean retained,
+            RepositoryFile... files) {
+
         RecordingStatus status = finishedAt != null ? RecordingStatus.FINISHED : RecordingStatus.ACTIVE;
         return new RecordingSession(
-                id, id, INSTANCE_ID, createdAt, finishedAt, status, null, null, List.of(files), retained);
+                id, id, instanceId, createdAt, finishedAt, status, null, null, List.of(files), retained);
     }
 
     private List<String> deletedSessionIds() {
@@ -300,13 +322,206 @@ class ProjectInstanceSessionCleanerJobTest {
     }
 
     @Nested
+    class MaxSessionsCap {
+
+        private final List<RecordingSession> sessions = new ArrayList<>();
+        private int ageHours = 0;
+
+        /** Appends a real session one hour older than the previous one — far inside the age window. */
+        private void real(String id) {
+            sessions.add(realSession(id, NOW.minus(Duration.ofHours(++ageHours))));
+        }
+
+        /** Appends a failed-empty session one hour older than the previous one. */
+        private void empty(String id) {
+            sessions.add(emptySession(id, NOW.minus(Duration.ofHours(++ageHours))));
+        }
+
+        @Test
+        void consecutiveFailedRunsCollapseIntoOneLogicalSession() {
+            // 3 real + 5 crashed + 3 real + 5 crashed + 2 real = 3+1+3+1+2 = 10 logical sessions
+            real("real-1");
+            real("real-2");
+            real("real-3");
+            empty("empty-1");
+            empty("empty-2");
+            empty("empty-3");
+            empty("empty-4");
+            empty("empty-5");
+            real("real-4");
+            real("real-5");
+            real("real-6");
+            empty("empty-6");
+            empty("empty-7");
+            empty("empty-8");
+            empty("empty-9");
+            empty("empty-10");
+            real("real-7");
+            real("real-8");
+
+            when(storage.listSessions(true)).thenReturn(sessions);
+
+            execute(10);
+
+            verify(repositoryManager, never()).deleteRecordingSession(anyString(), any());
+        }
+
+        @Test
+        void deletesOldestLogicalSessionsBeyondTheCap() {
+            // The 10-unit layout above plus a crash-loop run and a real session behind it
+            real("real-1");
+            real("real-2");
+            real("real-3");
+            empty("empty-1");
+            empty("empty-2");
+            empty("empty-3");
+            empty("empty-4");
+            empty("empty-5");
+            real("real-4");
+            real("real-5");
+            real("real-6");
+            empty("empty-6");
+            empty("empty-7");
+            empty("empty-8");
+            empty("empty-9");
+            empty("empty-10");
+            real("real-7");
+            real("real-8");
+            empty("old-empty-1");
+            empty("old-empty-2");
+            real("old-real");
+
+            when(storage.listSessions(true)).thenReturn(sessions);
+
+            execute(10);
+
+            // Both physical sessions of the over-cap crash-loop unit go, plus the over-cap real one
+            assertEquals(List.of("old-empty-1", "old-empty-2", "old-real"), deletedSessionIds());
+        }
+
+        @Test
+        void capDeletesSessionsYoungerThanTheAgeWindow() {
+            real("real-1");
+            real("real-2");
+            real("real-3");
+            real("real-4");
+
+            when(storage.listSessions(true)).thenReturn(sessions);
+
+            execute(3);
+
+            assertEquals(List.of("real-4"), deletedSessionIds());
+        }
+
+        @Test
+        void activeSessionOccupiesASlotButIsNeverDeleted() {
+            sessions.add(activeSession("live", NOW.minus(Duration.ofMinutes(30))));
+            real("real-1");
+            real("real-2");
+            real("real-3");
+
+            when(storage.listSessions(true)).thenReturn(sessions);
+
+            execute(3);
+
+            // The live session takes unit 0, pushing the oldest real session over the cap
+            assertEquals(List.of("real-3"), deletedSessionIds());
+        }
+
+        @Test
+        void overCapActiveSessionIsNeverDeleted() {
+            real("real-1");
+            sessions.add(activeSession("stale-live", NOW.minus(Duration.ofHours(5))));
+
+            when(storage.listSessions(true)).thenReturn(sessions);
+
+            execute(1);
+
+            verify(repositoryManager, never()).deleteRecordingSession(anyString(), any());
+        }
+
+        @Test
+        void retainedSessionsAreInvisibleToTheCap() {
+            empty("empty-1");
+            Instant pinnedAt = NOW.minus(Duration.ofHours(++ageHours));
+            sessions.add(session("pinned", pinnedAt, pinnedAt.plusSeconds(60), true,
+                    recording("pinned-file", pinnedAt, 10 * MB)));
+            empty("empty-2");
+            real("real-1");
+            real("real-2");
+
+            when(storage.listSessions(true)).thenReturn(sessions);
+
+            execute(2);
+
+            // The pinned session consumes no slot and no longer splits the crash-loop run:
+            // units are [empty-1, empty-2], [real-1], [real-2] — only real-2 is over the cap
+            assertEquals(List.of("real-2"), deletedSessionIds());
+        }
+
+        @Test
+        void keepNewestProtectionBeatsTheCapForLiveInstances() {
+            sessions.add(activeSession("live", NOW.minus(Duration.ofMinutes(30))));
+            empty("empty-1");
+            real("real-1");
+            empty("empty-2");
+
+            when(storage.listSessions(true)).thenReturn(sessions);
+
+            execute(2);
+
+            // real-1 is over the cap but is the newest finished session with data — protected
+            assertEquals(List.of("empty-2"), deletedSessionIds());
+        }
+
+        @Test
+        void noProtectionFromTheCapForFinishedInstances() {
+            when(instanceRepository.find(INSTANCE_ID))
+                    .thenReturn(Optional.of(instance(ProjectInstanceStatus.FINISHED)));
+
+            sessions.add(activeSession("live", NOW.minus(Duration.ofMinutes(30))));
+            empty("empty-1");
+            real("real-1");
+            empty("empty-2");
+
+            when(storage.listSessions(true)).thenReturn(sessions);
+
+            execute(2);
+
+            assertEquals(List.of("real-1", "empty-2"), deletedSessionIds());
+        }
+
+        @Test
+        void capAppliesPerInstanceIndependently() {
+            when(instanceRepository.find("inst-2"))
+                    .thenReturn(Optional.of(instance("inst-2", ProjectInstanceStatus.ACTIVE)));
+
+            real("real-1");
+            real("real-2");
+            real("real-3");
+            for (int i = 1; i <= 3; i++) {
+                Instant createdAt = NOW.minus(Duration.ofHours(++ageHours));
+                sessions.add(session("other-real-" + i, "inst-2", createdAt, createdAt.plusSeconds(60), false,
+                        recording("other-file-" + i, createdAt, 10 * MB)));
+            }
+
+            when(storage.listSessions(true)).thenReturn(sessions);
+
+            execute(4);
+
+            // 6 sessions in total, but each instance holds only 3 logical sessions — under the cap
+            verify(repositoryManager, never()).deleteRecordingSession(anyString(), any());
+        }
+    }
+
+    @Nested
     class DegenerateInput {
 
         @Test
         void toleratesEmptyRepository() {
             when(storage.listSessions(true)).thenReturn(List.of());
 
-            assertDoesNotThrow(ProjectInstanceSessionCleanerJobTest.this::execute);
+            assertDoesNotThrow(() -> execute());
             verify(repositoryManager, never()).deleteRecordingSession(anyString(), any());
         }
 

--- a/jeffrey-hub/core-hub/src/test/java/cafe/jeffrey/hub/core/scheduler/job/descriptor/ProjectInstanceSessionCleanerJobDescriptorTest.java
+++ b/jeffrey-hub/core-hub/src/test/java/cafe/jeffrey/hub/core/scheduler/job/descriptor/ProjectInstanceSessionCleanerJobDescriptorTest.java
@@ -1,0 +1,49 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.hub.core.scheduler.job.descriptor;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ProjectInstanceSessionCleanerJobDescriptorTest {
+
+    @Test
+    void paramsRoundTripThroughFactory() {
+        ProjectInstanceSessionCleanerJobDescriptor descriptor =
+                new ProjectInstanceSessionCleanerJobDescriptor(7, ChronoUnit.DAYS, 10);
+
+        assertEquals(
+                Map.of("duration", "7", "time-unit", "Days", "max-sessions", "10"),
+                descriptor.params());
+        assertEquals(descriptor, ProjectInstanceSessionCleanerJobDescriptor.of(descriptor.params()));
+    }
+
+    @Test
+    void rejectsNonPositiveMaxSessions() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new ProjectInstanceSessionCleanerJobDescriptor(7, ChronoUnit.DAYS, 0));
+        assertThrows(IllegalArgumentException.class,
+                () -> new ProjectInstanceSessionCleanerJobDescriptor(7, ChronoUnit.DAYS, -1));
+    }
+}

--- a/jeffrey-hub/pages-hub/src/views/server/SchedulerView.vue
+++ b/jeffrey-hub/pages-hub/src/views/server/SchedulerView.vue
@@ -202,7 +202,7 @@ const descriptions: Record<string, string> = {
     PROFILER_SETTINGS_SYNCHRONIZER:
         'Resolves the effective profiler settings (global → workspace → project) for every workspace and uploads them to the remote workspace, pruning legacy versions to the configured max-versions cap.',
     PROJECT_INSTANCE_SESSION_CLEANER:
-        'Removes Project Instance Sessions older than the configured duration. Once a session is removed, all associated Recordings and Additional Files (HeapDump, PerfCounters, ...) are removed as well.',
+        'Removes Project Instance Sessions older than the configured duration, and caps each instance at max-sessions logical sessions — a consecutive run of failed (0-byte) sessions counts as one, the live session occupies a slot, retained sessions are exempt. Oldest logical sessions beyond the cap are removed even before the age window expires. Once a session is removed, all associated Recordings and Additional Files (HeapDump, PerfCounters, ...) are removed as well.',
     PROJECT_INSTANCE_RECORDING_CLEANER:
         'Removes only Recordings in the active (latest) Project Instance Session. It does not remove recordings in older sessions — it just ensures that rolling recordings in the latest session are bounded by age.',
     PROJECT_STORAGE_QUOTA_CLEANER:

--- a/jeffrey-pages/src/views/docs/hub/configuration/HubConfigurationPage.vue
+++ b/jeffrey-pages/src/views/docs/hub/configuration/HubConfigurationPage.vue
@@ -263,8 +263,14 @@ onMounted(() => {
           <tr>
             <td><code>project-instance-session-cleaner</code></td>
             <td><code>1h</code></td>
-            <td><code>duration=7</code> / <code>time-unit=Days</code></td>
-            <td>Deletes finished sessions past the retention window</td>
+            <td><code>duration=7</code> / <code>time-unit=Days</code> / <code>max-sessions=10</code></td>
+            <td>
+              Deletes finished sessions past the retention window, and caps each instance at
+              <code>max-sessions</code> logical sessions — a consecutive run of failed (0-byte)
+              sessions counts as one, the live session occupies a slot, retained sessions are
+              exempt. Oldest logical sessions beyond the cap are deleted even before the
+              retention window expires.
+            </td>
           </tr>
           <tr>
             <td><code>project-instance-recording-cleaner</code></td>


### PR DESCRIPTION
## Summary
Extends the session retention policy for project instances with a configurable per-instance cap on logical sessions, complementing the existing age-based retention window. Sessions are now deleted when they exceed either the age window OR the per-instance session limit, whichever triggers first.

## Key Changes

- **New `InstanceSessionUnits` class**: Groups sessions into logical units where consecutive failed-empty sessions (crash loops) collapse into a single unit, while sessions with data or active sessions each form their own unit. This mirrors the UI's crash-loop grouping behavior.

- **Updated `ProjectInstanceSessionCleanerJobDescriptor`**: Added `maxSessions` parameter (validated to be positive) with serialization/deserialization support via `params()` and `of()` methods.

- **Refactored `ProjectInstanceSessionCleanerJob.executeOnRepository()`**:
  - Now includes active sessions in the processing pipeline (they occupy a cap slot but are never deleted)
  - Applies two independent deletion rules: age expiration AND per-instance cap
  - Protects the newest finished non-empty session for active instances (not for finished instances)
  - Retained sessions are excluded from both the cap and age window

- **Configuration updates**:
  - `scheduler-defaults.properties`: Added `max-sessions=10` default parameter with documentation
  - `HubConfigurationPage.vue`: Updated documentation to explain the new cap behavior

- **Comprehensive test coverage**:
  - New `InstanceSessionUnitsTest`: Unit tests for session grouping logic (crash-loop collapsing, sorting, edge cases)
  - New `ProjectInstanceSessionCleanerJobDescriptorTest`: Parameter serialization and validation
  - Extended `ProjectInstanceSessionCleanerJobTest`: Added `MaxSessionsCap` nested test class with 8 test cases covering:
    - Crash-loop collapsing into logical units
    - Deletion of oldest units beyond the cap
    - Cap enforcement independent of age window
    - Active session slot occupation without deletion
    - Retained session invisibility to the cap
    - Keep-newest protection for live instances (but not finished ones)
    - Per-instance cap independence

## Implementation Details

- Sessions are processed newest-first by creation time
- The protection slot (keep-newest for active instances) only applies to finished sessions with data, preventing the active session from claiming it
- Failed-empty classification relies on `RecordingSession.isFailedEmpty()`, requiring files to be loaded
- The cap applies independently per instance, allowing different instances to maintain their own session counts

https://claude.ai/code/session_01JWSezKGWr67sX3sq8jDXSM