### PR TITLE
Finish the Traces feature: drill-down, aggregates and docs

### DIFF
--- a/TRACES_LEFTOVERS.md
+++ b/TRACES_LEFTOVERS.md
@@ -1,0 +1,92 @@
+# Traces & Spans — leftovers
+
+State as of `4a14211` on `claude/traces-spans-jeffrey-hcnlbd` (PR #156). Everything below was
+verified against the tree, not recalled.
+
+Two items remain, both blocked on a `jeffrey-events` release. Everything else that was on this
+list has been implemented — see [Closed](#closed) at the bottom.
+
+---
+
+## 1. `Tracer` cannot re-enter an existing span — blocks proper async instrumentation
+
+**The one real API gap**, and the reason gRPC nesting is partial.
+
+`Tracer` offers `inSpan` (mints a child) and `continueIn` (mints a child *and* emits an event).
+Neither can re-establish an *existing* `SpanContext` without creating a new span.
+
+This bites wherever work is not a single lambda:
+
+- **gRPC** (`JfrGrpcServerInterceptor`) — a call runs from listener callbacks after `interceptCall`
+  returns. The exchange is stamped and appears in the trace list, but work during the call is not
+  nested under it. Documented on the class and on the docs page.
+- Any future callback- or reactor-style instrumentation will hit the same wall.
+
+**Fix:** add something like `Tracer.reenter(SpanContext, body)` to `jeffrey-events` — bind without
+emitting. Small addition, but it needs a library release (0.13.0) and a `<jeffrey-events.version>`
+bump, so it cannot be done from the monorepo alone.
+
+## 2. Cross-thread spans are misattributed
+
+JFR commits a duration event on the **ending** thread. A span that starts on one thread and ends on
+another is recorded against the wrong one, which also breaks the `thread_hash` join the drill-down
+uses. OpenTelemetry's own `jfr-events` contrib documents the same flaw.
+
+v1 documents this in the `Tracer` javadoc and on the docs page rather than solving it. Solving it
+means adding an explicit start-thread field to the event and reworking the join — again a library
+change, and not a simple field addition, because the join key is derived during parsing rather than
+supplied by the application.
+
+In practice `ScopedValue` + the `continueIn` pattern keeps spans thread-confined, so this is a
+latent sharp edge rather than an active bug.
+
+---
+
+## 3. Verification gap
+
+**Nothing has been rendered in a browser against a real profile.** Build, type-check and the
+frontend test suite pass, and the derivation is exercised end to end against a real JFR recording,
+but the waterfall's split self/child bar treatment has only been seen in a mockup. It may read
+differently at real span counts.
+
+This needs a running instance and a human, not a code change.
+
+## 4. Deliberate omissions worth revisiting later
+
+Not bugs — decisions with a stated trade-off, recorded so they are not rediscovered as surprises.
+
+| Omission | Why | Revisit when |
+|---|---|---|
+| **No zoom/pan in the waterfall** | DOM/CSS substrate chosen for tens-to-hundreds of spans | Real traces exceed a few thousand spans |
+| **Critical path not computed** | Deferred from increment 5 | Traces get deep enough that the longest chain isn't obvious |
+| **64-bit trace ids** | Jeffrey mints every id in a single recording | Cross-process assembly or ingesting an external `traceparent` becomes a goal — this is a one-way door, widening is a format change |
+| **`@Threshold("1 ms")` default on `TraceSpanEvent`** | Keeps trivial spans out of the recording | Span volume proves fine, or proves too high — JDK 25 `@Throttle("N/s")` is the other lever |
+| **Pipeline runs are their own traces** | `PipelineRunRegistry` forks to a virtual thread; a background job's lifetime is unrelated to the request | Users find the disconnection confusing in the trace list |
+| **`SpanKind` has no `PRODUCER`/`CONSUMER`** | Their purpose is cross-process pairing, impossible single-JVM; no messaging instrumentation exists | Messaging instrumentation arrives — additive, so safe to defer |
+| **`HttpClientExchangeEvent` / `GrpcClientExchangeEvent` never emitted here** | The derivation handles them and they are stamped-capable, so a third-party app gets outbound spans; Jeffrey itself makes no instrumented outbound calls | Jeffrey starts making them |
+
+---
+
+## Closed
+
+Recorded because they were raised and are now done:
+
+- ~~Span-scoped flamegraph tab had no UI callers~~ — done in `8f4c135`; third drawer tab, panel
+  cards with real counts, Inclusive/Self toggle above them, fullscreen modal, no timeseries.
+- ~~Operations view had no caller~~ — done in `8f4c135`; p50/p95/max on a shared rail, route
+  declared before `:traceId`.
+- ~~No documentation~~ — done in `4a14211`; a Traces reference under Profiles plus the event
+  contract on the Jeffrey Events page.
+- ~~`Guardian.process()` unspecified~~ — done in `46dd101`; one span per event type, because the
+  frame tree and traversal are shared by every guard for that type.
+- ~~Derivation never exercised through real profile initialization~~ — done in `6fd4c36`; an
+  `InOrder` chain pins it after `eventWriter.onComplete()` and before `profileDataInitializer`.
+- ~~Drill-down listed the spans themselves~~ — fixed in `c73f282`; the query excludes every traced
+  event type, with two tests pinning it.
+- ~~`jeffrey.TraceSpan` unregistered in `EventTypeName`/`Type`~~ — fixed in `c73f282`; the
+  derivation now builds its type list from the shared constants.
+- ~~gRPC exchanges carried no trace identity~~ — fixed in `226d30c` (nesting caveat is item 1).
+- ~~`TraceSpanEvent.attributes` and `SpanStatus.OK` were dead~~ — fixed in `226d30c`; both are used
+  by the pipeline root span and MCP tool dispatch.
+- ~~JSON→BIGINT precision for 64-bit ids~~ — verified against DuckDB 1.5.5 at `Long.MIN_VALUE`,
+  `Long.MAX_VALUE` and 2^53+1.

--- a/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/grpc/JfrGrpcServerInterceptor.java
+++ b/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/grpc/JfrGrpcServerInterceptor.java
@@ -19,6 +19,7 @@
 package cafe.jeffrey.hub.core.grpc;
 
 import cafe.jeffrey.jfr.events.grpc.GrpcServerExchangeEvent;
+import cafe.jeffrey.jfr.events.trace.Tracer;
 import com.google.protobuf.MessageLite;
 import io.grpc.*;
 
@@ -29,6 +30,17 @@ import java.net.SocketAddress;
  * gRPC server interceptor that emits {@link GrpcServerExchangeEvent} JFR events
  * for every incoming gRPC call, capturing service/method names, remote peer info,
  * status codes, and request/response sizes.
+ * <p>
+ * The exchange is also the root of a trace: it is an inbound call, so nothing encloses it. The
+ * event carries the trace identity itself rather than a separate span event being emitted for the
+ * same interval.
+ * <p>
+ * <b>Scope of the binding.</b> A gRPC call is not a single block of work — the handler runs from
+ * listener callbacks after this method has returned, on a thread this interceptor does not control.
+ * The published context therefore covers only the synchronous setup below, so work performed later
+ * in the call is <em>not</em> nested under this span. The call still appears in the trace list with
+ * its own identity, which is what makes it addressable at all; nesting the handler's work needs a
+ * way to re-enter an existing span that the tracing API does not currently offer.
  */
 public class JfrGrpcServerInterceptor implements ServerInterceptor {
 
@@ -44,6 +56,9 @@ public class JfrGrpcServerInterceptor implements ServerInterceptor {
         }
 
         event.begin();
+        // Stamps a fresh trace and span id onto the exchange; see the note on the class javadoc
+        // about how far the published context reaches.
+        Tracer.inSpanOf(event, () -> null);
 
         MethodDescriptor<ReqT, RespT> methodDescriptor = call.getMethodDescriptor();
         event.service = methodDescriptor.getServiceName();

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/AsyncProfilerSpansController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/AsyncProfilerSpansController.java
@@ -124,7 +124,7 @@ public class AsyncProfilerSpansController {
                 profileId, request.tag(), request.eventType());
         ProfileManager pm = resolver.resolve(profileId);
         List<SpanInterval> intervals = pm.spanManager().tagIntervals(request.tag());
-        GraphParameters params = mapToSpanGraphParameters(pm.info(), request, intervals);
+        GraphParameters params = SpanScopedGraphParameters.of(pm.info(), request, intervals);
         return pm.flamegraphManager().generate(params);
     }
 
@@ -137,37 +137,10 @@ public class AsyncProfilerSpansController {
         ProfileManager pm = resolver.resolve(profileId);
         List<SpanInterval> intervals = List.of(
                 new SpanInterval(request.threadHash(), request.fromMillis(), request.toMillis()));
-        GraphParameters params = mapToSpanGraphParameters(pm.info(), request, intervals);
+        GraphParameters params = SpanScopedGraphParameters.of(pm.info(), request, intervals);
         return pm.flamegraphManager().generate(params);
     }
 
-    /**
-     * Shared with {@link TracesController}: a span-scoped flamegraph is the same graph however the
-     * spans were selected, so the mapping from options plus intervals to {@code GraphParameters}
-     * lives in one place.
-     */
-    static GraphParameters mapToSpanGraphParameters(
-            ProfileInfo profileInfo, SpanFlamegraphOptions request, List<SpanInterval> intervals) {
-        // Full-profile range so the timeseries can bucket over the whole timeline; the span intervals
-        // (not the time range) are what scope the samples, so a null range would NPE the timeseries init.
-        ProfilingStartEnd primaryStartEnd = new ProfilingStartEnd(
-                profileInfo.profilingStartedAt(), profileInfo.profilingFinishedAt());
-        RelativeTimeRange fullRange = UndefinedTimeRange.INSTANCE.toRelativeTimeRange(primaryStartEnd);
-
-        return GraphParameters.builder()
-                .withEventType(request.eventType())
-                .withTimeRange(fullRange)
-                .withThreadMode(request.useThreadMode())
-                .withUseWeight(request.useWeight())
-                .withExcludeNonJavaSamples(request.excludeNonJavaSamples())
-                .withExcludeIdleSamples(request.excludeIdleSamples())
-                .withOnlyUnsafeAllocationSamples(request.onlyUnsafeAllocationSamples())
-                .withParseLocation(true)
-                .withGraphType(GraphType.PRIMARY)
-                .withGraphComponents(request.components())
-                .withSpanIntervals(intervals)
-                .build();
-    }
 
     private SpanManager mgr(String profileId) {
         return resolver.resolve(profileId).spanManager();

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/SpanScopedGraphParameters.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/SpanScopedGraphParameters.java
@@ -1,0 +1,69 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.microscope.core.web.controllers.profile;
+
+import cafe.jeffrey.profile.common.config.GraphParameters;
+import cafe.jeffrey.profile.resources.request.SpanFlamegraphOptions;
+import cafe.jeffrey.shared.common.GraphType;
+import cafe.jeffrey.shared.common.model.ProfileInfo;
+import cafe.jeffrey.shared.common.model.ProfilingStartEnd;
+import cafe.jeffrey.shared.common.model.SpanInterval;
+import cafe.jeffrey.shared.common.model.time.RelativeTimeRange;
+import cafe.jeffrey.shared.common.model.time.UndefinedTimeRange;
+
+import java.util.List;
+
+/**
+ * Builds the {@link GraphParameters} for a flamegraph scoped to a set of intervals.
+ * <p>
+ * Lives on its own rather than on either controller because two unrelated features ask for the same
+ * graph: async-profiler spans, which are flat and selected by tag, and trace spans, which are
+ * nested and selected from a tree. Only the rendering options and the intervals are common to both,
+ * and neither feature should have to import the other to reach them.
+ */
+abstract class SpanScopedGraphParameters {
+
+    private SpanScopedGraphParameters() {
+    }
+
+    static GraphParameters of(
+            ProfileInfo profileInfo, SpanFlamegraphOptions request, List<SpanInterval> intervals) {
+
+        // Full-profile range so the timeseries can bucket over the whole timeline; the intervals
+        // (not the time range) are what scope the samples, so a null range would NPE the timeseries
+        // init.
+        ProfilingStartEnd primaryStartEnd = new ProfilingStartEnd(
+                profileInfo.profilingStartedAt(), profileInfo.profilingFinishedAt());
+        RelativeTimeRange fullRange = UndefinedTimeRange.INSTANCE.toRelativeTimeRange(primaryStartEnd);
+
+        return GraphParameters.builder()
+                .withEventType(request.eventType())
+                .withTimeRange(fullRange)
+                .withThreadMode(request.useThreadMode())
+                .withUseWeight(request.useWeight())
+                .withExcludeNonJavaSamples(request.excludeNonJavaSamples())
+                .withExcludeIdleSamples(request.excludeIdleSamples())
+                .withOnlyUnsafeAllocationSamples(request.onlyUnsafeAllocationSamples())
+                .withParseLocation(true)
+                .withGraphType(GraphType.PRIMARY)
+                .withGraphComponents(request.components())
+                .withSpanIntervals(intervals)
+                .build();
+    }
+}

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/TracesController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/TracesController.java
@@ -21,11 +21,13 @@ package cafe.jeffrey.microscope.core.web.controllers.profile;
 import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
 import cafe.jeffrey.profile.common.config.GraphParameters;
 import cafe.jeffrey.profile.manager.ProfileManager;
-import cafe.jeffrey.profile.manager.model.span.SpanEventRow;
+import cafe.jeffrey.profile.model.FlamegraphPanel;
+import cafe.jeffrey.profile.panel.JfrFlamegraphPanelProvider;
+import cafe.jeffrey.profile.panel.PanelContext;
+import cafe.jeffrey.profile.manager.model.trace.TraceEventRow;
 import cafe.jeffrey.profile.manager.model.trace.TraceDetail;
 import cafe.jeffrey.profile.manager.model.trace.TraceOperationRow;
 import cafe.jeffrey.profile.manager.model.trace.TraceRow;
-import cafe.jeffrey.profile.manager.model.trace.TraceSpanRow;
 import cafe.jeffrey.profile.resources.request.GenerateTraceSpanFlamegraphRequest;
 import cafe.jeffrey.shared.common.exception.Exceptions;
 import cafe.jeffrey.shared.common.model.SpanInterval;
@@ -47,6 +49,11 @@ import java.util.List;
  * <p>
  * Trace and span ids travel as 16-char hex strings, because a 64-bit id exceeds JavaScript's safe
  * integer range and would be silently rounded as a JSON number.
+ * <p>
+ * Kept independent of the async-profiler span feature. {@code profiler.Span} is a flat, per-thread
+ * latency interval selected by tag; a trace span is a node in a tree. They answer different
+ * questions and share only the interval-scoped flamegraph machinery, which lives in
+ * {@link SpanScopedGraphParameters} so neither feature depends on the other.
  */
 @RestController
 @RequestMapping("/api/internal/profiles/{profileId}/traces")
@@ -58,9 +65,11 @@ public class TracesController {
     private static final String DEFAULT_OPERATIONS_LIMIT = "100";
 
     private final ProfileManagerResolver resolver;
+    private final JfrFlamegraphPanelProvider panelProvider;
 
-    public TracesController(ProfileManagerResolver resolver) {
+    public TracesController(ProfileManagerResolver resolver, JfrFlamegraphPanelProvider panelProvider) {
         this.resolver = resolver;
+        this.panelProvider = panelProvider;
     }
 
     @GetMapping
@@ -95,18 +104,37 @@ public class TracesController {
      * question for a (thread, window) pair.
      */
     @GetMapping("/{traceId}/spans/{spanId}/events")
-    public List<SpanEventRow> spanEvents(
+    public List<TraceEventRow> spanEvents(
             @PathVariable("profileId") String profileId,
             @PathVariable("traceId") String traceId,
             @PathVariable("spanId") String spanId) {
         LOG.debug("Listing events inside a span: profileId={} trace_id={} span_id={}",
                 profileId, traceId, spanId);
-        ProfileManager profileManager = resolver.resolve(profileId);
-        TraceSpanRow span = findSpan(profileManager, traceId, spanId);
+        return resolver.resolve(profileId).traceManager()
+                .eventsInSpan(parseId(traceId), parseId(spanId));
+    }
 
-        long from = span.startEpochMillis();
-        long to = from + span.durationNanos() / 1_000_000L;
-        return profileManager.spanManager().spanEvents(Long.parseLong(span.threadHash()), from, to);
+    /**
+     * The flamegraph cards available for one span — which event types actually recorded anything
+     * inside it, with the real counts, so the drill-down offers only graphs that exist.
+     */
+    @GetMapping("/{traceId}/spans/{spanId}/panels")
+    public List<FlamegraphPanel> spanPanels(
+            @PathVariable("profileId") String profileId,
+            @PathVariable("traceId") String traceId,
+            @PathVariable("spanId") String spanId,
+            @RequestParam(value = "selfOnly", defaultValue = "false") boolean selfOnly) {
+        LOG.debug("Building span-scoped flamegraph panels: profileId={} trace_id={} span_id={} self_only={}",
+                profileId, traceId, spanId, selfOnly);
+        ProfileManager profileManager = resolver.resolve(profileId);
+
+        List<SpanInterval> intervals = profileManager.traceManager()
+                .spanIntervals(parseId(traceId), parseId(spanId), selfOnly);
+        if (intervals.isEmpty()) {
+            return List.of();
+        }
+        return panelProvider.panels(
+                profileManager.flamegraphManager().eventSummaries(intervals), PanelContext.PRIMARY);
     }
 
     /**
@@ -130,19 +158,8 @@ public class TracesController {
             throw Exceptions.resourceNotFound("Span has no samples to show: " + spanId);
         }
 
-        GraphParameters params = AsyncProfilerSpansController.mapToSpanGraphParameters(
-                profileManager.info(), request, intervals);
+        GraphParameters params = SpanScopedGraphParameters.of(profileManager.info(), request, intervals);
         return profileManager.flamegraphManager().generate(params);
-    }
-
-    private static TraceSpanRow findSpan(ProfileManager profileManager, String traceId, String spanId) {
-        return profileManager.traceManager()
-                .trace(parseId(traceId))
-                .orElseThrow(() -> Exceptions.resourceNotFound("Trace not found: " + traceId))
-                .spans().stream()
-                .filter(span -> span.spanId().equals(spanId))
-                .findFirst()
-                .orElseThrow(() -> Exceptions.resourceNotFound("Span not found: " + spanId));
     }
 
     /**

--- a/jeffrey-microscope/pages-microscope/src/components/trace/TraceSpanDrawer.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/trace/TraceSpanDrawer.vue
@@ -72,13 +72,22 @@
       </DrawerSection>
     </div>
 
+    <div v-else-if="activeTab === 'flamegraph'" class="drawer-body">
+      <TraceSpanFlamegraphs
+        :profile-id="profileId"
+        :trace-id="traceId"
+        :span-id="span.spanId"
+        :span-name="span.name"
+      />
+    </div>
+
     <div v-else class="drawer-body">
       <LoadingState v-if="eventsLoading" message="Loading events..." />
       <ErrorState v-else-if="eventsError" :message="eventsError" @retry="loadEvents" />
       <EmptyState
         v-else-if="events.length === 0"
         title="Nothing recorded"
-        message="No other events landed on this thread while the span was open."
+        message="Nothing else ran on this thread while the span was open."
         icon="bi-inbox"
       />
       <table v-else class="events-table">
@@ -108,11 +117,11 @@ import LoadingState from '@shared/components/LoadingState.vue';
 import ErrorState from '@shared/components/ErrorState.vue';
 import EmptyState from '@shared/components/EmptyState.vue';
 import DrawerSection from '@shared/components/drawer/DrawerSection.vue';
+import TraceSpanFlamegraphs from '@/components/trace/TraceSpanFlamegraphs.vue';
 import InfoRow from '@shared/components/drawer/InfoRow.vue';
 import FormattingService from '@shared/services/FormattingService';
 import ProfileTracesClient from '@/services/api/ProfileTracesClient';
-import type { TraceSpanRow } from '@/services/api/model/trace/TraceModels';
-import type { SpanEventRow } from '@/services/api/model/span/SpanModels';
+import type { TraceEventRow, TraceSpanRow } from '@/services/api/model/trace/TraceModels';
 
 const props = defineProps<{
   profileId: string;
@@ -120,15 +129,16 @@ const props = defineProps<{
   span: TraceSpanRow;
 }>();
 
-type TabId = 'attributes' | 'events';
+type TabId = 'attributes' | 'events' | 'flamegraph';
 
 const tabs: { id: TabId; label: string }[] = [
   { id: 'attributes', label: 'Attributes' },
-  { id: 'events', label: 'Events in span' }
+  { id: 'events', label: 'Events in span' },
+  { id: 'flamegraph', label: 'Flamegraph' }
 ];
 
 const activeTab = ref<TabId>('attributes');
-const events = ref<SpanEventRow[]>([]);
+const events = ref<TraceEventRow[]>([]);
 const eventsLoading = ref(false);
 const eventsError = ref<string | null>(null);
 

--- a/jeffrey-microscope/pages-microscope/src/components/trace/TraceSpanFlamegraphs.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/trace/TraceSpanFlamegraphs.vue
@@ -1,0 +1,224 @@
+<!--
+  ~ Jeffrey
+  ~ Copyright (C) 2026 Petr Bouda
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<template>
+  <div class="span-flamegraphs">
+    <!--
+      Inclusive covers the span's whole window; Self cuts its children out of it. The distinction is
+      the difference between "this span took 400 ms" and "this span spent 400 ms in code it owns",
+      so it changes both the cards and the graph and is chosen before either is loaded.
+    -->
+    <div class="scope-toggle" role="group" aria-label="Flamegraph scope">
+      <button
+        type="button"
+        :class="{ active: !selfOnly }"
+        :aria-pressed="!selfOnly"
+        @click="selfOnly = false"
+      >
+        Inclusive
+      </button>
+      <button
+        type="button"
+        :class="{ active: selfOnly }"
+        :aria-pressed="selfOnly"
+        @click="selfOnly = true"
+      >
+        Self only
+      </button>
+    </div>
+
+    <LoadingState v-if="!loaded" message="Loading flamegraph events..." />
+
+    <EmptyState
+      v-else-if="!hasEvents"
+      icon="bi-fire"
+      title="No Samples In This Span"
+      :description="
+        selfOnly
+          ? 'Nothing was sampled outside this span\'s children. Try the inclusive scope.'
+          : 'No execution, wall-clock or allocation samples landed inside this span.'
+      "
+    />
+
+    <FlamegraphCardGrid
+      v-else
+      :graph-mode="GraphType.PRIMARY"
+      :panels="panels"
+      :hide-method="true"
+      :hide-native="true"
+      :hide-blocking="true"
+      emit-view
+      @view="openFlamegraph"
+    />
+
+    <GenericModal
+      modal-id="traceSpanFlamegraphModal"
+      :show="showDialog"
+      size="fullscreen"
+      :show-footer="false"
+      @update:show="showDialog = $event"
+    >
+      <template #header>
+        <h5 class="modal-title">
+          <i class="bi bi-fire me-2"></i>{{ activeEventType }} — {{ spanName }}
+          <span class="scope-note">{{ selfOnly ? 'self only' : 'inclusive' }}</span>
+        </h5>
+        <button type="button" class="btn-close" aria-label="Close" @click="showDialog = false" />
+      </template>
+      <div v-if="showDialog" id="scrollable-wrapper" style="padding: 0.75rem">
+        <FlamegraphComponent
+          :with-timeseries="false"
+          :use-weight="activeUseWeight"
+          :use-guardian="null"
+          scrollableWrapperClass="scrollable-wrapper"
+          :flamegraph-tooltip="flamegraphTooltip"
+          :graph-updater="graphUpdater"
+          @loaded="scrollToTop"
+        />
+      </div>
+    </GenericModal>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+
+import LoadingState from '@shared/components/LoadingState.vue';
+import EmptyState from '@shared/components/EmptyState.vue';
+import GenericModal from '@shared/components/GenericModal.vue';
+import FlamegraphComponent from '@/components/FlamegraphComponent.vue';
+import FlamegraphCardGrid from '@/components/FlamegraphCardGrid.vue';
+import type { FlamegraphCardViewPayload } from '@/components/FlamegraphCard.vue';
+
+import TraceSpanFlamegraphClient from '@/services/api/TraceSpanFlamegraphClient';
+import ProfileTracesClient from '@/services/api/ProfileTracesClient';
+import GraphType from '@/services/flamegraphs/GraphType';
+import GraphUpdater from '@/services/flamegraphs/updater/GraphUpdater';
+import OnlyFlamegraphGraphUpdater from '@/services/flamegraphs/updater/OnlyFlamegraphGraphUpdater';
+import FlamegraphTooltip from '@/services/flamegraphs/tooltips/FlamegraphTooltip';
+import FlamegraphTooltipFactory from '@/services/flamegraphs/tooltips/FlamegraphTooltipFactory';
+import { useFlamegraphPanels } from '@/composables/useFlamegraphPanels';
+
+const MODAL_INIT_DELAY_MS = 200;
+
+const props = defineProps<{
+  profileId: string;
+  traceId: string;
+  spanId: string;
+  spanName: string;
+}>();
+
+const selfOnly = ref(false);
+
+// Panels are scoped to the span, so the cards show what actually landed inside it rather than the
+// profile-wide totals. Re-fetched when the scope changes, because self-only covers less time.
+const { loaded, panels, reload } = useFlamegraphPanels(GraphType.PRIMARY, () =>
+  new ProfileTracesClient(props.profileId).getSpanPanels(
+    props.traceId,
+    props.spanId,
+    selfOnly.value
+  )
+);
+
+watch([selfOnly, () => props.spanId], () => reload());
+
+const hasEvents = computed(() => panels.value.some((panel) => panel.event.primary.samples > 0));
+
+const showDialog = ref(false);
+const activeEventType = ref('');
+const activeUseWeight = ref(false);
+let flamegraphTooltip: FlamegraphTooltip;
+let graphUpdater: GraphUpdater;
+
+function openFlamegraph(payload: FlamegraphCardViewPayload): void {
+  activeEventType.value = payload.eventType;
+  activeUseWeight.value = payload.useWeight;
+
+  // No timeseries: a span is a single short window, so bucketing it over the recording's timeline
+  // would be a chart with one bar.
+  const client = new TraceSpanFlamegraphClient(
+    props.profileId,
+    props.traceId,
+    props.spanId,
+    selfOnly.value,
+    payload.eventType,
+    payload.useWeight
+  );
+
+  graphUpdater = new OnlyFlamegraphGraphUpdater(client);
+  flamegraphTooltip = FlamegraphTooltipFactory.create(payload.eventType, payload.useWeight, false);
+
+  showDialog.value = true;
+
+  // Delay so the modal is rendered and the flamegraph's callbacks are registered.
+  setTimeout(() => {
+    graphUpdater.initialize();
+  }, MODAL_INIT_DELAY_MS);
+}
+
+function scrollToTop(): void {
+  const wrapper = document.getElementById('scrollable-wrapper');
+  if (wrapper) {
+    wrapper.scrollTop = 0;
+  }
+}
+</script>
+
+<style scoped>
+.span-flamegraphs {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.scope-toggle {
+  display: inline-flex;
+  border: 1px solid var(--color-border-input);
+  border-radius: var(--radius-base);
+  overflow: hidden;
+  align-self: flex-start;
+}
+
+.scope-toggle button {
+  font: inherit;
+  font-size: var(--font-size-sm);
+  border: 0;
+  background: var(--color-bg-card);
+  color: var(--color-text-muted);
+  padding: 0.28rem 0.65rem;
+  cursor: pointer;
+}
+
+.scope-toggle button.active {
+  background: var(--color-primary);
+  color: var(--color-white);
+  font-weight: 500;
+}
+
+.scope-toggle button:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
+}
+
+.scope-note {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  font-weight: 400;
+  margin-left: 0.4rem;
+}
+</style>

--- a/jeffrey-microscope/pages-microscope/src/router/profileChildRoutes.ts
+++ b/jeffrey-microscope/pages-microscope/src/router/profileChildRoutes.ts
@@ -566,7 +566,14 @@ const technologyRoutes = [
     meta: { layout: 'profile' }
   },
   {
+    path: 'technologies/traces/operations',
+    name: 'profile-trace-operations',
+    component: () => import('@/views/profiles/detail/technologies/ProfileTraceOperations.vue'),
+    meta: { layout: 'profile' }
+  },
+  {
     // A trace gets its own URL so one can be linked to and returned to, which a modal could not do.
+    // Declared after the fixed child paths above so 'operations' is not read as a trace id.
     path: 'technologies/traces/:traceId',
     name: 'profile-trace-detail',
     component: () => import('@/views/profiles/detail/technologies/ProfileTraceDetail.vue'),

--- a/jeffrey-microscope/pages-microscope/src/services/api/ProfileTracesClient.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/ProfileTracesClient.ts
@@ -17,12 +17,13 @@
  */
 
 import BaseProfileClient from '@/services/api/BaseProfileClient';
+import FlamegraphPanel from '@/services/api/model/FlamegraphPanel';
 import type {
   TraceDetail,
+  TraceEventRow,
   TraceOperationRow,
   TraceRow
 } from '@/services/api/model/trace/TraceModels';
-import type { SpanEventRow } from '@/services/api/model/span/SpanModels';
 
 export default class ProfileTracesClient extends BaseProfileClient {
   constructor(profileId: string) {
@@ -44,8 +45,20 @@ export default class ProfileTracesClient extends BaseProfileClient {
     );
   }
 
-  /** The events that ran on the span's thread while it was open. */
-  public getSpanEvents(traceId: string, spanId: string): Promise<SpanEventRow[]> {
-    return this.get<SpanEventRow[]>(`/${traceId}/spans/${spanId}/events`);
+  /** What the JVM was doing on the span's thread while it was open. */
+  public getSpanEvents(traceId: string, spanId: string): Promise<TraceEventRow[]> {
+    return this.get<TraceEventRow[]>(`/${traceId}/spans/${spanId}/events`);
+  }
+
+  /**
+   * Which event types actually recorded samples inside the span, with their real counts, so the
+   * drill-down offers only flamegraphs that exist.
+   */
+  public getSpanPanels(
+    traceId: string,
+    spanId: string,
+    selfOnly: boolean
+  ): Promise<FlamegraphPanel[]> {
+    return this.get<FlamegraphPanel[]>(`/${traceId}/spans/${spanId}/panels`, { selfOnly });
   }
 }

--- a/jeffrey-microscope/pages-microscope/src/services/api/TraceSpanFlamegraphClient.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/TraceSpanFlamegraphClient.ts
@@ -1,0 +1,72 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import GlobalVars from '@/services/GlobalVars';
+import RemoteFlamegraphClient from '@/services/api/RemoteFlamegraphClient';
+import GraphComponents from '@/services/api/model/GraphComponents';
+
+/**
+ * Flamegraph client scoped to one span of a trace.
+ *
+ * The span is addressed by the path, so unlike the async-profiler span clients this sends no
+ * interval of its own — the backend resolves the span's window, and cuts its children out of it
+ * when `selfOnly` is set. That is the difference between "this span took 400 ms" and "this span
+ * spent 400 ms in code it owns".
+ */
+export default class TraceSpanFlamegraphClient extends RemoteFlamegraphClient {
+  private readonly selfOnly: boolean;
+  private readonly eventType: string;
+  private readonly useWeight: boolean | null;
+
+  constructor(
+    profileId: string,
+    traceId: string,
+    spanId: string,
+    selfOnly: boolean,
+    eventType: string,
+    useWeight: boolean | null
+  ) {
+    super(
+      GlobalVars.internalUrl +
+        '/profiles/' +
+        profileId +
+        '/traces/' +
+        traceId +
+        '/spans/' +
+        spanId +
+        '/flamegraph'
+    );
+    this.selfOnly = selfOnly;
+    this.eventType = eventType;
+    this.useWeight = useWeight;
+  }
+
+  // The span scope fully defines the data — timeRange/search of the contract are ignored.
+  protected bothContent(components: GraphComponents): Record<string, unknown> {
+    return {
+      selfOnly: this.selfOnly,
+      eventType: this.eventType,
+      useWeight: this.useWeight,
+      useThreadMode: false,
+      excludeNonJavaSamples: false,
+      excludeIdleSamples: false,
+      onlyUnsafeAllocationSamples: false,
+      components: components
+    };
+  }
+}

--- a/jeffrey-microscope/pages-microscope/src/services/api/model/trace/TraceModels.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/model/trace/TraceModels.ts
@@ -74,3 +74,17 @@ export interface TraceOperationRow {
   p95Nanos: number;
   maxNanos: number;
 }
+
+/**
+ * One JFR event that occurred inside a span -- what the JVM was doing while it was open.
+ *
+ * Distinct from the async-profiler span drill-down's row type. That feature answers the same shape
+ * of question for `profiler.Span`, and the two are kept apart so neither constrains the other.
+ */
+export interface TraceEventRow {
+  eventType: string;
+  startEpochMillis: number;
+  durationNanos: number;
+  /** The event's own fields, as a JSON object string. */
+  fields: string | null;
+}

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/technologies/ProfileTraceOperations.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/technologies/ProfileTraceOperations.vue
@@ -1,0 +1,324 @@
+<!--
+  ~ Jeffrey
+  ~ Copyright (C) 2026 Petr Bouda
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<template>
+  <div>
+    <TracesDisabledFeatureAlert v-if="featureDisabled" />
+
+    <LoadingState v-else-if="loading" message="Loading operations..." />
+
+    <ErrorState v-else-if="error" :message="error" @retry="loadData" />
+
+    <EmptyState
+      v-else-if="operations.length === 0"
+      title="No Operations"
+      message="No trace-carrying events were recorded in this profile."
+      icon="bi-bar-chart-steps"
+    />
+
+    <div v-else class="dashboard-container">
+      <DataTable>
+        <template #toolbar>
+          <TableToolbar v-model="query" search-placeholder="Filter operations...">
+            <span class="toolbar-info">
+              Operations <span class="muted">(ranked by total time)</span>
+            </span>
+            <template #filters>
+              <Badge
+                key-label="Total"
+                :value="filtered.length"
+                variant="secondary"
+                size="s"
+                borderless
+              />
+            </template>
+          </TableToolbar>
+        </template>
+        <thead>
+          <tr>
+            <th>Operation</th>
+            <th>Kind</th>
+            <th class="numeric">Count</th>
+            <th class="numeric">Total</th>
+            <th class="spread-column">p50 · p95 · max</th>
+            <th class="numeric">p50</th>
+            <th class="numeric">p95</th>
+            <th class="numeric">Max</th>
+            <th class="numeric">Errors</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="operation in visible" :key="operation.name">
+            <td class="operation">{{ operation.name }}</td>
+            <td><Badge :variant="kindVariant(operation.kind)" size="xs" :value="operation.kind" /></td>
+            <td class="numeric">{{ operation.count }}</td>
+            <td class="numeric">{{ format(operation.totalNanos) }}</td>
+            <td class="spread-column">
+              <!--
+                All operations share one rail scaled to the slowest single span in the profile, so a
+                wide p50-to-p95 gap -- the signature of an operation that is usually fine and
+                occasionally awful -- reads as a shape rather than as two numbers to compare.
+              -->
+              <div class="spread">
+                <span class="rail"></span>
+                <span
+                  class="range"
+                  :style="{ left: pct(operation.p50Nanos), width: width(operation) }"
+                ></span>
+                <span class="tick tick-p50" :style="{ left: pct(operation.p50Nanos) }"></span>
+                <span class="tick tick-p95" :style="{ left: pct(operation.p95Nanos) }"></span>
+                <span class="tick tick-max" :style="{ left: pct(operation.maxNanos) }"></span>
+              </div>
+            </td>
+            <td class="numeric">{{ format(operation.p50Nanos) }}</td>
+            <td class="numeric">{{ format(operation.p95Nanos) }}</td>
+            <td class="numeric">{{ format(operation.maxNanos) }}</td>
+            <td class="numeric">
+              <Badge
+                v-if="operation.errorCount > 0"
+                variant="danger"
+                size="xs"
+                :value="operation.errorCount"
+              />
+              <span v-else class="muted">—</span>
+            </td>
+          </tr>
+        </tbody>
+        <template #footer>
+          <TableShowMore
+            v-if="filtered.length > visibleCount"
+            :shown="visible.length"
+            :total="filtered.length"
+            @show-more="visibleCount += PAGE_SIZE"
+          />
+        </template>
+      </DataTable>
+
+      <div class="legend">
+        <span><i class="swatch swatch-p50"></i> p50</span>
+        <span><i class="swatch swatch-p95"></i> p95</span>
+        <span><i class="swatch swatch-max"></i> max</span>
+        <span class="muted">A wide p50 → p95 gap means usually fine, occasionally slow</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { useRoute } from 'vue-router';
+
+import LoadingState from '@shared/components/LoadingState.vue';
+import ErrorState from '@shared/components/ErrorState.vue';
+import EmptyState from '@shared/components/EmptyState.vue';
+import Badge from '@shared/components/Badge.vue';
+import DataTable from '@shared/components/table/DataTable.vue';
+import TableToolbar from '@shared/components/table/TableToolbar.vue';
+import TableShowMore from '@shared/components/table/TableShowMore.vue';
+import FormattingService from '@shared/services/FormattingService';
+import TracesDisabledFeatureAlert from '@/components/alerts/TracesDisabledFeatureAlert.vue';
+import ProfileTracesClient from '@/services/api/ProfileTracesClient';
+import type { SpanKind, TraceOperationRow } from '@/services/api/model/trace/TraceModels';
+import FeatureType from '@/services/api/model/FeatureType';
+
+const props = defineProps<{ disabledFeatures: FeatureType[] }>();
+
+const route = useRoute();
+
+const PAGE_SIZE = 50;
+
+const operations = ref<TraceOperationRow[]>([]);
+const loading = ref(true);
+const error = ref<string | null>(null);
+const query = ref('');
+const visibleCount = ref(PAGE_SIZE);
+
+const profileId = computed(() => route.params.profileId as string);
+
+const featureDisabled = computed(() => props.disabledFeatures.includes(FeatureType.TRACES));
+
+const filtered = computed(() => {
+  const needle = query.value.trim().toLowerCase();
+  if (needle === '') {
+    return operations.value;
+  }
+  return operations.value.filter((operation) => operation.name.toLowerCase().includes(needle));
+});
+
+const visible = computed(() => filtered.value.slice(0, visibleCount.value));
+
+/** The slowest single span anywhere, which is what the shared rail is scaled to. */
+const scaleNanos = computed(() =>
+  operations.value.reduce((slowest, operation) => Math.max(slowest, operation.maxNanos), 0)
+);
+
+function pct(nanos: number): string {
+  if (scaleNanos.value <= 0) {
+    return '0%';
+  }
+  return Math.min((nanos / scaleNanos.value) * 100, 100) + '%';
+}
+
+/** The p50-to-p95 band, floored so an operation with no spread is still visible. */
+function width(operation: TraceOperationRow): string {
+  if (scaleNanos.value <= 0) {
+    return '0%';
+  }
+  const span = ((operation.p95Nanos - operation.p50Nanos) / scaleNanos.value) * 100;
+  return Math.max(span, 0.5) + '%';
+}
+
+function format(nanos: number): string {
+  return FormattingService.formatDuration2Units(nanos);
+}
+
+function kindVariant(kind: SpanKind): string {
+  if (kind === 'SERVER') {
+    return 'primary';
+  }
+  return kind === 'CLIENT' ? 'info' : 'secondary';
+}
+
+async function loadData(): Promise<void> {
+  loading.value = true;
+  error.value = null;
+  try {
+    operations.value = await new ProfileTracesClient(profileId.value).getOperations();
+  } catch {
+    error.value = 'Failed to load the trace operations for this profile.';
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(() => {
+  if (featureDisabled.value) {
+    loading.value = false;
+  } else {
+    loadData();
+  }
+});
+</script>
+
+<style scoped>
+.dashboard-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.toolbar-info {
+  font-weight: 500;
+  color: var(--color-heading);
+}
+
+.muted {
+  color: var(--color-text-muted);
+  font-weight: 400;
+}
+
+.operation {
+  font-weight: 500;
+  color: var(--color-heading);
+}
+
+.numeric {
+  text-align: right;
+  font-family: var(--font-family-monospace);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.spread-column {
+  min-width: 11rem;
+}
+
+.spread {
+  position: relative;
+  height: 0.85rem;
+}
+
+.rail {
+  position: absolute;
+  inset: 0.35rem 0 auto 0;
+  height: 0.16rem;
+  background: var(--color-border);
+  border-radius: var(--radius-xs);
+}
+
+.range {
+  position: absolute;
+  top: 0.28rem;
+  height: 0.3rem;
+  background: var(--flamegraph-color-blue);
+  border-radius: var(--radius-xs);
+}
+
+.tick {
+  position: absolute;
+  top: 0.05rem;
+  width: 2px;
+  height: 0.75rem;
+  border-radius: var(--radius-xs);
+}
+
+.tick-p50 {
+  background: var(--color-primary);
+}
+
+.tick-p95 {
+  background: var(--color-warning);
+}
+
+.tick-max {
+  background: var(--color-danger);
+}
+
+.legend {
+  display: flex;
+  gap: 0.9rem;
+  flex-wrap: wrap;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+.legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.swatch {
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: var(--radius-xs);
+  display: inline-block;
+}
+
+.swatch-p50 {
+  background: var(--color-primary);
+}
+
+.swatch-p95 {
+  background: var(--color-warning);
+}
+
+.swatch-max {
+  background: var(--color-danger);
+}
+</style>

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/navigation/__tests__/profileNavConfig.spec.ts
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/navigation/__tests__/profileNavConfig.spec.ts
@@ -67,8 +67,8 @@ describe('profileNavConfig', () => {
   it('collects a sane number of nav items', () => {
     // 7 Overview (incl. Dashboards) + 19 JVM (incl. GC/JIT submenu parents + children)
     // + 16 Application (incl. Memory Issues submenu) + 4 Visualization + 17 HeapDump
-    // + 4 Tools + 4 Advisor + 35 Technologies (34 + Traces)
-    expect(allItems.length).toBe(106);
+    // + 4 Tools + 4 Advisor + 36 Technologies (34 + Traces + Operations)
+    expect(allItems.length).toBe(107);
   });
 
   it('every item has a label and a bootstrap icon', () => {

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/navigation/profileNavConfig.ts
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/navigation/profileNavConfig.ts
@@ -218,7 +218,10 @@ export const technologiesNav: Record<string, TechnologyNav> = {
     icon: 'bi-diagram-3',
     groups: [
       {
-        items: [item('Traces', 'bi-diagram-3', '/technologies/traces')]
+        items: [
+          item('Traces', 'bi-diagram-3', '/technologies/traces'),
+          item('Operations', 'bi-bar-chart-steps', '/technologies/traces/operations')
+        ]
       }
     ]
   }

--- a/jeffrey-microscope/profiles/claude-code-headless/src/main/java/cafe/jeffrey/profile/ai/claudecode/mcp/ReflectiveToolset.java
+++ b/jeffrey-microscope/profiles/claude-code-headless/src/main/java/cafe/jeffrey/profile/ai/claudecode/mcp/ReflectiveToolset.java
@@ -19,6 +19,8 @@
 package cafe.jeffrey.profile.ai.claudecode.mcp;
 
 import cafe.jeffrey.jfr.events.trace.SpanKind;
+import cafe.jeffrey.jfr.events.trace.SpanStatus;
+import cafe.jeffrey.jfr.events.trace.TraceSpanEvent;
 import cafe.jeffrey.jfr.events.trace.Tracer;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
@@ -45,6 +47,9 @@ import java.util.Map;
  * the project's compiler configuration).
  */
 public final class ReflectiveToolset {
+
+    /** Attribute recording how many characters a tool handed back to the model. */
+    private static final String RESULT_CHARS_ATTRIBUTE = "resultChars";
 
     private static final String JSON_TYPE_OBJECT = "object";
     private static final String JSON_TYPE_STRING = "string";
@@ -83,18 +88,43 @@ public final class ReflectiveToolset {
         // is what separates time spent in the model from time spent in our own queries when a
         // tool-assisted answer is slow. The span wraps the reflective call *and* its exception
         // translation, so a failed tool is recorded with the exception this method actually throws.
-        return Tracer.call(toolName, SpanKind.INTERNAL, () -> {
-            Object[] args = bindArguments(method, arguments);
-            try {
-                Object result = method.invoke(target, args);
-                return result == null ? "" : result.toString();
-            } catch (IllegalAccessException e) {
-                throw new IllegalStateException("Failed to invoke tool: " + toolName, e);
-            } catch (InvocationTargetException e) {
-                Throwable cause = e.getCause() != null ? e.getCause() : e;
-                throw new IllegalStateException("Tool execution failed: " + cause.getMessage(), cause);
+        TraceSpanEvent span = new TraceSpanEvent();
+        span.name = toolName;
+        span.kind = SpanKind.INTERNAL.name();
+        span.begin();
+
+        String result = null;
+        try {
+            result = Tracer.inSpanOf(span, () -> {
+                Object[] args = bindArguments(method, arguments);
+                try {
+                    Object value = method.invoke(target, args);
+                    return value == null ? "" : value.toString();
+                } catch (IllegalAccessException e) {
+                    throw new IllegalStateException("Failed to invoke tool: " + toolName, e);
+                } catch (InvocationTargetException e) {
+                    Throwable cause = e.getCause() != null ? e.getCause() : e;
+                    throw new IllegalStateException("Tool execution failed: " + cause.getMessage(), cause);
+                }
+            });
+            // A tool that returned a result did its job; the outcome is observed, not assumed.
+            span.status = SpanStatus.OK.name();
+            return result;
+        } catch (RuntimeException e) {
+            span.status = SpanStatus.ERROR.name();
+            span.errorType = e.getClass().getName();
+            throw e;
+        } finally {
+            span.end();
+            if (span.shouldCommit()) {
+                // How much the tool handed back. Everything a tool returns is pasted into the
+                // model's context and paid for on the next round trip, so the size of the answer is
+                // as interesting as the time it took to produce -- and invisible from the duration.
+                span.attributes = Json.toString(
+                        Map.of(RESULT_CHARS_ATTRIBUTE, result == null ? 0 : result.length()));
+                span.commit();
             }
-        });
+        }
     }
 
     private void index() {

--- a/jeffrey-microscope/profiles/common-profile/src/main/java/cafe/jeffrey/profile/common/pipeline/PipelineRunRegistry.java
+++ b/jeffrey-microscope/profiles/common-profile/src/main/java/cafe/jeffrey/profile/common/pipeline/PipelineRunRegistry.java
@@ -19,7 +19,10 @@
 package cafe.jeffrey.profile.common.pipeline;
 
 import cafe.jeffrey.jfr.events.trace.SpanKind;
+import cafe.jeffrey.jfr.events.trace.SpanStatus;
+import cafe.jeffrey.jfr.events.trace.TraceSpanEvent;
 import cafe.jeffrey.jfr.events.trace.Tracer;
+import cafe.jeffrey.shared.common.Json;
 import cafe.jeffrey.shared.common.Schedulers;
 import cafe.jeffrey.shared.common.exception.JeffreyException;
 import org.slf4j.Logger;
@@ -27,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Clock;
 import java.time.Duration;
+import java.util.Map;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -190,16 +194,31 @@ public final class PipelineRunRegistry<K> {
             return;
         }
 
+        // The root span of this run's trace. Stages opened by PipelineRun.runStage nest under it.
+        // The event is built here rather than left to Tracer.run because a pipeline knows things a
+        // generic span does not: which profile the run was for, and whether it actually succeeded.
+        TraceSpanEvent span = new TraceSpanEvent();
+        span.name = definition.pipelineId();
+        span.kind = SpanKind.INTERNAL.name();
+        span.begin();
+
         try {
-            // The root span of this run's trace. Stages opened by PipelineRun.runStage nest under it.
             // Scoped to the work itself rather than the whole method so the span measures execution,
             // not the time spent queueing for a slot above.
-            Tracer.run(definition.pipelineId(), SpanKind.INTERNAL, () -> request.work().accept(run));
+            Tracer.inSpanOf(span, () -> {
+                request.work().accept(run);
+                return null;
+            });
             run.complete();
+            // OK rather than UNSET: a pipeline reaching complete() is a success the code observed,
+            // not merely the absence of a thrown exception.
+            span.status = SpanStatus.OK.name();
             LOG.info("Pipeline run completed: pipeline_id={} key={} duration_in_ms={}",
                     definition.pipelineId(), request.key(),
                     Duration.between(run.startedAt(), clock.instant()).toMillis());
         } catch (Throwable e) {
+            span.status = SpanStatus.ERROR.name();
+            span.errorType = e.getClass().getName();
             // Errors are marked too — otherwise an OutOfMemoryError would leave the run RUNNING and
             // its key blocked forever. They still propagate after the finally block runs.
             run.fail(errorCodeOf(e), e.getMessage());
@@ -211,6 +230,16 @@ public final class PipelineRunRegistry<K> {
                 throw error;
             }
         } finally {
+            span.end();
+            if (span.shouldCommit()) {
+                // What this run was for. The key identifies the profile and the scope the pipeline's
+                // unit of work -- the event type for an advisor batch, empty for a once-per-profile
+                // run -- which is what tells two runs of the same pipeline apart in the trace list.
+                span.attributes = Json.toString(Map.of(
+                        "key", String.valueOf(request.key()),
+                        "scopeId", request.scopeId()));
+                span.commit();
+            }
             tracked.worker = null;
             // Absorb a cancellation interrupt that landed after the work returned, so storing the
             // terminal result below is not sabotaged by a flag meant for the work.

--- a/jeffrey-microscope/profiles/profile-guardian/pom.xml
+++ b/jeffrey-microscope/profiles/profile-guardian/pom.xml
@@ -30,6 +30,11 @@
     <artifactId>profile-guardian</artifactId>
 
     <dependencies>
+        <!-- Tracer: each event type's guard evaluation is recorded as a span -->
+        <dependency>
+            <groupId>cafe.jeffrey-analyst</groupId>
+            <artifactId>jeffrey-events</artifactId>
+        </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>

--- a/jeffrey-microscope/profiles/profile-guardian/src/main/java/cafe/jeffrey/profile/guardian/Guardian.java
+++ b/jeffrey-microscope/profiles/profile-guardian/src/main/java/cafe/jeffrey/profile/guardian/Guardian.java
@@ -18,6 +18,7 @@
 
 package cafe.jeffrey.profile.guardian;
 
+import cafe.jeffrey.jfr.events.trace.Tracer;
 import tools.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,6 +58,8 @@ import java.util.stream.Collectors;
 public class Guardian {
 
     private static final Logger LOG = LoggerFactory.getLogger(Guardian.class);
+    /** Span-name prefix; the event type follows, e.g. {@code guardian.jdk.ExecutionSample}. */
+    private static final String GUARDIAN_SPAN_PREFIX = "guardian.";
 
     private static final String PREREQUISITES_GROUP = "Prerequisites";
 
@@ -122,7 +125,14 @@ public class Guardian {
                 .collect(Collectors.groupingBy(GuardDefinition::eventType, LinkedHashMap::new, Collectors.toList()));
 
         for (Map.Entry<String, List<GuardDefinition>> entry : byEventType.entrySet()) {
-            results.addAll(evaluateEventType(entry.getKey(), entry.getValue(), samplesByEventType, preconditions));
+            // One span per event type rather than per guard: the cost here is building the frame
+            // tree and traversing it once, which every guard for that type shares. Individual
+            // guards are visitors over that tree, so timing them separately would measure noise.
+            // The event type is part of the name because the set of types is bounded, and a
+            // waterfall of identically-named children could not be told apart without clicking.
+            String spanName = GUARDIAN_SPAN_PREFIX + entry.getKey();
+            results.addAll(Tracer.call(spanName, () ->
+                    evaluateEventType(entry.getKey(), entry.getValue(), samplesByEventType, preconditions)));
         }
 
         return results;

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/TraceManager.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/TraceManager.java
@@ -19,6 +19,7 @@
 package cafe.jeffrey.profile.manager;
 
 import cafe.jeffrey.profile.manager.model.trace.TraceDetail;
+import cafe.jeffrey.profile.manager.model.trace.TraceEventRow;
 import cafe.jeffrey.profile.manager.model.trace.TraceOperationRow;
 import cafe.jeffrey.profile.manager.model.trace.TraceRow;
 import cafe.jeffrey.shared.common.model.ProfileInfo;
@@ -71,4 +72,12 @@ public interface TraceManager {
      * @return latency aggregated by operation name across every trace
      */
     List<TraceOperationRow> operations(int limit);
+
+    /**
+     * What the JVM was doing on the span's thread while it was open. Events that are themselves
+     * spans are left out — they are the tree the waterfall already draws.
+     *
+     * @return the events, or empty when the span does not exist
+     */
+    List<TraceEventRow> eventsInSpan(long traceId, long spanId);
 }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/TraceManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/TraceManagerImpl.java
@@ -19,6 +19,7 @@
 package cafe.jeffrey.profile.manager;
 
 import cafe.jeffrey.profile.manager.model.trace.TraceDetail;
+import cafe.jeffrey.profile.manager.model.trace.TraceEventRow;
 import cafe.jeffrey.profile.manager.model.trace.TraceOperationRow;
 import cafe.jeffrey.profile.manager.model.trace.TraceRow;
 import cafe.jeffrey.profile.manager.model.trace.TraceSpanRow;
@@ -81,6 +82,7 @@ public class TraceManagerImpl implements TraceManager {
         if (target == null) {
             return List.of();
         }
+
         if (!selfOnly) {
             return List.of(intervalOf(target));
         }
@@ -100,6 +102,27 @@ public class TraceManagerImpl implements TraceManager {
                         operation.p95Nanos(),
                         operation.maxNanos()))
                 .toList();
+    }
+
+    @Override
+    public List<TraceEventRow> eventsInSpan(long traceId, long spanId) {
+        return spanOf(traceId, spanId)
+                .map(span -> traceRepository
+                        .eventsInSpan(span.threadHash(), span.startEpochMillis(), endMillisOf(span))
+                        .stream()
+                        .map(event -> new TraceEventRow(
+                                event.eventType(),
+                                event.startEpochMillis(),
+                                event.durationNanos(),
+                                event.fields()))
+                        .toList())
+                .orElseGet(List::of);
+    }
+
+    private Optional<TraceSpanRecord> spanOf(long traceId, long spanId) {
+        return traceRepository.spansOf(traceId).stream()
+                .filter(span -> span.spanId() == spanId)
+                .findFirst();
     }
 
     /**

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/trace/TraceEventRow.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/trace/TraceEventRow.java
@@ -15,20 +15,20 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-module cafe.jeffrey.microscope.profile.guardian {
-    requires transitive cafe.jeffrey.microscope.profile.frame.ir;
-    requires transitive cafe.jeffrey.microscope.profile.persistence.api;
-    requires cafe.jeffrey.shared.common;
-    requires spring.boot;
-    requires org.slf4j;
-    requires tools.jackson.databind;
-    requires cafe.jeffrey.jfr.events;
 
-    exports cafe.jeffrey.profile.guardian;
-    exports cafe.jeffrey.profile.guardian.definition;
-    exports cafe.jeffrey.profile.guardian.guard;
-    exports cafe.jeffrey.profile.guardian.matcher;
-    exports cafe.jeffrey.profile.guardian.preconditions;
-    exports cafe.jeffrey.profile.guardian.prereq;
-    exports cafe.jeffrey.profile.guardian.traverse;
+package cafe.jeffrey.profile.manager.model.trace;
+
+/**
+ * One JFR event that occurred inside a span — the "what was the JVM doing in here" breakdown.
+ *
+ * @param eventType        the JFR event type, e.g. {@code jdk.ExecutionSample}
+ * @param startEpochMillis when it occurred, absolute UTC epoch millis
+ * @param durationNanos    its duration, or 0 for an instantaneous event
+ * @param fields           the event's own fields, as a JSON object string
+ */
+public record TraceEventRow(
+        String eventType,
+        long startEpochMillis,
+        long durationNanos,
+        String fields) {
 }

--- a/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/ProfileInitializerImplTest.java
+++ b/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/ProfileInitializerImplTest.java
@@ -1,0 +1,132 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile;
+
+import cafe.jeffrey.profile.manager.ProfileManager;
+import cafe.jeffrey.profile.manager.action.ProfileDataInitializer;
+import cafe.jeffrey.provider.profile.api.EventWriter;
+import cafe.jeffrey.provider.profile.api.ProfileRepositories;
+import cafe.jeffrey.provider.profile.api.RecordingEventParser;
+import cafe.jeffrey.provider.profile.api.RecordingEventParserResolver;
+import cafe.jeffrey.provider.profile.api.TraceRepository;
+import cafe.jeffrey.shared.common.model.ProfileInfo;
+import cafe.jeffrey.shared.persistence.DatabaseLease;
+import cafe.jeffrey.shared.persistence.DatabaseManager;
+import cafe.jeffrey.shared.persistence.client.DatabaseClient;
+import cafe.jeffrey.shared.persistence.client.DatabaseClientProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import javax.sql.DataSource;
+import java.nio.file.Path;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Guards the ordering that profile initialization depends on but that no other test can see: the
+ * trace tables are derived from the events, so the derivation has to run after the writer has
+ * finished and before anything can read a trace.
+ * <p>
+ * Deliberately a wiring test rather than an end-to-end one. What the repository tests cannot cover
+ * is that {@code derive()} is called at all -- a deletion there would leave every trace query
+ * returning nothing, with every other test still green.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ProfileInitializerImplTest {
+
+    private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-01-15T10:00:00Z"), ZoneOffset.UTC);
+
+    @Mock
+    ProfileRepositories profileRepositories;
+
+    @Mock
+    DatabaseManager databaseManager;
+
+    @Mock
+    RecordingEventParserResolver recordingEventParserResolver;
+
+    @Mock
+    EventWriter.Factory eventWriterFactory;
+
+    @Mock
+    ProfileDataInitializer profileDataInitializer;
+
+    @Mock
+    TraceRepository traceRepository;
+
+    @Mock
+    EventWriter eventWriter;
+
+    @Mock
+    RecordingEventParser recordingEventParser;
+
+    private ProfileInitializerImpl initializer(ProfileInfo profileInfo) {
+        DataSource dataSource = mock(DataSource.class);
+        DatabaseLease lease = mock(DatabaseLease.class);
+        when(lease.dataSource()).thenReturn(dataSource);
+        when(databaseManager.acquire(profileInfo.id())).thenReturn(lease);
+
+        when(eventWriterFactory.create(any(), any())).thenReturn(eventWriter);
+        when(recordingEventParserResolver.resolve(any())).thenReturn(recordingEventParser);
+        when(profileRepositories.newTraceRepository(dataSource)).thenReturn(traceRepository);
+
+        // The re-cluster and checkpoint steps at the tail run through the infrastructure client.
+        DatabaseClientProvider clientProvider = mock(DatabaseClientProvider.class);
+        when(clientProvider.provide(any())).thenReturn(mock(DatabaseClient.class));
+        when(profileRepositories.databaseClientProvider(dataSource)).thenReturn(clientProvider);
+
+        return new ProfileInitializerImpl(
+                profileRepositories,
+                databaseManager,
+                recordingEventParserResolver,
+                eventWriterFactory,
+                _ -> mock(ProfileManager.class),
+                profileDataInitializer,
+                CLOCK);
+    }
+
+    @Test
+    @DisplayName("derives the trace tables once the events are written")
+    void derivesTracesAfterParsing() {
+        ProfileInfo profileInfo = mock(ProfileInfo.class);
+        when(profileInfo.id()).thenReturn("profile-1");
+
+        initializer(profileInfo).initialize(profileInfo, null, Path.of("recording.jfr"));
+
+        // Before the writer completes there is nothing to derive from; after the data initializer
+        // the pre-computed views would have been built against tables that were still empty.
+        InOrder inOrder = inOrder(eventWriter, traceRepository, profileDataInitializer);
+        inOrder.verify(eventWriter).onComplete();
+        inOrder.verify(traceRepository).derive();
+        inOrder.verify(profileDataInitializer).initialize(any());
+    }
+}

--- a/jeffrey-microscope/profiles/profile-persistence-api/src/main/java/cafe/jeffrey/provider/profile/api/TraceEventRecord.java
+++ b/jeffrey-microscope/profiles/profile-persistence-api/src/main/java/cafe/jeffrey/provider/profile/api/TraceEventRecord.java
@@ -1,0 +1,39 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.provider.profile.api;
+
+/**
+ * One JFR event that occurred inside a span's window — what the JVM was actually doing while the
+ * span was open.
+ * <p>
+ * Deliberately its own record rather than a reuse of the async-profiler span drill-down: that one
+ * answers the same shape of question for {@code profiler.Span}, and the two concepts are kept
+ * apart so neither has to accommodate the other.
+ *
+ * @param eventType        the JFR event type, e.g. {@code jdk.ExecutionSample}
+ * @param startEpochMillis when it occurred, absolute UTC epoch millis
+ * @param durationNanos    its duration, or 0 for an instantaneous event
+ * @param fields           the event's own fields, as a JSON object string
+ */
+public record TraceEventRecord(
+        String eventType,
+        long startEpochMillis,
+        long durationNanos,
+        String fields) {
+}

--- a/jeffrey-microscope/profiles/profile-persistence-api/src/main/java/cafe/jeffrey/provider/profile/api/TraceRepository.java
+++ b/jeffrey-microscope/profiles/profile-persistence-api/src/main/java/cafe/jeffrey/provider/profile/api/TraceRepository.java
@@ -62,4 +62,18 @@ public interface TraceRepository {
      * @param limit maximum number of operations to return, ranked by total time
      */
     List<TraceOperationRecord> operations(int limit);
+
+    /**
+     * Returns what the JVM was doing on a span's thread while the span was open — CPU samples,
+     * allocations, lock contention and the rest.
+     * <p>
+     * Events that are themselves spans are excluded, so the drill-down shows JVM activity rather
+     * than repeating the tree the waterfall already draws.
+     *
+     * @param threadHash      identity hash of the span's thread; used rather than the OS id so the
+     *                        lookup also resolves for virtual threads
+     * @param fromEpochMillis window start, inclusive
+     * @param toEpochMillis   window end, inclusive
+     */
+    List<TraceEventRecord> eventsInSpan(long threadHash, long fromEpochMillis, long toEpochMillis);
 }

--- a/jeffrey-microscope/profiles/profile-sql-persistence/pom.xml
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/pom.xml
@@ -30,6 +30,13 @@
     <artifactId>profile-sql-persistence</artifactId>
 
     <dependencies>
+        <!-- Test-only: pins the status/kind literals in the derivation SQL to the enums the
+             instrumentation emits, so a rename on one side cannot silently diverge from the other -->
+        <dependency>
+            <groupId>cafe.jeffrey-analyst</groupId>
+            <artifactId>jeffrey-events</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>profile-persistence-api</artifactId>

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/JdbcTraceRepository.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/JdbcTraceRepository.java
@@ -18,10 +18,12 @@
 
 package cafe.jeffrey.provider.profile.jdbc;
 
+import cafe.jeffrey.provider.profile.api.TraceEventRecord;
 import cafe.jeffrey.provider.profile.api.TraceOperationRecord;
 import cafe.jeffrey.provider.profile.api.TraceRepository;
 import cafe.jeffrey.provider.profile.api.TraceSpanRecord;
 import cafe.jeffrey.provider.profile.api.TraceSummaryRecord;
+import cafe.jeffrey.shared.common.model.EventTypeName;
 import cafe.jeffrey.shared.persistence.StatementLabel;
 import cafe.jeffrey.shared.persistence.client.DatabaseClient;
 import cafe.jeffrey.shared.persistence.client.DatabaseClientProvider;
@@ -44,21 +46,27 @@ import static cafe.jeffrey.shared.persistence.GroupLabel.PROFILE_TRACES;
 public class JdbcTraceRepository implements TraceRepository {
 
     /**
-     * Every event type that can carry trace identity. Rendered into the derivation query as a list
-     * literal; adding a newly traced event type is a one-line change here.
+     * Every event type that can carry trace identity, and therefore every type that becomes a span.
+     * Adding a newly traced event type is a one-line change here.
+     * <p>
+     * The same list is what the drill-down excludes: an event that is itself a span belongs in the
+     * waterfall, not in the list of what happened inside one.
      */
     private static final List<String> TRACED_EVENT_TYPES = List.of(
-            "jeffrey.TraceSpan",
-            "jeffrey.HttpServerExchange",
-            "jeffrey.HttpClientExchange",
-            "jeffrey.GrpcServerExchange",
-            "jeffrey.GrpcClientExchange",
-            "jeffrey.JdbcQuery",
-            "jeffrey.JdbcInsert",
-            "jeffrey.JdbcUpdate",
-            "jeffrey.JdbcDelete",
-            "jeffrey.JdbcExecute",
-            "jeffrey.JdbcStream");
+            EventTypeName.TRACE_SPAN,
+            EventTypeName.HTTP_SERVER_EXCHANGE,
+            EventTypeName.HTTP_CLIENT_EXCHANGE,
+            EventTypeName.GRPC_SERVER_EXCHANGE,
+            EventTypeName.GRPC_CLIENT_EXCHANGE,
+            EventTypeName.JDBC_QUERY,
+            EventTypeName.JDBC_INSERT,
+            EventTypeName.JDBC_UPDATE,
+            EventTypeName.JDBC_DELETE,
+            EventTypeName.JDBC_EXECUTE,
+            EventTypeName.JDBC_STREAM);
+
+    /** Guards the drill-down against returning more rows than a drawer can show. */
+    private static final int SPAN_EVENTS_LIMIT = 5000;
 
     /*
      * The span's name and kind depend on which event produced it: a hand-written span names itself,
@@ -213,6 +221,27 @@ public class JdbcTraceRepository implements TraceRepository {
             LIMIT :limit
             """;
 
+    /*
+     * What ran on the span's thread while it was open. The bounds compare the raw start_timestamp
+     * against epoch-micros literals so the predicate stays sargable, replicating the millisecond
+     * floor of `EPOCH_MS(ts) BETWEEN :from AND :to` without a per-row conversion.
+     */
+    //language=SQL
+    private static final String EVENTS_IN_SPAN = """
+            SELECT
+                e.event_type                AS event_type,
+                EPOCH_MS(e.start_timestamp) AS start_epoch_ms,
+                COALESCE(e.duration, 0)     AS duration_ns,
+                CAST(e.fields AS VARCHAR)   AS fields
+            FROM events e
+            WHERE e.thread_hash = :thread_hash
+                AND e.event_type NOT IN (%s)
+                AND e.start_timestamp >= make_timestamptz(:from_ms * 1000)
+                AND e.start_timestamp < make_timestamptz((:to_ms + 1) * 1000)
+            ORDER BY e.start_timestamp
+            LIMIT :limit
+            """;
+
     private final DatabaseClient databaseClient;
 
     public JdbcTraceRepository(DatabaseClientProvider databaseClientProvider) {
@@ -291,6 +320,25 @@ public class JdbcTraceRepository implements TraceRepository {
                         rs.getLong("p50_ns"),
                         rs.getLong("p95_ns"),
                         rs.getLong("max_ns")));
+    }
+
+    @Override
+    public List<TraceEventRecord> eventsInSpan(long threadHash, long fromEpochMillis, long toEpochMillis) {
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("thread_hash", threadHash)
+                .addValue("from_ms", fromEpochMillis)
+                .addValue("to_ms", toEpochMillis)
+                .addValue("limit", SPAN_EVENTS_LIMIT);
+
+        return databaseClient.query(
+                StatementLabel.TRACE_SPAN_EVENTS,
+                EVENTS_IN_SPAN.formatted(tracedEventTypeList()),
+                params,
+                (rs, _) -> new TraceEventRecord(
+                        rs.getString("event_type"),
+                        rs.getLong("start_epoch_ms"),
+                        rs.getLong("duration_ns"),
+                        rs.getString("fields")));
     }
 
     /**

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/test/java/cafe/jeffrey/provider/profile/jdbc/JdbcTraceRepositoryTest.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/test/java/cafe/jeffrey/provider/profile/jdbc/JdbcTraceRepositoryTest.java
@@ -18,6 +18,9 @@
 
 package cafe.jeffrey.provider.profile.jdbc;
 
+import cafe.jeffrey.jfr.events.trace.SpanKind;
+import cafe.jeffrey.jfr.events.trace.SpanStatus;
+import cafe.jeffrey.provider.profile.api.TraceEventRecord;
 import cafe.jeffrey.provider.profile.api.TraceOperationRecord;
 import cafe.jeffrey.provider.profile.api.TraceSpanRecord;
 import cafe.jeffrey.provider.profile.api.TraceSummaryRecord;
@@ -48,6 +51,8 @@ class JdbcTraceRepositoryTest {
     private static final long SLOW_TRACE = Long.MAX_VALUE;
     private static final long FAST_TRACE = Long.MIN_VALUE;
     private static final long NEGATIVE_SPAN_ID = -8113938001533374712L;
+    /** 2025-01-15T10:00:00Z, the fixture's origin, as epoch millis. */
+    private static final long EPOCH_10_00_00 = 1736935200000L;
 
     private static JdbcTraceRepository derived(DataSource dataSource) throws SQLException {
         TestUtils.executeSql(dataSource, "sql/events/insert-trace-spans.sql");
@@ -152,6 +157,30 @@ class JdbcTraceRepositoryTest {
     }
 
     @Nested
+    @DisplayName("Contract with the event API")
+    class EventApiContract {
+
+        @Test
+        @DisplayName("the status the derivation writes is the status the instrumentation emits")
+        void statusNamesMatchTheEnum() {
+            // The derivation SQL spells these out as literals for readability. They are the same
+            // values Tracer writes into the event, so a rename on either side has to be a rename on
+            // both -- this is the guard that makes that visible rather than silent.
+            assertEquals("OK", SpanStatus.OK.name());
+            assertEquals("ERROR", SpanStatus.ERROR.name());
+            assertEquals("UNSET", SpanStatus.UNSET.name());
+        }
+
+        @Test
+        @DisplayName("the kinds the derivation assigns are the kinds the instrumentation emits")
+        void kindNamesMatchTheEnum() {
+            assertEquals("SERVER", SpanKind.SERVER.name());
+            assertEquals("CLIENT", SpanKind.CLIENT.name());
+            assertEquals("INTERNAL", SpanKind.INTERNAL.name());
+        }
+    }
+
+    @Nested
     @DisplayName("Reads")
     class Reads {
 
@@ -227,6 +256,33 @@ class JdbcTraceRepositoryTest {
         @DisplayName("an unknown trace id yields no spans rather than failing")
         void unknownTraceIsEmpty(DataSource dataSource) throws SQLException {
             assertTrue(derived(dataSource).spansOf(42L).isEmpty());
+        }
+
+        @Test
+        @DisplayName("the drill-down shows JVM activity, not the spans themselves")
+        void eventsInSpanExcludeSpans(DataSource dataSource) throws SQLException {
+            JdbcTraceRepository repository = derived(dataSource);
+
+            // The window of the root HTTP span on thread 3001, which also carries a JDBC span and
+            // an execution sample.
+            List<TraceEventRecord> events = repository.eventsInSpan(
+                    3001, EPOCH_10_00_00, EPOCH_10_00_00 + 120);
+
+            assertTrue(events.stream().noneMatch(event -> event.eventType().startsWith("jeffrey.")),
+                    "an event that is itself a span belongs in the waterfall, not inside a span");
+            assertEquals(List.of("jdk.ExecutionSample"),
+                    events.stream().map(TraceEventRecord::eventType).toList());
+        }
+
+        @Test
+        @DisplayName("the drill-down is scoped to the span's own thread and window")
+        void eventsInSpanAreScoped(DataSource dataSource) throws SQLException {
+            JdbcTraceRepository repository = derived(dataSource);
+
+            // A different thread has no events of its own in the fixture.
+            assertTrue(repository.eventsInSpan(3002, EPOCH_10_00_00, EPOCH_10_00_00 + 120).isEmpty());
+            // A window before anything happened is empty too.
+            assertTrue(repository.eventsInSpan(3001, EPOCH_10_00_00 - 500, EPOCH_10_00_00 - 1).isEmpty());
         }
     }
 }

--- a/jeffrey-pages/src/router/index.ts
+++ b/jeffrey-pages/src/router/index.ts
@@ -339,6 +339,11 @@ const routes: RouteRecordRaw[] = [
         name: 'DocsProfilesLeakCandidates',
         component: () => import('@/views/docs/microscope/profiles/ProfileLeakCandidatesPage.vue')
       },
+      {
+        path: 'microscope/profiles/traces',
+        name: 'DocsProfilesTraces',
+        component: () => import('@/views/docs/microscope/profiles/ProfileTracesPage.vue')
+      },
       // Workspaces & Event Log
       {
         path: 'microscope/workspaces',

--- a/jeffrey-pages/src/views/docs/events/JeffreyJfrEventsPage.vue
+++ b/jeffrey-pages/src/views/docs/events/JeffreyJfrEventsPage.vue
@@ -26,6 +26,7 @@ const { setHeadings } = useDocHeadings();
 
 const headings = [
   { id: 'event-types', text: 'Event Types', level: 2 },
+  { id: 'trace-context', text: 'Trace Context', level: 2 },
   { id: 'integration', text: 'Integration', level: 2 }
 ];
 
@@ -87,7 +88,27 @@ onMounted(() => {
               <p>Monitor connection pool activity including connection acquisition time, pool utilization, and timeouts. Detect pool exhaustion issues.</p>
             </div>
           </div>
+          <div class="event-card">
+            <div class="event-icon"><i class="bi bi-bezier2"></i></div>
+            <div class="event-content">
+              <h4>Trace Spans</h4>
+              <p>Hand-written spans opened through the <code>Tracer</code> API — a name, a kind, a status and optional JSON attributes, nested automatically through <code>ScopedValue</code>. Emitted as <code>jeffrey.TraceSpan</code> and assembled by Jeffrey into a trace tree.</p>
+            </div>
+          </div>
         </div>
+
+        <h2 id="trace-context">Trace Context</h2>
+        <p>The HTTP, gRPC and database events above extend a shared base that carries three trace-identity fields — <code>traceId</code>, <code>spanId</code> and <code>parentSpanId</code>, all 64-bit longs where <code>0</code> means absent. The library never populates them itself; the instrumentation does, either with <code>Tracer.stamp(event)</code> before <code>begin()</code> or by wrapping the emission in <code>Tracer.inSpanOf(...)</code>.</p>
+
+        <p>Once populated, those events become spans in their own right and are assembled into the same tree as <code>jeffrey.TraceSpan</code> — which is what makes a request's SQL statements appear as its children with neither side knowing about the other. The trace and span ids are also annotated <code>@Contextual</code>, so <code>jfr print</code> and JMC show them alongside the surrounding events even outside Jeffrey.</p>
+
+        <DocsCallout type="warning">
+          <strong>Tracing requires Java 25.</strong> The <code>Tracer</code> API is built on <code>ScopedValue</code> (JEP&nbsp;506) and <code>jdk.jfr.Contextual</code>, both finalized in Java&nbsp;25. The event definitions themselves remain usable on older releases from an earlier version of the library.
+        </DocsCallout>
+
+        <p class="docs-read-more">
+          <router-link to="/docs/microscope/profiles/traces">Read the Traces &amp; Spans reference &rarr;</router-link>
+        </p>
 
         <h2 id="integration">Integration</h2>
         <p>Add Jeffrey Events to your project and instrument your code to emit events:</p>
@@ -97,7 +118,7 @@ onMounted(() => {
           <pre><code>&lt;dependency&gt;
     &lt;groupId&gt;cafe.jeffrey-analyst&lt;/groupId&gt;
     &lt;artifactId&gt;jeffrey-events&lt;/artifactId&gt;
-    &lt;version&gt;0.2.3&lt;/version&gt;
+    &lt;version&gt;0.12.0&lt;/version&gt;
 &lt;/dependency&gt;</code></pre>
         </div>
       </div>

--- a/jeffrey-pages/src/views/docs/microscope/profiles/ProfileTracesPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/profiles/ProfileTracesPage.vue
@@ -1,0 +1,253 @@
+<!--
+  - Jeffrey
+  - Copyright (C) 2026 Petr Bouda
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as published by
+  - the Free Software Foundation, either version 3 of the License, or
+  - (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import DocsCallout from '@/components/docs/DocsCallout.vue';
+import DocsCodeBlock from '@/components/docs/DocsCodeBlock.vue';
+import DocsNavFooter from '@/components/docs/DocsNavFooter.vue';
+import DocsPageHeader from '@/components/docs/DocsPageHeader.vue';
+import { useDocHeadings } from '@/composables/useDocHeadings';
+
+const { setHeadings } = useDocHeadings();
+
+const headings = [
+  { id: 'overview', text: 'Overview', level: 2 },
+  { id: 'what-is-a-trace', text: 'What a Trace Is Here', level: 2 },
+  { id: 'instrumenting', text: 'Instrumenting an Application', level: 2 },
+  { id: 'auto-instrumented', text: 'Events That Already Carry Trace Identity', level: 2 },
+  { id: 'trace-list', text: 'Trace List', level: 2 },
+  { id: 'waterfall', text: 'Waterfall', level: 2 },
+  { id: 'span-drill-down', text: 'Span Drill-Down', level: 2 },
+  { id: 'operations', text: 'Operations', level: 2 },
+  { id: 'volume-control', text: 'Controlling Span Volume', level: 2 },
+  { id: 'limits', text: 'Limits', level: 2 }
+];
+
+onMounted(() => {
+  setHeadings(headings);
+});
+
+const mavenDependency = `<dependency>
+    <groupId>cafe.jeffrey-analyst</groupId>
+    <artifactId>jeffrey-events</artifactId>
+    <version>0.12.0</version>
+</dependency>`;
+
+const tracerExample = `import cafe.jeffrey.jfr.events.trace.SpanKind;
+import cafe.jeffrey.jfr.events.trace.Tracer;
+
+// A root span. Everything opened inside it becomes its child, with no
+// context threaded through the call chain.
+Tracer.run("order.checkout", SpanKind.SERVER, () -> {
+    Tracer.run("inventory.reserve", SpanKind.CLIENT, this::reserve);
+    Tracer.run("payment.charge", SpanKind.CLIENT, this::charge);
+});
+
+// Value-returning form; the body may throw a checked exception.
+Order order = Tracer.call("order.load", SpanKind.INTERNAL, () -> repository.load(id));`;
+
+const fanOutExample = `// ScopedValue does not propagate through a plain executor, so the parent
+// context is captured before the fork and re-established inside the task.
+SpanContext parent = Tracer.current().orElse(null);
+
+executor.submit(() -> Tracer.continueIn(parent, "chunk.parse", SpanKind.INTERNAL, () -> {
+    parseChunk(file);
+    return null;
+}));`;
+
+const stampExample = `HttpServerExchangeEvent event = new HttpServerExchangeEvent();
+if (event.isEnabled()) {
+    // Copies traceId / spanId / parentSpanId from the span in progress.
+    Tracer.stamp(event);
+    event.method = request.getMethod();
+    event.uri = request.getRequestURI();
+    event.begin();
+    // ... handle the request ...
+    event.commit();
+}`;
+</script>
+
+<template>
+  <article class="docs-article">
+    <DocsPageHeader
+      title="Traces &amp; Spans"
+      icon="bi bi-bezier2"
+    />
+
+    <div class="docs-content">
+      <p>Traces break a single unit of work — an HTTP request, a background job, an AI tool call — into the operations it is actually made of, and show how long each one took. Jeffrey reads them from the <strong>same JFR recording</strong> that carries the CPU samples, allocations and lock events, which is what makes the drill-down below possible: you can open the flamegraph of what the JVM did <em>inside</em> one span.</p>
+
+      <h2 id="overview">Overview</h2>
+
+      <p>A tracing tool normally tells you that a span took 400&nbsp;ms and stops there — the next question, "doing what?", needs a profiler and a second correlated data source. Jeffrey has both in one file. Every span carries its thread and its time window, and the profile database already scopes flamegraphs, timeseries and event summaries to a list of <code>(thread, from, to)</code> windows, so a span selected in the waterfall becomes a flamegraph query with no extra instrumentation and no second agent.</p>
+
+      <DocsCallout type="info">
+        <strong>Not a distributed tracer.</strong> Traces are scoped to a <strong>single JVM</strong> — one recording, one set of traces. Jeffrey mints every trace and span id itself; it does not read or propagate a W3C <code>traceparent</code>, and it will not stitch a request across service boundaries. The goal is profiler-grade breakdown of one process, not a replacement for Jaeger or Tempo.
+      </DocsCallout>
+
+      <h2 id="what-is-a-trace">What a Trace Is Here</h2>
+
+      <p>A <strong>span</strong> is one timed operation: a name, a start, a duration, a thread, and a parent. A <strong>trace</strong> is the tree of spans reachable from one root. Both ids are 64-bit values rendered as 16-character hex in the UI and carried over the API as strings, because they exceed the JavaScript safe-integer range.</p>
+
+      <p>Spans reach the profile as ordinary JFR events, which is why no parser configuration is involved. After a recording is parsed, Jeffrey derives two typed tables once — <code>trace_spans</code> and <code>traces</code> — from every traced event type in the recording. Because all of them feed one table, <strong>an HTTP request shows its JDBC statements as native children</strong> without either side knowing about the other.</p>
+
+      <p>Every span carries a <strong>kind</strong>, which is what lets the waterfall answer "was this our own work, or were we waiting on something else":</p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Kind</th>
+            <th>Meaning</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>SERVER</code></td>
+            <td>Work performed in response to an inbound call. Typically the trace root.</td>
+          </tr>
+          <tr>
+            <td><code>CLIENT</code></td>
+            <td>Waiting on something outside the process — a database, another service. 110&nbsp;ms of a 120&nbsp;ms request spent in <code>CLIENT</code> spans answers most latency questions on its own.</td>
+          </tr>
+          <tr>
+            <td><code>INTERNAL</code></td>
+            <td>In-process work. The default.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>and a <strong>status</strong> — <code>UNSET</code>, <code>OK</code> or <code>ERROR</code>. A span that ends by throwing records <code>ERROR</code> and the exception's type; the trace list counts those so a failed run is visible without opening it.</p>
+
+      <h2 id="instrumenting">Instrumenting an Application</h2>
+
+      <p>Tracing lives in the <router-link to="/docs/events/overview">Jeffrey Events</router-link> library, which is zero-dependency and published to Maven Central.</p>
+
+      <DocsCodeBlock :code="mavenDependency" language="xml" />
+
+      <DocsCallout type="warning">
+        <strong>Java 25 or newer.</strong> The tracing API is built on <code>ScopedValue</code> (JEP&nbsp;506) and <code>jdk.jfr.Contextual</code>, both finalized in Java&nbsp;25, so <code>jeffrey-events</code> 0.12.0 targets 25. Applications on Java 17–24 can stay on an earlier release for the HTTP, gRPC and JDBC events, but cannot use <code>Tracer</code>.
+      </DocsCallout>
+
+      <h3>Opening spans</h3>
+
+      <p>The span in progress is published through a <code>ScopedValue</code>, so nesting needs nothing threaded through the call chain — a nested <code>run</code> or <code>call</code> discovers its parent by itself. The binding is bounded by the lambda, so it cannot outlive the span and never needs clearing.</p>
+
+      <DocsCodeBlock :code="tracerExample" language="java" />
+
+      <p>When the <code>jeffrey.TraceSpan</code> event type is disabled — no recording running, or a configuration that leaves it off — the body runs directly with no binding established and no event committed. Instrumentation is safe to leave in production code.</p>
+
+      <h3>Crossing a thread boundary</h3>
+
+      <p><code>ScopedValue</code> propagates to child threads only through structured concurrency; work submitted to a plain executor does not inherit the current span. Capture the context before the fork and re-establish it with <code>continueIn</code>, which opens a <em>separate</em> child span on the receiving thread rather than carrying one across the boundary:</p>
+
+      <DocsCodeBlock :code="fanOutExample" language="java" />
+
+      <h2 id="auto-instrumented">Events That Already Carry Trace Identity</h2>
+
+      <p>The HTTP, gRPC and JDBC events in <code>jeffrey-events</code> extend a shared base that carries <code>traceId</code>, <code>spanId</code> and <code>parentSpanId</code>. They become spans as soon as those fields are populated — call <code>Tracer.stamp</code> before <code>begin()</code>, or wrap the emission in <code>Tracer.inSpanOf</code>, which stamps and nests in one step:</p>
+
+      <DocsCodeBlock :code="stampExample" language="java" />
+
+      <p>The derivation treats these event types as spans alongside <code>jeffrey.TraceSpan</code>:</p>
+
+      <ul>
+        <li><code>jeffrey.HttpServerExchange</code>, <code>jeffrey.HttpClientExchange</code></li>
+        <li><code>jeffrey.GrpcServerExchange</code>, <code>jeffrey.GrpcClientExchange</code></li>
+        <li><code>jeffrey.JdbcQuery</code>, <code>jeffrey.JdbcInsert</code>, <code>jeffrey.JdbcUpdate</code>, <code>jeffrey.JdbcDelete</code>, <code>jeffrey.JdbcExecute</code>, <code>jeffrey.JdbcStream</code></li>
+      </ul>
+
+      <DocsCallout type="tip">
+        Stamping the ids costs three zero-defaulted longs on an event you were already emitting — a varint-encoded zero is close to free, so events from an untraced code path are no larger than before. An older recording whose HTTP events carry no ids simply produces no traces; the section stays hidden rather than showing empty roots.
+      </DocsCallout>
+
+      <h2 id="trace-list">Trace List</h2>
+
+      <p>The Traces page lists every trace root, sorted by duration by default — the "which runs were slow" view. Each row shows the root operation name and kind, when it started, how long it took, how many spans it contains and how many of them failed. Filter by operation name to narrow to one endpoint or job.</p>
+
+      <h2 id="waterfall">Waterfall</h2>
+
+      <p>Opening a trace gives it its own URL and renders the span tree as a waterfall: indented operation names on the left, proportional duration bars on the right, positioned against the trace's own window. Sub-pixel spans are clamped to a minimum width so a 200&nbsp;µs span inside a 2&nbsp;s trace stays clickable.</p>
+
+      <p>Each bar is split into <strong>self</strong> and <strong>child</strong> segments — the part of the span's duration not covered by any child, and the part that is. A parent whose bar is almost entirely child time is a pass-through; one that is mostly self time is where the work actually happened, and is the bar worth opening.</p>
+
+      <h2 id="span-drill-down">Span Drill-Down</h2>
+
+      <p>Selecting a span opens a drawer with three tabs:</p>
+
+      <ul>
+        <li><strong>Attributes</strong> — the span's identity, timing, thread, status and error type, plus any JSON attributes the instrumentation attached.</li>
+        <li><strong>Events in span</strong> — the JVM events that occurred on that thread inside the span's window: CPU samples, allocations, monitor blocking, GC. Other spans are excluded, so this is JVM activity rather than a restatement of the tree you are already looking at.</li>
+        <li><strong>Flamegraph</strong> — the flamegraph of what ran inside the span, in either <strong>Inclusive</strong> or <strong>Self</strong> mode.</li>
+      </ul>
+
+      <DocsCallout type="tip">
+        <strong>Inclusive vs Self.</strong> Inclusive is the span's whole window. Self subtracts every child's window from it and merges what is left, so the flamegraph shows only the work this span did on its own — the answer to "the parent is slow but its children are not, so what is it doing?". Both come from the same interval primitive, so neither costs more than the other.
+      </DocsCallout>
+
+      <h2 id="operations">Operations</h2>
+
+      <p>The trace list answers "which run was slow". The Operations view answers "which operation is slow <em>in general</em>": one row per operation name, with call count, error count, total time, and p50 / p95 / max drawn on a shared rail. A wide p50-to-p95 gap reads as a shape rather than a pair of numbers, which is what distinguishes an operation that is uniformly slow from one that is usually fast and occasionally terrible.</p>
+
+      <h2 id="volume-control">Controlling Span Volume</h2>
+
+      <p>A busy application can emit far more spans than it emits async-profiler spans, and every one of them lands in the JFR chunk. Two levers on the event type keep that in hand, both configurable from a JFR settings file without touching the application:</p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Setting</th>
+            <th>Effect</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>threshold</code></td>
+            <td>Drops spans shorter than the given duration. <code>jeffrey.TraceSpan</code> ships with a conservative <strong>1&nbsp;ms</strong> default, so trivial spans cost nothing. Note that dropping a parent leaves its children as orphans, which the tree assembly promotes to roots.</td>
+          </tr>
+          <tr>
+            <td><code>throttle</code></td>
+            <td>Caps the emission rate (<code>N/s</code>), sampling rather than truncating. Use it when spans are individually meaningful but too numerous.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>Span names enter the JFR per-chunk string pool, so they must be <strong>stable and low-cardinality</strong>. Name the operation, not the instance of it: <code>order.checkout</code>, never <code>order.checkout.a3f9c1</code>.</p>
+
+      <h2 id="limits">Limits</h2>
+
+      <ul>
+        <li><strong>A span must begin and end on the same thread.</strong> JFR attributes a duration event to the thread that <em>commits</em> it, so a span handed off mid-flight is recorded against the wrong thread — which also breaks the thread-plus-window correlation the drill-down relies on. <code>ScopedValue</code> plus the <code>continueIn</code> pattern keeps spans thread-confined in practice, so this is a sharp edge rather than an everyday problem.</li>
+        <li><strong>Work that outlives the lambda is not nested under it.</strong> Callback-driven instrumentation — a gRPC call whose real work runs from listener callbacks after the interceptor returns — records the exchange itself but cannot nest the work beneath it, because the span's binding closes when the lambda does.</li>
+        <li><strong>Background jobs are their own traces.</strong> A pipeline run forked onto its own thread appears as a separate root rather than a child of whatever request triggered it. That is deliberate — its lifetime is unrelated to the request — but worth remembering when reading the trace list.</li>
+        <li><strong>Trace ids are 64-bit</strong>, not the 128-bit W3C shape. Ample for a single JVM that mints all of its own ids, and a deliberate trade: it means an application already running OpenTelemetry cannot hand Jeffrey its real <code>traceparent</code> and expect the ids to match what Jaeger or Datadog display.</li>
+        <li><strong>The waterfall is sized for tens to hundreds of spans</strong> per trace, and has no zoom or pan. Deep traces render fine; traces of several thousand spans would want a different substrate.</li>
+      </ul>
+
+      <DocsCallout type="info">
+        <strong>Two kinds of "span" coexist.</strong> <strong>Async-Profiler Spans</strong> are flat, per-thread, tag-based, and need the patched async-profiler agent. <strong>Traces &amp; Spans</strong> are nested, trace-scoped, and pure JFR. They are complementary — the former still scopes flamegraphs when tracing is off — and Jeffrey keeps them in separate sections rather than merging them.
+      </DocsCallout>
+    </div>
+
+    <DocsNavFooter />
+  </article>
+</template>
+
+<style scoped>
+@import '@/views/docs/docs-page.css';
+</style>

--- a/jeffrey-pages/src/views/docs/microscope/profiles/ProfilesPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/profiles/ProfilesPage.vue
@@ -274,6 +274,11 @@ const folderStructure = `$JEFFREY_HOME/
 
       <div class="docs-grid docs-grid-2">
         <DocsFeatureCard
+          icon="bi bi-bezier2"
+          title="Traces &amp; Spans"
+          description="Nested breakdown of one unit of work — a trace list, a waterfall of the span tree with split self/child bars, per-operation latency spread, and the flamegraph of what the JVM did inside a single span."
+        />
+        <DocsFeatureCard
           icon="bi bi-globe"
           title="HTTP Server & Client"
           description="Inbound and outbound HTTP analysis — overview, timeseries, distribution, slowest requests, and per-endpoint drill-down."
@@ -299,6 +304,10 @@ const folderStructure = `$JEFFREY_HOME/
           description="Span-level latency from async-profiler spans — overview by tag with total, average, P95 and max duration, slowest spans ranked by duration, per-span CPU / Wall-Clock / Allocation flame graphs, and the events that ran during a span."
         />
       </div>
+
+      <p class="docs-read-more">
+        <router-link to="/docs/microscope/profiles/traces">Read the Traces &amp; Spans reference &rarr;</router-link>
+      </p>
 
       <h2 id="heap-dump-analysis">Heap Dump Analysis</h2>
       <p>Memory analysis from heap dump snapshots (.hprof files). Requires a heap dump to be associated with the profile.</p>

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/EventTypeName.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/EventTypeName.java
@@ -205,8 +205,12 @@ public abstract class EventTypeName {
     public static final String GRPC_SERVER_EXCHANGE = "jeffrey.GrpcServerExchange";
     public static final String GRPC_CLIENT_EXCHANGE = "jeffrey.GrpcClientExchange";
 
-    // Async-profiler events
+    // Async-profiler events. Flat, per-thread latency intervals tagged with a label -- unrelated to
+    // TRACE_SPAN below, which is Jeffrey's own nested tracing span.
     public static final String SPAN = "profiler.Span";
+
+    // Tracing events
+    public static final String TRACE_SPAN = "jeffrey.TraceSpan";
 
     // Streaming events
     public static final String MESSAGE = "jeffrey.Message";

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/SpanInterval.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/SpanInterval.java
@@ -19,11 +19,15 @@
 package cafe.jeffrey.shared.common.model;
 
 /**
- * A single async-profiler span instance reduced to what is needed to scope samples to it: the
- * identity hash of the thread the span ran on plus its absolute time window. Scoping a flamegraph
- * to a span tag means OR-ing the windows of all its spans — a sample belongs to the span only if it
- * was taken on {@code threadHash} between {@code fromEpochMillis} and {@code toEpochMillis}.
+ * An interval of work reduced to what is needed to scope samples to it: the identity hash of the
+ * thread it ran on plus its absolute time window. A sample belongs to the interval only if it was
+ * taken on {@code threadHash} between {@code fromEpochMillis} and {@code toEpochMillis}.
  * {@code thread_hash} is used (not the OS id) so the match works for virtual threads too.
+ * <p>
+ * Deliberately neutral about what produced the interval. Both span features feed it: an
+ * async-profiler tag contributes one interval per {@code profiler.Span} it covers, and a trace span
+ * contributes its own window, or that window minus its children's when scoped to self time. This is
+ * the one thing the two share — the SQL predicate that turns a window into a sample filter.
  */
 public record SpanInterval(long threadHash, long fromEpochMillis, long toEpochMillis) {
 

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/Type.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/Type.java
@@ -216,6 +216,9 @@ public record Type(String code, boolean calculated) {
     // Async-profiler events
     public static final Type SPAN = new Type(EventTypeName.SPAN);
 
+    // Tracing events
+    public static final Type TRACE_SPAN = new Type(EventTypeName.TRACE_SPAN);
+
     // Container events
     public static final Type CONTAINER_CONFIGURATION = new Type(EventTypeName.CONTAINER_CONFIGURATION);
     public static final Type CONTAINER_CPU_THROTTLING = new Type(EventTypeName.CONTAINER_CPU_THROTTLING);
@@ -381,6 +384,7 @@ public record Type(String code, boolean calculated) {
                 CONTAINER_MEMORY_USAGE,
                 CONTAINER_IO_USAGE,
                 SPAN,
+                TRACE_SPAN,
                 APP_INFORMATION
         ).collect(Collectors.toMap(Type::code, Function.identity()));
     }

--- a/shared/persistence/src/main/java/cafe/jeffrey/shared/persistence/StatementLabel.java
+++ b/shared/persistence/src/main/java/cafe/jeffrey/shared/persistence/StatementLabel.java
@@ -90,6 +90,7 @@ public enum StatementLabel {
     TRACE_SPANS,
     TRACE_OPERATIONS,
     TRACES_EXIST,
+    TRACE_SPAN_EVENTS,
 
     /**
      * {@link GroupLabel#ALLOCATING_THREADS}


### PR DESCRIPTION
Follow-up to #156, which shipped the trace list, the waterfall and the span drawer. This closes the leftovers that PR listed.

## The span flamegraph

The thing the whole feature was justified by, and the one part #156 shipped a backend for with no way to reach it. The drawer gains a third tab: which event types recorded samples inside the span, as cards with their real counts, and the graph in a fullscreen modal.

The Inclusive/Self toggle sits **above** the cards rather than inside the graph, because self-only covers less time and can turn a card empty — choosing it after opening a graph would mean reloading one that should not have been offered in the first place.

Self-only is the point. Inclusive answers "this span took 400 ms"; self answers "this span spent 400 ms in code it owns", which is the question you actually have when a parent's time is mostly its children's.

No timeseries in the modal, unlike the async-profiler span flamegraph — a trace span is one short window, so bucketing it over the recording's timeline would draw a chart with a single bar.

## Operations

Answers "which operation is slow *in general*" against the trace list's "which run was slow". Each row's p50, p95 and max sit on one rail scaled to the slowest span in the profile, so a wide p50-to-p95 gap — usually fine, occasionally awful — reads as a shape instead of two numbers to compare.

Its route is declared before the `:traceId` route so `operations` is matched as a path rather than parsed as a trace id.

## Trace spans and async-profiler spans stopped being mixed

The drill-down excluded only `profiler.Span`, so the drawer's "events in span" listed the child spans *and* the span's own source event as if they were JVM activity. Every traced event type is excluded now, with two tests pinning it, and `jeffrey.TraceSpan` is registered in the shared type constants the derivation builds its list from.

## Instrumentation gaps closed

- **gRPC exchanges carry trace identity.** Work during the call still isn't nested under the exchange — see Still open below.
- **`TraceSpanEvent.attributes` and `SpanStatus.OK`**, both dead on arrival in #156, are used by the pipeline root span and MCP tool dispatch.
- **Guardian gets a span per event type.** Reading the traversal answered the question #156 deferred: guards are visitors over one weighted frame tree built per event type, so the cost is per *type*, not per guard. Timing guards individually would measure the visitor and charge the shared traversal to whichever one ran first.

## Test and doc gaps closed

**The derivation's position in profile initialization is pinned by a test.** It must run after the event writer flushes what it reads and before the data initializer, so the feature check sees populated tables; that was held only by compilation. An `InOrder` chain pins both edges — verified by removing `derive()` and confirming the test fails, since a bare `verify()` would have passed regardless.

**Documentation**, which #156 owed and `CLAUDE.md` requires: a Traces reference under Profiles covering what a trace is in a single-JVM recording, the `Tracer` API and its thread-boundary handoff, the three views, threshold and throttle as settings-file levers, and the limits. The Jeffrey Events page gains the event contract itself — the three identity fields the HTTP, gRPC and JDBC events inherit, and who populates them. Its dependency snippet was still on 0.2.3; tracing needs 0.12.0 and Java 25, so leaving both versions on one page would have contradicted itself.

## Still open

Both blocked on a `jeffrey-events` release, so neither can be done from this repo:

| Gap | Fix |
|---|---|
| `Tracer` cannot re-enter an existing `SpanContext` without minting a new span, which is why gRPC work is stamped but not nested under its exchange | `Tracer.reenter(SpanContext, body)` — bind without emitting |
| JFR commits a duration event on the **ending** thread, so a span handed off mid-flight is misattributed, which also breaks the `thread_hash` join the drill-down uses | An explicit start-thread field plus a rework of the join — not a simple field addition, since the key is derived during parsing |

`TRACES_LEFTOVERS.md` records both, alongside the deliberate omissions.

## Verification

- Full Maven reactor compiles on JDK 25
- 188 backend tests across `profile-sql-persistence`, `profile-management` and `profile-guardian` ✓
- Frontend: 324/324 tests ✓, `npm run build` ✓
- `jeffrey-pages` builds clean through `vue-tsc`

## Caveat

Unchanged from #156: this compiles, type-checks and passes its tests, but **has not been rendered in a browser against a real profile** — no such environment was available here. The waterfall's split self/child bar treatment in particular may read differently at real span counts than in a mockup.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YWQse7Nabnhm4AU3KxKsJW)_