### PR TITLE
Make the filesystem layer independent of the default FileSystem provider

### DIFF
--- a/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/project/repository/AsprofFileRepositoryStorage.java
+++ b/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/project/repository/AsprofFileRepositoryStorage.java
@@ -106,7 +106,9 @@ public class AsprofFileRepositoryStorage implements RepositoryStorage {
 
     private Path resolveWorkspacePath(RepositoryInfo repositoryInfo) {
         String workspacesPath = repositoryInfo.workspacesPath();
-        Path resolvedWorkspacesPath = workspacesPath == null ? workspacesDir : Path.of(workspacesPath);
+        Path resolvedWorkspacesPath = workspacesPath == null
+                ? workspacesDir
+                : workspacesDir.getFileSystem().getPath(workspacesPath);
         return resolvedWorkspacesPath
                 .resolve(repositoryInfo.relativeWorkspacePath());
     }

--- a/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/streaming/SessionPaths.java
+++ b/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/streaming/SessionPaths.java
@@ -38,7 +38,10 @@ public abstract class SessionPaths {
     public static Path resolve(
             HubJeffreyDirs jeffreyDirs, RepositoryInfo repositoryInfo, ProjectInstanceSessionInfo sessionInfo) {
         String workspacesPath = repositoryInfo.workspacesPath();
-        Path resolvedWorkspacesPath = workspacesPath == null ? jeffreyDirs.workspaces() : Path.of(workspacesPath);
+        Path defaultWorkspaces = jeffreyDirs.workspaces();
+        Path resolvedWorkspacesPath = workspacesPath == null
+                ? defaultWorkspaces
+                : defaultWorkspaces.getFileSystem().getPath(workspacesPath);
 
         return resolvedWorkspacesPath
                 .resolve(repositoryInfo.relativeWorkspacePath())

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/configuration/RemoteWorkspaceConfiguration.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/configuration/RemoteWorkspaceConfiguration.java
@@ -47,8 +47,8 @@ public class RemoteWorkspaceConfiguration {
     }
 
     @Bean(destroyMethod = "close")
-    public CachedHubClientsFactory remoteClientsFactory() {
-        return new CachedHubClientsFactory();
+    public CachedHubClientsFactory remoteClientsFactory(MicroscopeJeffreyDirs jeffreyDirs) {
+        return new CachedHubClientsFactory(jeffreyDirs::newTempDir);
     }
 
     @Bean

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/compression/Lz4Compressor.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/compression/Lz4Compressor.java
@@ -55,11 +55,11 @@ public class Lz4Compressor {
      * @throws IOException if compression fails
      */
     public Path compressAndMove(Path source) throws IOException {
-        String targetFilename = source.toString() + LZ4_EXTENSION;
+        Path target = source.resolveSibling(source.getFileName() + LZ4_EXTENSION);
         try (TempDirectory tempDir = tempDirFactory.newTempDir()) {
             Path tempFile = compressToDir(source, tempDir.path());
             compress(source, tempFile);
-            return Files.move(tempFile, Path.of(targetFilename), ATOMIC_MOVE, REPLACE_EXISTING);
+            return Files.move(tempFile, target, ATOMIC_MOVE, REPLACE_EXISTING);
         }
     }
 

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/filesystem/FileSystemUtils.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/filesystem/FileSystemUtils.java
@@ -24,7 +24,6 @@ import org.slf4j.LoggerFactory;
 import cafe.jeffrey.shared.common.Json;
 import cafe.jeffrey.shared.common.model.repository.SupportedRecordingFile;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -193,8 +192,7 @@ public abstract class FileSystemUtils {
 
         try (Stream<Path> files = Files.walk(directory)) {
             files.sorted(Comparator.reverseOrder())
-                    .map(Path::toFile)
-                    .forEach(File::delete);
+                    .forEach(FileSystemUtils::delete);
         } catch (IOException e) {
             throw new RuntimeException("Cannot complete removing of a directory: " + directory, e);
         }

--- a/shared/hub-client/src/main/java/cafe/jeffrey/hub/client/CachedHubClientsFactory.java
+++ b/shared/hub-client/src/main/java/cafe/jeffrey/hub/client/CachedHubClientsFactory.java
@@ -22,6 +22,7 @@ import cafe.jeffrey.microscope.grpc.client.*;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import cafe.jeffrey.hub.client.manager.TempDirProvider;
 import cafe.jeffrey.shared.common.model.hub.HubAddress;
 
 import java.io.Closeable;
@@ -37,6 +38,12 @@ public class CachedHubClientsFactory implements HubClients.Factory, Closeable {
     private static final Logger LOG = LoggerFactory.getLogger(CachedHubClientsFactory.class);
 
     private final ConcurrentHashMap<HubAddress, CachedEntry> cache = new ConcurrentHashMap<>();
+
+    private final TempDirProvider tempDirProvider;
+
+    public CachedHubClientsFactory(TempDirProvider tempDirProvider) {
+        this.tempDirProvider = tempDirProvider;
+    }
 
     @Override
     public HubClients apply(HubAddress address) {
@@ -76,7 +83,7 @@ public class CachedHubClientsFactory implements HubClients.Factory, Closeable {
         HubClients clients = new HubClients(
                 new DiscoveryClient(connection),
                 new RepositoryClient(connection),
-                new RecordingStreamClient(connection),
+                new RecordingStreamClient(connection, tempDirProvider),
                 new ProfilerClient(connection),
                 new InstancesClient(connection),
                 new ProjectsClient(connection),

--- a/shared/hub-client/src/main/java/cafe/jeffrey/hub/client/RecordingStreamClient.java
+++ b/shared/hub-client/src/main/java/cafe/jeffrey/hub/client/RecordingStreamClient.java
@@ -26,7 +26,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import cafe.jeffrey.hub.api.v1.*;
+import cafe.jeffrey.hub.client.manager.TempDirProvider;
 import cafe.jeffrey.shared.common.Schedulers;
+import cafe.jeffrey.shared.common.filesystem.TempDirectory;
 
 import java.io.*;
 import java.nio.file.Files;
@@ -52,9 +54,11 @@ public class RecordingStreamClient {
     private static final long UNKNOWN_CONTENT_LENGTH = -1;
 
     private final RecordingDownloadServiceGrpc.RecordingDownloadServiceBlockingStub stub;
+    private final TempDirProvider tempDirProvider;
 
-    public RecordingStreamClient(GrpcHubConnection connection) {
+    public RecordingStreamClient(GrpcHubConnection connection, TempDirProvider tempDirProvider) {
         this.stub = RecordingDownloadServiceGrpc.newBlockingStub(connection.getChannel());
+        this.tempDirProvider = tempDirProvider;
     }
 
     public CompletableFuture<Resource> downloadRecordings(
@@ -123,10 +127,14 @@ public class RecordingStreamClient {
 
     /**
      * Collects gRPC data chunks into a temporary file and returns it as a Spring Resource.
+     * The temp directory is intentionally not closed on success — the returned Resource is backed
+     * by the file inside it, so ownership passes to the consumer and the application's temp-dir
+     * lifecycle removes the leftovers.
      */
-    private static Resource collectChunksToResource(Iterator<DataChunk> chunks) {
+    private Resource collectChunksToResource(Iterator<DataChunk> chunks) {
+        TempDirectory tempDir = tempDirProvider.newTempDir();
         try {
-            Path tempFile = Files.createTempFile("grpc-download-", ".tmp");
+            Path tempFile = Files.createTempFile(tempDir.path(), "grpc-download-", ".tmp");
 
             try (OutputStream out = new BufferedOutputStream(Files.newOutputStream(tempFile))) {
                 while (chunks.hasNext()) {
@@ -136,6 +144,7 @@ public class RecordingStreamClient {
 
             return new FileSystemResource(tempFile);
         } catch (IOException e) {
+            tempDir.close();
             throw new UncheckedIOException("Failed to collect gRPC data chunks to temp file", e);
         }
     }


### PR DESCRIPTION
Remove the default-filesystem coupling from the Path-based layer so any
java.nio.file.FileSystem (e.g. an in-memory one in tests) can back it:

- FileSystemUtils.removeDirectory: delete via Files.delete instead of
  Path::toFile + File::delete, which only works on the default provider
  and silently swallows deletion failures
- SessionPaths/AsprofFileRepositoryStorage: resolve the stored workspaces
  path against the injected root's FileSystem instead of Path.of
- Lz4Compressor.compressAndMove: build the target via resolveSibling
  instead of string concatenation + Path.of
- RecordingStreamClient: write buffered downloads into a directory from
  the injected TempDirProvider instead of Files.createTempFile, so the
  files land under the app-managed temp dir instead of leaking into the
  OS temp dir