### PR TITLE
Add trace and span support to jeffrey-events

### DIFF
--- a/utilities/jeffrey-events/pom.xml
+++ b/utilities/jeffrey-events/pom.xml
@@ -54,7 +54,18 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <junit.version>6.0.3</junit.version>
+        <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
     </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>
@@ -63,8 +74,13 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.14.0</version>
                 <configuration>
-                    <release>17</release>
+                    <release>25</release>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/JeffreyEventRegistry.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/JeffreyEventRegistry.java
@@ -26,6 +26,7 @@ import cafe.jeffrey.jfr.events.jdbc.pool.*;
 import cafe.jeffrey.jfr.events.jdbc.statement.*;
 import cafe.jeffrey.jfr.events.message.AlertEvent;
 import cafe.jeffrey.jfr.events.message.MessageEvent;
+import cafe.jeffrey.jfr.events.trace.TraceSpanEvent;
 import jdk.jfr.Event;
 
 import java.util.List;
@@ -49,7 +50,8 @@ public abstract class JeffreyEventRegistry {
             PooledJdbcConnectionBorrowedEvent.class,
             PooledJdbcConnectionCreatedEvent.class,
             AcquiringPooledJdbcConnectionTimeoutEvent.class,
-            JdbcPoolStatisticsEvent.class
+            JdbcPoolStatisticsEvent.class,
+            TraceSpanEvent.class
     );
 
     private JeffreyEventRegistry() {

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/http/AbstractHttpExchangeEvent.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/http/AbstractHttpExchangeEvent.java
@@ -18,11 +18,12 @@
 
 package cafe.jeffrey.jfr.events.http;
 
+import cafe.jeffrey.jfr.events.trace.AbstractTracedEvent;
 import jdk.jfr.*;
 
 @Category({"Application", "HTTP"})
 @StackTrace(false)
-public abstract class AbstractHttpExchangeEvent extends Event {
+public abstract class AbstractHttpExchangeEvent extends AbstractTracedEvent {
 
     @Label("Remote Address")
     public String remoteHost;

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/jdbc/statement/JdbcBaseEvent.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/jdbc/statement/JdbcBaseEvent.java
@@ -18,11 +18,11 @@
 
 package cafe.jeffrey.jfr.events.jdbc.statement;
 
+import cafe.jeffrey.jfr.events.trace.AbstractTracedEvent;
 import jdk.jfr.Description;
-import jdk.jfr.Event;
 import jdk.jfr.Label;
 
-public abstract class JdbcBaseEvent extends Event {
+public abstract class JdbcBaseEvent extends AbstractTracedEvent {
 
     @Label("SQL Query")
     @Description("The SQL statement executed by the JDBC statement")

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/AbstractTracedEvent.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/AbstractTracedEvent.java
@@ -1,0 +1,58 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.trace;
+
+import jdk.jfr.Contextual;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+
+/**
+ * Trace identity carried by every event that can take part in a trace.
+ * <p>
+ * The ids are plain {@code long}s rather than strings on purpose: JFR varint-encodes integral
+ * fields, while every distinct string value enters the per-chunk constant pool. Trace and span ids
+ * are the highest-cardinality values an event can carry, so encoding them as strings is the single
+ * biggest recording-size risk in a tracing setup.
+ * <p>
+ * A value of {@code 0} means "absent" — zero is also the cheapest varint encoding, so an event that
+ * never takes part in a trace costs practically nothing over its untraced shape. A span with
+ * {@code parentSpanId == 0} is a root span.
+ * <p>
+ * The trace id is 64-bit, not the 128-bit shape used by W3C Trace Context and OpenTelemetry.
+ * Jeffrey mints every id itself within a single recording, where 64 bits is far more than enough;
+ * the trade-off is that an externally supplied 128-bit trace id cannot be stored without loss.
+ * <p>
+ * {@link Contextual} on the id fields does nothing for Jeffrey's own analysis — it reconstructs the
+ * span-to-event association from the thread and the time window. It is there so that {@code jfr
+ * print} and JDK Mission Control show the trace and span id next to every lock, I/O and exception
+ * event that occurred inside the span, for anyone opening the recording in another tool.
+ */
+public abstract class AbstractTracedEvent extends Event {
+
+    @Label("Trace Id")
+    @Contextual
+    public long traceId;
+
+    @Label("Span Id")
+    @Contextual
+    public long spanId;
+
+    @Label("Parent Span Id")
+    public long parentSpanId;
+}

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/SpanContext.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/SpanContext.java
@@ -1,0 +1,72 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.trace;
+
+import java.util.random.RandomGenerator;
+
+/**
+ * Where a span sits in its trace: the trace it belongs to, its own id, and its parent's.
+ * <p>
+ * Immutable by design — a nested span never mutates its parent's context, it derives a new one via
+ * {@link #child(RandomGenerator)}. That is what makes the context safe to publish through a
+ * {@link java.lang.ScopedValue}.
+ * <p>
+ * Because the context carries the parent id as well as its own, it fully describes a span's
+ * position, which is what lets {@link Tracer#stamp(AbstractTracedEvent)} fill in an event in one
+ * step.
+ *
+ * @param traceId      identifies the whole trace; shared by every span within it
+ * @param spanId       identifies this span; unique within the trace
+ * @param parentSpanId the enclosing span's id, or {@code 0} when this span is a root
+ */
+public record SpanContext(long traceId, long spanId, long parentSpanId) {
+
+    /**
+     * Starts a new trace: a fresh trace id, a fresh span id, and no parent.
+     */
+    public static SpanContext root(RandomGenerator random) {
+        return new SpanContext(nonZero(random), nonZero(random), 0);
+    }
+
+    /**
+     * Derives a child of this span — same trace, new span id, parented to this one.
+     */
+    public SpanContext child(RandomGenerator random) {
+        return new SpanContext(traceId, nonZero(random), spanId);
+    }
+
+    /**
+     * @return whether this span starts a trace rather than continuing one
+     */
+    public boolean isRoot() {
+        return parentSpanId == 0;
+    }
+
+    /**
+     * Ids use {@code 0} to mean "absent", so a generated id must never be zero. The retry is
+     * effectively free: the odds of drawing zero are one in 2^64.
+     */
+    private static long nonZero(RandomGenerator random) {
+        long value;
+        do {
+            value = random.nextLong();
+        } while (value == 0);
+        return value;
+    }
+}

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/SpanKind.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/SpanKind.java
@@ -19,8 +19,13 @@
 package cafe.jeffrey.jfr.events.trace;
 
 /**
- * What role a span plays in the operation it describes. Mirrors the OpenTelemetry span-kind
- * vocabulary so the concept reads the same to anyone who has used a tracer before.
+ * What role a span plays in the operation it describes — in practice, whether the time it covers
+ * was the process's own work or time spent waiting on something else.
+ * <p>
+ * The names are OpenTelemetry's, so the concept reads the same to anyone who has used a tracer
+ * before, but the set is deliberately smaller. OpenTelemetry also defines {@code PRODUCER} and
+ * {@code CONSUMER}, whose purpose is to pair a span in one process with its counterpart in
+ * another; a trace assembled from a single JVM recording has no such counterpart to pair with.
  */
 public enum SpanKind {
 
@@ -34,11 +39,5 @@ public enum SpanKind {
     SERVER,
 
     /** Issuing an outbound request and waiting for its response, e.g. an HTTP call or a SQL query. */
-    CLIENT,
-
-    /** Publishing a message that is handled asynchronously. */
-    PRODUCER,
-
-    /** Consuming a message published elsewhere. */
-    CONSUMER
+    CLIENT
 }

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/SpanKind.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/SpanKind.java
@@ -1,0 +1,44 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.trace;
+
+/**
+ * What role a span plays in the operation it describes. Mirrors the OpenTelemetry span-kind
+ * vocabulary so the concept reads the same to anyone who has used a tracer before.
+ */
+public enum SpanKind {
+
+    /**
+     * A span covering work the process performs for itself — the default for an operation that
+     * neither receives nor issues a remote call.
+     */
+    INTERNAL,
+
+    /** Handling an inbound request, e.g. an HTTP or gRPC server exchange. */
+    SERVER,
+
+    /** Issuing an outbound request and waiting for its response, e.g. an HTTP call or a SQL query. */
+    CLIENT,
+
+    /** Publishing a message that is handled asynchronously. */
+    PRODUCER,
+
+    /** Consuming a message published elsewhere. */
+    CONSUMER
+}

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/SpanStatus.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/SpanStatus.java
@@ -16,38 +16,20 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package cafe.jeffrey.jfr.events.grpc;
+package cafe.jeffrey.jfr.events.trace;
 
-import cafe.jeffrey.jfr.events.trace.AbstractTracedEvent;
-import jdk.jfr.*;
+/**
+ * How a span finished. {@link #UNSET} is the default: an operation that completed without the
+ * instrumentation expressing an opinion is not the same as one explicitly declared successful.
+ */
+public enum SpanStatus {
 
-@Category({"Application", "gRPC"})
-@StackTrace(false)
-public abstract class AbstractGrpcExchangeEvent extends AbstractTracedEvent {
+    /** The instrumentation did not record an outcome. */
+    UNSET,
 
-    @Label("Service Name")
-    public String service;
+    /** The operation completed as intended. */
+    OK,
 
-    @Label("Method Name")
-    public String method;
-
-    @Label("Remote Address")
-    public String remoteHost;
-
-    @Label("Remote Port")
-    public int remotePort;
-
-    @Label("Status Code")
-    public String status;
-
-    @Label("Authority")
-    public String authority;
-
-    @Label("Request Size")
-    @DataAmount
-    public long requestSize;
-
-    @Label("Response Size")
-    @DataAmount
-    public long responseSize;
+    /** The operation failed. The failure is described by the span's error type. */
+    ERROR
 }

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/TraceSpanEvent.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/TraceSpanEvent.java
@@ -1,0 +1,68 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.trace;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
+import jdk.jfr.Threshold;
+
+/**
+ * One span in a trace: a named interval of work, linked to its parent by
+ * {@link AbstractTracedEvent#parentSpanId}.
+ * <p>
+ * JFR supplies the parts that would otherwise have to be recorded by hand — the start timestamp,
+ * the duration and the thread — so the event only has to carry what makes the interval meaningful.
+ * <p>
+ * The default {@link Threshold} keeps trivially short spans out of the recording. It can be lowered
+ * or removed per recording through the usual JFR configuration
+ * ({@code -XX:StartFlightRecording:cafe.jeffrey.jfr.events.trace.TraceSpanEvent#threshold=0ms}).
+ *
+ * @see Tracer
+ */
+@Name(TraceSpanEvent.NAME)
+@Label("Trace Span")
+@Description("A single named interval of work within a trace")
+@Category({"Application", "Tracing"})
+@StackTrace(false)
+@Threshold("1 ms")
+public class TraceSpanEvent extends AbstractTracedEvent {
+
+    public static final String NAME = "jeffrey.TraceSpan";
+
+    @Label("Name")
+    @Description("Operation name; must be a stable, low-cardinality label")
+    public String name;
+
+    @Label("Kind")
+    public String kind;
+
+    @Label("Status")
+    public String status;
+
+    @Label("Error Type")
+    @Description("Class name of the exception that ended the span, when it ended in an error")
+    public String errorType;
+
+    @Label("Attributes")
+    @Description("Operation-specific detail, encoded as a JSON object")
+    public String attributes;
+}

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/Tracer.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/Tracer.java
@@ -1,0 +1,276 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.trace;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.random.RandomGenerator;
+
+/**
+ * Records nested spans into the JFR recording.
+ * <p>
+ * The span currently in progress is published through a {@link ScopedValue}, so a nested
+ * {@link #call} or {@link #run} discovers its parent without the caller threading anything through.
+ * The binding is bounded by the lambda, which means it cannot outlive the span and never needs to be
+ * cleared.
+ *
+ * <pre>{@code
+ * Tracer.run("order.checkout", SpanKind.SERVER, () -> {
+ *     Tracer.run("inventory.reserve", SpanKind.CLIENT, this::reserve);
+ *     Tracer.run("payment.charge", SpanKind.CLIENT, this::charge);
+ * });
+ * }</pre>
+ *
+ * <h2>Cost when nothing is recording</h2>
+ * When the {@link TraceSpanEvent} type is disabled — no JFR recording, or a configuration that
+ * leaves the event off — the body runs directly with no binding established and no event allocated
+ * beyond the (escape-analysable) event instance itself. Instrumentation is therefore safe to leave
+ * in production code.
+ *
+ * <h2>Limits</h2>
+ * <ul>
+ *   <li><b>A span must begin and end on the same thread.</b> JFR attributes a duration event to the
+ *       thread that commits it, so a span handed off mid-flight is recorded against the wrong
+ *       thread — which in turn breaks the thread-plus-time-window correlation Jeffrey uses to show
+ *       what the JVM was doing inside the span. Use {@link #continueIn} to open a <em>separate</em>
+ *       child span on the receiving thread rather than carrying one across the boundary.</li>
+ *   <li><b>{@link ScopedValue} propagates to child threads only through structured concurrency.</b>
+ *       Work submitted to a plain executor does not inherit the current span; pass the
+ *       {@link SpanContext} explicitly and re-establish it with {@link #continueIn}.</li>
+ *   <li><b>Span names must be stable and low-cardinality.</b> Every distinct name enters the JFR
+ *       per-chunk string pool, so a name built from a request id or a user id inflates the
+ *       recording. Name the operation, not the instance of it.</li>
+ * </ul>
+ */
+public final class Tracer {
+
+    private static final ScopedValue<SpanContext> CURRENT = ScopedValue.newInstance();
+
+    private Tracer() {
+    }
+
+    /**
+     * @return the span currently in progress on this thread, or empty when none is
+     */
+    public static Optional<SpanContext> current() {
+        return CURRENT.isBound() ? Optional.of(CURRENT.get()) : Optional.empty();
+    }
+
+    /**
+     * Records a span around {@code body}, with kind {@link SpanKind#INTERNAL}.
+     */
+    public static void run(String name, Runnable body) {
+        run(name, SpanKind.INTERNAL, body);
+    }
+
+    /**
+     * Records a span around {@code body}.
+     */
+    public static void run(String name, SpanKind kind, Runnable body) {
+        Objects.requireNonNull(body, "body must not be null");
+        call(name, kind, () -> {
+            body.run();
+            return null;
+        });
+    }
+
+    /**
+     * Records a span around {@code body}, with kind {@link SpanKind#INTERNAL}, and returns its result.
+     */
+    public static <R, X extends Throwable> R call(String name, ScopedValue.CallableOp<? extends R, X> body) throws X {
+        return call(name, SpanKind.INTERNAL, body);
+    }
+
+    /**
+     * Records a span around {@code body} and returns its result.
+     * <p>
+     * An exception escaping {@code body} marks the span {@link SpanStatus#ERROR}, records the
+     * exception's class name, and is rethrown unchanged.
+     *
+     * @param name a stable, low-cardinality operation name
+     * @param kind what role the operation plays
+     * @param body the work the span covers
+     */
+    public static <R, X extends Throwable> R call(
+            String name, SpanKind kind, ScopedValue.CallableOp<? extends R, X> body) throws X {
+
+        Objects.requireNonNull(name, "name must not be null");
+        Objects.requireNonNull(kind, "kind must not be null");
+        Objects.requireNonNull(body, "body must not be null");
+
+        TraceSpanEvent event = new TraceSpanEvent();
+        if (!event.isEnabled()) {
+            return body.call();
+        }
+        return record(event, name, kind, newSpanContext(), body);
+    }
+
+    /**
+     * Opens a span for {@code body} without emitting a {@link TraceSpanEvent}, for instrumentation
+     * whose <em>own</em> event already describes the interval — an HTTP exchange, a gRPC call, a
+     * JDBC statement. Emitting a trace span alongside such an event would record the same interval
+     * twice.
+     * <p>
+     * The caller stamps its own event with {@link #stamp(AbstractTracedEvent)} from inside
+     * {@code body}, and anything nested inside it is parented correctly for free:
+     *
+     * <pre>{@code
+     * Tracer.inSpan(() -> {
+     *     event.begin();
+     *     try {
+     *         chain.doFilter(request, response);
+     *     } finally {
+     *         event.end();
+     *         if (event.shouldCommit()) {
+     *             Tracer.stamp(event);
+     *             event.commit();
+     *         }
+     *     }
+     *     return null;
+     * });
+     * }</pre>
+     * <p>
+     * Unlike {@link #call}, this always establishes a binding: whether the interval is recorded is
+     * the caller's event's decision, not this method's.
+     */
+    public static <R, X extends Throwable> R inSpan(ScopedValue.CallableOp<? extends R, X> body) throws X {
+        Objects.requireNonNull(body, "body must not be null");
+        return ScopedValue.where(CURRENT, newSpanContext()).call(body);
+    }
+
+    /**
+     * Opens a span for {@code body} and stamps it onto {@code event} — the whole of the
+     * "my own event is the span" pattern in one call, and the form to prefer over pairing
+     * {@link #inSpan} with {@link #stamp} by hand.
+     * <p>
+     * The ids are stamped when the span opens, not when the event commits: they are known up front,
+     * and the {@link ScopedValue} binding is gone by the time a caller's {@code finally} block runs,
+     * so stamping there would silently do nothing.
+     *
+     * <pre>{@code
+     * event.begin();
+     * try {
+     *     Tracer.inSpanOf(event, () -> {
+     *         chain.doFilter(request, response);
+     *         return null;
+     *     });
+     * } finally {
+     *     event.end();
+     *     if (event.shouldCommit()) {
+     *         event.status = response.getStatus();
+     *         event.commit();
+     *     }
+     * }
+     * }</pre>
+     */
+    public static <R, X extends Throwable> R inSpanOf(
+            AbstractTracedEvent event, ScopedValue.CallableOp<? extends R, X> body) throws X {
+
+        Objects.requireNonNull(event, "event must not be null");
+        Objects.requireNonNull(body, "body must not be null");
+        return inSpan(() -> {
+            stamp(event);
+            return body.call();
+        });
+    }
+
+    /**
+     * Copies the span currently in progress onto {@code event}, so the event takes its place in the
+     * trace. Does nothing when no span is in progress, leaving the event's ids at {@code 0} — the
+     * encoding for "not part of a trace".
+     */
+    public static void stamp(AbstractTracedEvent event) {
+        Objects.requireNonNull(event, "event must not be null");
+        if (CURRENT.isBound()) {
+            stamp(event, CURRENT.get());
+        }
+    }
+
+    private static void stamp(AbstractTracedEvent event, SpanContext context) {
+        event.traceId = context.traceId();
+        event.spanId = context.spanId();
+        event.parentSpanId = context.parentSpanId();
+    }
+
+    /**
+     * Records a span whose parent is {@code parent} rather than whatever this thread currently has
+     * bound — the way to keep a trace connected across an executor boundary, where
+     * {@link ScopedValue} does not propagate on its own.
+     * <p>
+     * Pass {@code null} to start a fresh trace.
+     */
+    public static <R, X extends Throwable> R continueIn(
+            SpanContext parent, String name, SpanKind kind, ScopedValue.CallableOp<? extends R, X> body) throws X {
+
+        Objects.requireNonNull(name, "name must not be null");
+        Objects.requireNonNull(kind, "kind must not be null");
+        Objects.requireNonNull(body, "body must not be null");
+
+        TraceSpanEvent event = new TraceSpanEvent();
+        if (!event.isEnabled()) {
+            return body.call();
+        }
+        return record(event, name, kind, childOf(parent), body);
+    }
+
+    /**
+     * Derives the context for a span about to start on this thread: a child of whatever is bound,
+     * or a fresh root when nothing is.
+     */
+    private static SpanContext newSpanContext() {
+        return childOf(CURRENT.isBound() ? CURRENT.get() : null);
+    }
+
+    private static SpanContext childOf(SpanContext parent) {
+        RandomGenerator random = ThreadLocalRandom.current();
+        return parent == null ? SpanContext.root(random) : parent.child(random);
+    }
+
+    private static <R, X extends Throwable> R record(
+            TraceSpanEvent event,
+            String name,
+            SpanKind kind,
+            SpanContext context,
+            ScopedValue.CallableOp<? extends R, X> body) throws X {
+
+        Throwable failure = null;
+        event.begin();
+        try {
+            return ScopedValue.where(CURRENT, context).call(body);
+        } catch (Throwable t) {
+            failure = t;
+            throw t;
+        } finally {
+            event.end();
+            if (event.shouldCommit()) {
+                stamp(event, context);
+                event.name = name;
+                event.kind = kind.name();
+                if (failure == null) {
+                    event.status = SpanStatus.UNSET.name();
+                } else {
+                    event.status = SpanStatus.ERROR.name();
+                    event.errorType = failure.getClass().getName();
+                }
+                event.commit();
+            }
+        }
+    }
+}

--- a/utilities/jeffrey-events/src/main/java/module-info.java
+++ b/utilities/jeffrey-events/src/main/java/module-info.java
@@ -24,6 +24,7 @@ module cafe.jeffrey.jfr.events {
     exports cafe.jeffrey.jfr.events.jdbc.pool;
     exports cafe.jeffrey.jfr.events.jdbc.statement;
     exports cafe.jeffrey.jfr.events.message;
+    exports cafe.jeffrey.jfr.events.trace;
 
     // JFR rewrites event-class bytecode at registration through
     // MethodHandles.privateLookupIn(eventClass, ...); the event packages
@@ -33,4 +34,5 @@ module cafe.jeffrey.jfr.events {
     opens cafe.jeffrey.jfr.events.jdbc.pool to jdk.jfr;
     opens cafe.jeffrey.jfr.events.jdbc.statement to jdk.jfr;
     opens cafe.jeffrey.jfr.events.message to jdk.jfr;
+    opens cafe.jeffrey.jfr.events.trace to jdk.jfr;
 }

--- a/utilities/jeffrey-events/src/test/java/cafe/jeffrey/jfr/events/trace/TracerTest.java
+++ b/utilities/jeffrey-events/src/test/java/cafe/jeffrey/jfr/events/trace/TracerTest.java
@@ -1,0 +1,318 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.trace;
+
+import cafe.jeffrey.jfr.events.http.HttpServerExchangeEvent;
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TracerTest {
+
+    @Nested
+    @DisplayName("Span context")
+    class SpanContexts {
+
+        @Test
+        @DisplayName("a root span gets a fresh trace and a fresh span id")
+        void rootHasBothIds() {
+            SpanContext root = SpanContext.root(new java.util.Random(42));
+
+            assertNotEquals(0, root.traceId());
+            assertNotEquals(0, root.spanId());
+        }
+
+        @Test
+        @DisplayName("a root has no parent")
+        void rootHasNoParent() {
+            SpanContext root = SpanContext.root(new java.util.Random(42));
+
+            assertEquals(0, root.parentSpanId());
+            assertTrue(root.isRoot());
+        }
+
+        @Test
+        @DisplayName("a child keeps the trace id, takes a new span id, and points at its parent")
+        void childKeepsTraceId() {
+            SpanContext root = SpanContext.root(new java.util.Random(42));
+            SpanContext child = root.child(new java.util.Random(43));
+
+            assertEquals(root.traceId(), child.traceId());
+            assertNotEquals(root.spanId(), child.spanId());
+            assertEquals(root.spanId(), child.parentSpanId());
+            assertFalse(child.isRoot());
+        }
+    }
+
+    @Nested
+    @DisplayName("When an event is its own span")
+    class OwnEventAsSpan {
+
+        @Test
+        @DisplayName("stamp copies the current span onto the event")
+        void stampFillsTheEvent() {
+            HttpServerExchangeEvent event = new HttpServerExchangeEvent();
+
+            SpanContext context = Tracer.inSpan(() -> {
+                Tracer.stamp(event);
+                return Tracer.current().orElseThrow();
+            });
+
+            assertEquals(context.traceId(), event.traceId);
+            assertEquals(context.spanId(), event.spanId);
+            assertEquals(context.parentSpanId(), event.parentSpanId);
+        }
+
+        @Test
+        @DisplayName("inSpanOf stamps the event and parents nested work under it")
+        void inSpanOfStampsAndParents() throws IOException {
+            HttpServerExchangeEvent exchange = new HttpServerExchangeEvent();
+
+            Map<String, RecordedEvent> spans = recordSpans(() -> Tracer.inSpanOf(exchange, () -> {
+                Tracer.run("query", SpanKind.CLIENT, () -> {
+                });
+                return null;
+            }));
+
+            assertNotEquals(0, exchange.traceId);
+            assertEquals(0, exchange.parentSpanId, "an inbound request is the root of its trace");
+            assertEquals(exchange.spanId, spans.get("query").getLong("parentSpanId"));
+        }
+
+        @Test
+        @DisplayName("the binding is gone once inSpan returns, so stamping afterwards is a no-op")
+        void stampingAfterTheSpanClosesDoesNothing() {
+            HttpServerExchangeEvent event = new HttpServerExchangeEvent();
+
+            Tracer.inSpan(() -> null);
+            Tracer.stamp(event);
+
+            assertEquals(0, event.traceId,
+                    "stamp must be called inside the span - prefer inSpanOf, which cannot get this wrong");
+        }
+
+        @Test
+        @DisplayName("stamp outside a span leaves the ids at zero")
+        void stampOutsideASpanIsANoOp() {
+            HttpServerExchangeEvent event = new HttpServerExchangeEvent();
+
+            Tracer.stamp(event);
+
+            assertEquals(0, event.traceId);
+            assertEquals(0, event.spanId);
+            assertEquals(0, event.parentSpanId);
+        }
+
+        @Test
+        @DisplayName("inSpan opens a binding even though it emits no trace span event of its own")
+        void inSpanBindsWithoutEmitting() throws IOException {
+            HttpServerExchangeEvent exchange = new HttpServerExchangeEvent();
+
+            Map<String, RecordedEvent> spans = recordSpans(() -> Tracer.inSpan(() -> {
+                Tracer.stamp(exchange);
+                Tracer.run("query", SpanKind.CLIENT, () -> {
+                });
+                return null;
+            }));
+
+            assertEquals(1, spans.size(), "inSpan must not emit a span event of its own");
+            RecordedEvent query = spans.get("query");
+            assertEquals(exchange.traceId, query.getLong("traceId"));
+            assertEquals(exchange.spanId, query.getLong("parentSpanId"),
+                    "the enclosing exchange is the parent of the work it triggered");
+        }
+    }
+
+    @Nested
+    @DisplayName("When nothing is recording")
+    class WithoutRecording {
+
+        @Test
+        @DisplayName("the body still runs and its result is returned")
+        void bodyRuns() {
+            Object result = new Object();
+
+            assertSame(result, Tracer.call("noop", SpanKind.INTERNAL, () -> result));
+        }
+
+        @Test
+        @DisplayName("no span context is published")
+        void noContextIsBound() {
+            Tracer.run("noop", SpanKind.INTERNAL, () -> assertTrue(Tracer.current().isEmpty()));
+        }
+    }
+
+    @Nested
+    @DisplayName("When a recording is active")
+    class WithRecording {
+
+        @Test
+        @DisplayName("nested calls form a tree under a single trace id")
+        void nestedCallsFormATree() throws IOException {
+            Map<String, RecordedEvent> spans = recordSpans(() ->
+                    Tracer.run("checkout", SpanKind.SERVER, () -> {
+                        Tracer.run("reserve", SpanKind.CLIENT, () -> {
+                        });
+                        Tracer.run("charge", SpanKind.CLIENT, () -> {
+                        });
+                    }));
+
+            assertEquals(3, spans.size());
+            RecordedEvent checkout = spans.get("checkout");
+            RecordedEvent reserve = spans.get("reserve");
+            RecordedEvent charge = spans.get("charge");
+
+            long traceId = checkout.getLong("traceId");
+            assertNotEquals(0, traceId);
+            assertEquals(traceId, reserve.getLong("traceId"));
+            assertEquals(traceId, charge.getLong("traceId"));
+
+            assertEquals(0, checkout.getLong("parentSpanId"), "the outermost span is a root");
+            assertEquals(checkout.getLong("spanId"), reserve.getLong("parentSpanId"));
+            assertEquals(checkout.getLong("spanId"), charge.getLong("parentSpanId"));
+            assertNotEquals(reserve.getLong("spanId"), charge.getLong("spanId"));
+        }
+
+        @Test
+        @DisplayName("the kind is recorded and the status defaults to UNSET")
+        void recordsKindAndDefaultStatus() throws IOException {
+            Map<String, RecordedEvent> spans = recordSpans(() ->
+                    Tracer.run("lookup", SpanKind.CLIENT, () -> {
+                    }));
+
+            assertEquals(SpanKind.CLIENT.name(), spans.get("lookup").getString("kind"));
+            assertEquals(SpanStatus.UNSET.name(), spans.get("lookup").getString("status"));
+        }
+
+        @Test
+        @DisplayName("an escaping exception marks the span ERROR and is rethrown unchanged")
+        void failureIsRecordedAndRethrown() throws IOException {
+            IllegalStateException thrown = new IllegalStateException("card declined");
+
+            Map<String, RecordedEvent> spans = recordSpans(() -> {
+                IllegalStateException actual = assertThrows(IllegalStateException.class,
+                        () -> Tracer.run("charge", SpanKind.CLIENT, () -> {
+                            throw thrown;
+                        }));
+                assertSame(thrown, actual);
+            });
+
+            RecordedEvent charge = spans.get("charge");
+            assertEquals(SpanStatus.ERROR.name(), charge.getString("status"));
+            assertEquals(IllegalStateException.class.getName(), charge.getString("errorType"));
+        }
+
+        @Test
+        @DisplayName("the span context is visible to the body and gone once it returns")
+        void contextIsBoundForTheBodyOnly() throws IOException {
+            recordSpans(() -> {
+                Tracer.run("outer", SpanKind.INTERNAL, () -> assertTrue(Tracer.current().isPresent()));
+                assertTrue(Tracer.current().isEmpty());
+            });
+        }
+
+        @Test
+        @DisplayName("continueIn re-parents onto a context carried across a thread boundary")
+        void continueInReparents() throws Exception {
+            Map<String, RecordedEvent> spans = recordSpans(() -> {
+                SpanContext carried = Tracer.call("submit", SpanKind.SERVER,
+                        () -> Tracer.current().orElseThrow());
+                runOnAnotherThread(() ->
+                        Tracer.continueIn(carried, "handle", SpanKind.CONSUMER, () -> null));
+            });
+
+            RecordedEvent submit = spans.get("submit");
+            RecordedEvent handle = spans.get("handle");
+            assertEquals(submit.getLong("traceId"), handle.getLong("traceId"));
+            assertEquals(submit.getLong("spanId"), handle.getLong("parentSpanId"));
+        }
+
+        @Test
+        @DisplayName("a plain executor does not inherit the current span")
+        void plainExecutorDoesNotInherit() throws IOException {
+            recordSpans(() -> Tracer.run("outer", SpanKind.SERVER,
+                    () -> runOnAnotherThread(() -> {
+                        assertFalse(Tracer.current().isPresent());
+                        return null;
+                    })));
+        }
+    }
+
+    /**
+     * Runs {@code body} on a fresh platform thread and waits for it, so a test can assert what a
+     * plain executor hand-off does and does not carry.
+     */
+    private static void runOnAnotherThread(ScopedValue.CallableOp<?, ? extends Exception> body) {
+        Thread thread = new Thread(() -> {
+            try {
+                body.call();
+            } catch (Exception e) {
+                throw new IllegalStateException(e);
+            }
+        });
+        thread.start();
+        try {
+            thread.join();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /**
+     * Records {@code body} into a real JFR recording and returns the emitted spans keyed by name.
+     * The threshold is dropped to zero because the test spans do no work.
+     */
+    private static Map<String, RecordedEvent> recordSpans(Runnable body) throws IOException {
+        Path dump = Files.createTempFile("tracer-test", ".jfr");
+        try (Recording recording = new Recording()) {
+            recording.enable(TraceSpanEvent.NAME).withThreshold(Duration.ZERO);
+            recording.start();
+            body.run();
+            recording.stop();
+            recording.dump(dump);
+
+            List<RecordedEvent> events = RecordingFile.readAllEvents(dump);
+            return events.stream()
+                    .filter(event -> event.getEventType().getName().equals(TraceSpanEvent.NAME))
+                    .collect(Collectors.toMap(event -> event.getString("name"), Function.identity()));
+        } finally {
+            Files.deleteIfExists(dump);
+        }
+    }
+}

--- a/utilities/jeffrey-events/src/test/java/cafe/jeffrey/jfr/events/trace/TracerTest.java
+++ b/utilities/jeffrey-events/src/test/java/cafe/jeffrey/jfr/events/trace/TracerTest.java
@@ -253,7 +253,7 @@ class TracerTest {
                 SpanContext carried = Tracer.call("submit", SpanKind.SERVER,
                         () -> Tracer.current().orElseThrow());
                 runOnAnotherThread(() ->
-                        Tracer.continueIn(carried, "handle", SpanKind.CONSUMER, () -> null));
+                        Tracer.continueIn(carried, "handle", SpanKind.INTERNAL, () -> null));
             });
 
             RecordedEvent submit = spans.get("submit");


### PR DESCRIPTION
Introduces the JFR event contract and instrumentation API for building
traces out of a single JVM's recording.

The module moves to release 25, since both ScopedValue and
jdk.jfr.Contextual are Java 25 APIs. That is a breaking change for
consumers still on 17-24 and warrants a major version bump when this is
published.

New cafe.jeffrey.jfr.events.trace package:

  AbstractTracedEvent  trace identity as three longs. Longs rather than
                       strings because JFR varint-encodes integral fields
                       while every distinct string grows the per-chunk
                       constant pool, and ids are the highest-cardinality
                       values an event can carry. 0 means absent, which is
                       also the cheapest encoding, so an untraced event
                       costs practically nothing over its previous shape.
                       The ids carry @Contextual so jfr print and JMC show
                       them beside every event inside the span.
  TraceSpanEvent       jeffrey.TraceSpan, with a 1 ms default threshold.
  SpanContext          trace id, span id and parent span id.
  SpanKind/SpanStatus  OpenTelemetry's vocabulary.
  Tracer               ScopedValue-based; nesting comes from the binding.

AbstractHttpExchangeEvent, AbstractGrpcExchangeEvent and JdbcBaseEvent now
extend AbstractTracedEvent, so the events that already describe request
intervals can take their place in a trace.

Tracer offers two shapes. run/call emit a TraceSpanEvent for work that has
no event of its own. inSpanOf covers instrumentation whose own event
already describes the interval -- an HTTP exchange, a JDBC statement --
opening the span without emitting a second event for the same interval and
stamping the ids onto the caller's event. Stamping happens when the span
opens rather than when the event commits: the ScopedValue binding is gone
by the time a caller's finally block runs, so stamping there would
silently do nothing. TracerTest covers that trap directly.

Everything degrades to a direct call when the event type is disabled, so
instrumentation is safe to leave in production code.

Adds a test tree to the module, which had none.