### PR TITLE
Fix correctness issues found by the Traces deep analysis

### DIFF
--- a/TRACES_ANALYSIS.md
+++ b/TRACES_ANALYSIS.md
@@ -1,0 +1,151 @@
+# Traces & Spans — deep analysis (2026-08-15)
+
+A correctness and design review of the Distributed Traces feature (`jeffrey.TraceSpan` /
+`jeffrey.TraceScope`): the derivation SQL, the `trace_spans`/`traces` schema, `TraceManagerImpl`'s
+tree assembly and interval arithmetic, `TracesController`, and the frontend surface
+(`ProfileTraces.vue`, `ProfileTraceOperations.vue`, `components/trace/*`,
+`ProfileTracesClient.ts`). Every finding below was verified against the tree; the fixes were
+applied on this branch and are covered by new tests.
+
+Method Tracing (`jdk.MethodTrace`) and Async-Profiler Spans (`profiler.Span`) are separate
+features and were out of scope, except where a shared utility forced care
+(`ThreadWindowEvents` is shared with the async-profiler drill-down and its behavior there is
+unchanged).
+
+---
+
+## Fixed on this branch
+
+### 1. Operation flamegraphs absorbed unrelated work across idle gaps
+
+`OPERATION_INTERVALS` reduced each `(trace, thread)` to `MIN(from_us)/MAX(to_us)`. A thread that
+worked on a trace early, did something unrelated, and came back later handed the operation-scoped
+flamegraph one window spanning the whole idle gap — the graph silently included samples from work
+that was never part of the operation. The per-span path (`TraceManagerImpl.selfIntervals`) already
+preserved gaps; the operation path did not.
+
+**Fix:** a gaps-and-islands pass in SQL (`JdbcTraceRepository.OPERATION_INTERVALS`): overlapping
+and touching windows merge, disjoint stints stay separate rows. The reduction still happens in SQL
+— the unbounded fetch this query replaced (see `TRACES_LEFTOVERS.md`, closed items) stays closed.
+Test: `OperationIntervals.disjointActivityKeepsTheGap` with the new
+`insert-disjoint-thread-activity.sql` fixture.
+
+### 2. `trace_spans` had no uniqueness on `(trace_id, span_id)`
+
+`TraceManagerImpl.assemble` documents that a span id identifies exactly one span and that "the
+derivation is what guarantees it" — but the derivation didn't. Duplicate rows (re-imported chunk,
+id-reusing instrumentation) made `traces.span_count` (a raw `COUNT(*)`) disagree with the waterfall,
+which draws only the first row per id.
+
+**Fix:** `DERIVE_TRACE_SPANS` now dedupes with
+`QUALIFY ROW_NUMBER() OVER (PARTITION BY trace_id, span_id ORDER BY start_timestamp, duration) = 1`
+(earliest occurrence wins — the row the waterfall drew anyway), and `trace_spans` gained
+`PRIMARY KEY (trace_id, span_id)` so a future dedupe regression fails loudly instead of skewing
+counts silently. `derive()`'s DELETE-then-INSERT idempotency is unaffected (re-verified by
+`derivationIsIdempotent`). Test: `Derivation.dedupesRepeatedSpanIds` with
+`insert-duplicate-span-events.sql`. The manager's defensive first-row-wins handling stays, as a
+render-whatever-the-database-holds guard.
+
+### 3. Dead index `trace_spans_thread_hash_idx`
+
+No query filters or joins *into* `trace_spans` by `thread_hash` — every use is a projection or the
+driving side of a probe into `threads` (whose `thread_hash` is the primary key). The index cost
+derive-time insert work and file size for zero reads. **Fix:** dropped from `V001__init.sql`.
+`trace_spans_trace_id_idx` is kept alongside the new composite PK because every trace read filters
+on `trace_id` alone, and a composite ART key is not a reliable prefix-lookup substitute.
+
+### 4. Nondeterministic ordering at LIMIT boundaries
+
+Four queries ordered by a tie-prone key with no tie-break: `SLOWEST_TRACES` (`duration DESC`),
+`TRACES_OF_OPERATION` (`start_timestamp`, microsecond-accurate so ties happen),
+`OPERATIONS` and `SPAN_BREAKDOWN_OF_OPERATION` (`total_ns DESC`). A tied row at the limit boundary
+could come and go between identical requests. **Fix:** deterministic tie-breaks appended —
+`trace_id` for the trace lists, the full group key for the aggregates. Test:
+`Reads.tiedDurationsOrderDeterministically` with `insert-tied-duration-traces.sql`.
+
+### 5. Silent 5000-row truncation in the span events drill-down
+
+`ThreadWindowEvents.ROW_LIMIT = 5000` capped `eventsInSpan` with no signal anywhere — a busy span's
+drill-down presented the first 5000 events as if they were the whole window. **Fix:** the
+repository fetches `ROW_LIMIT + 1` and returns a `ThreadWindowEventsPage(events, truncated)`;
+`TraceManager.eventsInSpan` returns the new `TraceSpanEvents` record; `TracesController` serializes
+it; `ProfileTracesClient.getSpanEvents` types it; `TraceSpansModal.vue` shows a one-line notice
+("Showing the first N events…") when the flag is set. The async-profiler drill-down shares
+`ThreadWindowEvents` and is behaviorally unchanged (3-arg `params` overload kept). Tests:
+`Reads.eventsInSpanExcludeSpans` asserts the untruncated flag;
+`TraceManagerImplTest.EventsInSpan.propagatesTruncation` asserts propagation.
+
+### 6. Frontend consistency fixes
+
+- `TraceOperationDetail.vue` — `ErrorState` now wires `@retry="load"` like its sibling views.
+  (Note: the shared `ErrorState.vue` currently declares no `retry` emit at all — see report-only
+  items.)
+- Route names `profile-traces` / `profile-trace-operations` renamed to
+  `profile-technologies-traces` / `profile-technologies-traces-operations`, matching every other
+  `profile-technologies-*` sibling. Grep confirmed nothing navigates by these names.
+- `MODAL_INIT_DELAY_MS = 200` existed as four identical private constants
+  (`TraceSpansModal`, `TraceOperationFlamegraphs`, `SpanEventsModal`, `SpanTagFlamegraphs`);
+  hoisted to `GraphUpdater.MODAL_INIT_DELAY_MS`, the class whose callback registration the delay
+  exists for.
+- `ProfileTraces.vue` declared `TRACE_FETCH_LIMIT = 100` "mirroring" the backend default but called
+  `getTraces()` without it — the header note would lie if the backend default ever changed. The
+  limit is now passed explicitly, making the frontend constant authoritative.
+
+### 7. Precision honesty (comments only)
+
+`traces.duration` is nanosecond-*valued* but only microsecond-*accurate* at its endpoints:
+`epoch_ns(start_timestamp)` scales a microsecond-resolution `TIMESTAMPTZ`. The `DERIVE_TRACES`
+comment now says so. No code change — the arithmetic was already correct.
+
+---
+
+## Verified sound (no change needed)
+
+- **Derivation design.** Structural span discovery (`spanId` column in `event_types.columns`)
+  means third-party instrumentation participates with zero code changes, and the
+  `scopedSpanId`-vs-`spanId` naming firewall keeps scopes out of the waterfall. IDs round-trip
+  JSON via `json_extract_string(...)::BIGINT` with boundary tests at `Long.MIN/MAX` and negative
+  span ids.
+- **Tree assembly** (`TraceManagerImpl.assemble`): orphans promoted to roots, self-parents and
+  parent cycles survive, depth-first draw order deterministic — all covered by
+  `TraceManagerImplTest`.
+- **Self-time arithmetic**: same-thread-only child subtraction, overlap merge, clipping to the
+  parent window, half-open millisecond cuts so a sample is never counted twice — covered by
+  `SelfTime` and `SpanIntervals` tests.
+- **Root election, `has_platform_span` three-state thread logic, error counting, event-field
+  stripping** — all match their stated invariants and are tested against real DuckDB.
+- **Controller layer**: `boundedLimit` caps caller limits at 10,000; hex ids parse via
+  `Long.parseUnsignedLong` with 404 on malformed input; framework types stay at the boundary.
+- **Frontend architecture**: shared-component reuse, design tokens throughout, extracted and
+  vitest-covered pure logic (`TraceWaterfallLayout`, `traceOperationStats`, `timeUnits`, …),
+  three-state view pattern, `GenericModal` usage — the trace surface is the most
+  convention-compliant area of the app.
+
+---
+
+## Report-only findings (deliberate, or out of scope)
+
+Recorded in `TRACES_LEFTOVERS.md` §4 so they are decisions, not surprises:
+
+1. **Per-request `spansOf(traceId)` re-reads** — `trace()`, `spanIntervals()`, `eventsInSpan()`
+   each fetch the trace's spans. They back separate HTTP requests against a small indexed table;
+   caching across requests is a real design cost for an unmeasured win.
+2. **Scope events joined via JSON extraction** — `OPERATION_INTERVALS` re-parses `fields` for
+   `jeffrey.TraceScope` rows. The event-type filter keeps the set small and only gRPC-server
+   traffic emits scopes today; a third derived table isn't yet worth its schema.
+3. **`ErrorState` has no retry emit** — every `@retry` listener in the app is currently inert; the
+   fix is an `@shared` component change outside this feature's scope.
+4. **Interval cardinality** — the islands merge returns one row per contiguous busy stretch; a
+   pathological operation could inflate the flamegraph filter's `UNNEST` lists. Not worth a cap
+   until measured.
+5. **Verification gap (pre-existing, still open)** — per `TRACES_LEFTOVERS.md` §3, no screen of
+   this feature has been rendered in a browser against a real profile. This needs a running
+   instance with a trace-carrying recording; nothing in this analysis substitutes for it.
+
+Out-of-scope observations handed over for a future pass: the Method Tracing surface carries most
+of the codebase's convention debt (missing three-state views in its flamegraph page, hardcoded
+colors/shadows/fonts, hand-rolled search instead of the `DataTable` toolbar, a
+`method|class` vs `BY_METHOD|BY_CLASS` type mismatch in `ProfileMethodTracingClient`, silent
+`CumulationMode` fallback, zero frontend tests), and `AsyncProfilerSpansController.slowestSpans`
+accepts an unbounded caller `limit` where `TracesController.boundedLimit` exists precisely for
+that.

--- a/TRACES_LEFTOVERS.md
+++ b/TRACES_LEFTOVERS.md
@@ -31,6 +31,10 @@ Not bugs — decisions with a stated trade-off.
 | **Old recordings misread HTTP/gRPC/JDBC status** | `status` → `statusCode` and the removal of `isSuccess` are breaking schema changes; fallbacks were considered and declined in favour of one shape | A user reports it on a recording worth keeping — the fallback is three one-line reads |
 | **P99 shown only when the trace sample is complete** | There is no server-side p99 column, and a p99 over the first 1,000 traces beside a p95 over all of them is two different questions in one row | A p99 aggregate is added to the `OPERATIONS` query |
 | **`TraceSpanInlineDetail` hand-rolls its key/value tables** | `@shared` `DrawerSection`/`InfoRow` fit the identity block but not the two data-driven tables, which need a label-side tooltip and a sub-key | Those shared components grow a richer label slot |
+| **Span drill-downs re-read `spansOf(traceId)` per request** | `trace()`, `spanIntervals()` and `eventsInSpan()` each fetch the trace's spans; they back separate HTTP requests against a small indexed table, and caching across requests is a design cost with no measured win | A profiled slow drill-down names this read as the cost |
+| **Scope events are joined via JSON extraction per query** | `OPERATION_INTERVALS` re-parses `fields` for `jeffrey.TraceScope` rows; the event-type filter keeps that set small, and only re-entered spans (gRPC server traffic today) emit scopes at all. A third derived table was judged more schema than the join is worth | Scope-emitting instrumentation broadens beyond gRPC |
+| **`@retry` listeners on `ErrorState` are inert** | The shared `ErrorState.vue` declares no `retry` emit and renders no retry button, so every `@retry` in the app is wiring to nothing. Trace views wire it anyway for the day the shared component grows the button — an `@shared` change, out of this feature's scope | `ErrorState` gains a retry button |
+| **Operation intervals are unbounded per busy stretch** | The gaps-and-islands merge returns one row per contiguous busy stretch per `(trace, thread)` rather than one per pair; a pathological operation of thousands of alternating disjoint spans would inflate the `UNNEST` list parameters behind the span-scoped flamegraph filter | A hot operation's flamegraph request measurably slows on the interval lists |
 
 ---
 
@@ -61,8 +65,10 @@ Not bugs — decisions with a stated trade-off.
   duration is the same number in the list and in the detail.
 - ~~`has_platform_span` computed per query, two ways~~ — one stored column, one convention: a span
   whose thread did not resolve is not counted as platform.
-- ~~`spansOfOperation` unbounded~~ — replaced by an interval aggregate that returns one row per
-  `(trace, thread)`.
+- ~~`spansOfOperation` unbounded~~ — replaced by an interval aggregate, later refined: windows are
+  merged per `(trace, thread)` with idle gaps preserved (gaps-and-islands), because a plain MIN/MAX
+  per pair handed the operation flamegraph one window spanning a thread's idle gap and absorbed
+  whatever unrelated work ran in it.
 - ~~`derive()` not idempotent~~ — both tables are cleared first, and a test runs it twice.
 - ~~Every virtual thread collapsed into one~~ — `EventThreadCleaner` no longer groups on a null
   `os_id`, which is what `trace_spans.thread_hash` depends on.

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/TracesController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/TracesController.java
@@ -24,12 +24,12 @@ import cafe.jeffrey.profile.manager.ProfileManager;
 import cafe.jeffrey.profile.model.FlamegraphPanel;
 import cafe.jeffrey.profile.panel.JfrFlamegraphPanelProvider;
 import cafe.jeffrey.profile.panel.PanelContext;
-import cafe.jeffrey.profile.manager.model.trace.TraceEventRow;
 import cafe.jeffrey.profile.manager.model.trace.TraceDetail;
 import cafe.jeffrey.profile.manager.model.trace.TraceOperationRow;
 import cafe.jeffrey.profile.manager.model.trace.TraceOverview;
 import cafe.jeffrey.profile.manager.model.trace.TraceOperationSummary;
 import cafe.jeffrey.profile.manager.model.trace.TraceRow;
+import cafe.jeffrey.profile.manager.model.trace.TraceSpanEvents;
 import cafe.jeffrey.profile.resources.request.GenerateTraceOperationFlamegraphRequest;
 import cafe.jeffrey.profile.resources.request.GenerateTraceSpanFlamegraphRequest;
 import cafe.jeffrey.profile.resources.request.SpanFlamegraphOptions;
@@ -163,7 +163,7 @@ public class TracesController {
      * question for a (thread, window) pair.
      */
     @GetMapping("/{traceId}/spans/{spanId}/events")
-    public List<TraceEventRow> spanEvents(
+    public TraceSpanEvents spanEvents(
             @PathVariable("profileId") String profileId,
             @PathVariable("traceId") String traceId,
             @PathVariable("spanId") String spanId) {

--- a/jeffrey-microscope/pages-microscope/src/components/span/SpanEventsModal.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/span/SpanEventsModal.vue
@@ -105,7 +105,6 @@ import TimeseriesEventAxeFormatter from '@/services/timeseries/TimeseriesEventAx
 import type { SpanEventRow } from '@/services/api/model/span/SpanModels';
 
 const NANOS_PER_MILLI = 1_000_000;
-const MODAL_INIT_DELAY_MS = 200;
 const SPAN_FG_SCROLL_ID = 'span-fg-scroll';
 
 const props = defineProps<{
@@ -203,7 +202,7 @@ function openFlamegraph(type: string): void {
 
   setTimeout(() => {
     graphUpdater.initialize();
-  }, MODAL_INIT_DELAY_MS);
+  }, GraphUpdater.MODAL_INIT_DELAY_MS);
 }
 
 function backToEvents(): void {

--- a/jeffrey-microscope/pages-microscope/src/components/span/SpanTagFlamegraphs.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/span/SpanTagFlamegraphs.vue
@@ -72,8 +72,6 @@ import FlamegraphTooltip from '@/services/flamegraphs/tooltips/FlamegraphTooltip
 import FlamegraphTooltipFactory from '@/services/flamegraphs/tooltips/FlamegraphTooltipFactory';
 import { useFlamegraphPanels } from '@/composables/useFlamegraphPanels';
 
-const MODAL_INIT_DELAY_MS = 200;
-
 const props = defineProps<{
   profileId: string;
   tag: string;
@@ -85,7 +83,7 @@ const { loaded, error, panels } = useFlamegraphPanels(GraphType.PRIMARY, () =>
   new ProfileAsyncProfilerClient(props.profileId).getPanels(props.tag)
 );
 
-const hasEvents = computed(() => panels.value.some((panel) => panel.event.primary.samples > 0));
+const hasEvents = computed(() => panels.value.some(panel => panel.event.primary.samples > 0));
 
 // Flamegraph modal state
 const showDialog = ref(false);
@@ -114,16 +112,17 @@ function openFlamegraph(payload: FlamegraphCardViewPayload) {
   );
 
   graphUpdater.value = new FullGraphUpdater(client, false);
-  flamegraphTooltip.value =
-    FlamegraphTooltipFactory.create(payload.eventType, payload.useWeight, false);
+  flamegraphTooltip.value = FlamegraphTooltipFactory.create(
+    payload.eventType,
+    payload.useWeight,
+    false
+  );
 
   showDialog.value = true;
 
   // Delay so the modal (flamegraph + timeseries) is rendered and callbacks registered.
   setTimeout(() => {
     graphUpdater.value?.initialize();
-  }, MODAL_INIT_DELAY_MS);
+  }, GraphUpdater.MODAL_INIT_DELAY_MS);
 }
-
-
 </script>

--- a/jeffrey-microscope/pages-microscope/src/components/trace/TraceOperationDetail.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/trace/TraceOperationDetail.vue
@@ -19,7 +19,7 @@
 <template>
   <div class="dashboard-container">
     <LoadingState v-if="loading" message="Loading operation details..." />
-    <ErrorState v-else-if="error" :message="error" />
+    <ErrorState v-else-if="error" :message="error" @retry="load" />
 
     <template v-else>
       <TabBar v-model="activeTab" :tabs="tabs" class="mb-3" />
@@ -54,7 +54,7 @@
           secondary-title="Traces"
           time-unit="milliseconds"
           :visible-minutes="60"
-          :independentSecondaryAxis="true"
+          :independent-secondary-axis="true"
           :primary-axis-type="AxisFormatType.DURATION_IN_NANOS"
           :secondary-axis-type="AxisFormatType.NUMBER"
         />
@@ -166,9 +166,7 @@ function openTrace(trace: TraceRow): void {
  * (thread, window) and the profiler attributes them to the carrier, so an operation that never left
  * its virtual threads has nothing to draw — the tab stays and explains that, rather than vanishing.
  */
-const samplesAreReachable = computed(() =>
-  traces.value.some(trace => trace.hasPlatformSpan)
-);
+const samplesAreReachable = computed(() => traces.value.some(trace => trace.hasPlatformSpan));
 
 const tabs: TabBarItem[] = [
   { id: 'summary', label: 'Summary', icon: 'grid-1x2' },
@@ -186,15 +184,15 @@ const tabs: TabBarItem[] = [
 const buckets = computed(() =>
   timelineBuckets(
     traces.value,
-    (trace) => trace.startMillisFromBeginning,
-    (trace) => trace.durationNanos,
+    trace => trace.startMillisFromBeginning,
+    trace => trace.durationNanos,
     TIMELINE_BUCKETS,
     recordingSpan.value
   )
 );
 
-const primaryData = computed<number[][]>(() => buckets.value.map((b) => [b.mid, b.maxDuration]));
-const secondaryData = computed<number[][]>(() => buckets.value.map((b) => [b.mid, b.count]));
+const primaryData = computed<number[][]>(() => buckets.value.map(b => [b.mid, b.maxDuration]));
+const secondaryData = computed<number[][]>(() => buckets.value.map(b => [b.mid, b.count]));
 
 // Silence about a cap reads as "this is all of them", which it would not be.
 const capNote = computed<string | undefined>(() => {
@@ -244,4 +242,3 @@ async function load(): Promise<void> {
 // operation remounts it. `useFlamegraphPanels` only fetches on mount, which is why the key is there.
 onMounted(load);
 </script>
-

--- a/jeffrey-microscope/pages-microscope/src/components/trace/TraceOperationFlamegraphs.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/trace/TraceOperationFlamegraphs.vue
@@ -80,8 +80,6 @@ import FlamegraphTooltipFactory from '@/services/flamegraphs/tooltips/Flamegraph
 import { useFlamegraphPanels } from '@/composables/useFlamegraphPanels';
 import type { TraceOperationId } from '@/services/api/model/trace/TraceModels';
 
-const MODAL_INIT_DELAY_MS = 200;
-
 const props = defineProps<{
   profileId: string;
   operation: TraceOperationId;
@@ -124,16 +122,17 @@ function openFlamegraph(payload: FlamegraphCardViewPayload) {
   );
 
   graphUpdater.value = new FullGraphUpdater(client, false);
-  flamegraphTooltip.value =
-    FlamegraphTooltipFactory.create(payload.eventType, payload.useWeight, false);
+  flamegraphTooltip.value = FlamegraphTooltipFactory.create(
+    payload.eventType,
+    payload.useWeight,
+    false
+  );
 
   showDialog.value = true;
 
   // Delay so the modal (flamegraph + timeseries) is rendered and callbacks registered.
   setTimeout(() => {
     graphUpdater.value?.initialize();
-  }, MODAL_INIT_DELAY_MS);
+  }, GraphUpdater.MODAL_INIT_DELAY_MS);
 }
-
-
 </script>

--- a/jeffrey-microscope/pages-microscope/src/components/trace/TraceSpansModal.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/trace/TraceSpansModal.vue
@@ -67,13 +67,19 @@
           icon="bi-inbox"
         />
 
-        <EventWindowTimeline
-          v-else-if="selected"
-          :events="spanEvents"
-          :window-start-millis="spanWindowStartMillis"
-          :window-millis="spanWindowMillis"
-          @flamegraph="openFlamegraphForType"
-        />
+        <template v-else-if="selected">
+          <div v-if="eventsTruncated" class="ts-truncated-note">
+            <i class="bi bi-info-circle"></i>
+            Showing the first {{ spanEvents.length }} events recorded in this window — the span held
+            more than the drill-down can list.
+          </div>
+          <EventWindowTimeline
+            :events="spanEvents"
+            :window-start-millis="spanWindowStartMillis"
+            :window-millis="spanWindowMillis"
+            @flamegraph="openFlamegraphForType"
+          />
+        </template>
       </div>
 
       <div v-else-if="mode === 'flamegraph'" class="ts-fg-view">
@@ -171,7 +177,6 @@ import type {
 } from '@/services/api/model/trace/TraceModels';
 
 const TRACE_FG_SCROLL_ID = 'trace-fg-scroll';
-const MODAL_INIT_DELAY_MS = 200;
 
 const props = defineProps<{
   show: boolean;
@@ -190,6 +195,7 @@ const error = ref<string | null>(null);
 
 const mode = ref<'spans' | 'events' | 'flamegraph-picker' | 'flamegraph'>('spans');
 const spanEvents = ref<TraceEventRow[]>([]);
+const eventsTruncated = ref(false);
 const eventsLoading = ref(false);
 const eventsError = ref<string | null>(null);
 /** Which view the graph was opened from, so its back button can return there. */
@@ -244,9 +250,7 @@ const spanWindowMillis = computed(() =>
  * The event timeline is drawn against the events table, whose timestamps are millisecond-resolution,
  * so the span's microsecond start is floored to the millisecond its events were filed under.
  */
-const spanWindowStartMillis = computed(() =>
-  floorToMillis(selected.value?.startEpochMicros ?? 0)
-);
+const spanWindowStartMillis = computed(() => floorToMillis(selected.value?.startEpochMicros ?? 0));
 
 async function loadEvents(): Promise<void> {
   const span = selected.value;
@@ -256,12 +260,15 @@ async function loadEvents(): Promise<void> {
   eventsLoading.value = true;
   eventsError.value = null;
   try {
-    spanEvents.value = await new ProfileTracesClient(props.profileId).getSpanEvents(
+    const page = await new ProfileTracesClient(props.profileId).getSpanEvents(
       props.traceId,
       span.spanId
     );
+    spanEvents.value = page.events;
+    eventsTruncated.value = page.truncated;
   } catch {
     spanEvents.value = [];
+    eventsTruncated.value = false;
     eventsError.value = 'Failed to load the events recorded inside this span.';
   } finally {
     eventsLoading.value = false;
@@ -346,7 +353,7 @@ function openFlamegraph(request: TraceSpanFlamegraphRequest): void {
   // Delay so the flamegraph is rendered and its callbacks are registered.
   setTimeout(() => {
     graphUpdater.initialize();
-  }, MODAL_INIT_DELAY_MS);
+  }, GraphUpdater.MODAL_INIT_DELAY_MS);
 }
 
 /**
@@ -370,6 +377,7 @@ async function load(): Promise<void> {
   selected.value = null;
   mode.value = 'spans';
   spanEvents.value = [];
+  eventsTruncated.value = false;
   eventsError.value = null;
   try {
     detail.value = await new ProfileTracesClient(props.profileId).getTrace(props.traceId);
@@ -470,5 +478,17 @@ watch(
 .ts-fg-scroll {
   max-height: calc(100vh - 220px);
   overflow: auto;
+}
+
+.ts-truncated-note {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  background: var(--color-light);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 0.4rem 0.6rem;
 }
 </style>

--- a/jeffrey-microscope/pages-microscope/src/router/profileChildRoutes.ts
+++ b/jeffrey-microscope/pages-microscope/src/router/profileChildRoutes.ts
@@ -561,13 +561,13 @@ const technologyRoutes = [
   },
   {
     path: 'technologies/traces',
-    name: 'profile-traces',
+    name: 'profile-technologies-traces',
     component: () => import('@/views/profiles/detail/technologies/ProfileTraces.vue'),
     meta: { layout: 'profile' }
   },
   {
     path: 'technologies/traces/operations',
-    name: 'profile-trace-operations',
+    name: 'profile-technologies-traces-operations',
     component: () => import('@/views/profiles/detail/technologies/ProfileTraceOperations.vue'),
     meta: { layout: 'profile' }
   },

--- a/jeffrey-microscope/pages-microscope/src/services/api/ProfileTracesClient.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/ProfileTracesClient.ts
@@ -20,12 +20,12 @@ import BaseProfileClient from '@/services/api/BaseProfileClient';
 import FlamegraphPanel from '@/services/api/model/FlamegraphPanel';
 import type {
   TraceDetail,
-  TraceEventRow,
   TraceOperationId,
   TraceOperationRow,
   TraceOperationSummary,
   TraceOverview,
-  TraceRow
+  TraceRow,
+  TraceSpanEvents
 } from '@/services/api/model/trace/TraceModels';
 
 /**
@@ -88,9 +88,12 @@ export default class ProfileTracesClient extends BaseProfileClient {
     return this.get<FlamegraphPanel[]>('/operation/panels', operationParams(operation));
   }
 
-  /** What the JVM was doing on the span's thread while it was open. */
-  public getSpanEvents(traceId: string, spanId: string): Promise<TraceEventRow[]> {
-    return this.get<TraceEventRow[]>(`/${traceId}/spans/${spanId}/events`);
+  /**
+   * What the JVM was doing on the span's thread while it was open — a page, with a flag saying
+   * whether the window held more events than the backend's row cap.
+   */
+  public getSpanEvents(traceId: string, spanId: string): Promise<TraceSpanEvents> {
+    return this.get<TraceSpanEvents>(`/${traceId}/spans/${spanId}/events`);
   }
 
   /**

--- a/jeffrey-microscope/pages-microscope/src/services/api/model/trace/TraceModels.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/model/trace/TraceModels.ts
@@ -170,6 +170,16 @@ export interface TraceEventRow {
 }
 
 /**
+ * A page of the events inside one span. A busy window can hold more events than the backend's row
+ * cap, and the flag is what lets the drill-down say "showing the first N events" instead of
+ * presenting a truncated list as the whole window.
+ */
+export interface TraceSpanEvents {
+  events: TraceEventRow[];
+  truncated: boolean;
+}
+
+/**
  * One span name in an operation's breakdown. Times are inclusive — a parent contains its children,
  * so the rows sum past the operation's own duration.
  */

--- a/jeffrey-microscope/pages-microscope/src/services/flamegraphs/updater/GraphUpdater.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/flamegraphs/updater/GraphUpdater.ts
@@ -22,6 +22,13 @@ import TimeRange from '@/services/api/model/TimeRange';
 import FlamegraphClient from '@/services/api/FlamegraphClient';
 
 export default abstract class GraphUpdater {
+  /**
+   * How long a modal waits after swapping a flamegraph view in before calling initialize():
+   * the graph component has to render and register its callbacks here first. One constant for
+   * every modal-hosted flamegraph, so the timing cannot drift apart per view.
+   */
+  public static readonly MODAL_INIT_DELAY_MS = 200;
+
   protected flamegraphRegistered: boolean = false;
   protected timeseriesRegistered: boolean = false;
   protected httpClient: FlamegraphClient;

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/technologies/ProfileTraces.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/technologies/ProfileTraces.vue
@@ -71,7 +71,7 @@ const props = defineProps<{ disabledFeatures: FeatureType[] }>();
 const route = useRoute();
 const router = useRouter();
 
-/** Mirrors TracesController's DEFAULT_TRACES_LIMIT, which caps what `getTraces()` returns. */
+/** Passed explicitly on the fetch, so the cap the header note reports is the cap actually used. */
 const TRACE_FETCH_LIMIT = 100;
 
 const traces = ref<TraceRow[]>([]);
@@ -139,7 +139,7 @@ async function loadData(): Promise<void> {
     const client = new ProfileTracesClient(profileId.value);
     const [loadedOverview, loadedTraces] = await Promise.all([
       client.getOverview(),
-      client.getTraces()
+      client.getTraces(TRACE_FETCH_LIMIT)
     ]);
     overview.value = loadedOverview;
     traces.value = loadedTraces;
@@ -158,4 +158,3 @@ onMounted(() => {
   }
 });
 </script>
-

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/TraceManager.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/TraceManager.java
@@ -19,11 +19,11 @@
 package cafe.jeffrey.profile.manager;
 
 import cafe.jeffrey.profile.manager.model.trace.TraceDetail;
-import cafe.jeffrey.profile.manager.model.trace.TraceEventRow;
 import cafe.jeffrey.profile.manager.model.trace.TraceOperationRow;
 import cafe.jeffrey.profile.manager.model.trace.TraceOperationSummary;
 import cafe.jeffrey.profile.manager.model.trace.TraceOverview;
 import cafe.jeffrey.profile.manager.model.trace.TraceRow;
+import cafe.jeffrey.profile.manager.model.trace.TraceSpanEvents;
 import cafe.jeffrey.provider.profile.api.TraceOperationId;
 import cafe.jeffrey.shared.common.model.ProfileInfo;
 import cafe.jeffrey.shared.common.model.SpanInterval;
@@ -87,9 +87,10 @@ public interface TraceManager {
      * Reduces every trace of one type to the {@code (thread, window)} intervals a flamegraph can be
      * scoped to, so the graph shows exactly the samples taken while traces of that type were running.
      * <p>
-     * One interval per {@code (trace, thread)}: a trace's window bounds all of its spans, and
-     * splitting by thread is what keeps a concurrently-running thread's samples out of the graph
-     * when a trace hands work off.
+     * Windows are merged per {@code (trace, thread)} with idle gaps preserved: splitting by thread
+     * is what keeps a concurrently-running thread's samples out of the graph when a trace hands
+     * work off, and preserving the gaps is what keeps out the unrelated work a thread did between
+     * two stints on the same trace.
      *
      * @param operation the trace type to scope to
      * @return the intervals, or empty when no trace is of that type
@@ -115,7 +116,8 @@ public interface TraceManager {
      * What the JVM was doing on the span's thread while it was open. Events that are themselves
      * spans are left out — they are the tree the waterfall already draws.
      *
-     * @return the events, or empty when the span does not exist
+     * @return a page of events — empty when the span does not exist — with a flag saying whether
+     *         the window held more than the row cap allowed
      */
-    List<TraceEventRow> eventsInSpan(long traceId, long spanId);
+    TraceSpanEvents eventsInSpan(long traceId, long spanId);
 }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/TraceManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/TraceManagerImpl.java
@@ -27,8 +27,10 @@ import cafe.jeffrey.profile.manager.model.trace.TraceOperationSummary;
 import cafe.jeffrey.profile.manager.model.trace.TraceOperationThreads;
 import cafe.jeffrey.profile.manager.model.trace.TraceOverview;
 import cafe.jeffrey.profile.manager.model.trace.TraceRow;
+import cafe.jeffrey.profile.manager.model.trace.TraceSpanEvents;
 import cafe.jeffrey.profile.manager.model.trace.TraceSpanRow;
 import cafe.jeffrey.provider.profile.api.EventFieldRecord;
+import cafe.jeffrey.provider.profile.api.ThreadWindowEventsPage;
 import cafe.jeffrey.provider.profile.api.TraceOperationId;
 import cafe.jeffrey.provider.profile.api.TraceOperationThreadsRecord;
 import cafe.jeffrey.provider.profile.api.TraceOverviewRecord;
@@ -203,19 +205,23 @@ public class TraceManagerImpl implements TraceManager {
     }
 
     @Override
-    public List<TraceEventRow> eventsInSpan(long traceId, long spanId) {
+    public TraceSpanEvents eventsInSpan(long traceId, long spanId) {
         return spanOf(traceId, spanId)
-                .map(span -> traceRepository
-                        .eventsInSpan(span.threadHash(),
-                                toMillis(span.startEpochMicros()), toMillis(endMicrosOf(span)))
-                        .stream()
-                        .map(event -> new TraceEventRow(
-                                event.eventType(),
-                                event.startEpochMillis(),
-                                event.durationNanos(),
-                                event.fields()))
-                        .toList())
-                .orElseGet(List::of);
+                .map(span -> {
+                    ThreadWindowEventsPage page = traceRepository.eventsInSpan(
+                            span.threadHash(),
+                            toMillis(span.startEpochMicros()), toMillis(endMicrosOf(span)));
+
+                    List<TraceEventRow> events = page.events().stream()
+                            .map(event -> new TraceEventRow(
+                                    event.eventType(),
+                                    event.startEpochMillis(),
+                                    event.durationNanos(),
+                                    event.fields()))
+                            .toList();
+                    return new TraceSpanEvents(events, page.truncated());
+                })
+                .orElse(TraceSpanEvents.EMPTY);
     }
 
     private Optional<TraceSpanRecord> spanOf(long traceId, long spanId) {
@@ -236,8 +242,9 @@ public class TraceManagerImpl implements TraceManager {
      * one and carries on until every id has been placed.
      * <p>
      * Rows sharing an id are the one shape that does lose a span: a span id identifies a span, and
-     * the derivation is what guarantees it. Only the first row of an id is drawn, and the trace
-     * still renders.
+     * the derivation dedupes on it before the primary key enforces it. Only the first row of an id
+     * is drawn — a defence kept even though a well-formed database cannot produce the shape, because
+     * a trace must render whatever the database holds.
      */
     private static List<TraceSpanRow> assemble(List<TraceSpanRecord> spans) {
         Set<Long> known = new HashSet<>();

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/trace/TraceSpanEvents.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/trace/TraceSpanEvents.java
@@ -1,0 +1,34 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.trace;
+
+import java.util.List;
+
+/**
+ * The events that ran inside one span's window, and whether the window held more than the row cap
+ * allowed. The flag reaches the UI so a busy span's drill-down can say "showing the first N events"
+ * instead of presenting a truncated list as the whole window.
+ *
+ * @param events    what ran on the span's thread while it was open, ordered by start time
+ * @param truncated whether the window held more events than the cap allowed
+ */
+public record TraceSpanEvents(List<TraceEventRow> events, boolean truncated) {
+
+    public static final TraceSpanEvents EMPTY = new TraceSpanEvents(List.of(), false);
+}

--- a/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/TraceManagerImplTest.java
+++ b/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/TraceManagerImplTest.java
@@ -21,7 +21,10 @@ package cafe.jeffrey.profile.manager;
 import cafe.jeffrey.profile.manager.model.trace.TraceDetail;
 import cafe.jeffrey.profile.manager.model.trace.TraceOverview;
 import cafe.jeffrey.profile.manager.model.trace.TraceRow;
+import cafe.jeffrey.profile.manager.model.trace.TraceSpanEvents;
 import cafe.jeffrey.profile.manager.model.trace.TraceSpanRow;
+import cafe.jeffrey.provider.profile.api.ThreadWindowEventRecord;
+import cafe.jeffrey.provider.profile.api.ThreadWindowEventsPage;
 import cafe.jeffrey.provider.profile.api.TraceOverviewRecord;
 import cafe.jeffrey.provider.profile.api.TraceRepository;
 import cafe.jeffrey.provider.profile.api.TraceSpanRecord;
@@ -446,4 +449,31 @@ class TraceManagerImplTest {
 
     // Operation intervals are reduced in SQL now, not here, so what used to be asserted against a
     // mocked span list is asserted against real DuckDB in JdbcTraceRepositoryTest.OperationIntervals.
+
+    @Nested
+    @DisplayName("Events in a span")
+    class EventsInSpan {
+
+        @Test
+        @DisplayName("a truncated window says so rather than passing the page off as complete")
+        void propagatesTruncation() {
+            when(traceRepository.spansOf(TRACE)).thenReturn(List.of(span(1, null, "root", 0, 100)));
+            when(traceRepository.eventsInSpan(THREAD, 0, 100)).thenReturn(new ThreadWindowEventsPage(
+                    List.of(new ThreadWindowEventRecord("jdk.ExecutionSample", 5, MS, "{}")), true));
+
+            TraceSpanEvents events = new TraceManagerImpl(traceRepository).eventsInSpan(TRACE, 1);
+
+            assertTrue(events.truncated(), "the flag is what the UI's notice hangs off");
+            assertEquals(1, events.events().size());
+            assertEquals("jdk.ExecutionSample", events.events().getFirst().eventType());
+        }
+
+        @Test
+        @DisplayName("an unknown span yields an empty page rather than failing")
+        void unknownSpanIsEmpty() {
+            when(traceRepository.spansOf(TRACE)).thenReturn(List.of());
+
+            assertEquals(TraceSpanEvents.EMPTY, new TraceManagerImpl(traceRepository).eventsInSpan(TRACE, 1));
+        }
+    }
 }

--- a/jeffrey-microscope/profiles/profile-persistence-api/src/main/java/cafe/jeffrey/provider/profile/api/ThreadWindowEventsPage.java
+++ b/jeffrey-microscope/profiles/profile-persistence-api/src/main/java/cafe/jeffrey/provider/profile/api/ThreadWindowEventsPage.java
@@ -1,0 +1,32 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.provider.profile.api;
+
+import java.util.List;
+
+/**
+ * One page of a thread-window drill-down: the events that fit under the row cap, and whether the
+ * window held more. The flag is what lets the UI say "showing the first N events" instead of
+ * silently presenting a truncated list as the whole of the window.
+ *
+ * @param events    the events that fit under the cap, ordered by start time
+ * @param truncated whether the window held more events than the cap allowed
+ */
+public record ThreadWindowEventsPage(List<ThreadWindowEventRecord> events, boolean truncated) {
+}

--- a/jeffrey-microscope/profiles/profile-persistence-api/src/main/java/cafe/jeffrey/provider/profile/api/TraceRepository.java
+++ b/jeffrey-microscope/profiles/profile-persistence-api/src/main/java/cafe/jeffrey/provider/profile/api/TraceRepository.java
@@ -104,8 +104,8 @@ public interface TraceRepository {
     List<TraceSpanRecord> spansOf(long traceId);
 
     /**
-     * The windows one operation occupied, one per {@code (trace, thread)} — what a flamegraph scoped
-     * to a whole trace type is built from.
+     * The windows one operation occupied, merged per {@code (trace, thread)} with idle gaps
+     * preserved — what a flamegraph scoped to a whole trace type is built from.
      * <p>
      * Reduced in SQL rather than by fetching every span and collapsing them here: the spans of a hot
      * operation are unbounded and all but these bounds are discarded.
@@ -127,13 +127,16 @@ public interface TraceRepository {
      * <p>
      * Events that are themselves spans are excluded, so the drill-down shows JVM activity rather
      * than repeating the tree the waterfall already draws.
+     * <p>
+     * The result is a page: a busy window can hold more events than the drill-down's row cap, and
+     * the page says so rather than passing off the first rows as the whole window.
      *
      * @param threadHash      identity hash of the span's thread; used rather than the OS id so the
      *                        lookup also resolves for virtual threads
      * @param fromEpochMillis window start, inclusive
      * @param toEpochMillis   window end, inclusive
      */
-    List<ThreadWindowEventRecord> eventsInSpan(long threadHash, long fromEpochMillis, long toEpochMillis);
+    ThreadWindowEventsPage eventsInSpan(long threadHash, long fromEpochMillis, long toEpochMillis);
 
     /**
      * How the recording described the fields of the given event types — the label, description and

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/JdbcTraceRepository.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/JdbcTraceRepository.java
@@ -20,6 +20,7 @@ package cafe.jeffrey.provider.profile.jdbc;
 
 import cafe.jeffrey.provider.profile.api.EventFieldRecord;
 import cafe.jeffrey.provider.profile.api.ThreadWindowEventRecord;
+import cafe.jeffrey.provider.profile.api.ThreadWindowEventsPage;
 import cafe.jeffrey.provider.profile.api.TraceOperationId;
 import cafe.jeffrey.provider.profile.api.TraceOperationRecord;
 import cafe.jeffrey.provider.profile.api.TraceOperationSpanRecord;
@@ -108,6 +109,12 @@ public class JdbcTraceRepository implements TraceRepository {
      * The ids are pulled out once in the CTE, which the filter then reuses by name, so each is read
      * out of the JSON a single time. The two predicates drop events that were never part of a
      * trace: their id fields are 0, the wire encoding for "absent".
+     *
+     * QUALIFY enforces the invariant the primary key states: one row per (trace_id, span_id). A
+     * duplicated event -- a re-imported chunk, third-party instrumentation reusing an id -- keeps
+     * its earliest occurrence, which is the row the waterfall would have drawn anyway, and because
+     * the dedupe happens before DERIVE_TRACES runs, span_count and error_count agree with the
+     * waterfall by construction instead of over-counting rows nobody renders.
      */
     //language=SQL
     private static final String DERIVE_TRACE_SPANS = """
@@ -142,6 +149,8 @@ public class JdbcTraceRepository implements TraceRepository {
                 json_extract_string(fields, '$.attributes')                     AS attributes,
                 NULLIF(CAST(json_merge_patch(fields, '%s') AS VARCHAR), '{}')   AS event_fields
             FROM spans
+            QUALIFY ROW_NUMBER() OVER (PARTITION BY trace_id, span_id
+                                       ORDER BY start_timestamp, duration) = 1
             """;
 
     /*
@@ -153,7 +162,10 @@ public class JdbcTraceRepository implements TraceRepository {
      * arbitrary choice there is an arbitrary answer to "what kind of request was this".
      *
      * Duration spans the whole trace rather than reusing the root's own duration: the same number
-     * whenever the root encloses its children, and the more honest one when it does not.
+     * whenever the root encloses its children, and the more honest one when it does not. The value
+     * is nanosecond-valued but only microsecond-accurate at its endpoints: `s.duration` carries
+     * full nanoseconds, while `epoch_ns(start_timestamp)` scales up a microsecond-resolution
+     * TIMESTAMPTZ, whose sub-microsecond part was already gone.
      *
      * `has_platform_span` is settled here, once, rather than by a correlated EXISTS per query.
      * `th.is_virtual = FALSE` is TRUE only for a thread that resolved *and* is a platform thread;
@@ -234,13 +246,16 @@ public class JdbcTraceRepository implements TraceRepository {
             %s
             """;
 
+    // Both lists carry a trace_id tie-break: duration and start_timestamp can tie (the latter is
+    // only microsecond-accurate), and a tied row at the LIMIT boundary would otherwise come and go
+    // between two identical requests.
     private static final String SLOWEST_TRACES = TRACE_SUMMARIES.formatted("""
-            ORDER BY duration DESC
+            ORDER BY duration DESC, trace_id
                 LIMIT :limit""");
 
     private static final String TRACES_OF_OPERATION = TRACE_SUMMARIES.formatted("""
             WHERE %s
-                ORDER BY start_timestamp
+                ORDER BY start_timestamp, trace_id
                 LIMIT :limit""".formatted(OPERATION_PREDICATE));
 
     private static final String TRACE_BY_ID = TRACE_SUMMARIES.formatted("WHERE trace_id = :trace_id");
@@ -290,14 +305,22 @@ public class JdbcTraceRepository implements TraceRepository {
             WHERE list_contains(json_extract_string(columns, '$[*].field'), 'scopedSpanId')""";
 
     /*
-     * The window each of an operation's traces occupied on each thread, which is all the span-scoped
+     * The windows each of an operation's traces occupied on each thread, which is all the span-scoped
      * flamegraph needs from it.
      *
      * Reduced here rather than in Java: this used to fetch every span of every trace of the type --
      * unbounded, on the hot path of both the panel list and the flamegraph -- only for the manager to
-     * collapse them to one interval per (trace, thread) and drop the rest. A hot operation
-     * materialised hundreds of thousands of span records, each holding up to three strings, per
-     * request. The group-by returns what survives that reduction and nothing else.
+     * collapse them and drop the rest. A hot operation materialised hundreds of thousands of span
+     * records, each holding up to three strings, per request. The merge returns what survives that
+     * reduction and nothing else.
+     *
+     * Overlapping and touching windows are merged per (trace, thread), but gaps between them are
+     * preserved -- the gaps-and-islands pass below. A plain MIN/MAX per (trace, thread) was tried
+     * first and quietly over-approximated: a thread active early and again late in a trace got one
+     * window spanning its idle gap, and the operation flamegraph absorbed whatever unrelated work
+     * that thread did in between. The row count is one per contiguous busy stretch instead of one
+     * per (trace, thread) -- bounded by the operation's span and scope count, in practice close to
+     * the old cardinality.
      *
      * The bounds stay in microseconds, the resolution the stored timestamp carries; crossing into
      * the events table's millisecond domain happens in one place in the manager, not here.
@@ -336,13 +359,32 @@ public class JdbcTraceRepository implements TraceRepository {
                   ON m.trace_id = json_extract_string(e.fields, '$.traceId')::BIGINT
                  AND m.span_id = json_extract_string(e.fields, '$.scopedSpanId')::BIGINT
                 WHERE e.event_type IN (%s)
+            ),
+            numbered AS (
+                SELECT
+                    trace_id, thread_hash, from_us, to_us,
+                    CASE WHEN from_us > MAX(to_us) OVER (
+                             PARTITION BY trace_id, thread_hash
+                             ORDER BY from_us, to_us
+                             ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)
+                         THEN 1 ELSE 0 END AS starts_island
+                FROM windows
+            ),
+            islands AS (
+                SELECT
+                    trace_id, thread_hash, from_us, to_us,
+                    SUM(starts_island) OVER (
+                        PARTITION BY trace_id, thread_hash
+                        ORDER BY from_us, to_us
+                        ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS island
+                FROM numbered
             )
             SELECT
                 thread_hash             AS thread_hash,
                 MIN(from_us)            AS from_epoch_us,
                 MAX(to_us)              AS to_epoch_us
-            FROM windows
-            GROUP BY trace_id, thread_hash
+            FROM islands
+            GROUP BY trace_id, thread_hash, island
             """.formatted(OPERATION_PREDICATE, SCOPE_EVENT_TYPES);
 
     /*
@@ -396,7 +438,7 @@ public class JdbcTraceRepository implements TraceRepository {
                 MAX(duration)                                       AS max_ns
             FROM traces
             GROUP BY root_name, root_kind, root_event_type
-            ORDER BY total_ns DESC
+            ORDER BY total_ns DESC, root_name, root_kind, root_event_type
             LIMIT :limit
             """;
 
@@ -426,7 +468,7 @@ public class JdbcTraceRepository implements TraceRepository {
             WHERE %s
               AND s.span_id <> t.root_span_id
             GROUP BY s.name
-            ORDER BY total_ns DESC
+            ORDER BY total_ns DESC, name
             LIMIT :limit
             """.formatted(OPERATION_PREDICATE);
 
@@ -688,12 +730,20 @@ public class JdbcTraceRepository implements TraceRepository {
     }
 
     @Override
-    public List<ThreadWindowEventRecord> eventsInSpan(long threadHash, long fromEpochMillis, long toEpochMillis) {
-        return databaseClient.query(
+    public ThreadWindowEventsPage eventsInSpan(long threadHash, long fromEpochMillis, long toEpochMillis) {
+        // One row past the cap: an extra row means the window held more than the page carries, and
+        // saying so is the difference between a truncated list and a list passed off as complete.
+        List<ThreadWindowEventRecord> rows = databaseClient.query(
                 StatementLabel.TRACE_SPAN_EVENTS,
                 EVENTS_IN_SPAN,
-                ThreadWindowEvents.params(threadHash, fromEpochMillis, toEpochMillis),
+                ThreadWindowEvents.params(
+                        threadHash, fromEpochMillis, toEpochMillis, ThreadWindowEvents.ROW_LIMIT + 1),
                 ThreadWindowEvents.mapper());
+
+        if (rows.size() <= ThreadWindowEvents.ROW_LIMIT) {
+            return new ThreadWindowEventsPage(rows, false);
+        }
+        return new ThreadWindowEventsPage(List.copyOf(rows.subList(0, ThreadWindowEvents.ROW_LIMIT)), true);
     }
 
     @Override

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/ThreadWindowEvents.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/ThreadWindowEvents.java
@@ -74,18 +74,26 @@ final class ThreadWindowEvents {
     }
 
     /**
-     * The bind parameters every caller supplies. The exclusion's own parameters, if it has any, are
-     * added by the caller on top of these.
+     * The bind parameters every caller supplies, capped at {@link #ROW_LIMIT}. The exclusion's own
+     * parameters, if it has any, are added by the caller on top of these.
      *
      * @param fromEpochMillis window start, inclusive
      * @param toEpochMillis   window end, inclusive
      */
     static MapSqlParameterSource params(long threadHash, long fromEpochMillis, long toEpochMillis) {
+        return params(threadHash, fromEpochMillis, toEpochMillis, ROW_LIMIT);
+    }
+
+    /**
+     * Same bind parameters with the caller's own row cap — what a caller binds when it wants to
+     * detect truncation by fetching one row past {@link #ROW_LIMIT}.
+     */
+    static MapSqlParameterSource params(long threadHash, long fromEpochMillis, long toEpochMillis, int limit) {
         return new MapSqlParameterSource()
                 .addValue("thread_hash", threadHash)
                 .addValue("from_ms", fromEpochMillis)
                 .addValue("to_ms", toEpochMillis)
-                .addValue("limit", ROW_LIMIT);
+                .addValue("limit", limit);
     }
 
     static RowMapper<ThreadWindowEventRecord> mapper() {

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/resources/db/migration/profile/V001__init.sql
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/resources/db/migration/profile/V001__init.sql
@@ -199,6 +199,10 @@ CREATE TABLE IF NOT EXISTS pipeline_runs
 -- `parent_span_id` is NULL for a root span (the wire encoding uses 0 for "absent", normalised here
 -- so SQL null-semantics apply).
 --
+-- The primary key states the invariant every read relies on: a span id identifies exactly one span
+-- of its trace. The derivation dedupes before inserting, so the key turns a future dedupe
+-- regression into a loud failure instead of a silent skew between span_count and the waterfall.
+--
 CREATE TABLE IF NOT EXISTS trace_spans
 (
     trace_id                       BIGINT      NOT NULL,
@@ -224,7 +228,8 @@ CREATE TABLE IF NOT EXISTS trace_spans
     -- rows, an exchange's uri, method and status code. These are schema, not attributes -- each is a
     -- labelled field of its event type -- so they are kept apart from the map above. Null for an
     -- event that declares nothing of its own, a hand-written span being the usual case.
-    event_fields                   VARCHAR
+    event_fields                   VARCHAR,
+    PRIMARY KEY (trace_id, span_id)
 );
 
 --
@@ -272,6 +277,8 @@ CREATE TABLE IF NOT EXISTS traces
 
 -- Unlike `events`, these two are small, written once by the derivation and then read interactively
 -- by every trace query, so the ingest-cost argument against ART indexes above does not apply here.
+-- The single-column index exists alongside the composite primary key because every trace read
+-- filters on trace_id alone, and the composite ART key is not a reliable substitute for a
+-- prefix-only lookup.
 CREATE INDEX IF NOT EXISTS trace_spans_trace_id_idx ON trace_spans (trace_id);
-CREATE INDEX IF NOT EXISTS trace_spans_thread_hash_idx ON trace_spans (thread_hash);
 CREATE INDEX IF NOT EXISTS traces_operation_idx ON traces (root_name, root_kind, root_event_type);

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/test/java/cafe/jeffrey/provider/profile/jdbc/JdbcTraceRepositoryTest.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/test/java/cafe/jeffrey/provider/profile/jdbc/JdbcTraceRepositoryTest.java
@@ -21,6 +21,7 @@ package cafe.jeffrey.provider.profile.jdbc;
 import cafe.jeffrey.jfr.events.trace.SpanKind;
 import cafe.jeffrey.jfr.events.trace.SpanStatus;
 import cafe.jeffrey.provider.profile.api.ThreadWindowEventRecord;
+import cafe.jeffrey.provider.profile.api.ThreadWindowEventsPage;
 import cafe.jeffrey.provider.profile.api.TraceOperationId;
 import cafe.jeffrey.provider.profile.api.TraceOperationRecord;
 import cafe.jeffrey.provider.profile.api.TraceOperationSpanRecord;
@@ -38,6 +39,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.sql.DataSource;
 import java.sql.SQLException;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -212,6 +214,35 @@ class JdbcTraceRepositoryTest {
             assertEquals(EPOCH_10_00_00, request.fromEpochMillis());
             assertEquals(EPOCH_10_00_00 + 120, request.toEpochMillis(),
                     "the scope sits inside the exchange, so the exchange still bounds the thread");
+        }
+
+        /** The same trace, plus a second, later stint of the slow trace on the pool thread. */
+        private JdbcTraceRepository withDisjointActivity(DataSource dataSource) throws SQLException {
+            TestUtils.executeSql(dataSource, "sql/events/insert-trace-spans.sql");
+            TestUtils.executeSql(dataSource, "sql/events/insert-disjoint-thread-activity.sql");
+            JdbcTraceRepository repository = new JdbcTraceRepository(new DatabaseClientProvider(dataSource));
+            repository.derive();
+            return repository;
+        }
+
+        @Test
+        @DisplayName("a thread active twice with a gap keeps two intervals rather than one spanning it")
+        void disjointActivityKeepsTheGap(DataSource dataSource) throws SQLException {
+            // Collapsing a thread to MIN/MAX handed the flamegraph one window across the idle gap,
+            // absorbing whatever unrelated work the thread did between its two stints on the trace.
+            List<SpanInterval> intervals =
+                    withDisjointActivity(dataSource).operationIntervals(FLAMEGRAPH_OPERATION);
+
+            List<SpanInterval> pool = intervals.stream()
+                    .filter(interval -> interval.threadHash() == 3002L)
+                    .sorted(Comparator.comparingLong(SpanInterval::fromEpochMillis))
+                    .toList();
+
+            assertEquals(2, pool.size(), "one interval per stint, not one spanning the gap");
+            assertEquals(EPOCH_10_00_00 + 60, pool.get(0).fromEpochMillis());
+            assertEquals(EPOCH_10_00_00 + 80, pool.get(0).toEpochMillis());
+            assertEquals(EPOCH_10_00_00 + 100, pool.get(1).fromEpochMillis());
+            assertEquals(EPOCH_10_00_00 + 110, pool.get(1).toEpochMillis());
         }
 
         @Test
@@ -476,6 +507,28 @@ class JdbcTraceRepositoryTest {
         }
 
         @Test
+        @DisplayName("rows claiming the same span id are deduped to the earliest occurrence")
+        void dedupesRepeatedSpanIds(DataSource dataSource) throws SQLException {
+            // A re-imported chunk or instrumentation that reused an id. Without the dedupe, both
+            // rows landed in trace_spans, span_count counted them both, and the waterfall drew one.
+            TestUtils.executeSql(dataSource, "sql/events/insert-trace-spans.sql");
+            TestUtils.executeSql(dataSource, "sql/events/insert-duplicate-span-events.sql");
+            JdbcTraceRepository repository = new JdbcTraceRepository(new DatabaseClientProvider(dataSource));
+            repository.derive();
+
+            List<TraceSpanRecord> spans = repository.spansOf(SLOW_TRACE);
+
+            assertEquals(spans.size(), spans.stream().map(TraceSpanRecord::spanId).distinct().count(),
+                    "a span id has to identify exactly one span");
+            TraceSpanRecord kept = spans.stream()
+                    .filter(span -> span.spanId() == 112L).findFirst().orElseThrow();
+            assertEquals("listSpans", kept.name(),
+                    "the earliest occurrence wins, the row the waterfall would have drawn anyway");
+            assertEquals(spans.size(), repository.summaryOf(SLOW_TRACE).orElseThrow().spanCount(),
+                    "span_count must agree with the rows the waterfall draws");
+        }
+
+        @Test
         @DisplayName("an event carrying ids but no span shape still lands in the trace")
         void fallsBackForAnIncompleteShape(DataSource dataSource) throws SQLException {
             // Third-party instrumentation that stamped only the ids, or a recording older than the
@@ -563,6 +616,24 @@ class JdbcTraceRepositoryTest {
             JdbcTraceRepository repository = derived(dataSource);
 
             assertEquals(1, repository.slowestTraces(1).size());
+        }
+
+        @Test
+        @DisplayName("traces with the same duration are listed in a stable order")
+        void tiedDurationsOrderDeterministically(DataSource dataSource) throws SQLException {
+            // Ordering by duration alone leaves a tied row at the LIMIT boundary free to come and
+            // go between two identical requests; trace_id breaks the tie.
+            TestUtils.executeSql(dataSource, "sql/events/insert-trace-spans.sql");
+            TestUtils.executeSql(dataSource, "sql/events/insert-tied-duration-traces.sql");
+            JdbcTraceRepository repository = new JdbcTraceRepository(new DatabaseClientProvider(dataSource));
+            repository.derive();
+
+            List<Long> ids = repository.slowestTraces(10).stream()
+                    .map(TraceSummaryRecord::traceId)
+                    .toList();
+
+            assertEquals(List.of(SLOW_TRACE, 7001L, 7002L, FAST_TRACE), ids,
+                    "the two 7ms traces fall back to trace_id order");
         }
 
         @Test
@@ -776,13 +847,15 @@ class JdbcTraceRepositoryTest {
 
             // The window of the root HTTP span on thread 3001, which also carries a JDBC span and
             // an execution sample.
-            List<ThreadWindowEventRecord> events = repository.eventsInSpan(
+            ThreadWindowEventsPage page = repository.eventsInSpan(
                     3001, EPOCH_10_00_00, EPOCH_10_00_00 + 120);
+            List<ThreadWindowEventRecord> events = page.events();
 
             assertTrue(events.stream().noneMatch(event -> event.eventType().startsWith("jeffrey.")),
                     "an event that is itself a span belongs in the waterfall, not inside a span");
             assertEquals(List.of("jdk.ExecutionSample"),
                     events.stream().map(ThreadWindowEventRecord::eventType).toList());
+            assertFalse(page.truncated(), "a handful of events is nowhere near the row cap");
         }
 
         @Test
@@ -791,9 +864,9 @@ class JdbcTraceRepositoryTest {
             JdbcTraceRepository repository = derived(dataSource);
 
             // A different thread has no events of its own in the fixture.
-            assertTrue(repository.eventsInSpan(3002, EPOCH_10_00_00, EPOCH_10_00_00 + 120).isEmpty());
+            assertTrue(repository.eventsInSpan(3002, EPOCH_10_00_00, EPOCH_10_00_00 + 120).events().isEmpty());
             // A window before anything happened is empty too.
-            assertTrue(repository.eventsInSpan(3001, EPOCH_10_00_00 - 500, EPOCH_10_00_00 - 1).isEmpty());
+            assertTrue(repository.eventsInSpan(3001, EPOCH_10_00_00 - 500, EPOCH_10_00_00 - 1).events().isEmpty());
         }
     }
 }

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/test/resources/sql/events/insert-disjoint-thread-activity.sql
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/test/resources/sql/events/insert-disjoint-thread-activity.sql
@@ -1,0 +1,11 @@
+-- Fixture for JdbcTraceRepositoryTest.OperationIntervals, layered on top of insert-trace-spans.sql.
+--
+-- A second span of the slow trace on the pool thread, well after the first one ended: the thread
+-- worked on the trace at +60..+80ms and again at +100..+110ms, and did something unrelated in
+-- between. An interval reduction that collapses a thread to MIN/MAX would hand the flamegraph one
+-- window spanning the idle gap, absorbing that unrelated work; merging with gaps preserved keeps
+-- the two stints apart.
+INSERT INTO events (event_type, start_timestamp, start_timestamp_from_beginning, duration, samples, weight, weight_entity, stacktrace_hash, thread_hash, fields)
+VALUES
+    ('jeffrey.TraceSpan', '2025-01-15T10:00:00.100Z', 100, 10000000, 1, NULL, NULL, NULL, 3002,
+     '{"traceId":9223372036854775807,"spanId":555,"parentSpanId":111,"name":"flamegraph.recluster","kind":"INTERNAL","status":"UNSET"}');

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/test/resources/sql/events/insert-duplicate-span-events.sql
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/test/resources/sql/events/insert-duplicate-span-events.sql
@@ -1,0 +1,10 @@
+-- Fixture for JdbcTraceRepositoryTest.Derivation, layered on top of insert-trace-spans.sql.
+--
+-- A second event claiming span 112 of the slow trace -- a re-imported chunk, or third-party
+-- instrumentation that reused an id. The derivation must keep exactly one row per (trace, span):
+-- the earliest occurrence, which is the row the waterfall would have drawn anyway, so span_count
+-- agrees with what the UI renders.
+INSERT INTO events (event_type, start_timestamp, start_timestamp_from_beginning, duration, samples, weight, weight_entity, stacktrace_hash, thread_hash, fields)
+VALUES
+    ('jeffrey.JdbcQuery', '2025-01-15T10:00:00.015Z', 15, 99000000, 1, NULL, NULL, NULL, 3001,
+     '{"traceId":9223372036854775807,"spanId":112,"parentSpanId":111,"name":"listSpans-duplicate","kind":"CLIENT","status":"UNSET","group":"PROFILE_EVENTS"}');

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/test/resources/sql/events/insert-tied-duration-traces.sql
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/test/resources/sql/events/insert-tied-duration-traces.sql
@@ -1,0 +1,11 @@
+-- Fixture for JdbcTraceRepositoryTest.Reads, layered on top of insert-trace-spans.sql.
+--
+-- Two traces with exactly the same duration, so ordering by duration alone cannot decide between
+-- them. The slowest-traces list breaks the tie on trace_id; without that, the trace at a LIMIT
+-- boundary comes and goes between two identical requests.
+INSERT INTO events (event_type, start_timestamp, start_timestamp_from_beginning, duration, samples, weight, weight_entity, stacktrace_hash, thread_hash, fields)
+VALUES
+    ('jeffrey.HttpServerExchange', '2025-01-15T10:00:03.000Z', 3000, 7000000, 1, NULL, NULL, NULL, 3001,
+     '{"traceId":7002,"spanId":331,"parentSpanId":0,"name":"GET /tied","kind":"SERVER","status":"UNSET","method":"GET","uri":"/tied","statusCode":200}'),
+    ('jeffrey.HttpServerExchange', '2025-01-15T10:00:04.000Z', 4000, 7000000, 1, NULL, NULL, NULL, 3001,
+     '{"traceId":7001,"spanId":332,"parentSpanId":0,"name":"GET /tied","kind":"SERVER","status":"UNSET","method":"GET","uri":"/tied","statusCode":200}');


### PR DESCRIPTION
- Operation flamegraph windows: merge per (trace, thread) with idle gaps
  preserved (gaps-and-islands) instead of MIN/MAX, so the graph no longer
  absorbs unrelated work a thread did between two stints on a trace
- trace_spans: dedupe on (trace_id, span_id) in the derivation and enforce
  it with a primary key, so traces.span_count always agrees with the
  waterfall; drop the unused thread_hash index
- Deterministic tie-breaks on every LIMITed trace query (slowest traces,
  traces of an operation, operations, span breakdown)
- Span events drill-down reports truncation: eventsInSpan returns a page
  with a truncated flag, surfaced as a notice in the spans modal
- Frontend: wire @retry on TraceOperationDetail's ErrorState, align trace
  route names with the profile-technologies-* convention, hoist the
  modal-init delay to GraphUpdater, pass the trace fetch limit explicitly
- Document duration precision (ns-valued, us-accurate endpoints) and
  record the consciously deferred items in TRACES_LEFTOVERS.md; full
  analysis in TRACES_ANALYSIS.md