### PR TITLE
Simplify JFR event registration documentation

### DIFF
--- a/utilities/jeffrey-events/skills/jeffrey-traces-core/SKILL.md
+++ b/utilities/jeffrey-events/skills/jeffrey-traces-core/SKILL.md
@@ -104,17 +104,9 @@ Understand this model first; every rule follows from it.
 - If the application runs on the module path, `jeffrey-events` already
   `opens` its event packages to `jdk.jfr`; nothing to configure. On the
   classpath, nothing to configure either.
-
-**Optional but recommended** — register all event types eagerly at startup so
-their metadata is present in every recording even before the first event fires
-(e.g. in an `ApplicationListener<ApplicationReadyEvent>` or any init hook):
-
-```java
-import cafe.jeffrey.jfr.events.JeffreyEventRegistry;
-import jdk.jfr.FlightRecorder;
-
-JeffreyEventRegistry.all().forEach(FlightRecorder::register);
-```
+- No registration step is needed: JFR auto-registers each event type the
+  first time an instance of its class is created, so committed events always
+  land in the recording with full metadata.
 
 ---
 


### PR DESCRIPTION
## Summary
Updated the JFR event registration documentation in the `jeffrey-traces-core` skill to reflect that manual event registration is no longer necessary. JFR automatically registers event types when instances are created, eliminating the need for explicit registration steps.

## Changes
- Removed the "Optional but recommended" section that documented manual event registration via `JeffreyEventRegistry.all().forEach(FlightRecorder::register)`
- Replaced it with a clearer explanation that JFR auto-registers each event type on first instantiation, ensuring committed events always have full metadata in recordings
- Simplified the configuration guidance to clarify that no registration step is needed

## Details
This change reflects the actual behavior of JFR and reduces unnecessary configuration complexity for users of the `jeffrey-events` skill. The documentation now accurately conveys that event metadata is automatically available in recordings without requiring developers to add initialization code.

https://claude.ai/code/session_01DS23siJQkmNjxeJGVAZaYP