### PR TITLE
Simplify the Tracer API: fork, Runnable overloads, no-arg contexts

### DIFF
--- a/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/grpc/JfrGrpcServerInterceptor.java
+++ b/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/grpc/JfrGrpcServerInterceptor.java
@@ -88,7 +88,6 @@ public class JfrGrpcServerInterceptor implements ServerInterceptor {
                         event.commitSpan();
                     }
                     super.close(status, trailers);
-                    return null;
                 });
             }
 
@@ -99,7 +98,6 @@ public class JfrGrpcServerInterceptor implements ServerInterceptor {
                         event.responseSize += proto.getSerializedSize();
                     }
                     super.sendMessage(message);
-                    return null;
                 });
             }
         };
@@ -114,7 +112,6 @@ public class JfrGrpcServerInterceptor implements ServerInterceptor {
                         event.requestSize += proto.getSerializedSize();
                     }
                     super.onMessage(message);
-                    return null;
                 });
             }
 
@@ -123,7 +120,6 @@ public class JfrGrpcServerInterceptor implements ServerInterceptor {
             public void onHalfClose() {
                 Tracer.reenter(span, () -> {
                     super.onHalfClose();
-                    return null;
                 });
             }
 
@@ -131,7 +127,6 @@ public class JfrGrpcServerInterceptor implements ServerInterceptor {
             public void onCancel() {
                 Tracer.reenter(span, () -> {
                     super.onCancel();
-                    return null;
                 });
             }
 
@@ -139,7 +134,6 @@ public class JfrGrpcServerInterceptor implements ServerInterceptor {
             public void onComplete() {
                 Tracer.reenter(span, () -> {
                     super.onComplete();
-                    return null;
                 });
             }
 
@@ -147,7 +141,6 @@ public class JfrGrpcServerInterceptor implements ServerInterceptor {
             public void onReady() {
                 Tracer.reenter(span, () -> {
                     super.onReady();
-                    return null;
                 });
             }
         };

--- a/jeffrey-microscope/profiles/common-profile/src/main/java/cafe/jeffrey/profile/common/pipeline/PipelineRunRegistry.java
+++ b/jeffrey-microscope/profiles/common-profile/src/main/java/cafe/jeffrey/profile/common/pipeline/PipelineRunRegistry.java
@@ -205,10 +205,7 @@ public final class PipelineRunRegistry<K> {
         try {
             // Scoped to the work itself rather than the whole method so the span measures execution,
             // not the time spent queueing for a slot above.
-            Tracer.inSpanOf(span, () -> {
-                request.work().accept(run);
-                return null;
-            });
+            Tracer.inSpanOf(span, () -> request.work().accept(run));
             run.complete();
             // OK rather than UNSET: a pipeline reaching complete() is a success the code observed,
             // not merely the absence of a thrown exception.

--- a/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/api/DbBasedFlamegraphGenerator.java
+++ b/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/api/DbBasedFlamegraphGenerator.java
@@ -30,7 +30,6 @@ import cafe.jeffrey.flamegraph.provider.FlamegraphDataProvider;
 import cafe.jeffrey.flamegraph.provider.TimeseriesDataProvider;
 import cafe.jeffrey.frameir.Frame;
 import cafe.jeffrey.provider.profile.api.ProfileEventStreamRepository;
-import cafe.jeffrey.jfr.events.trace.SpanContext;
 import cafe.jeffrey.jfr.events.trace.SpanKind;
 import cafe.jeffrey.jfr.events.trace.Tracer;
 import cafe.jeffrey.shared.common.span.Spans;
@@ -62,16 +61,14 @@ public class DbBasedFlamegraphGenerator implements GraphGenerator {
 
     @Override
     public byte[] generate(GraphParameters params) {
-        // Both branches run on a shared pool, where ScopedValue does not reach. The enclosing span is
-        // captured here and re-established inside each task so the two halves of a graph request stay
-        // under the request that asked for them instead of starting traces of their own.
-        SpanContext parent = Tracer.current().orElse(null);
-
+        // Both branches run on a shared pool, where ScopedValue does not reach. fork captures the
+        // enclosing span here and re-establishes it inside each task so the two halves of a graph
+        // request stay under the request that asked for them instead of starting traces of their own.
         CompletableFuture<cafe.jeffrey.flamegraph.proto.FlamegraphData> flameFuture;
         if (GraphComponents.isFlamegraphCompatible(params.graphComponents())) {
             FlamegraphDataProvider flamegraphProvider = FlamegraphDataProvider.primary(eventRepository, params);
             flameFuture = CompletableFuture.supplyAsync(
-                    () -> Tracer.continueIn(parent, SPAN_FLAMEGRAPH_BRANCH, SpanKind.INTERNAL,
+                    Tracer.fork(SPAN_FLAMEGRAPH_BRANCH, SpanKind.INTERNAL,
                             () -> flamegraphProvider.provideProto(minFrameThresholdPct)),
                     Schedulers.sharedParallel());
         } else {
@@ -82,7 +79,7 @@ public class DbBasedFlamegraphGenerator implements GraphGenerator {
         if (GraphComponents.isTimeseriesCompatible(params.graphComponents())) {
             TimeseriesDataProvider timeseriesProvider = new TimeseriesDataProvider(eventRepository, params);
             timeseriesFuture = CompletableFuture.supplyAsync(
-                    () -> Tracer.continueIn(parent, SPAN_TIMESERIES_BRANCH, SpanKind.INTERNAL,
+                    Tracer.fork(SPAN_TIMESERIES_BRANCH, SpanKind.INTERNAL,
                             timeseriesProvider::provide),
                     Schedulers.sharedParallel());
         } else {

--- a/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/api/DbBasedFlamegraphGenerator.java
+++ b/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/api/DbBasedFlamegraphGenerator.java
@@ -30,7 +30,6 @@ import cafe.jeffrey.flamegraph.provider.FlamegraphDataProvider;
 import cafe.jeffrey.flamegraph.provider.TimeseriesDataProvider;
 import cafe.jeffrey.frameir.Frame;
 import cafe.jeffrey.provider.profile.api.ProfileEventStreamRepository;
-import cafe.jeffrey.jfr.events.trace.SpanKind;
 import cafe.jeffrey.jfr.events.trace.Tracer;
 import cafe.jeffrey.shared.common.span.Spans;
 import cafe.jeffrey.timeseries.SingleSerie;
@@ -68,7 +67,7 @@ public class DbBasedFlamegraphGenerator implements GraphGenerator {
         if (GraphComponents.isFlamegraphCompatible(params.graphComponents())) {
             FlamegraphDataProvider flamegraphProvider = FlamegraphDataProvider.primary(eventRepository, params);
             flameFuture = CompletableFuture.supplyAsync(
-                    Tracer.fork(SPAN_FLAMEGRAPH_BRANCH, SpanKind.INTERNAL,
+                    Tracer.fork(SPAN_FLAMEGRAPH_BRANCH,
                             () -> flamegraphProvider.provideProto(minFrameThresholdPct)),
                     Schedulers.sharedParallel());
         } else {
@@ -79,7 +78,7 @@ public class DbBasedFlamegraphGenerator implements GraphGenerator {
         if (GraphComponents.isTimeseriesCompatible(params.graphComponents())) {
             TimeseriesDataProvider timeseriesProvider = new TimeseriesDataProvider(eventRepository, params);
             timeseriesFuture = CompletableFuture.supplyAsync(
-                    Tracer.fork(SPAN_TIMESERIES_BRANCH, SpanKind.INTERNAL,
+                    Tracer.fork(SPAN_TIMESERIES_BRANCH,
                             timeseriesProvider::provide),
                     Schedulers.sharedParallel());
         } else {

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/action/ProfileDataInitializerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/action/ProfileDataInitializerImpl.java
@@ -20,7 +20,6 @@ package cafe.jeffrey.profile.manager.action;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import cafe.jeffrey.jfr.events.trace.SpanKind;
 import cafe.jeffrey.jfr.events.trace.Tracer;
 import cafe.jeffrey.shared.common.Schedulers;
 import cafe.jeffrey.shared.common.exception.Exceptions;
@@ -72,7 +71,7 @@ public class ProfileDataInitializerImpl implements ProfileDataInitializer {
 
         // Create and cache data for EventViewer
         var viewerFuture = CompletableFuture
-                .runAsync(Tracer.fork(SPAN_EVENT_VIEWER, SpanKind.INTERNAL, () -> {
+                .runAsync(Tracer.fork(SPAN_EVENT_VIEWER, () -> {
                     profileManager.eventViewerManager().eventTypesTree();
                     LOG.info("Event Viewer has been initialized: profile_id={} profile_name={}",
                             profileInfo.id(), profileInfo.name());
@@ -81,7 +80,7 @@ public class ProfileDataInitializerImpl implements ProfileDataInitializer {
 
         // Create Guardian results
         var guardianFuture = CompletableFuture
-                .runAsync(Tracer.fork(SPAN_GUARDIAN, SpanKind.INTERNAL, () -> {
+                .runAsync(Tracer.fork(SPAN_GUARDIAN, () -> {
                     profileManager.guardianManager().guardResults();
                     LOG.info("Guardian Results has been generated: profile_id={} profile_name={}",
                             profileInfo.id(), profileInfo.name());
@@ -90,7 +89,7 @@ public class ProfileDataInitializerImpl implements ProfileDataInitializer {
 
         // Create Thread View
         var threadsFuture = CompletableFuture
-                .runAsync(Tracer.fork(SPAN_THREAD_VIEWER, SpanKind.INTERNAL, () -> {
+                .runAsync(Tracer.fork(SPAN_THREAD_VIEWER, () -> {
                     profileManager.threadManager().threadRows();
                     LOG.info("Thread Viewer has been generated: profile_id={} profile_name={}",
                             profileInfo.id(), profileInfo.name());

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/action/ProfileDataInitializerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/action/ProfileDataInitializerImpl.java
@@ -20,7 +20,6 @@ package cafe.jeffrey.profile.manager.action;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import cafe.jeffrey.jfr.events.trace.SpanContext;
 import cafe.jeffrey.jfr.events.trace.SpanKind;
 import cafe.jeffrey.jfr.events.trace.Tracer;
 import cafe.jeffrey.shared.common.Schedulers;
@@ -67,38 +66,34 @@ public class ProfileDataInitializerImpl implements ProfileDataInitializer {
 
         ExecutorService executor = this.concurrent ? Schedulers.sharedParallel() : Schedulers.sharedSingle();
 
-        // ScopedValue does not cross an executor boundary, so the enclosing span is captured here and
-        // re-established inside each task. Without this the three views below would each start their
-        // own trace instead of appearing under the initialization that asked for them.
-        SpanContext parent = Tracer.current().orElse(null);
+        // ScopedValue does not cross an executor boundary; fork captures the enclosing span here and
+        // re-establishes it inside each task. Without this the three views below would each start
+        // their own trace instead of appearing under the initialization that asked for them.
 
         // Create and cache data for EventViewer
         var viewerFuture = CompletableFuture
-                .runAsync(() -> Tracer.continueIn(parent, SPAN_EVENT_VIEWER, SpanKind.INTERNAL, () -> {
+                .runAsync(Tracer.fork(SPAN_EVENT_VIEWER, SpanKind.INTERNAL, () -> {
                     profileManager.eventViewerManager().eventTypesTree();
                     LOG.info("Event Viewer has been initialized: profile_id={} profile_name={}",
                             profileInfo.id(), profileInfo.name());
-                    return null;
                 }), executor)
                 .exceptionally(toException("EventViewer", profileInfo));
 
         // Create Guardian results
         var guardianFuture = CompletableFuture
-                .runAsync(() -> Tracer.continueIn(parent, SPAN_GUARDIAN, SpanKind.INTERNAL, () -> {
+                .runAsync(Tracer.fork(SPAN_GUARDIAN, SpanKind.INTERNAL, () -> {
                     profileManager.guardianManager().guardResults();
                     LOG.info("Guardian Results has been generated: profile_id={} profile_name={}",
                             profileInfo.id(), profileInfo.name());
-                    return null;
                 }), executor)
                 .exceptionally(toException("Guardian", profileInfo));
 
         // Create Thread View
         var threadsFuture = CompletableFuture
-                .runAsync(() -> Tracer.continueIn(parent, SPAN_THREAD_VIEWER, SpanKind.INTERNAL, () -> {
+                .runAsync(Tracer.fork(SPAN_THREAD_VIEWER, SpanKind.INTERNAL, () -> {
                     profileManager.threadManager().threadRows();
                     LOG.info("Thread Viewer has been generated: profile_id={} profile_name={}",
                             profileInfo.id(), profileInfo.name());
-                    return null;
                 }), executor)
                 .exceptionally(toException("ThreadViewer", profileInfo));
 

--- a/jeffrey-microscope/profiles/recording-parser/jdk-jfr-parser/src/main/java/cafe/jeffrey/jfrparser/jdk/ParallelRecordingFileIterator.java
+++ b/jeffrey-microscope/profiles/recording-parser/jdk-jfr-parser/src/main/java/cafe/jeffrey/jfrparser/jdk/ParallelRecordingFileIterator.java
@@ -18,7 +18,6 @@
 
 package cafe.jeffrey.jfrparser.jdk;
 
-import cafe.jeffrey.jfr.events.trace.SpanKind;
 import cafe.jeffrey.jfr.events.trace.Tracer;
 import cafe.jeffrey.shared.common.Schedulers;
 
@@ -82,7 +81,7 @@ public class ParallelRecordingFileIterator<PARTIAL, RESULT> implements Recording
         // shared pool, which ScopedValue does not reach, so without it each file would parse under
         // a trace of its own rather than under the parse that spawned it.
         return CompletableFuture.supplyAsync(
-                Tracer.fork(SPAN_CHUNK_PARSE, SpanKind.INTERNAL,
+                Tracer.fork(SPAN_CHUNK_PARSE,
                         () -> singleFileIterator.apply(recording).partialCollect(collector)),
                 Schedulers.sharedBulkParallel());
     }

--- a/jeffrey-microscope/profiles/recording-parser/jdk-jfr-parser/src/main/java/cafe/jeffrey/jfrparser/jdk/ParallelRecordingFileIterator.java
+++ b/jeffrey-microscope/profiles/recording-parser/jdk-jfr-parser/src/main/java/cafe/jeffrey/jfrparser/jdk/ParallelRecordingFileIterator.java
@@ -18,7 +18,6 @@
 
 package cafe.jeffrey.jfrparser.jdk;
 
-import cafe.jeffrey.jfr.events.trace.SpanContext;
 import cafe.jeffrey.jfr.events.trace.SpanKind;
 import cafe.jeffrey.jfr.events.trace.Tracer;
 import cafe.jeffrey.shared.common.Schedulers;
@@ -66,12 +65,8 @@ public class ParallelRecordingFileIterator<PARTIAL, RESULT> implements Recording
     }
 
     private List<PARTIAL> _iterate(Collector<PARTIAL, ?> collector) {
-        // Captured before the fork: the workers run on a shared pool, which ScopedValue does not
-        // reach, so without this each file would parse under a trace of its own rather than under
-        // the parse that spawned it.
-        SpanContext parent = Tracer.current().orElse(null);
         List<CompletableFuture<PARTIAL>> futures = recordings.stream()
-                .map(future -> asyncExecution(parent, future, collector))
+                .map(recording -> asyncExecution(recording, collector))
                 .toList();
 
         CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new))
@@ -82,13 +77,12 @@ public class ParallelRecordingFileIterator<PARTIAL, RESULT> implements Recording
                 .toList();
     }
 
-    private CompletableFuture<PARTIAL> asyncExecution(
-            SpanContext parent,
-            Path recording,
-            Collector<PARTIAL, ?> collector) {
-
+    private CompletableFuture<PARTIAL> asyncExecution(Path recording, Collector<PARTIAL, ?> collector) {
+        // fork captures the enclosing span here, on the submitting thread: the workers run on a
+        // shared pool, which ScopedValue does not reach, so without it each file would parse under
+        // a trace of its own rather than under the parse that spawned it.
         return CompletableFuture.supplyAsync(
-                () -> Tracer.continueIn(parent, SPAN_CHUNK_PARSE, SpanKind.INTERNAL,
+                Tracer.fork(SPAN_CHUNK_PARSE, SpanKind.INTERNAL,
                         () -> singleFileIterator.apply(recording).partialCollect(collector)),
                 Schedulers.sharedBulkParallel());
     }

--- a/jeffrey-pages/src/views/docs/events/TracerApiPage.vue
+++ b/jeffrey-pages/src/views/docs/events/TracerApiPage.vue
@@ -35,9 +35,9 @@ const headings = [
   { id: 'api-current', text: 'current', level: 3 },
   { id: 'api-stamp', text: 'stamp', level: 3 },
   { id: 'api-inspanof', text: 'inSpanOf', level: 3 },
-  { id: 'api-inspan', text: 'inSpan', level: 3 },
   { id: 'api-openspanof-reenter', text: 'openSpanOf / reenter', level: 3 },
   { id: 'api-continuein', text: 'continueIn', level: 3 },
+  { id: 'api-fork', text: 'fork', level: 3 },
   { id: 'semantics', text: 'Semantics at a Glance', level: 2 },
   { id: 'choosing', text: 'Choosing the Right Method', level: 2 },
   { id: 'composed-tree', text: 'A Complete Tree', level: 2 },
@@ -62,9 +62,11 @@ const quickStartTree = `trace 5f3a90c2…                                      e
    └─ payment.charge     CLIENT                      jeffrey.TraceSpan`;
 
 const spanContextShape = `public record SpanContext(long traceId, long spanId, long parentSpanId) {
-    public static SpanContext root(RandomGenerator random) { … }   // fresh trace, no parent
-    public SpanContext child(RandomGenerator random) { … }         // same trace, new span id, parented here
+    public static SpanContext root() { … }        // fresh trace, no parent
+    public SpanContext child() { … }              // same trace, new span id, parented here
     public boolean isRoot() { return parentSpanId == 0; }
+
+    // Forms taking a RandomGenerator explicitly exist for tests that need deterministic ids.
 }`;
 
 const runCallSignatures = `// Runnable forms — for side-effecting work
@@ -110,9 +112,10 @@ const callErrorExample = `IllegalStateException thrown = assertThrows(IllegalSta
 
 const currentSignature = `static Optional<SpanContext> current()
 
-// Typical use: capture the context before forking to an executor
+// Typical use: capture the context when the hand-off site and the wrapping
+// site are not the same place — otherwise prefer fork, which captures for you
 SpanContext parent = Tracer.current().orElse(null);
-executor.submit(() -> Tracer.continueIn(parent, "chunk.parse", SpanKind.INTERNAL, () -> { … }));`;
+request.attachTraceContext(parent);   // continueIn(parent, …) runs elsewhere, later`;
 
 const stampExample = `// From DatabaseClient — every SQL statement becomes a leaf span
 JdbcInsertEvent event = new JdbcInsertEvent("insert_recording", "microscope");
@@ -161,22 +164,6 @@ const inSpanOfTree = `trace 2b7fe410…
 No jeffrey.TraceSpan is emitted for the root — the exchange event carries
 the ids itself. Emitting one would record the same interval twice.`;
 
-const inSpanExample = `// A scope that exists only so the work underneath it hangs together
-Tracer.inSpan(() -> {
-    Tracer.stamp(first);      // both stamped events become children
-    Tracer.stamp(second);     // of the span opened here
-    return null;
-});`;
-
-const inSpanTree = `trace 77a1bc09…
-└─ (span with an id, but no event ever records it)
-   ├─ listSpans    JdbcQueryEvent   leaf
-   └─ countSpans   JdbcQueryEvent   leaf
-
-In the assembled tree the unrecorded parent does not exist, so both
-children are promoted to roots of the trace. They still share one
-trace id — the grouping survives, the extra level does not.`;
-
 const openReenterExample = `// From JfrGrpcServerInterceptor — a gRPC call runs from listener callbacks
 // long after the interceptor returned, on threads it does not control.
 GrpcServerExchangeEvent event = new GrpcServerExchangeEvent();
@@ -185,11 +172,8 @@ SpanContext span = Tracer.openSpanOf(event);   // stamps the event, binds NOTHIN
 
 return new SimpleForwardingServerCallListener<>(listener) {
     @Override
-    public void onHalfClose() {                // where a unary handler actually runs
-        Tracer.reenter(span, () -> {           // resumes the SAME span, not a child
-            super.onHalfClose();
-            return null;
-        });
+    public void onHalfClose() {                          // where a unary handler actually runs
+        Tracer.reenter(span, () -> super.onHalfClose()); // resumes the SAME span, not a child
     }
     // onMessage / onCancel / onComplete / onReady wrapped the same way
 };`;
@@ -203,17 +187,26 @@ but the only honest record of where the span actually ran:
    jeffrey.TraceScope  scopedSpanId=<root>  thread=grpc-default-executor-0   (onMessage)
    jeffrey.TraceScope  scopedSpanId=<root>  thread=grpc-default-executor-2   (onHalfClose)`;
 
-const continueInExample = `// From ParallelRecordingFileIterator — per-chunk parsing forked to a pool.
-// ScopedValue does not propagate through a plain executor, so the parent
-// context is captured before the fork and re-established inside the task.
+const continueInExample = `// The manual form: capture the context on the submitting thread,
+// re-establish it inside the task. fork (below) packages this pattern.
 SpanContext parent = Tracer.current().orElse(null);
 
-for (Path chunk : chunks) {
-    executor.submit(() -> Tracer.continueIn(parent, "chunk.parse", SpanKind.INTERNAL, () -> {
-        parseChunk(chunk);
-        return null;
-    }));
-}`;
+executor.submit(() ->
+    Tracer.continueIn(parent, "chunk.parse", SpanKind.INTERNAL, () -> parseChunk(chunk)));`;
+
+const forkExample = `// From ParallelRecordingFileIterator — per-chunk parsing forked to a pool.
+// fork captures the enclosing span HERE, on the submitting thread, and
+// continueIn runs inside the task when the pool eventually executes it.
+return CompletableFuture.supplyAsync(
+        Tracer.fork("chunk.parse", SpanKind.INTERNAL,
+                () -> singleFileIterator.apply(recording).partialCollect(collector)),
+        Schedulers.sharedBulkParallel());
+
+// From ProfileDataInitializerImpl — the Runnable form
+CompletableFuture.runAsync(
+        Tracer.fork("guardian.results", SpanKind.INTERNAL,
+                () -> profileManager.guardianManager().guardResults()),
+        executor);`;
 
 const continueInTree = `trace 9d02f7c3…
 └─ POST /api/internal/recordings   SERVER              (request thread)
@@ -232,14 +225,14 @@ const composedTree = `trace a3f9c1d4…                                         
       ├─ profile-info.insert              INTERNAL     jeffrey.TraceSpan         ← run
       │  └─ insert_profile                CLIENT       JdbcInsertEvent           ← stamp
       ├─ recording.parse                  INTERNAL     jeffrey.TraceSpan         ← run
-      │  ├─ chunk.parse                   INTERNAL     jeffrey.TraceSpan         ← continueIn (pool)
-      │  └─ chunk.parse                   INTERNAL     jeffrey.TraceSpan         ← continueIn (pool)
+      │  ├─ chunk.parse                   INTERNAL     jeffrey.TraceSpan         ← fork (pool)
+      │  └─ chunk.parse                   INTERNAL     jeffrey.TraceSpan         ← fork (pool)
       ├─ events.flush                     INTERNAL     jeffrey.TraceSpan         ← run
       │  └─ insert_events                 CLIENT       JdbcInsertEvent           ← stamp
       └─ profile.data-init                INTERNAL     jeffrey.TraceSpan         ← run
-         ├─ eventviewer.tree              INTERNAL     jeffrey.TraceSpan         ← continueIn (pool)
-         ├─ guardian.results              INTERNAL     jeffrey.TraceSpan         ← continueIn (pool)
-         └─ threads.rows                  INTERNAL     jeffrey.TraceSpan         ← continueIn (pool)`;
+         ├─ eventviewer.tree              INTERNAL     jeffrey.TraceSpan         ← fork (pool)
+         ├─ guardian.results              INTERNAL     jeffrey.TraceSpan         ← fork (pool)
+         └─ threads.rows                  INTERNAL     jeffrey.TraceSpan         ← fork (pool)`;
 </script>
 
 <template>
@@ -331,7 +324,7 @@ const composedTree = `trace a3f9c1d4…                                         
 
       <DocsCodeBlock :code="currentSignature" language="java" />
 
-      <p>Returns the <code>SpanContext</code> bound on this thread, or empty when none is. Its main job is capturing the parent before work is handed to an executor, since <code>ScopedValue</code> does not cross that boundary on its own — see <a href="#api-continuein">continueIn</a>.</p>
+      <p>Returns the <code>SpanContext</code> bound on this thread, or empty when none is. Its job is capturing the parent when work will continue somewhere <code>ScopedValue</code> cannot reach — for the common executor case <a href="#api-fork">fork</a> does the capture itself, so reach for <code>current()</code> when the captured context has to travel further than the wrapping site, paired with <a href="#api-continuein">continueIn</a>.</p>
 
       <h3 id="api-stamp">stamp — make an event a leaf of the current span</h3>
 
@@ -347,7 +340,8 @@ const composedTree = `trace a3f9c1d4…                                         
 
       <h3 id="api-inspanof">inSpanOf — the event is the span</h3>
 
-      <p><code>static &lt;R, X&gt; R inSpanOf(AbstractTracedEvent event, ScopedValue.CallableOp&lt;R, X&gt; body) throws X</code></p>
+      <p><code>static &lt;R, X&gt; R inSpanOf(AbstractTracedEvent event, ScopedValue.CallableOp&lt;R, X&gt; body) throws X</code><br>
+      <code>static void inSpanOf(AbstractTracedEvent event, Runnable body)</code></p>
 
       <p>For instrumentation whose <em>own</em> event already describes the interval — an HTTP exchange, a gRPC call, a pipeline run. Emitting a <code>jeffrey.TraceSpan</code> alongside such an event would record the same interval twice, so none is emitted: the event carries the ids, and everything traced inside the body nests underneath it. The ids are stamped when the span opens, not when the event commits — they are known up front, and the binding is gone by the time a caller's <code>finally</code> block runs, so stamping there would silently do nothing.</p>
 
@@ -357,20 +351,11 @@ const composedTree = `trace a3f9c1d4…                                         
 
       <p>Unlike <code>call</code>, this always establishes the binding, even with nothing recording: whether an interval is recorded at all is the caller's event's decision, not this method's.</p>
 
-      <h3 id="api-inspan">inSpan — a scope without an event</h3>
-
-      <p><code>static &lt;R, X&gt; R inSpan(ScopedValue.CallableOp&lt;R, X&gt; body) throws X</code></p>
-
-      <p>Opens a span for the body without emitting anything and without attaching it to an event — a scope that only needs to exist so the work underneath it hangs together. Pairing it with <code>stamp</code> is deliberately different from <code>inSpanOf</code>: the stamped event becomes a <em>child</em> of the span opened here, rather than being the span itself.</p>
-
-      <DocsCodeBlock :code="inSpanExample" language="java" />
-
-      <DocsCodeBlock :code="inSpanTree" language="text" />
-
       <h3 id="api-openspanof-reenter">openSpanOf / reenter — a span the work arrives back into</h3>
 
       <p><code>static SpanContext openSpanOf(AbstractTracedEvent event)</code><br>
-      <code>static &lt;R, X&gt; R reenter(SpanContext context, ScopedValue.CallableOp&lt;R, X&gt; body) throws X</code></p>
+      <code>static &lt;R, X&gt; R reenter(SpanContext context, ScopedValue.CallableOp&lt;R, X&gt; body) throws X</code><br>
+      <code>static void reenter(SpanContext context, Runnable body)</code></p>
 
       <p>For instrumentation that cannot wrap its work in one lambda. A callback-driven protocol is the case this pair exists for: a gRPC call runs from listener callbacks long after the interceptor that started it has returned, on threads it does not control, so there is no single block for <code>inSpanOf</code> to enclose. <code>openSpanOf</code> stamps the event and hands back the context <em>without binding anything</em>; the caller keeps it and re-establishes it per callback with <code>reenter</code>.</p>
 
@@ -384,13 +369,29 @@ const composedTree = `trace a3f9c1d4…                                         
 
       <h3 id="api-continuein">continueIn — carry a trace across an executor</h3>
 
-      <p><code>static &lt;R, X&gt; R continueIn(SpanContext parent, String name, SpanKind kind, ScopedValue.CallableOp&lt;R, X&gt; body) throws X</code></p>
+      <p><code>static &lt;R, X&gt; R continueIn(SpanContext parent, String name, SpanKind kind, ScopedValue.CallableOp&lt;R, X&gt; body) throws X</code><br>
+      <code>static void continueIn(SpanContext parent, String name, SpanKind kind, Runnable body)</code></p>
 
       <p><code>ScopedValue</code> propagates to child threads only through structured concurrency; work submitted to a plain executor does not inherit the current span. <code>continueIn</code> is the bridge: it records a span whose parent is the <em>given</em> context rather than whatever the receiving thread has bound, so the forked work stays in the trace. It mints a <strong>child</strong> and emits a <code>jeffrey.TraceSpan</code> for it — the receiving thread is doing a separate piece of work, which is exactly what distinguishes it from <code>reenter</code>. Pass <code>null</code> to start a fresh trace.</p>
 
       <DocsCodeBlock :code="continueInExample" language="java" />
 
       <DocsCodeBlock :code="continueInTree" language="text" />
+
+      <p>The capture-and-continue two-step above is packaged by <a href="#api-fork">fork</a>; <code>continueIn</code> remains the primitive for when the context arrives from somewhere other than the wrapping site — stored on a request object, or handed over by a protocol.</p>
+
+      <h3 id="api-fork">fork — wrap a task for an executor</h3>
+
+      <p><code>static Runnable fork(String name, SpanKind kind, Runnable body)</code><br>
+      <code>static &lt;T&gt; Supplier&lt;T&gt; fork(String name, SpanKind kind, Supplier&lt;T&gt; body)</code></p>
+
+      <p>The packaged form of the executor pattern: <code>fork</code> captures the span in progress <em>when it is called</em> and returns a task that, wherever it eventually runs, records its work as a child of that span via <code>continueIn</code>. Wrap on the thread whose span the work belongs to, submit the result. The <code>Supplier</code> form hands straight to <code>CompletableFuture.supplyAsync</code>; called outside any span, the task starts a fresh trace.</p>
+
+      <p>This exists because the manual two-step had a silent failure mode: forgetting the capture didn't break anything visibly — the forked work just fell out of the trace and became a root of its own. With <code>fork</code> the capture cannot be forgotten, because it <em>is</em> the wrap.</p>
+
+      <DocsCodeBlock :code="forkExample" language="java" />
+
+      <p>The resulting tree is exactly the one shown for <code>continueIn</code> above — <code>fork</code> is that call, made later, with the capture already done.</p>
 
       <h2 id="semantics">Semantics at a Glance</h2>
 
@@ -429,12 +430,6 @@ const composedTree = `trace a3f9c1d4…                                         
             <td>Still binds: recording is the event's decision</td>
           </tr>
           <tr>
-            <td><code>inSpan</code></td>
-            <td>Nothing</td>
-            <td>Yes — always</td>
-            <td>Still binds</td>
-          </tr>
-          <tr>
             <td><code>openSpanOf</code></td>
             <td>Nothing (fills the event's ids)</td>
             <td>No — deliberately</td>
@@ -451,6 +446,12 @@ const composedTree = `trace a3f9c1d4…                                         
             <td><code>jeffrey.TraceSpan</code></td>
             <td>Yes — child of the given parent</td>
             <td>Still binds; no event. The handed-over context is the only link, so dropping it would orphan every stamp underneath</td>
+          </tr>
+          <tr>
+            <td><code>fork</code></td>
+            <td><code>jeffrey.TraceSpan</code> (via <code>continueIn</code>, when the task runs)</td>
+            <td>Captures at wrap time; binds inside the task</td>
+            <td>Same as <code>continueIn</code>: the task still binds, no event</td>
           </tr>
         </tbody>
       </table>
@@ -479,22 +480,22 @@ const composedTree = `trace a3f9c1d4…                                         
           </tr>
           <tr>
             <td>Work handed to a plain executor — a separate operation on the receiving thread</td>
-            <td><code>Tracer.current()</code> before the fork + <code>continueIn</code> inside the task</td>
+            <td><code>fork</code> around the task, on the submitting thread</td>
+          </tr>
+          <tr>
+            <td>The parent context comes from somewhere other than the submitting site — stored, or handed over by a protocol</td>
+            <td><code>continueIn</code> with that context</td>
           </tr>
           <tr>
             <td>One operation arriving in pieces — a protocol's callbacks</td>
             <td><code>openSpanOf</code> once + <code>reenter</code> per callback</td>
-          </tr>
-          <tr>
-            <td>A grouping scope with no interval of its own</td>
-            <td><code>inSpan</code></td>
           </tr>
         </tbody>
       </table>
 
       <h2 id="composed-tree">A Complete Tree</h2>
 
-      <p>Jeffrey's own recording-upload flow composes almost every method on this page. An HTTP request roots the trace through <code>inSpanOf</code>, the pipeline stages are <code>call</code>/<code>run</code> spans, chunk parsing and profile-data branches fork through <code>continueIn</code>, and every SQL statement along the way is a <code>stamp</code>ed leaf:</p>
+      <p>Jeffrey's own recording-upload flow composes almost every method on this page. An HTTP request roots the trace through <code>inSpanOf</code>, the pipeline stages are <code>call</code>/<code>run</code> spans, chunk parsing and profile-data branches are handed to pools with <code>fork</code>, and every SQL statement along the way is a <code>stamp</code>ed leaf:</p>
 
       <DocsCodeBlock :code="composedTree" language="text" />
 
@@ -535,17 +536,17 @@ const composedTree = `trace a3f9c1d4…                                         
           </tr>
           <tr>
             <td><code>ParallelRecordingFileIterator</code></td>
-            <td><code>current</code> + <code>continueIn</code></td>
+            <td><code>fork</code></td>
             <td>Per-chunk JFR parsing forked to a worker pool</td>
           </tr>
           <tr>
             <td><code>ProfileDataInitializerImpl</code></td>
-            <td><code>current</code> + <code>continueIn</code></td>
+            <td><code>fork</code></td>
             <td>Parallel initialization branches: event viewer, guardian, thread viewer</td>
           </tr>
           <tr>
             <td><code>DbBasedFlamegraphGenerator</code></td>
-            <td><code>current</code> + <code>continueIn</code> + <code>call</code></td>
+            <td><code>fork</code> + <code>call</code></td>
             <td>Flamegraph and timeseries generated as parallel branches of one request</td>
           </tr>
           <tr>

--- a/jeffrey-pages/src/views/docs/events/TracerApiPage.vue
+++ b/jeffrey-pages/src/views/docs/events/TracerApiPage.vue
@@ -198,13 +198,13 @@ const forkExample = `// From ParallelRecordingFileIterator — per-chunk parsing
 // fork captures the enclosing span HERE, on the submitting thread, and
 // continueIn runs inside the task when the pool eventually executes it.
 return CompletableFuture.supplyAsync(
-        Tracer.fork("chunk.parse", SpanKind.INTERNAL,
+        Tracer.fork("chunk.parse",
                 () -> singleFileIterator.apply(recording).partialCollect(collector)),
         Schedulers.sharedBulkParallel());
 
 // From ProfileDataInitializerImpl — the Runnable form
 CompletableFuture.runAsync(
-        Tracer.fork("guardian.results", SpanKind.INTERNAL,
+        Tracer.fork("guardian.results",
                 () -> profileManager.guardianManager().guardResults()),
         executor);`;
 
@@ -370,7 +370,8 @@ const composedTree = `trace a3f9c1d4…                                         
       <h3 id="api-continuein">continueIn — carry a trace across an executor</h3>
 
       <p><code>static &lt;R, X&gt; R continueIn(SpanContext parent, String name, SpanKind kind, ScopedValue.CallableOp&lt;R, X&gt; body) throws X</code><br>
-      <code>static void continueIn(SpanContext parent, String name, SpanKind kind, Runnable body)</code></p>
+      <code>static void continueIn(SpanContext parent, String name, SpanKind kind, Runnable body)</code><br>
+      Kind-less forms of both default to <code>SpanKind.INTERNAL</code>, like <code>run</code> and <code>call</code>.</p>
 
       <p><code>ScopedValue</code> propagates to child threads only through structured concurrency; work submitted to a plain executor does not inherit the current span. <code>continueIn</code> is the bridge: it records a span whose parent is the <em>given</em> context rather than whatever the receiving thread has bound, so the forked work stays in the trace. It mints a <strong>child</strong> and emits a <code>jeffrey.TraceSpan</code> for it — the receiving thread is doing a separate piece of work, which is exactly what distinguishes it from <code>reenter</code>. Pass <code>null</code> to start a fresh trace.</p>
 
@@ -383,7 +384,8 @@ const composedTree = `trace a3f9c1d4…                                         
       <h3 id="api-fork">fork — wrap a task for an executor</h3>
 
       <p><code>static Runnable fork(String name, SpanKind kind, Runnable body)</code><br>
-      <code>static &lt;T&gt; Supplier&lt;T&gt; fork(String name, SpanKind kind, Supplier&lt;T&gt; body)</code></p>
+      <code>static &lt;T&gt; Supplier&lt;T&gt; fork(String name, SpanKind kind, Supplier&lt;T&gt; body)</code><br>
+      Kind-less forms of both default to <code>SpanKind.INTERNAL</code> — forked work is in-process work unless declared otherwise.</p>
 
       <p>The packaged form of the executor pattern: <code>fork</code> captures the span in progress <em>when it is called</em> and returns a task that, wherever it eventually runs, records its work as a child of that span via <code>continueIn</code>. Wrap on the thread whose span the work belongs to, submit the result. The <code>Supplier</code> form hands straight to <code>CompletableFuture.supplyAsync</code>; called outside any span, the task starts a fresh trace.</p>
 

--- a/jeffrey-pages/src/views/docs/microscope/profiles/ProfileTracesPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/profiles/ProfileTracesPage.vue
@@ -72,12 +72,12 @@ const virtualThreadExample = `POST /api/internal/recordings/…   tomcat-handler
 
 const fanOutExample = `// ScopedValue does not propagate through a plain executor. fork captures the
 // enclosing span here, on the submitting thread, and the task re-establishes
-// it wherever the pool eventually runs it.
-executor.submit(Tracer.fork("chunk.parse", SpanKind.INTERNAL, () -> parseChunk(file)));
+// it wherever the pool eventually runs it. The kind defaults to INTERNAL.
+executor.submit(Tracer.fork("chunk.parse", () -> parseChunk(file)));
 
 // Supplier form for value-returning tasks:
 CompletableFuture.supplyAsync(
-    Tracer.fork("chunk.parse", SpanKind.INTERNAL, () -> parseAndCollect(file)),
+    Tracer.fork("chunk.parse", () -> parseAndCollect(file)),
     executor);`;
 
 const reenterExample = `// A gRPC call arrives in pieces, on threads the interceptor does not control,

--- a/jeffrey-pages/src/views/docs/microscope/profiles/ProfileTracesPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/profiles/ProfileTracesPage.vue
@@ -70,14 +70,15 @@ const virtualThreadExample = `POST /api/internal/recordings/…   tomcat-handler
     profile.data-init             tomcat-handler-53  virtual    933ms    0
       guardian.results            parallel           platform   932ms   63`;
 
-const fanOutExample = `// ScopedValue does not propagate through a plain executor, so the parent
-// context is captured before the fork and re-established inside the task.
-SpanContext parent = Tracer.current().orElse(null);
+const fanOutExample = `// ScopedValue does not propagate through a plain executor. fork captures the
+// enclosing span here, on the submitting thread, and the task re-establishes
+// it wherever the pool eventually runs it.
+executor.submit(Tracer.fork("chunk.parse", SpanKind.INTERNAL, () -> parseChunk(file)));
 
-executor.submit(() -> Tracer.continueIn(parent, "chunk.parse", SpanKind.INTERNAL, () -> {
-    parseChunk(file);
-    return null;
-}));`;
+// Supplier form for value-returning tasks:
+CompletableFuture.supplyAsync(
+    Tracer.fork("chunk.parse", SpanKind.INTERNAL, () -> parseAndCollect(file)),
+    executor);`;
 
 const reenterExample = `// A gRPC call arrives in pieces, on threads the interceptor does not control,
 // so the span is opened without binding and resumed around every callback.
@@ -178,7 +179,7 @@ if (event.isEnabled()) {
 
       <h3>Crossing a thread boundary</h3>
 
-      <p><code>ScopedValue</code> propagates to child threads only through structured concurrency; work submitted to a plain executor does not inherit the current span. Capture the context before the fork and re-establish it with <code>continueIn</code>, which opens a <em>separate</em> child span on the receiving thread rather than carrying one across the boundary:</p>
+      <p><code>ScopedValue</code> propagates to child threads only through structured concurrency; work submitted to a plain executor does not inherit the current span. Wrap the task with <code>Tracer.fork</code>, which captures the current span when the task is wrapped and opens a <em>separate</em> child span on the receiving thread rather than carrying one across the boundary. (The underlying primitive, <code>continueIn</code>, remains available for when the captured context has to travel further than the wrapping site.)</p>
 
       <DocsCodeBlock :code="fanOutExample" language="java" />
 
@@ -188,7 +189,7 @@ if (event.isEnabled()) {
 
       <DocsCodeBlock :code="reenterExample" language="java" />
 
-      <p>Each re-entry emits a <code>jeffrey.TraceScope</code> event recording which thread the span ran on and for how long. That is what the drill-down and the span-scoped flamegraph read: a re-entered span can be committed on a thread it barely ran on, and the scopes are the only record of where the work actually happened. Spans that are never re-entered emit none — <code>call</code>, <code>inSpan</code> and <code>inSpanOf</code> are thread-confined already, so their span is its own single scope and existing instrumentation pays nothing.</p>
+      <p>Each re-entry emits a <code>jeffrey.TraceScope</code> event recording which thread the span ran on and for how long. That is what the drill-down and the span-scoped flamegraph read: a re-entered span can be committed on a thread it barely ran on, and the scopes are the only record of where the work actually happened. Spans that are never re-entered emit none — <code>call</code> and <code>inSpanOf</code> are thread-confined already, so their span is its own single scope and existing instrumentation pays nothing.</p>
 
       <h2 id="auto-instrumented">Every Instrumented Event Is a Span</h2>
 

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/SpanContext.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/SpanContext.java
@@ -18,6 +18,7 @@
 
 package cafe.jeffrey.jfr.events.trace;
 
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.random.RandomGenerator;
 
 /**
@@ -38,14 +39,32 @@ import java.util.random.RandomGenerator;
 public record SpanContext(long traceId, long spanId, long parentSpanId) {
 
     /**
-     * Starts a new trace: a fresh trace id, a fresh span id, and no parent.
+     * Starts a new trace: a fresh trace id, a fresh span id, and no parent. Ids are drawn from the
+     * calling thread's {@link ThreadLocalRandom}.
+     */
+    public static SpanContext root() {
+        return root(ThreadLocalRandom.current());
+    }
+
+    /**
+     * The form of {@link #root()} that takes the generator explicitly, for tests that need
+     * deterministic ids.
      */
     public static SpanContext root(RandomGenerator random) {
         return new SpanContext(nonZero(random), nonZero(random), 0);
     }
 
     /**
-     * Derives a child of this span — same trace, new span id, parented to this one.
+     * Derives a child of this span — same trace, new span id, parented to this one. The id is drawn
+     * from the calling thread's {@link ThreadLocalRandom}.
+     */
+    public SpanContext child() {
+        return child(ThreadLocalRandom.current());
+    }
+
+    /**
+     * The form of {@link #child()} that takes the generator explicitly, for tests that need
+     * deterministic ids.
      */
     public SpanContext child(RandomGenerator random) {
         return new SpanContext(traceId, nonZero(random), spanId);

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/TraceScopeEvent.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/TraceScopeEvent.java
@@ -37,10 +37,10 @@ import jdk.jfr.StackTrace;
  * {@link Tracer#reenter} lambda, so it cannot straddle a thread by construction — which is what
  * makes it a trustworthy join key for "what was the JVM doing while this span was running".
  * <p>
- * Emitted only by {@link Tracer#reenter}. {@link Tracer#call}, {@link Tracer#inSpan} and
- * {@link Tracer#inSpanOf} are thread-confined already — their span <em>is</em> its own single scope
- * — so emitting one there would record the same interval twice. Instrumentation that never
- * re-enters therefore pays nothing for this event type existing.
+ * Emitted only by {@link Tracer#reenter}. {@link Tracer#call} and {@link Tracer#inSpanOf} are
+ * thread-confined already — their span <em>is</em> its own single scope — so emitting one there
+ * would record the same interval twice. Instrumentation that never re-enters therefore pays nothing
+ * for this event type existing.
  *
  * <h2>Why the field is not called {@code spanId}</h2>
  * The derivation discovers which event types are spans structurally, by looking for a declared

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/Tracer.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/Tracer.java
@@ -20,8 +20,7 @@ package cafe.jeffrey.jfr.events.trace;
 
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.random.RandomGenerator;
+import java.util.function.Supplier;
 
 /**
  * Records nested spans into the JFR recording.
@@ -54,8 +53,9 @@ import java.util.random.RandomGenerator;
  *       emits a {@link TraceScopeEvent} per activation so the threads the span really ran on are
  *       recorded even though its own event can only name one.</li>
  *   <li><b>{@link ScopedValue} propagates to child threads only through structured concurrency.</b>
- *       Work submitted to a plain executor does not inherit the current span; pass the
- *       {@link SpanContext} explicitly and re-establish it with {@link #continueIn}.</li>
+ *       Work submitted to a plain executor does not inherit the current span; wrap the task with
+ *       {@link #fork}, or pass the {@link SpanContext} explicitly and re-establish it with
+ *       {@link #continueIn}.</li>
  *   <li><b>Span names must be stable and low-cardinality.</b> Every distinct name enters the JFR
  *       per-chunk string pool, so a name built from a request id or a user id inflates the
  *       recording. Name the operation, not the instance of it.</li>
@@ -125,23 +125,6 @@ public final class Tracer {
     }
 
     /**
-     * Opens a span for {@code body} without emitting a {@link TraceSpanEvent} and without attaching
-     * it to an event, for a scope that only needs to exist so the work underneath it hangs together.
-     * <p>
-     * Instrumentation whose <em>own</em> event already describes the interval — an HTTP exchange, a
-     * gRPC call — wants {@link #inSpanOf} instead, which makes that event the span. Pairing this
-     * method with {@link #stamp} does something different: the stamped event becomes a child of the
-     * span opened here rather than the span itself.
-     * <p>
-     * Unlike {@link #call}, this always establishes a binding: whether an interval is recorded at
-     * all is the caller's event's decision, not this method's.
-     */
-    public static <R, X extends Throwable> R inSpan(ScopedValue.CallableOp<? extends R, X> body) throws X {
-        Objects.requireNonNull(body, "body must not be null");
-        return ScopedValue.where(CURRENT, newSpanContext()).call(body);
-    }
-
-    /**
      * Opens a span and makes {@code event} that span, for instrumentation whose own event already
      * describes the interval — an HTTP exchange, a gRPC call. Emitting a {@link TraceSpanEvent}
      * alongside such an event would record the same interval twice, so none is emitted; the event
@@ -179,6 +162,18 @@ public final class Tracer {
     }
 
     /**
+     * The {@link Runnable} form of {@link #inSpanOf(AbstractTracedEvent, ScopedValue.CallableOp)},
+     * for a body with no result and no checked exception.
+     */
+    public static void inSpanOf(AbstractTracedEvent event, Runnable body) {
+        Objects.requireNonNull(body, "body must not be null");
+        inSpanOf(event, () -> {
+            body.run();
+            return null;
+        });
+    }
+
+    /**
      * Opens a span on {@code event} and hands back its context <em>without</em> binding it, for
      * instrumentation that cannot wrap its work in a lambda.
      * <p>
@@ -204,8 +199,7 @@ public final class Tracer {
      * <p>
      * Distinct from {@link #continueIn}, which mints a <em>child</em> and emits a span event for it:
      * this rebinds the very same span, because a protocol's callbacks are not separate operations,
-     * they are the same operation arriving in pieces. Distinct from {@link #inSpan}, which opens a
-     * new span rather than resuming one.
+     * they are the same operation arriving in pieces.
      * <p>
      * Each re-entry emits a {@link TraceScopeEvent} recording which thread the span ran on and for
      * how long. That is not bookkeeping for its own sake: once a span is re-entered it can be closed
@@ -248,6 +242,18 @@ public final class Tracer {
     }
 
     /**
+     * The {@link Runnable} form of {@link #reenter(SpanContext, ScopedValue.CallableOp)}, for a
+     * callback with no result and no checked exception.
+     */
+    public static void reenter(SpanContext context, Runnable body) {
+        Objects.requireNonNull(body, "body must not be null");
+        reenter(context, () -> {
+            body.run();
+            return null;
+        });
+    }
+
+    /**
      * Gives {@code event} a span of its own, nested inside the span currently in progress, so the
      * event takes its place in the trace. Does nothing when no span is in progress, leaving the
      * event's ids at {@code 0} — the encoding for "not part of a trace".
@@ -260,7 +266,7 @@ public final class Tracer {
     public static void stamp(AbstractTracedEvent event) {
         Objects.requireNonNull(event, "event must not be null");
         if (CURRENT.isBound()) {
-            stampSelf(event, CURRENT.get().child(ThreadLocalRandom.current()));
+            stampSelf(event, CURRENT.get().child());
         }
     }
 
@@ -302,6 +308,56 @@ public final class Tracer {
     }
 
     /**
+     * The {@link Runnable} form of
+     * {@link #continueIn(SpanContext, String, SpanKind, ScopedValue.CallableOp)}, for a task with no
+     * result and no checked exception.
+     */
+    public static void continueIn(SpanContext parent, String name, SpanKind kind, Runnable body) {
+        Objects.requireNonNull(body, "body must not be null");
+        continueIn(parent, name, kind, () -> {
+            body.run();
+            return null;
+        });
+    }
+
+    /**
+     * Wraps {@code body} so that, wherever it eventually runs, it is recorded as a child of the span
+     * in progress <em>here</em> — the packaged form of capturing {@link #current} before an executor
+     * hand-off and re-establishing it inside the task with {@link #continueIn}.
+     * <p>
+     * The capture happens when this method is called, not when the task runs, so wrap on the thread
+     * whose span the work belongs to and submit the result. Called outside any span, the task starts
+     * a fresh trace — the same fallback {@link #continueIn} has for a {@code null} parent.
+     *
+     * <pre>{@code
+     * CompletableFuture.runAsync(
+     *         Tracer.fork("chunk.parse", SpanKind.INTERNAL, () -> parseChunk(file)),
+     *         executor);
+     * }</pre>
+     */
+    public static Runnable fork(String name, SpanKind kind, Runnable body) {
+        Objects.requireNonNull(name, "name must not be null");
+        Objects.requireNonNull(kind, "kind must not be null");
+        Objects.requireNonNull(body, "body must not be null");
+
+        SpanContext parent = CURRENT.isBound() ? CURRENT.get() : null;
+        return () -> continueIn(parent, name, kind, body);
+    }
+
+    /**
+     * The value-returning form of {@link #fork(String, SpanKind, Runnable)}, shaped as a
+     * {@link Supplier} so it hands straight to {@code CompletableFuture.supplyAsync}.
+     */
+    public static <T> Supplier<T> fork(String name, SpanKind kind, Supplier<T> body) {
+        Objects.requireNonNull(name, "name must not be null");
+        Objects.requireNonNull(kind, "kind must not be null");
+        Objects.requireNonNull(body, "body must not be null");
+
+        SpanContext parent = CURRENT.isBound() ? CURRENT.get() : null;
+        return () -> continueIn(parent, name, kind, body::get);
+    }
+
+    /**
      * Derives the context for a span about to start on this thread: a child of whatever is bound,
      * or a fresh root when nothing is.
      */
@@ -310,8 +366,7 @@ public final class Tracer {
     }
 
     private static SpanContext childOf(SpanContext parent) {
-        RandomGenerator random = ThreadLocalRandom.current();
-        return parent == null ? SpanContext.root(random) : parent.child(random);
+        return parent == null ? SpanContext.root() : parent.child();
     }
 
     private static <R, X extends Throwable> R record(

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/Tracer.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/Tracer.java
@@ -308,6 +308,15 @@ public final class Tracer {
     }
 
     /**
+     * The form of {@link #continueIn(SpanContext, String, SpanKind, ScopedValue.CallableOp)} with
+     * kind {@link SpanKind#INTERNAL} — forked work is in-process work unless declared otherwise.
+     */
+    public static <R, X extends Throwable> R continueIn(
+            SpanContext parent, String name, ScopedValue.CallableOp<? extends R, X> body) throws X {
+        return continueIn(parent, name, SpanKind.INTERNAL, body);
+    }
+
+    /**
      * The {@link Runnable} form of
      * {@link #continueIn(SpanContext, String, SpanKind, ScopedValue.CallableOp)}, for a task with no
      * result and no checked exception.
@@ -321,6 +330,14 @@ public final class Tracer {
     }
 
     /**
+     * The {@link Runnable} form of {@link #continueIn(SpanContext, String, SpanKind, Runnable)},
+     * with kind {@link SpanKind#INTERNAL}.
+     */
+    public static void continueIn(SpanContext parent, String name, Runnable body) {
+        continueIn(parent, name, SpanKind.INTERNAL, body);
+    }
+
+    /**
      * Wraps {@code body} so that, wherever it eventually runs, it is recorded as a child of the span
      * in progress <em>here</em> — the packaged form of capturing {@link #current} before an executor
      * hand-off and re-establishing it inside the task with {@link #continueIn}.
@@ -331,7 +348,7 @@ public final class Tracer {
      *
      * <pre>{@code
      * CompletableFuture.runAsync(
-     *         Tracer.fork("chunk.parse", SpanKind.INTERNAL, () -> parseChunk(file)),
+     *         Tracer.fork("chunk.parse", () -> parseChunk(file)),
      *         executor);
      * }</pre>
      */
@@ -345,6 +362,13 @@ public final class Tracer {
     }
 
     /**
+     * The form of {@link #fork(String, SpanKind, Runnable)} with kind {@link SpanKind#INTERNAL}.
+     */
+    public static Runnable fork(String name, Runnable body) {
+        return fork(name, SpanKind.INTERNAL, body);
+    }
+
+    /**
      * The value-returning form of {@link #fork(String, SpanKind, Runnable)}, shaped as a
      * {@link Supplier} so it hands straight to {@code CompletableFuture.supplyAsync}.
      */
@@ -355,6 +379,13 @@ public final class Tracer {
 
         SpanContext parent = CURRENT.isBound() ? CURRENT.get() : null;
         return () -> continueIn(parent, name, kind, body::get);
+    }
+
+    /**
+     * The form of {@link #fork(String, SpanKind, Supplier)} with kind {@link SpanKind#INTERNAL}.
+     */
+    public static <T> Supplier<T> fork(String name, Supplier<T> body) {
+        return fork(name, SpanKind.INTERNAL, body);
     }
 
     /**

--- a/utilities/jeffrey-events/src/test/java/cafe/jeffrey/jfr/events/trace/TracerTest.java
+++ b/utilities/jeffrey-events/src/test/java/cafe/jeffrey/jfr/events/trace/TracerTest.java
@@ -589,6 +589,21 @@ class TracerTest {
         }
 
         @Test
+        @DisplayName("the kind-less forms record INTERNAL, like run and call")
+        void kindLessFormsDefaultToInternal() throws IOException {
+            Map<String, RecordedEvent> spans = recordSpans(() -> {
+                Runnable task = Tracer.fork("handle", () -> {
+                });
+                task.run();
+                Tracer.continueIn(null, "carried", () -> {
+                });
+            });
+
+            assertEquals(SpanKind.INTERNAL.name(), spans.get("handle").getString("kind"));
+            assertEquals(SpanKind.INTERNAL.name(), spans.get("carried").getString("kind"));
+        }
+
+        @Test
         @DisplayName("fork outside any span starts a fresh trace, like continueIn with a null parent")
         void forkOutsideASpanStartsAFreshTrace() {
             Runnable task = Tracer.fork("handle", SpanKind.INTERNAL,

--- a/utilities/jeffrey-events/src/test/java/cafe/jeffrey/jfr/events/trace/TracerTest.java
+++ b/utilities/jeffrey-events/src/test/java/cafe/jeffrey/jfr/events/trace/TracerTest.java
@@ -80,6 +80,20 @@ class TracerTest {
             assertEquals(root.spanId(), child.parentSpanId());
             assertFalse(child.isRoot());
         }
+
+        @Test
+        @DisplayName("the no-arg forms draw from the calling thread's random and behave the same")
+        void noArgFormsBehaveTheSame() {
+            SpanContext root = SpanContext.root();
+            SpanContext child = root.child();
+
+            assertNotEquals(0, root.traceId());
+            assertNotEquals(0, root.spanId());
+            assertTrue(root.isRoot());
+            assertEquals(root.traceId(), child.traceId());
+            assertEquals(root.spanId(), child.parentSpanId());
+            assertNotEquals(root.spanId(), child.spanId());
+        }
     }
 
     @Nested
@@ -91,7 +105,7 @@ class TracerTest {
         void stampFillsTheEvent() {
             JdbcQueryEvent event = new JdbcQueryEvent("listSpans", "profile");
 
-            SpanContext context = Tracer.inSpan(() -> {
+            SpanContext context = Tracer.continueIn(null, "scope", SpanKind.INTERNAL, () -> {
                 Tracer.stamp(event);
                 return Tracer.current().orElseThrow();
             });
@@ -108,10 +122,9 @@ class TracerTest {
             JdbcQueryEvent first = new JdbcQueryEvent("listSpans", "profile");
             JdbcQueryEvent second = new JdbcQueryEvent("countSpans", "profile");
 
-            Tracer.inSpan(() -> {
+            Tracer.continueIn(null, "scope", SpanKind.INTERNAL, () -> {
                 Tracer.stamp(first);
                 Tracer.stamp(second);
-                return null;
             });
 
             assertEquals(first.traceId, second.traceId);
@@ -136,11 +149,12 @@ class TracerTest {
         }
 
         @Test
-        @DisplayName("the binding is gone once inSpan returns, so stamping afterwards is a no-op")
+        @DisplayName("the binding is gone once the span closes, so stamping afterwards is a no-op")
         void stampingAfterTheSpanClosesDoesNothing() {
             HttpServerExchangeEvent event = new HttpServerExchangeEvent();
 
-            Tracer.inSpan(() -> null);
+            Tracer.continueIn(null, "scope", SpanKind.INTERNAL, () -> {
+            });
             Tracer.stamp(event);
 
             assertEquals(0, event.traceId,
@@ -160,22 +174,21 @@ class TracerTest {
         }
 
         @Test
-        @DisplayName("inSpan opens a binding even though it emits no trace span event of its own")
-        void inSpanBindsWithoutEmitting() throws IOException {
+        @DisplayName("a stamped event and a nested span inside one scope share that scope as parent")
+        void stampedEventAndNestedSpanShareTheParent() throws IOException {
+            HttpServerExchangeEvent exchange = new HttpServerExchangeEvent();
             JdbcQueryEvent statement = new JdbcQueryEvent("listSpans", "profile");
 
-            Map<String, RecordedEvent> spans = recordSpans(() -> Tracer.inSpan(() -> {
+            Map<String, RecordedEvent> spans = recordSpans(() -> Tracer.inSpanOf(exchange, () -> {
                 Tracer.stamp(statement);
                 Tracer.run("query", SpanKind.CLIENT, () -> {
                 });
-                return null;
             }));
 
-            assertEquals(1, spans.size(), "inSpan must not emit a span event of its own");
             RecordedEvent query = spans.get("query");
             assertEquals(statement.traceId, query.getLong("traceId"));
             assertEquals(statement.parentSpanId, query.getLong("parentSpanId"),
-                    "both hang off the span inSpan opened - a stamped event is a leaf, not a scope");
+                    "both hang off the exchange's span - a stamped event is a leaf, not a scope");
         }
     }
 
@@ -503,7 +516,6 @@ class TracerTest {
             List<RecordedEvent> scopes = recordEvents(TraceScopeEvent.NAME, () -> {
                 Tracer.run("checkout", SpanKind.SERVER, () -> {
                 });
-                Tracer.inSpan(() -> null);
                 Tracer.inSpanOf(new HttpServerExchangeEvent(), () -> null);
                 Tracer.continueIn(SpanContext.root(new java.util.Random(42)), "handle",
                         SpanKind.INTERNAL, () -> null);
@@ -532,6 +544,100 @@ class TracerTest {
                     () -> new AssertionError("reenter was handed a context and must bind it")));
 
             assertEquals(opened, bound);
+        }
+    }
+
+    @Nested
+    @DisplayName("Forking work to an executor")
+    class Forking {
+
+        @Test
+        @DisplayName("fork captures the span at wrap time and reparents the task under it")
+        void forkCapturesAtWrapTime() throws IOException {
+            Map<String, RecordedEvent> spans = recordSpans(() -> {
+                Runnable task = Tracer.call("submit", SpanKind.SERVER,
+                        () -> Tracer.fork("handle", SpanKind.INTERNAL, () -> {
+                        }));
+                // Run only after the submitting span has closed, the way an executor would.
+                runOnAnotherThread(() -> {
+                    task.run();
+                    return null;
+                });
+            });
+
+            RecordedEvent submit = spans.get("submit");
+            RecordedEvent handle = spans.get("handle");
+            assertEquals(submit.getLong("traceId"), handle.getLong("traceId"));
+            assertEquals(submit.getLong("spanId"), handle.getLong("parentSpanId"));
+        }
+
+        @Test
+        @DisplayName("the supplier form returns the body's value and stays in the trace")
+        void forkSupplierReturnsTheValue() throws IOException {
+            Object result = new Object();
+
+            Map<String, RecordedEvent> spans = recordSpans(() -> {
+                var task = Tracer.call("submit", SpanKind.SERVER,
+                        () -> Tracer.fork("handle", SpanKind.INTERNAL, () -> result));
+                runOnAnotherThread(() -> {
+                    assertSame(result, task.get());
+                    return null;
+                });
+            });
+
+            assertEquals(spans.get("submit").getLong("spanId"), spans.get("handle").getLong("parentSpanId"));
+        }
+
+        @Test
+        @DisplayName("fork outside any span starts a fresh trace, like continueIn with a null parent")
+        void forkOutsideASpanStartsAFreshTrace() {
+            Runnable task = Tracer.fork("handle", SpanKind.INTERNAL,
+                    () -> assertTrue(Tracer.current().orElseThrow().isRoot()));
+
+            runOnAnotherThread(() -> {
+                task.run();
+                return null;
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("Runnable forms")
+    class RunnableForms {
+
+        @Test
+        @DisplayName("reenter's runnable form binds the same span")
+        void reenterRunnableBindsTheSameSpan() {
+            SpanContext opened = SpanContext.root(new java.util.Random(42));
+
+            Tracer.reenter(opened, () -> assertEquals(opened, Tracer.current().orElseThrow()));
+        }
+
+        @Test
+        @DisplayName("inSpanOf's runnable form stamps the event and parents nested work under it")
+        void inSpanOfRunnableStampsAndParents() throws IOException {
+            HttpServerExchangeEvent exchange = new HttpServerExchangeEvent();
+
+            Map<String, RecordedEvent> spans = recordSpans(() -> Tracer.inSpanOf(exchange, () ->
+                    Tracer.run("query", SpanKind.CLIENT, () -> {
+                    })));
+
+            assertNotEquals(0, exchange.traceId);
+            assertEquals(exchange.spanId, spans.get("query").getLong("parentSpanId"));
+        }
+
+        @Test
+        @DisplayName("continueIn's runnable form records a child of the given parent")
+        void continueInRunnableReparents() throws IOException {
+            SpanContext carried = SpanContext.root(new java.util.Random(42));
+
+            Map<String, RecordedEvent> spans = recordSpans(() ->
+                    Tracer.continueIn(carried, "handle", SpanKind.INTERNAL, () -> {
+                    }));
+
+            RecordedEvent handle = spans.get("handle");
+            assertEquals(carried.traceId(), handle.getLong("traceId"));
+            assertEquals(carried.spanId(), handle.getLong("parentSpanId"));
         }
     }
 


### PR DESCRIPTION
Four ergonomic changes to cafe.jeffrey.jfr.events.trace, keeping the
model intact:

- Tracer.fork(name, kind, body) packages the capture-then-continueIn
  executor pattern: it captures the span in progress at wrap time and
  returns a Runnable/Supplier that records its work as a child wherever
  it eventually runs. Forgetting the manual capture silently detached
  the forked subtree; with fork the capture is the wrap. All three
  call sites (ParallelRecordingFileIterator, ProfileDataInitializerImpl,
  DbBasedFlamegraphGenerator) move to it.

- Runnable overloads for inSpanOf, reenter and continueIn remove the
  'return null;' boilerplate from bodies with no result and no checked
  exception (nine call sites, seven of them in JfrGrpcServerInterceptor).

- Tracer.inSpan is removed: it had no production call sites, and its
  unrecorded parent span was orphan-promoted by the tree assembly, so
  the grouping it promised never survived into the rendered tree. Its
  tests now exercise stamp through continueIn/inSpanOf.

- SpanContext gains no-arg root()/child() drawing from the calling
  thread's ThreadLocalRandom; the RandomGenerator forms remain for
  deterministic tests.

The Tracer API reference page and the Traces & Spans page are updated
to match: fork is documented with its own section and trees, inSpan is
gone from the reference, and the examples mirror the new call sites.