### PR TITLE
Unified span lifecycle: failed() on every traced event, single commitSpan() verb, event documentation

### DIFF
--- a/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/persistence/HeapDumpDatabaseClient.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/persistence/HeapDumpDatabaseClient.java
@@ -101,7 +101,7 @@ public final class HeapDumpDatabaseClient {
         } finally {
             if (event.shouldCommit()) {
                 event.sql = sql;
-                event.stampAndCommit();
+                event.commitSpan();
             }
         }
     }
@@ -135,7 +135,7 @@ public final class HeapDumpDatabaseClient {
                 event.sql = sql;
                 event.rows = rows;
                 event.params = paramsToJson(params);
-                event.stampAndCommit();
+                event.commitSpan();
             }
         }
         return rows;
@@ -157,7 +157,7 @@ public final class HeapDumpDatabaseClient {
                 event.sql = sql;
                 event.rows = rows;
                 event.params = paramsToJson(params);
-                event.stampAndCommit();
+                event.commitSpan();
             }
         }
         return rows;
@@ -179,7 +179,7 @@ public final class HeapDumpDatabaseClient {
                 event.sql = sql;
                 event.rows = rows;
                 event.params = paramsToJson(params);
-                event.stampAndCommit();
+                event.commitSpan();
             }
         }
         return rows;
@@ -202,7 +202,7 @@ public final class HeapDumpDatabaseClient {
             if (event.shouldCommit()) {
                 event.sql = APPENDER_SQL_PREFIX + tableName;
                 event.rows = rows;
-                event.stampAndCommit();
+                event.commitSpan();
             }
         }
     }
@@ -230,7 +230,7 @@ public final class HeapDumpDatabaseClient {
             if (event.shouldCommit()) {
                 event.sql = APPENDER_SQL_PREFIX + primaryTable + " + " + secondaryTable;
                 event.rows = rows;
-                event.stampAndCommit();
+                event.commitSpan();
             }
         }
     }
@@ -266,7 +266,7 @@ public final class HeapDumpDatabaseClient {
             if (event.shouldCommit()) {
                 event.sql = sql;
                 event.rows = rows;
-                event.stampAndCommit();
+                event.commitSpan();
             }
         }
         return rows;
@@ -294,7 +294,7 @@ public final class HeapDumpDatabaseClient {
                 event.sql = sql;
                 event.rows = result.isPresent() ? 1 : 0;
                 event.params = paramsToJson(params);
-                event.stampAndCommit();
+                event.commitSpan();
             }
         }
         return result;
@@ -320,7 +320,7 @@ public final class HeapDumpDatabaseClient {
                 event.sql = sql;
                 event.rows = out.size();
                 event.params = paramsToJson(params);
-                event.stampAndCommit();
+                event.commitSpan();
             }
         }
         return out;
@@ -348,7 +348,7 @@ public final class HeapDumpDatabaseClient {
                 event.sql = sql;
                 event.rows = present ? 1 : 0;
                 event.params = paramsToJson(params);
-                event.stampAndCommit();
+                event.commitSpan();
             }
         }
         return value;
@@ -384,7 +384,7 @@ public final class HeapDumpDatabaseClient {
         } finally {
             if (event.shouldCommit()) {
                 event.rows = rows;
-                event.stampAndCommit();
+                event.commitSpan();
             }
         }
     }
@@ -403,7 +403,7 @@ public final class HeapDumpDatabaseClient {
         JdbcStreamEvent event = new JdbcStreamEvent(stmt.label(), groupLabel);
         // Stamped eagerly, unlike every other emitter here: the event commits from the stream's
         // onClose, which may run after the enclosing span's binding is gone — or inside someone
-        // else's — so stampAndCommit there would attach the statement to the wrong place.
+        // else's — so letting commitSpan stamp there would attach the statement to the wrong place.
         Tracer.stamp(event);
         event.sql = sql;
         event.params = paramsToJson(params);

--- a/jeffrey-pages/src/views/docs/events/JeffreyJfrEventsPage.vue
+++ b/jeffrey-pages/src/views/docs/events/JeffreyJfrEventsPage.vue
@@ -153,7 +153,7 @@ Tracer.inSpanOf(event, () -> {                 // 2. stamps traceId/spanId/paren
 
         <ol>
           <li><strong>Extend <code>AbstractTracedEvent</code>.</strong> This is what makes the event a span — it declares the <code>spanId</code> field Jeffrey discovers structurally. <code>@Span</code> on a plain <code>jdk.jfr.Event</code> does nothing.</li>
-          <li><strong>Stamp the ids.</strong> The derivation drops events whose <code>traceId</code>/<code>spanId</code> are 0. Run the work through <code>Tracer.inSpanOf(event, ...)</code> so the event joins the active trace — or roots a new one if none is active. An event that should sit <em>under</em> the current span rather than be one of its own — a leaf, like a statement — commits through <code>event.stampAndCommit()</code> instead, which stamps and commits in one call.</li>
+          <li><strong>Stamp the ids.</strong> The derivation drops events whose <code>traceId</code>/<code>spanId</code> are 0. Run the work through <code>Tracer.inSpanOf(event, ...)</code> so the event joins the active trace — or roots a new one if none is active. An event that should sit <em>under</em> the current span rather than be one of its own — a leaf, like a statement — commits through <code>event.commitSpan()</code> instead, which stamps and commits in one call.</li>
           <li><strong>Declare the name with <code>@Span</code>.</strong> The template travels inside every recording, so Traces by Operation lists <code>PUBLISH orders</code> rather than <code>com.acme.KafkaPublish</code>, and one operation groups as one row across recordings.</li>
         </ol>
 

--- a/jeffrey-pages/src/views/docs/events/TracerApiPage.vue
+++ b/jeffrey-pages/src/views/docs/events/TracerApiPage.vue
@@ -125,7 +125,7 @@ event.end();
 if (event.shouldCommit()) {
     event.sql = sql;
     event.rows = rows;
-    event.stampAndCommit();   // child ids under the span in progress, then commits;
+    event.commitSpan();       // stamps child ids under the span in progress, then commits;
 }                             // no-op ids outside a span — the untraced shape`;
 
 const stampTree = `trace 8c1d33f0…
@@ -355,7 +355,7 @@ const composedTree = `trace a3f9c1d4…                                         
 
       <p>Gives the event a span of its own, nested inside the span currently in progress, so the event takes its place in the trace. Nothing is bound to the minted id — that is what makes a stamped event a <strong>leaf</strong>: the work it describes is the event itself, not a scope other spans can nest inside. Outside any span it does nothing, leaving the ids at <code>0</code> — the encoding for "not part of a trace" — so the same instrumentation works traced and untraced.</p>
 
-      <p>An emitter that commits in its own <code>finally</code> should not call <code>stamp</code> directly: <code>event.stampAndCommit()</code> folds the stamp into the commit, so forgetting it — which silently drops the event from every trace — stops being possible. Call <code>stamp</code> yourself only when the commit is deferred past the enclosing binding, e.g. an event committed from a stream's <code>close()</code>.</p>
+      <p>An emitter that commits in its own <code>finally</code> should not call <code>stamp</code> directly: <code>event.commitSpan()</code> folds the stamp into the commit — it stamps an event that does not yet carry identity and leaves one that does untouched — so forgetting the stamp, which silently drops the event from every trace, stops being possible. Call <code>stamp</code> yourself only when the commit is deferred past the enclosing binding, e.g. an event committed from a stream's <code>close()</code>.</p>
 
       <DocsCodeBlock :code="stampExample" language="java" />
 

--- a/jeffrey-pages/src/views/docs/microscope/profiles/ProfileTracesPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/profiles/ProfileTracesPage.vue
@@ -107,7 +107,7 @@ if (event.isEnabled()) {
     event.rows = rows;
     // Gives the statement a span of its own under the span in progress,
     // derives the span shape from the event's own fields, then commits.
-    event.stampAndCommit();
+    event.commitSpan();
 }`;
 </script>
 
@@ -202,7 +202,7 @@ if (event.isEnabled()) {
 
       <p>The HTTP, gRPC and JDBC events in <code>jeffrey-events</code> extend <code>AbstractTracedEvent</code>, which carries the whole span shape — <code>traceId</code>, <code>spanId</code>, <code>parentSpanId</code>, plus the <code>name</code>, <code>kind</code>, <code>status</code>, <code>errorType</code> and <code>attributes</code> a <code>jeffrey.TraceSpan</code> carries. An event that has them <em>is</em> a span; there is nothing for Jeffrey to work out from the event type.</p>
 
-      <p>Two forms populate them. <code>stampAndCommit()</code> gives the event a span of its own nested inside the span in progress and commits it — the form for a leaf, like a statement, folding the stamp into the commit so it cannot be forgotten. <code>Tracer.inSpanOf</code> makes the event <em>be</em> the span it opens, so anything traced underneath nests inside it — the form for an entry point, like an inbound request, committed through <code>commitSpan()</code>. Both let the event derive its own name and status first:</p>
+      <p>Both roles commit through <code>commitSpan()</code>, which stamps an event that does not yet carry trace identity and leaves one that does untouched. A leaf, like a statement, is stamped by the commit itself with a span of its own nested inside the span in progress — the stamp cannot be forgotten. An entry point, like an inbound request, runs through <code>Tracer.inSpanOf</code> first, which makes the event <em>be</em> the span it opens, so anything traced underneath nests inside it. Both let the event derive its own name and status first:</p>
 
       <DocsCodeBlock :code="stampExample" language="java" />
 

--- a/jeffrey-pages/src/views/docs/microscope/profiles/TracerApiPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/profiles/TracerApiPage.vue
@@ -124,7 +124,7 @@ if (event.isEnabled()) {
     event.rows = rows;
     // Gives the statement a span of its own nested under the span in progress,
     // derives name/kind/status from the event's own fields, then commits.
-    event.stampAndCommit();
+    event.commitSpan();
 }`;
 
 const continueInExample = `// ScopedValue does not propagate through a plain executor, so the parent
@@ -309,7 +309,7 @@ const volumeExample = `# Drop spans shorter than 1 ms (their children are orphan
 
       <p>Gives <code>event</code> a span of its own, nested inside the span in progress. Does nothing when no span is in progress, leaving the ids at <code>0</code> — the encoding for "not part of a trace".</p>
 
-      <p>An emitter that commits in its own <code>finally</code> should not call it directly: <code>event.stampAndCommit()</code> folds the stamp into the commit, so forgetting the stamp — which silently drops the event from every trace — stops being possible. Reach for <code>stamp</code> itself only when the commit is deferred past the enclosing binding, e.g. an event committed from a stream's <code>close()</code>.</p>
+      <p>An emitter that commits in its own <code>finally</code> should not call it directly: <code>event.commitSpan()</code> folds the stamp into the commit — it stamps an event that does not yet carry identity and leaves one that does untouched — so forgetting the stamp, which silently drops the event from every trace, stops being possible. Reach for <code>stamp</code> itself only when the commit is deferred past the enclosing binding, e.g. an event committed from a stream's <code>close()</code>.</p>
 
       <DocsCodeBlock :code="stampExample" language="java" />
 

--- a/shared/persistence/src/main/java/cafe/jeffrey/shared/persistence/client/DatabaseClient.java
+++ b/shared/persistence/src/main/java/cafe/jeffrey/shared/persistence/client/DatabaseClient.java
@@ -78,7 +78,7 @@ public class DatabaseClient {
                 event.sql = sql;
                 event.rows = rows;
                 event.params = paramSourceToJson(paramSource);
-                event.stampAndCommit();
+                event.commitSpan();
             }
         }
 
@@ -102,7 +102,7 @@ public class DatabaseClient {
                 event.rows = rows;
                 event.isLob = true;
                 event.params = paramSourceToJson(paramSource);
-                event.stampAndCommit();
+                event.commitSpan();
             }
         }
 
@@ -128,7 +128,7 @@ public class DatabaseClient {
                 // Don't populate `params` and `sql` in batch processing
                 // event.sql = sql;
                 // event.params = paramSourceToString(paramSource);
-                event.stampAndCommit();
+                event.commitSpan();
             }
         }
 
@@ -151,7 +151,7 @@ public class DatabaseClient {
                 event.sql = sql;
                 event.rows = rows;
                 event.params = paramSourceToJson(paramSource);
-                event.stampAndCommit();
+                event.commitSpan();
             }
         }
 
@@ -174,7 +174,7 @@ public class DatabaseClient {
                 event.sql = sql;
                 event.rows = rows;
                 event.params = paramSourceToJson(paramSource);
-                event.stampAndCommit();
+                event.commitSpan();
             }
         }
 
@@ -225,7 +225,7 @@ public class DatabaseClient {
             if (event.shouldCommit()) {
                 event.sql = sql;
                 event.rows = rows;
-                event.stampAndCommit();
+                event.commitSpan();
             }
         }
 
@@ -245,7 +245,7 @@ public class DatabaseClient {
         } finally {
             if (event.shouldCommit()) {
                 event.sql = sql;
-                event.stampAndCommit();
+                event.commitSpan();
             }
         }
     }
@@ -265,7 +265,7 @@ public class DatabaseClient {
             if (event.shouldCommit()) {
                 event.sql = sql;
                 event.rows = list != null ? list.size() : 0;
-                event.stampAndCommit();
+                event.commitSpan();
             }
         }
 
@@ -291,7 +291,7 @@ public class DatabaseClient {
             if (event.shouldCommit()) {
                 event.sql = sql;
                 event.rows = handler.getRowCount();
-                event.stampAndCommit();
+                event.commitSpan();
             }
         }
 
@@ -316,7 +316,7 @@ public class DatabaseClient {
                 event.sql = sql;
                 event.rows = list != null ? list.size() : 0;
                 event.params = paramSourceToJson(paramSource);
-                event.stampAndCommit();
+                event.commitSpan();
             }
         }
 
@@ -339,7 +339,7 @@ public class DatabaseClient {
                 event.sql = sql;
                 event.rows = longValue != null ? 1 : 0;
                 event.params = paramSourceToJson(paramSource);
-                event.stampAndCommit();
+                event.commitSpan();
             }
         }
         return longValue;
@@ -369,7 +369,7 @@ public class DatabaseClient {
                 event.sql = sql;
                 event.rows = exists ? 1 : 0;
                 event.params = paramSourceToJson(paramSource);
-                event.stampAndCommit();
+                event.commitSpan();
             }
         }
 
@@ -409,7 +409,7 @@ public class DatabaseClient {
                 event.rows = rows;
                 event.samples = samples;
                 event.params = paramSourceToJson(paramSource);
-                event.stampAndCommit();
+                event.commitSpan();
             }
         }
     }

--- a/utilities/jeffrey-events/README.md
+++ b/utilities/jeffrey-events/README.md
@@ -1,11 +1,153 @@
-# Jeffrey-specific Event Types
+# jeffrey-events
 
-Project contains event types that can be visualized in Jeffrey.
+Custom JFR event types and a tracing API for instrumenting JVM applications, visualized by
+[Jeffrey](https://github.com/petrbouda/jeffrey).
 
-https://github.com/petrbouda/jeffrey
+The events are ordinary JFR events written into the JVM's flight recording — there is no separate
+"send data" step, no collector, no agent. Record with whatever starts a JFR recording, upload the
+`.jfr` file to Jeffrey, and every event lands in its profile database: HTTP exchanges feed the HTTP
+dashboards, JDBC statements the Database dashboard, and events carrying trace identity assemble
+into full request traces with per-span flamegraphs.
 
-### Event Types
+- **Zero dependencies** — only `jdk.jfr`.
+- **Zero cost when off** — every emit path checks `event.isEnabled()` first; with no recording
+  running the instrumented code runs directly. Safe to leave in production code.
+- **Java 25+** for the `Tracer` API (built on `ScopedValue` and `jdk.jfr.Contextual`); the plain
+  event types work on earlier releases via older versions of this library.
 
-- HTTP Request / Response
-- JDBC Pool
-- JDBC Statements
+```xml
+<dependency>
+    <groupId>cafe.jeffrey-analyst</groupId>
+    <artifactId>jeffrey-events</artifactId>
+    <version><!-- latest from Maven Central --></version>
+</dependency>
+```
+
+## Sixty seconds of tracing
+
+An inbound request becomes the root of a trace, hand-written spans describe the application logic
+inside it, and every statement or outbound call nests underneath — all through a `ScopedValue`, so
+nothing is threaded through your signatures:
+
+```java
+// 1. The request event IS the root span (in a servlet filter, first in the chain)
+HttpServerExchangeEvent event = new HttpServerExchangeEvent();
+event.begin();
+try {
+    Tracer.inSpanOf(event, () -> {
+        chain.doFilter(request, response);
+        return null;
+    });
+} finally {
+    event.end();
+    if (event.shouldCommit()) {
+        event.method = request.getMethod();
+        event.uri = matchedTemplate(request);      // "/api/users/{id}", never the raw path
+        event.statusCode = response.getStatus();
+        event.commitSpan();
+    }
+}
+
+// 2. Application logic becomes named spans (jeffrey.TraceSpan events)
+Tracer.run("order.checkout", SpanKind.SERVER, () -> {
+    Tracer.run("inventory.reserve", SpanKind.CLIENT, this::reserve);
+    Tracer.run("payment.charge", SpanKind.CLIENT, this::charge);
+});
+
+// 3. A statement (or outbound HTTP call) is a leaf, committed in its own finally
+JdbcQueryEvent query = new JdbcQueryEvent("UserMapper.selectById", "UserMapper");
+query.begin();
+try {
+    result = doQuery();
+    query.end();
+} catch (Exception e) {
+    query.failed(e);                               // the span shows red, errorType recorded
+    throw e;
+} finally {
+    if (query.shouldCommit()) {
+        query.sql = sql;
+        query.commitSpan();                        // stamps as a child of the span in progress
+    }
+}
+```
+
+Record and verify:
+
+```bash
+java -XX:StartFlightRecording=filename=app.jfr,settings=profile -jar app.jar
+jfr print --events "jeffrey.*" app.jfr
+```
+
+Then upload `app.jfr` to Jeffrey — it auto-detects the event types and activates the matching
+dashboards.
+
+## Event catalog
+
+| JFR name | Class | Role in a trace |
+|---|---|---|
+| `jeffrey.HttpServerExchange` | `http.HttpServerExchangeEvent` | root span of an inbound request |
+| `jeffrey.HttpClientExchange` | `http.HttpClientExchangeEvent` | leaf: outbound HTTP call |
+| `jeffrey.GrpcServerExchange` | `grpc.GrpcServerExchangeEvent` | root span of an inbound call |
+| `jeffrey.GrpcClientExchange` | `grpc.GrpcClientExchangeEvent` | leaf: outbound gRPC call |
+| `jeffrey.JdbcQuery` / `JdbcInsert` / `JdbcUpdate` / `JdbcDelete` / `JdbcExecute` | `jdbc.statement.*` | leaf: one statement per event, split by verb |
+| `jeffrey.JdbcStream` | `jdbc.statement.JdbcStreamEvent` | leaf: query consumed as a stream (deferred commit) |
+| `jeffrey.TraceSpan` | `trace.TraceSpanEvent` | interior span, emitted by `Tracer.run`/`call`/`continueIn` |
+| `jeffrey.TraceScope` | `trace.TraceScopeEvent` | where a re-entered span ran; emitted by `Tracer.reenter` only |
+| `jeffrey.JdbcPoolStatistics` + `PooledJdbcConnection*` | `jdbc.pool.*` | not spans: pool gauges and durations |
+| `jeffrey.Message` / `jeffrey.Alert` | `message.*` | not spans: operational notes and alerts |
+
+Each package's `package-info` documents its emit patterns in detail; the `trace.Tracer` javadoc
+covers the tracing model itself.
+
+## The rules that make traces assemble
+
+1. **One root per request, opened with `Tracer.inSpanOf`.** The inbound-request event *is* the
+   root span; no separate span event is emitted for the same interval.
+2. **Everything commits through `commitSpan()`.** It stamps an event that does not yet carry trace
+   identity as a child of the span in progress, keeps one that does exactly as it is, and leaves
+   the ids at zero when no span is bound (recorded, just untraced). A bare `commit()` skips both
+   the stamp and the event's self-description — it is the deliberate opt-out, not the default.
+3. **Failures are stated with `failed(throwable)`** — on any traced event — then rethrown. Events
+   that derive a verdict from their own fields (HTTP status ≥ 400, gRPC status ≠ OK) only ever
+   escalate; they never paint over a recorded failure.
+4. **Names must be stable and low-cardinality**: the URI template, the mapper method id,
+   `order.checkout`. Every distinct string enters the JFR per-chunk constant pool; the identity of
+   an individual request lives in the trace id, which is already there.
+5. **A trace does not cross a plain executor by itself.** `ScopedValue` propagates only through
+   structured concurrency — wrap tasks with `Tracer.fork(...)`, or carry `Tracer.current()` and
+   re-establish it with `Tracer.continueIn(parent, ...)`. For one operation arriving in callback
+   pieces on foreign threads, open with `Tracer.openSpanOf(event)` and wrap each callback in
+   `Tracer.reenter(ctx, ...)`.
+
+## Volume control
+
+Never bake thresholds into instrumentation — a dropped span orphans its children. Set them per
+recording instead:
+
+```bash
+# Drop hand-written spans shorter than 1 ms
+-XX:StartFlightRecording=...,cafe.jeffrey.jfr.events.trace.TraceSpanEvent#threshold=1ms
+
+# Keep re-entry nesting but stop recording where re-entered spans ran
+-XX:StartFlightRecording=...,cafe.jeffrey.jfr.events.trace.TraceScopeEvent#enabled=false
+```
+
+## Instrumentation guides
+
+The [`skills/`](skills) directory contains complete, framework-specific guides (also written to be
+consumed by AI coding agents):
+
+- [`jeffrey-traces-core`](skills/jeffrey-traces-core/SKILL.md) — the data model, emit rules,
+  recording setup, verification. Read first.
+- [`jeffrey-traces-spring-rest-server`](skills/jeffrey-traces-spring-rest-server/SKILL.md) — the
+  servlet filter that roots every request's trace.
+- [`jeffrey-traces-http-client`](skills/jeffrey-traces-http-client/SKILL.md) — the client
+  interceptor for outbound calls.
+- [`jeffrey-traces-mybatis`](skills/jeffrey-traces-mybatis/SKILL.md) — the MyBatis interceptor
+  emitting one statement event per mapper call.
+
+Full documentation: [jeffrey-analyst.cafe](https://www.jeffrey-analyst.cafe).
+
+## License
+
+Apache License 2.0 — see [LICENSE](LICENSE).

--- a/utilities/jeffrey-events/skills/jeffrey-traces-core/SKILL.md
+++ b/utilities/jeffrey-events/skills/jeffrey-traces-core/SKILL.md
@@ -59,7 +59,7 @@ Understand this model first; every rule follows from it.
    The value `0` means "absent". An event whose `traceId`/`spanId` are `0` still
    appears in the dashboards, but it is **not part of any trace** — this is the
    single most common instrumentation mistake (committing with `commit()`
-   instead of `stampAndCommit()`/`commitSpan()`).
+   instead of `commitSpan()`).
 
 3. **Jeffrey detects spans from metadata, not from event names.** Any event
    type that declares a `spanId` field takes part in traces — including your
@@ -97,6 +97,11 @@ Understand this model first; every rule follows from it.
   but not `Tracer` — no hand-written spans and no cross-event trace nesting.
 - `Tracer.openSpanOf` / `Tracer.reenter` / `jeffrey.TraceScope` arrived after
   0.12.0 — use 0.13.0 or newer for the callback-driven patterns in §5.
+- In releases **after 0.13.0** there is a single commit verb: `commitSpan()`
+  stamps an event that does not yet carry identity (`stampAndCommit()` is a
+  deprecated alias), and `failed(Throwable)` exists on **every** traced event.
+  On 0.13.0 itself, commit leaf events with `stampAndCommit()` and note that
+  `failed` exists only on JDBC statement events.
 - The library has **zero dependencies** (only `jdk.jfr`) and is safe to leave
   on in production: when no recording is running, every emit path checks
   `event.isEnabled()` and runs the body directly with nothing allocated beyond
@@ -130,7 +135,9 @@ Field notes:
   `uri`, `method`, `mediaType`, `statusCode`, `queryParams` (JSON),
   `pathParams` (JSON), `requestLength`, `responseLength`. Span name and status
   are derived for you in `describeSpan()`: name = `"{method} {uri}"`, status =
-  `ERROR` when `statusCode >= 400`. **Never set `name`/`status` yourself.**
+  `ERROR` when `statusCode >= 400`. **Never set `name`/`status` yourself** — a
+  transport failure that produced no status code is recorded with
+  `event.failed(throwable)`, which the derived verdict never paints over.
 - **JDBC events** (`JdbcBaseEvent`): constructor `(String name, String group)`
   — `name` is the statement label, `group` groups statements in the Database
   dashboard. Fields: `sql`, `params` (JSON), `rows`. `JdbcInsertEvent` adds
@@ -156,12 +163,13 @@ They are plain events (not spans); emit them from your pool's hook points
    additionally call `Tracer.run` around the request — that would record the
    same interval twice.
 
-2. **Leaf events use `stampAndCommit()`, never `commit()`.** A JDBC statement
-   or HTTP client event committed in its own `finally` must end with
-   `event.stampAndCommit()`. It stamps the event as a child of the span in
-   progress (or leaves ids at `0` when there is none — still valid, just
-   untraced) and then runs `describeSpan()` + `commit()`. A bare `commit()`
-   silently drops the event from every trace.
+2. **Every traced event commits through `commitSpan()`, never `commit()`.** A
+   JDBC statement or HTTP client event committed in its own `finally` must end
+   with `event.commitSpan()`. It stamps an event that does not yet carry trace
+   identity as a child of the span in progress (or leaves ids at `0` when there
+   is none — still valid, just untraced), keeps an event that already carries
+   identity exactly as it is, and then runs `describeSpan()` + `commit()`. A
+   bare `commit()` silently drops the event from every trace.
 
 3. **Always follow the guard/begin/end/shouldCommit shape:**
 
@@ -175,12 +183,12 @@ They are plain events (not spans); emit them from your pool's hook points
        result = doWork();
        event.end();                    // interval ends when the work ends
    } catch (Exception e) {
-       event.failed(e);                // JDBC events; rethrow afterwards
+       event.failed(e);                // any traced event; rethrow afterwards
        throw e;
    } finally {
        if (event.shouldCommit()) {     // respects per-recording thresholds
            event.sql = ...;            // fill fields only when committing
-           event.stampAndCommit();
+           event.commitSpan();
        }
    }
    ```
@@ -271,17 +279,18 @@ doing a separate piece of work.
 ### Deferred commits
 
 If an event is committed after the enclosing binding is gone (e.g. from a
-stream's `close()`), `stampAndCommit()` in the `finally` would find no span
-and record ids of `0`. Stamp eagerly instead: call `Tracer.stamp(event)` at
-construction (inside the span) and commit later with `event.commitSpan()` —
-`stampAndCommit()` never re-stamps an event that already carries identity.
+stream's `close()`), `commitSpan()` in the `finally` would find no span and
+record ids of `0` — or worse, run inside someone else's binding and stamp the
+event into the wrong trace. Stamp eagerly instead: call `Tracer.stamp(event)`
+at construction (inside the span) and commit later with `event.commitSpan()` —
+it never re-stamps an event that already carries identity.
 
 ### Custom traced event types
 
 To make your own domain event a span (a batch job step, a cache rebuild),
 extend `AbstractTracedEvent`, declare your fields, optionally override
 `describeSpan()` to derive `name`/`status` from them, and commit through
-`commitSpan()`/`stampAndCommit()`. Jeffrey picks it up with no configuration —
+`commitSpan()`. Jeffrey picks it up with no configuration —
 span participation is detected from the `spanId` field in the recording's
 metadata.
 
@@ -335,8 +344,8 @@ Check, for one request you exercised:
 4. No high-cardinality names (raw URIs, ids, literal-bearing SQL as names).
 
 An event with all-zero ids means a `commit()` slipped in where
-`stampAndCommit()`/`commitSpan()` belonged, or work crossed an executor
-without `fork`/`continueIn`.
+`commitSpan()` belonged, or work crossed an executor without
+`fork`/`continueIn`.
 
 Then upload `app.jfr` to Jeffrey (create a project → upload recording →
 initialize profile). Jeffrey auto-detects the event types and activates the
@@ -348,7 +357,7 @@ self time and flamegraphs.
 
 | Symptom in Jeffrey | Cause | Fix |
 |---|---|---|
-| Events in HTTP/DB dashboards but Traces empty or flat | committed with `commit()` | use `stampAndCommit()` (leaves) / `commitSpan()` (root) |
+| Events in HTTP/DB dashboards but Traces empty or flat | committed with `commit()` | use `commitSpan()` |
 | Leaf spans are roots of their own one-span traces | executor/`@Async` boundary, or no root filter in front | `Tracer.fork`/`continueIn`; register the root filter first in the chain |
 | Children of a request orphaned & promoted to roots | root event re-stamped, or `TraceSpan` threshold dropped the parent | never stamp an `inSpanOf` event again; commit root via `commitSpan()`; mind thresholds |
 | Huge recordings | high-cardinality span names / URIs / `params` | templates & statement ids as names; ids belong in the trace id |

--- a/utilities/jeffrey-events/skills/jeffrey-traces-http-client/SKILL.md
+++ b/utilities/jeffrey-events/skills/jeffrey-traces-http-client/SKILL.md
@@ -12,17 +12,19 @@ companion skill **`jeffrey-traces-spring-rest-server`**.
 
 The client exchange is a **leaf span**: the downstream work happens in another
 process this recording cannot see, so the event is committed with
-`stampAndCommit()` — nesting it under the span in progress (usually the server
+`commitSpan()` — nesting it under the span in progress (usually the server
 exchange of the request being served) — never with `Tracer.inSpanOf`.
 
 Rules recap (from the core skill) that this code embodies:
 
-- Leaf events commit with `stampAndCommit()` in their own `finally`; a bare
+- Leaf events commit with `commitSpan()` in their own `finally`; a bare
   `commit()` silently drops the call from every trace.
 - `uri` must be low-cardinality: the URI template you expanded, or host + path
   with variable segments collapsed — never a URL containing an entity id.
 - `statusCode` drives span status automatically: `describeSpan()` marks
-  `>= 400` as `ERROR` — never set `name`/`status` yourself.
+  `>= 400` as `ERROR` — never set `name`/`status` yourself. A transport
+  failure that produced no status code is recorded with `event.failed(e)`,
+  which the derived verdict never paints over.
 
 ---
 
@@ -48,6 +50,11 @@ public class JeffreyJfrRestTemplateInterceptor implements ClientHttpRequestInter
             response = execution.execute(request, body);
             event.end();
             return response;
+        } catch (IOException e) {
+            // No status code ever arrived - the recorded failure is the
+            // verdict: status=ERROR + the exception's class as errorType.
+            event.failed(e);
+            throw e;
         } finally {
             if (event.shouldCommit()) {
                 event.method = request.getMethod().name();
@@ -59,9 +66,9 @@ public class JeffreyJfrRestTemplateInterceptor implements ClientHttpRequestInter
                 event.remotePort = request.getURI().getPort();
                 event.requestLength = body.length;
                 event.statusCode = response != null ? response.getStatusCode().value() : 0;
-                // A leaf: nested under the span in progress (usually the
-                // server exchange of the request being served).
-                event.stampAndCommit();
+                // A leaf: commitSpan() stamps it under the span in progress
+                // (usually the server exchange of the request being served).
+                event.commitSpan();
             }
         }
     }
@@ -99,8 +106,8 @@ carries the right identity.
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| Calls in the HTTP Client dashboard but not in Traces | committed with `commit()` | `stampAndCommit()` in the `finally` |
+| Calls in the HTTP Client dashboard but not in Traces | committed with `commit()` | `commitSpan()` in the `finally` |
 | Client calls are roots of their own one-span traces | call ran outside a bound span (no server filter, `@Async`, scheduled job) | register the root-span filter (`jeffrey-traces-spring-rest-server`); wrap background work with `Tracer.fork`/`continueIn` |
 | One "endpoint" per entity id | raw expanded URL recorded as `uri` | record the template / normalized path |
-| Connection failures look green | exception path leaves `statusCode = 0` and status `UNSET` | acceptable (UNSET ≠ OK), or set `statusCode` from the exception mapping if you need red spans for transport errors |
+| Connection failures look green | exception path missing `failed(e)` | catch the transport exception, call `event.failed(e)`, rethrow (on 0.13.0, where HTTP events have no `failed`, UNSET ≠ OK is the best available) |
 | Async call measured as ~0 ms | event ended when the request was *sent*, not when the response arrived | complete the event from the response callback (deferred-commit pattern, §3) |

--- a/utilities/jeffrey-events/skills/jeffrey-traces-mybatis/SKILL.md
+++ b/utilities/jeffrey-events/skills/jeffrey-traces-mybatis/SKILL.md
@@ -14,7 +14,7 @@ Your mappers need **zero changes**. A MyBatis `Interceptor` (plugin) on the
 
 Rules recap (from the core skill) that this code embodies:
 
-- Every statement event is a **leaf span**: committed with `stampAndCommit()`
+- Every statement event is a **leaf span**: committed with `commitSpan()`
   in its own `finally`, so it nests under whatever span is in progress on the
   executing thread (usually the HTTP request), or records as untraced-but-
   present when there is none. A bare `commit()` would drop it from every trace.
@@ -87,7 +87,7 @@ public class JeffreyJfrMyBatisInterceptor implements Interceptor {
                 event.rows = countRows(result);
                 // Leaf span: nested under the HTTP request (or Tracer span)
                 // in progress on this thread; untraced-but-recorded when none.
-                event.stampAndCommit();
+                event.commitSpan();
             }
         }
     }
@@ -163,7 +163,7 @@ public class JeffreyJfrMyBatisInterceptor implements Interceptor {
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| Statements present in the Database dashboard but not in Traces | committed with `commit()` | `stampAndCommit()` in the `finally` |
+| Statements present in the Database dashboard but not in Traces | committed with `commit()` | `commitSpan()` in the `finally` |
 | SQL spans are roots of their own one-span traces | statement ran outside a bound span (no HTTP filter, `@Async`, batch job) | register the root-span filter (`jeffrey-traces-spring-rest-server`); wrap background work with `Tracer.fork`/`continueIn` |
 | One "statement" per parameter combination | parameter values leaked into the event **name** | name from `MappedStatement.getId()` only; values go to `params` at most |
 | Failed statements look green | exception path missing `failed(t)` | catch `Throwable`, call `event.failed(t)`, rethrow |

--- a/utilities/jeffrey-events/skills/jeffrey-traces-spring-rest-server/SKILL.md
+++ b/utilities/jeffrey-events/skills/jeffrey-traces-spring-rest-server/SKILL.md
@@ -19,8 +19,9 @@ Rules recap (from the core skill) that this code embodies:
 
 - The exchange event **is** the root span: `Tracer.inSpanOf` stamps it when the
   span opens — the `finally` block only fills HTTP fields and calls
-  `commitSpan()`, never `stampAndCommit()` (re-stamping would mint a fresh span
-  id and orphan every child).
+  `commitSpan()`, which commits the event under the identity it already
+  carries (it never re-stamps; minting fresh ids at commit time would orphan
+  every child).
 - The span name must be low-cardinality: the **matched URI template**
   (`/api/users/{id}`), never the raw path.
 - `statusCode` drives span status automatically: `describeSpan()` marks
@@ -93,9 +94,8 @@ public class JeffreyJfrHttpEventFilter extends OncePerRequestFilter {
                 event.statusCode = response.getStatus();
                 event.requestLength = parseLong(request.getHeader("Content-Length"));
                 event.responseLength = parseLong(response.getHeader("Content-Length"));
-                // commitSpan(), NOT stampAndCommit(): inSpanOf already stamped
-                // the ids when the span opened. Re-stamping would mint a fresh
-                // span id and orphan every child recorded under the original.
+                // inSpanOf already stamped the ids when the span opened;
+                // commitSpan() commits under that identity and never re-stamps.
                 event.commitSpan();
             }
         }
@@ -161,6 +161,6 @@ public class JeffreyInstrumentationConfiguration {
 |---|---|---|
 | One "endpoint" per user/entity in the HTTP dashboard | raw URI recorded instead of the template | `HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE`; a fixed `<unmatched>` label for handler-less requests |
 | SQL spans not nested under requests | filter registered after work-dispatching filters, or missing entirely | `Ordered.HIGHEST_PRECEDENCE`, URL pattern `/*` |
-| Request span missing, children promoted to roots | root committed with `stampAndCommit()` (re-stamped) | `commitSpan()` for the `inSpanOf` event |
+| Request span missing, children promoted to roots | root re-stamped by hand (`Tracer.stamp` after `inSpanOf`), or on 0.13.0 committed with `stampAndCommit()` | never stamp an `inSpanOf` event again; commit with `commitSpan()` |
 | 5xx/4xx not red in Traces | `statusCode` not set before commit | set it in the `finally`, before `commitSpan()` |
 | Async servlet requests measured wrong | interval ends when the container thread returns, not when the response completes | complete the event from an `AsyncListener`, stamping eagerly with `Tracer.stamp` + `commitSpan()` (deferred-commit pattern in the core skill) |

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/JeffreyEventRegistry.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/JeffreyEventRegistry.java
@@ -31,6 +31,14 @@ import jdk.jfr.Event;
 
 import java.util.List;
 
+/**
+ * Every event type this library ships, in one list — for tooling that needs the catalog: eager
+ * {@link jdk.jfr.FlightRecorder#register registration}, settings generation, documentation.
+ * <p>
+ * Ordinary instrumentation never needs it: JFR auto-registers an event type the first time an
+ * instance of its class is created, so committed events always land in the recording with full
+ * metadata.
+ */
 public abstract class JeffreyEventRegistry {
 
     private static final List<Class<? extends Event>> EVENTS = List.of(

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/grpc/AbstractGrpcExchangeEvent.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/grpc/AbstractGrpcExchangeEvent.java
@@ -76,6 +76,10 @@ public abstract class AbstractGrpcExchangeEvent extends AbstractTracedEvent {
     @Override
     protected void describeSpan() {
         name = service + METHOD_SEPARATOR + method;
-        status = OK_STATUS_CODE.equals(statusCode) ? SpanStatus.OK.name() : SpanStatus.ERROR.name();
+        // A failure recorded with failed() is the writer's statement and must not be painted over
+        // by a derived verdict — deriving only escalates, it never downgrades an ERROR.
+        if (!SpanStatus.ERROR.name().equals(status)) {
+            status = OK_STATUS_CODE.equals(statusCode) ? SpanStatus.OK.name() : SpanStatus.ERROR.name();
+        }
     }
 }

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/grpc/package-info.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/grpc/package-info.java
@@ -1,0 +1,72 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * gRPC exchange events: one event per call, on whichever side of the wire this process stands.
+ * <p>
+ * Both events share the {@link cafe.jeffrey.jfr.events.grpc.AbstractGrpcExchangeEvent} shape and
+ * derive their span the same way — named {@code "{service}/{method}"}, failed by any status but
+ * {@code OK}:
+ * <ul>
+ *   <li>{@link cafe.jeffrey.jfr.events.grpc.GrpcServerExchangeEvent} ({@code
+ *       jeffrey.GrpcServerExchange}) — an inbound call, normally the <b>root of its trace</b></li>
+ *   <li>{@link cafe.jeffrey.jfr.events.grpc.GrpcClientExchangeEvent} ({@code
+ *       jeffrey.GrpcClientExchange}) — an outbound call, a <b>leaf</b> under the span in
+ *       progress</li>
+ * </ul>
+ *
+ * <h2>Emitting from interceptors</h2>
+ * A gRPC call is not a single block of work: the handler runs from listener callbacks after the
+ * interceptor has returned, on threads the interceptor does not control. The server exchange is
+ * therefore opened <em>without</em> binding, via
+ * {@link cafe.jeffrey.jfr.events.trace.Tracer#openSpanOf Tracer.openSpanOf}, and re-established
+ * around every callback with {@link cafe.jeffrey.jfr.events.trace.Tracer#reenter Tracer.reenter} —
+ * each re-entry also records which thread the call actually ran on:
+ *
+ * <pre>{@code
+ * GrpcServerExchangeEvent event = new GrpcServerExchangeEvent();
+ * if (!event.isEnabled()) {
+ *     return next.startCall(call, headers);
+ * }
+ * event.begin();
+ * SpanContext span = Tracer.openSpanOf(event);   // stamps the ids, binds nothing yet
+ * event.service = call.getMethodDescriptor().getServiceName();
+ * event.method = call.getMethodDescriptor().getBareMethodName();
+ *
+ * // ... in every wrapped listener callback (onMessage, onHalfClose, ...):
+ * Tracer.reenter(span, () -> {
+ *     super.onHalfClose();                       // the unary handler runs inside this one
+ * });
+ *
+ * // ... in the wrapped ServerCall.close(status, trailers):
+ * Tracer.reenter(span, () -> {
+ *     event.statusCode = status.getCode().name();
+ *     event.end();
+ *     if (event.shouldCommit()) {
+ *         event.commitSpan();
+ *     }
+ *     super.close(status, trailers);
+ * });
+ * }</pre>
+ *
+ * A blocking client call fits the simpler leaf shape instead — begin/end around the call,
+ * {@link cafe.jeffrey.jfr.events.trace.AbstractTracedEvent#failed(Throwable) failed(Throwable)} on
+ * the exception path, {@code commitSpan()} in the {@code finally} — exactly like an outbound HTTP
+ * exchange (see {@link cafe.jeffrey.jfr.events.http}).
+ */
+package cafe.jeffrey.jfr.events.grpc;

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/http/HttpClientExchangeEvent.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/http/HttpClientExchangeEvent.java
@@ -23,6 +23,15 @@ import jdk.jfr.Description;
 import jdk.jfr.Label;
 import jdk.jfr.Name;
 
+/**
+ * An outbound HTTP call — a <b>leaf span</b>, committed with
+ * {@link cafe.jeffrey.jfr.events.trace.AbstractTracedEvent#commitSpan() commitSpan()} in the
+ * emitter's own {@code finally} so it nests under the span in progress. A transport failure that
+ * never produced a status code is recorded with
+ * {@link cafe.jeffrey.jfr.events.trace.AbstractTracedEvent#failed(Throwable) failed(Throwable)}.
+ * See the {@linkplain cafe.jeffrey.jfr.events.http package documentation} for the full emit
+ * pattern.
+ */
 @Name(HttpClientExchangeEvent.NAME)
 @Label("HTTP Client Exchange")
 @Description("Information about a single HTTP Client Request/Response Exchange")

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/http/HttpServerExchangeEvent.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/http/HttpServerExchangeEvent.java
@@ -23,6 +23,12 @@ import jdk.jfr.Description;
 import jdk.jfr.Label;
 import jdk.jfr.Name;
 
+/**
+ * An inbound HTTP request/response exchange — normally the <b>root span</b> of the request's
+ * trace, opened with {@link cafe.jeffrey.jfr.events.trace.Tracer#inSpanOf Tracer.inSpanOf} from a
+ * servlet filter registered first in the chain. See the {@linkplain cafe.jeffrey.jfr.events.http
+ * package documentation} for the full emit pattern.
+ */
 @Name(HttpServerExchangeEvent.NAME)
 @Label("HTTP Server Exchange")
 @Description("Information about a single HTTP Server Request/Response Exchange")

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/http/package-info.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/http/package-info.java
@@ -1,0 +1,102 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * HTTP exchange events: one event per request/response pair, on whichever side of the wire this
+ * process stands.
+ * <p>
+ * Both events share the {@link cafe.jeffrey.jfr.events.http.AbstractHttpExchangeEvent} shape and
+ * derive their span the same way — named {@code "{method} {uri}"}, failed at status {@code 400}
+ * and above — but they play opposite roles in a trace:
+ * <ul>
+ *   <li>{@link cafe.jeffrey.jfr.events.http.HttpServerExchangeEvent} ({@code
+ *       jeffrey.HttpServerExchange}) describes an <em>inbound</em> request and is normally the
+ *       <b>root of the request's trace</b>: nothing in this process encloses it.</li>
+ *   <li>{@link cafe.jeffrey.jfr.events.http.HttpClientExchangeEvent} ({@code
+ *       jeffrey.HttpClientExchange}) describes an <em>outbound</em> call and is a <b>leaf</b>: the
+ *       downstream work happens in a process this recording cannot see.</li>
+ * </ul>
+ *
+ * <h2>Emitting the server exchange (the trace root)</h2>
+ * The natural integration point is a servlet filter registered first in the chain, so security,
+ * routing and data access all happen inside the span. The event <em>is</em> the root span:
+ * {@link cafe.jeffrey.jfr.events.trace.Tracer#inSpanOf Tracer.inSpanOf} stamps it with fresh ids
+ * and binds the context for the duration of the request — no separate span event is emitted for
+ * the same interval.
+ *
+ * <pre>{@code
+ * HttpServerExchangeEvent event = new HttpServerExchangeEvent();
+ * if (!event.isEnabled()) {
+ *     chain.doFilter(request, response);
+ *     return;
+ * }
+ * event.begin();
+ * try {
+ *     Tracer.inSpanOf(event, () -> {
+ *         chain.doFilter(request, response);
+ *         return null;
+ *     });
+ * } finally {
+ *     event.end();
+ *     if (event.shouldCommit()) {
+ *         event.method = request.getMethod();
+ *         event.uri = matchedTemplate(request);        // "/api/users/{id}", never the raw path
+ *         event.statusCode = response.getStatus();
+ *         event.commitSpan();                          // already stamped by inSpanOf
+ *     }
+ * }
+ * }</pre>
+ *
+ * <h2>Emitting the client exchange (a leaf)</h2>
+ * A client interceptor commits in its own {@code finally};
+ * {@link cafe.jeffrey.jfr.events.trace.AbstractTracedEvent#commitSpan() commitSpan()} nests the
+ * event under whatever span is in progress — usually the server exchange of the request being
+ * served — or records it untraced when there is none. A transport failure that never produced a
+ * status code is recorded with
+ * {@link cafe.jeffrey.jfr.events.trace.AbstractTracedEvent#failed(Throwable) failed(Throwable)}.
+ *
+ * <pre>{@code
+ * HttpClientExchangeEvent event = new HttpClientExchangeEvent();
+ * if (!event.isEnabled()) {
+ *     return execution.execute(request, body);
+ * }
+ * event.begin();
+ * try {
+ *     ClientHttpResponse response = execution.execute(request, body);
+ *     event.end();
+ *     event.statusCode = response.getStatusCode().value();
+ *     return response;
+ * } catch (IOException e) {
+ *     event.failed(e);                                 // no status code ever arrived
+ *     throw e;
+ * } finally {
+ *     if (event.shouldCommit()) {
+ *         event.method = request.getMethod().name();
+ *         event.uri = request.getURI().getHost() + normalizedPath(request);
+ *         event.commitSpan();                          // stamps as a child of the span in progress
+ *     }
+ * }
+ * }</pre>
+ *
+ * <h2>Cardinality</h2>
+ * The {@code uri} field must be the matched template ({@code /api/users/{id}}) or a path with
+ * variable segments collapsed — never a URL containing an entity id. Jeffrey's HTTP dashboards
+ * aggregate per endpoint on it, and the span name is derived from it. Request identity already
+ * lives in the trace id.
+ */
+package cafe.jeffrey.jfr.events.http;

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/jdbc/pool/package-info.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/jdbc/pool/package-info.java
@@ -1,0 +1,79 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Connection-pool events feeding Jeffrey's pool dashboard: a periodic gauge snapshot plus the
+ * pool's own duration and failure reports.
+ * <ul>
+ *   <li>{@link cafe.jeffrey.jfr.events.jdbc.pool.JdbcPoolStatisticsEvent} ({@code
+ *       jeffrey.JdbcPoolStatistics}) — total/idle/active/max/min connections and pending threads,
+ *       sampled every second ({@code @Period("1 s")})</li>
+ *   <li>{@link cafe.jeffrey.jfr.events.jdbc.pool.PooledJdbcConnectionAcquiredEvent},
+ *       {@link cafe.jeffrey.jfr.events.jdbc.pool.PooledJdbcConnectionBorrowedEvent},
+ *       {@link cafe.jeffrey.jfr.events.jdbc.pool.PooledJdbcConnectionCreatedEvent} — how long an
+ *       acquire, a borrow, or a physical connection creation took</li>
+ *   <li>{@link cafe.jeffrey.jfr.events.jdbc.pool.AcquiringPooledJdbcConnectionTimeoutEvent} — an
+ *       acquire that gave up</li>
+ * </ul>
+ * These are plain events, not spans — see
+ * {@link cafe.jeffrey.jfr.events.jdbc.pool.JdbcPoolEvent} for why. Emit them from the pool's own
+ * hook points; HikariCP's {@code MetricsTrackerFactory} exposes exactly the callbacks these events
+ * mirror:
+ *
+ * <pre>{@code
+ * public class JfrMetricsTracker implements IMetricsTracker {
+ *     private final String poolName;
+ *
+ *     public JfrMetricsTracker(String poolName) {
+ *         this.poolName = poolName;
+ *     }
+ *
+ *     @Override
+ *     public void recordConnectionAcquiredNanos(long elapsedAcquiredNanos) {
+ *         PooledJdbcConnectionAcquiredEvent event = new PooledJdbcConnectionAcquiredEvent();
+ *         event.poolName = poolName;
+ *         event.elapsedTime = elapsedAcquiredNanos;
+ *         event.commit();
+ *     }
+ *
+ *     @Override
+ *     public void recordConnectionTimeout() {
+ *         AcquiringPooledJdbcConnectionTimeoutEvent event =
+ *                 new AcquiringPooledJdbcConnectionTimeoutEvent();
+ *         event.poolName = poolName;
+ *         event.commit();
+ *     }
+ * }
+ * }</pre>
+ *
+ * The statistics event is periodic: register a hook once and fill it from the pool's gauges — JFR
+ * calls it on its own schedule, so there is nothing to emit per operation:
+ *
+ * <pre>{@code
+ * FlightRecorder.addPeriodicEvent(JdbcPoolStatisticsEvent.class, () -> {
+ *     JdbcPoolStatisticsEvent event = new JdbcPoolStatisticsEvent();
+ *     event.poolName = poolName;
+ *     event.total = poolBean.getTotalConnections();
+ *     event.active = poolBean.getActiveConnections();
+ *     event.idle = poolBean.getIdleConnections();
+ *     event.pendingThreads = poolBean.getThreadsAwaitingConnection();
+ *     event.commit();
+ * });
+ * }</pre>
+ */
+package cafe.jeffrey.jfr.events.jdbc.pool;

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/jdbc/statement/JdbcBaseEvent.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/jdbc/statement/JdbcBaseEvent.java
@@ -21,7 +21,6 @@ package cafe.jeffrey.jfr.events.jdbc.statement;
 import cafe.jeffrey.jfr.events.trace.AbstractTracedEvent;
 import cafe.jeffrey.jfr.events.trace.SpanKind;
 import cafe.jeffrey.jfr.events.trace.Span;
-import cafe.jeffrey.jfr.events.trace.SpanStatus;
 import jdk.jfr.Description;
 import jdk.jfr.Label;
 
@@ -58,14 +57,5 @@ public abstract class JdbcBaseEvent extends AbstractTracedEvent {
         this.name = name;
         this.group = group;
         this.kind = SpanKind.CLIENT.name();
-    }
-
-    /**
-     * Records that the statement threw, which is what makes a failed statement count as an error in
-     * the trace it belongs to.
-     */
-    public void failed(Throwable failure) {
-        this.status = SpanStatus.ERROR.name();
-        this.errorType = failure.getClass().getName();
     }
 }

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/jdbc/statement/JdbcDeleteEvent.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/jdbc/statement/JdbcDeleteEvent.java
@@ -23,7 +23,7 @@ import jdk.jfr.Label;
 import jdk.jfr.Name;
 
 @Name(JdbcDeleteEvent.NAME)
-@Label("JDBC Insert Statement")
+@Label("JDBC Delete Statement")
 @Category({"Application", "JDBC"})
 public class JdbcDeleteEvent extends JdbcBaseEvent {
 

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/jdbc/statement/JdbcStreamEvent.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/jdbc/statement/JdbcStreamEvent.java
@@ -22,6 +22,14 @@ import jdk.jfr.Category;
 import jdk.jfr.Label;
 import jdk.jfr.Name;
 
+/**
+ * A query consumed as a stream, committed when the stream closes rather than when the statement
+ * returns. That deferred commit may run after the enclosing span's binding is gone — or inside
+ * someone else's — so the emitter stamps eagerly with
+ * {@link cafe.jeffrey.jfr.events.trace.Tracer#stamp Tracer.stamp} at construction;
+ * {@link cafe.jeffrey.jfr.events.trace.AbstractTracedEvent#commitSpan() commitSpan()} never
+ * re-stamps an event that already carries identity.
+ */
 @Name(JdbcStreamEvent.NAME)
 @Label("JDBC Stream Statement")
 @Category({"Application", "JDBC"})

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/jdbc/statement/package-info.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/jdbc/statement/package-info.java
@@ -1,0 +1,88 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * JDBC statement events: one event per statement run against a database, split by verb so the
+ * Database dashboard can aggregate reads and writes separately.
+ * <ul>
+ *   <li>{@link cafe.jeffrey.jfr.events.jdbc.statement.JdbcQueryEvent} ({@code jeffrey.JdbcQuery})
+ *       — SELECT</li>
+ *   <li>{@link cafe.jeffrey.jfr.events.jdbc.statement.JdbcInsertEvent} ({@code jeffrey.JdbcInsert})
+ *       — INSERT, with {@code isLob}/{@code isBatch} markers</li>
+ *   <li>{@link cafe.jeffrey.jfr.events.jdbc.statement.JdbcUpdateEvent} ({@code jeffrey.JdbcUpdate})
+ *       — UPDATE</li>
+ *   <li>{@link cafe.jeffrey.jfr.events.jdbc.statement.JdbcDeleteEvent} ({@code jeffrey.JdbcDelete})
+ *       — DELETE</li>
+ *   <li>{@link cafe.jeffrey.jfr.events.jdbc.statement.JdbcExecuteEvent} ({@code
+ *       jeffrey.JdbcExecute}) — DDL and anything else</li>
+ *   <li>{@link cafe.jeffrey.jfr.events.jdbc.statement.JdbcStreamEvent} ({@code jeffrey.JdbcStream})
+ *       — a query consumed as a stream, committed when the stream closes</li>
+ * </ul>
+ * Every statement event is a <b>leaf span</b> of kind {@code CLIENT}: the constructor takes the
+ * statement's {@code name} (its label — a mapper method id, a named query — never SQL text) and a
+ * {@code group} the dashboard clusters statements under.
+ *
+ * <h2>The emit shape</h2>
+ * Committed in its own {@code finally} through
+ * {@link cafe.jeffrey.jfr.events.trace.AbstractTracedEvent#commitSpan() commitSpan()}, the event
+ * nests under whatever span is in progress on the executing thread — usually the request being
+ * served — or records untraced-but-present when there is none.
+ *
+ * <pre>{@code
+ * JdbcQueryEvent event = new JdbcQueryEvent("UserMapper.selectById", "UserMapper");
+ * if (!event.isEnabled()) {
+ *     return doQuery();
+ * }
+ * event.begin();
+ * List<User> rows = null;
+ * try {
+ *     rows = doQuery();
+ *     event.end();                    // interval ends when the work ends
+ *     return rows;
+ * } catch (Exception e) {
+ *     event.failed(e);                // status=ERROR + errorType; the span shows red
+ *     throw e;
+ * } finally {
+ *     if (event.shouldCommit()) {     // respects per-recording thresholds
+ *         event.sql = sql;            // fill fields only when actually committing
+ *         event.rows = rows != null ? rows.size() : 0;
+ *         event.commitSpan();         // stamps as a child of the span in progress
+ *     }
+ * }
+ * }</pre>
+ *
+ * On the exception path {@code end()} is deliberately not called — {@code commit()} closes the
+ * interval itself.
+ *
+ * <h2>Deferred commits</h2>
+ * A {@link cafe.jeffrey.jfr.events.jdbc.statement.JdbcStreamEvent} commits from the stream's
+ * {@code close()}, which may run after the enclosing span's binding is gone — or inside someone
+ * else's. Such an emitter stamps eagerly with
+ * {@link cafe.jeffrey.jfr.events.trace.Tracer#stamp Tracer.stamp} at construction;
+ * {@code commitSpan()} never re-stamps an event that already carries identity.
+ *
+ * <h2>Correctness notes</h2>
+ * <ul>
+ *   <li>{@code sql} with {@code ?} placeholders is <em>good</em>: identical statements aggregate.
+ *       Never inline parameter values into {@code sql} — and never into the <em>name</em>.</li>
+ *   <li>Parameter values, if recorded at all, go into {@code params} as a JSON object string —
+ *       scrub anything sensitive; the recording contains it verbatim.</li>
+ *   <li>For large batches set {@code isBatch} and skip {@code sql}/{@code params}.</li>
+ * </ul>
+ */
+package cafe.jeffrey.jfr.events.jdbc.statement;

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/message/package-info.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/message/package-info.java
@@ -1,0 +1,49 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Free-form operational messages an application writes into its own recording, so that "what the
+ * process thought was happening" sits next to the samples and events that show what actually did.
+ * <ul>
+ *   <li>{@link cafe.jeffrey.jfr.events.message.MessageEvent} ({@code jeffrey.Message}) — a
+ *       lifecycle or monitoring note: a cache warmed, a feature flag flipped, a threshold
+ *       crossed</li>
+ *   <li>{@link cafe.jeffrey.jfr.events.message.AlertEvent} ({@code jeffrey.Alert}) — a condition
+ *       that requires attention; same shape, stronger claim</li>
+ * </ul>
+ * Both carry a stable {@code type} (an identifier such as {@code CONNECTION_POOL_EXHAUSTED} —
+ * screaming snake case, one per kind of message, never per occurrence), a short {@code title}, a
+ * detailed {@code message}, a {@code severity} (the name of a
+ * {@link cafe.jeffrey.jfr.events.message.Severity} constant), a {@code category} and the
+ * {@code source} component that raised it.
+ *
+ * <pre>{@code
+ * AlertEvent alert = new AlertEvent();
+ * alert.type = "EVENT_PROCESSING_FAILED";
+ * alert.title = "Recording ingestion failed";
+ * alert.message = "Chunk 42 of profile.jfr could not be parsed: " + e.getMessage();
+ * alert.severity = Severity.HIGH.name();
+ * alert.category = "AVAILABILITY";
+ * alert.source = "recording-ingestion";
+ * alert.commit();
+ * }</pre>
+ *
+ * These are instants, not spans: they mark a moment, carry no duration of their own, and do not
+ * take part in traces.
+ */
+package cafe.jeffrey.jfr.events.message;

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/AbstractTracedEvent.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/AbstractTracedEvent.java
@@ -131,39 +131,47 @@ public abstract class AbstractTracedEvent extends Event {
     }
 
     /**
-     * Describes the span and commits the event, which is how every instrumented event should be
-     * committed. Pairing {@link #describeSpan()} with {@link #commit()} by hand works too, but is
-     * one more thing for an emitter to forget.
+     * The one way an instrumented event is committed: stamps the event into the trace in progress
+     * when it does not yet carry identity, describes the span, and commits. One verb for every
+     * emitter, whatever the event's role in the trace — which matters because the historical split
+     * between a stamping and a non-stamping commit is exactly how every heap-dump statement once
+     * went missing from the traces it ran inside, with nothing failing to say so.
+     * <ul>
+     *   <li><b>A leaf committed in its own {@code finally}</b> — a JDBC statement, an outbound HTTP
+     *       call — is stamped here, at commit time, as a child of the span in progress. Stamping
+     *       late rather than at construction costs nothing (the enclosing binding is stack-scoped,
+     *       so the ids are identical at both points) and an event that falls under the JFR
+     *       threshold never pays for minting ids it will not record.</li>
+     *   <li><b>An event that already carries identity</b> — one that <em>is</em> its span
+     *       ({@link Tracer#inSpanOf}, {@link Tracer#openSpanOf}), or a deferred emitter that
+     *       stamped eagerly with {@link Tracer#stamp} — is committed as it is. Re-stamping would
+     *       mint a fresh span id and orphan everything recorded under the original one.</li>
+     *   <li><b>No span in progress</b> — the ids stay {@code 0}: the event is recorded, feeds its
+     *       dashboard, and is simply not part of any trace.</li>
+     * </ul>
+     * The one emit shape that needs a second call is a deferred commit: an event committed from a
+     * stream's {@code close()} may run after the enclosing span's binding is gone, or inside
+     * someone else's, so such an emitter must stamp eagerly with {@link Tracer#stamp} at
+     * construction — this method then commits it under the identity it already carries.
+     * <p>
+     * The inherited {@link #commit()} remains the raw path: it neither stamps nor runs
+     * {@link #describeSpan()}, so reach for it only for an event that must deliberately stay
+     * outside the trace in progress.
      */
     public final void commitSpan() {
+        if (spanId == 0) {
+            Tracer.stamp(this);
+        }
         describeSpan();
         commit();
     }
 
     /**
-     * Stamps the event into the trace in progress and commits it — the whole emit path of a leaf
-     * event in one call, so an emitter cannot commit without stamping. Forgetting the stamp is not
-     * a hypothetical: it is exactly how every heap-dump statement went missing from the traces it
-     * ran inside, with nothing failing to say so.
-     * <p>
-     * Stamping happens here, at commit time, rather than back at construction. For an emitter that
-     * commits in its own {@code finally} the two are the same ids — the enclosing binding is
-     * stack-scoped, so it is identical at both points — and an event that falls under the JFR
-     * threshold then never pays for minting ids it will not record. The one shape this does not
-     * fit is a deferred commit: an event committed from a stream's {@code close()} may run after
-     * the enclosing span's binding is gone, or inside someone else's, so such an emitter must
-     * stamp eagerly with {@link Tracer#stamp} at construction and commit with {@link #commitSpan()}.
-     * <p>
-     * An event that already carries identity is committed as it is. Re-stamping would mint a fresh
-     * span id at commit time and orphan everything recorded under the original one — which is why
-     * this is safe to call on a pre-stamped event, and why an event that <em>is</em> its span
-     * ({@link Tracer#inSpanOf}, {@link Tracer#openSpanOf}) still reads better committed through
-     * {@link #commitSpan()}.
+     * @deprecated {@link #commitSpan()} now stamps an unstamped event exactly as this method did,
+     * so the two commit paths collapsed into one; this alias only delegates.
      */
+    @Deprecated(since = "0.14.0", forRemoval = true)
     public final void stampAndCommit() {
-        if (spanId == 0) {
-            Tracer.stamp(this);
-        }
         commitSpan();
     }
 }

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/AbstractTracedEvent.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/AbstractTracedEvent.java
@@ -87,6 +87,34 @@ public abstract class AbstractTracedEvent extends Event {
     public String attributes;
 
     /**
+     * Records that the operation this event describes threw, which is what makes it count as a
+     * failure in the trace it belongs to: the span status becomes {@link SpanStatus#ERROR} and the
+     * exception's class name is kept as the error type.
+     * <p>
+     * This is the one way a failure is stated, for every event family alike — a JDBC statement that
+     * threw, an HTTP call that never got a response, a gRPC call torn down by the transport. Call it
+     * on the exception path and rethrow; never assign {@link #status} directly.
+     * <p>
+     * A recorded failure survives {@link #describeSpan()}: an event type that derives its verdict
+     * from its own fields — an HTTP exchange from its status code — only ever escalates to
+     * {@link SpanStatus#ERROR}, so a transport failure recorded here is not painted over by a
+     * status code that was never received.
+     *
+     * <pre>{@code
+     * try {
+     *     response = execution.execute(request, body);
+     * } catch (IOException e) {
+     *     event.failed(e);
+     *     throw e;
+     * }
+     * }</pre>
+     */
+    public final void failed(Throwable failure) {
+        this.status = SpanStatus.ERROR.name();
+        this.errorType = failure.getClass().getName();
+    }
+
+    /**
      * Fills in the span shape from the event's own fields, called once immediately before the event
      * is committed.
      * <p>

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/package-info.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/package-info.java
@@ -1,0 +1,46 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * The tracing core: what makes any Jeffrey event part of a trace, and the API for recording spans
+ * of your own.
+ * <ul>
+ *   <li>{@link cafe.jeffrey.jfr.events.trace.AbstractTracedEvent} — the span shape every traced
+ *       event carries: ids, name, kind, status, error type, attributes, and the single commit verb
+ *       {@link cafe.jeffrey.jfr.events.trace.AbstractTracedEvent#commitSpan() commitSpan()}</li>
+ *   <li>{@link cafe.jeffrey.jfr.events.trace.Tracer} — records hand-written spans
+ *       ({@code run}/{@code call}), opens an event as its own span ({@code inSpanOf} /
+ *       {@code openSpanOf}), and carries traces across threads ({@code fork}, {@code continueIn},
+ *       {@code reenter})</li>
+ *   <li>{@link cafe.jeffrey.jfr.events.trace.TraceSpanEvent} ({@code jeffrey.TraceSpan}) — the
+ *       event {@code Tracer} emits for an interval no other instrumentation describes</li>
+ *   <li>{@link cafe.jeffrey.jfr.events.trace.TraceScopeEvent} ({@code jeffrey.TraceScope}) — one
+ *       stretch of a re-entered span's life on one thread; emitted only by
+ *       {@link cafe.jeffrey.jfr.events.trace.Tracer#reenter Tracer.reenter}</li>
+ *   <li>{@link cafe.jeffrey.jfr.events.trace.SpanContext} — a span's position in its trace,
+ *       immutable and safe to carry across threads</li>
+ *   <li>{@link cafe.jeffrey.jfr.events.trace.Span} — the metadata annotation that writes an event
+ *       type's naming template into every recording it appears in</li>
+ * </ul>
+ * Start with {@link cafe.jeffrey.jfr.events.trace.Tracer} — its class documentation covers the
+ * model, the cost when nothing is recording, and the limits.
+ *
+ * <p>Requires Java 25: the API is built on {@link java.lang.ScopedValue} and
+ * {@code jdk.jfr.Contextual}, both finalized there.
+ */
+package cafe.jeffrey.jfr.events.trace;

--- a/utilities/jeffrey-events/src/test/java/cafe/jeffrey/jfr/events/trace/TracerTest.java
+++ b/utilities/jeffrey-events/src/test/java/cafe/jeffrey/jfr/events/trace/TracerTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.net.ConnectException;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -302,6 +303,37 @@ class TracerTest {
 
             assertEquals(SpanStatus.ERROR.name(), statement.status);
             assertEquals(IllegalStateException.class.getName(), statement.errorType);
+        }
+
+        @Test
+        @DisplayName("a transport failure recorded on an HTTP call survives the derived verdict")
+        void transportFailureSurvivesDescribeSpan() {
+            HttpClientExchangeEvent exchange = new HttpClientExchangeEvent();
+            exchange.method = "POST";
+            exchange.uri = "payments.internal/api/v1/charge";
+
+            exchange.failed(new ConnectException("connection refused"));
+            exchange.commitSpan();
+
+            assertEquals(SpanStatus.ERROR.name(), exchange.status,
+                    "no status code ever arrived - the recorded failure is the verdict");
+            assertEquals(ConnectException.class.getName(), exchange.errorType);
+        }
+
+        @Test
+        @DisplayName("a failure recorded on a gRPC call is not painted over by the derived verdict")
+        void grpcFailureIsNotDowngraded() {
+            GrpcServerExchangeEvent exchange = new GrpcServerExchangeEvent();
+            exchange.service = "jeffrey.api.v1.WorkspaceService";
+            exchange.method = "List";
+            exchange.statusCode = "OK";
+
+            exchange.failed(new IllegalStateException("stream reset"));
+            exchange.commitSpan();
+
+            assertEquals(SpanStatus.ERROR.name(), exchange.status,
+                    "deriving a verdict only escalates, it never downgrades a recorded failure");
+            assertEquals(IllegalStateException.class.getName(), exchange.errorType);
         }
 
         @Test

--- a/utilities/jeffrey-events/src/test/java/cafe/jeffrey/jfr/events/trace/TracerTest.java
+++ b/utilities/jeffrey-events/src/test/java/cafe/jeffrey/jfr/events/trace/TracerTest.java
@@ -188,12 +188,12 @@ class TracerTest {
         }
 
         @Test
-        @DisplayName("stampAndCommit stamps the leaf exactly as stamp does")
-        void stampAndCommitStampsTheLeaf() {
+        @DisplayName("commitSpan stamps the leaf exactly as stamp does")
+        void commitSpanStampsTheLeaf() {
             JdbcQueryEvent event = new JdbcQueryEvent("listSpans", "profile");
 
             SpanContext context = Tracer.continueIn(null, "scope", SpanKind.INTERNAL, () -> {
-                event.stampAndCommit();
+                event.commitSpan();
                 return Tracer.current().orElseThrow();
             });
 
@@ -204,11 +204,11 @@ class TracerTest {
         }
 
         @Test
-        @DisplayName("stampAndCommit outside a span leaves the ids at zero")
-        void stampAndCommitOutsideASpanIsANoOp() {
+        @DisplayName("commitSpan outside a span leaves the ids at zero")
+        void commitSpanOutsideASpanIsANoOp() {
             JdbcQueryEvent event = new JdbcQueryEvent("listSpans", "profile");
 
-            event.stampAndCommit();
+            event.commitSpan();
 
             assertEquals(0, event.traceId);
             assertEquals(0, event.spanId);
@@ -216,8 +216,8 @@ class TracerTest {
         }
 
         @Test
-        @DisplayName("stampAndCommit leaves an event that already carries identity alone")
-        void stampAndCommitDoesNotRestampAnOwnSpan() {
+        @DisplayName("commitSpan leaves an event that already carries identity alone")
+        void commitSpanDoesNotRestampAnOwnSpan() {
             HttpServerExchangeEvent exchange = new HttpServerExchangeEvent();
             exchange.method = "GET";
             exchange.uri = "/api/internal/profiles/{profileId}";
@@ -225,13 +225,29 @@ class TracerTest {
             SpanContext own = Tracer.openSpanOf(exchange);
 
             Tracer.continueIn(null, "scope", SpanKind.INTERNAL, () -> {
-                exchange.stampAndCommit();
+                exchange.commitSpan();
             });
 
             assertEquals(own.traceId(), exchange.traceId,
                     "re-stamping would mint fresh ids and orphan everything recorded under the original span");
             assertEquals(own.spanId(), exchange.spanId);
             assertEquals(own.parentSpanId(), exchange.parentSpanId);
+        }
+
+        @Test
+        @SuppressWarnings("removal")
+        @DisplayName("the deprecated stampAndCommit alias behaves exactly like commitSpan")
+        void deprecatedStampAndCommitStillStamps() {
+            JdbcQueryEvent event = new JdbcQueryEvent("listSpans", "profile");
+
+            SpanContext context = Tracer.continueIn(null, "scope", SpanKind.INTERNAL, () -> {
+                event.stampAndCommit();
+                return Tracer.current().orElseThrow();
+            });
+
+            assertEquals(context.traceId(), event.traceId,
+                    "code written against the old two-verb API keeps landing in traces unchanged");
+            assertEquals(context.spanId(), event.parentSpanId);
         }
     }
 


### PR DESCRIPTION
Part 1 of the TraceSpan instrumentation-simplification work (PR 1 of a planned series). This PR removes the two most common ways instrumentation silently goes wrong, and gives the event catalog real documentation.

## What changed

**`failed(Throwable)` is promoted from `JdbcBaseEvent` to `AbstractTracedEvent`** — every event family gets the same failure verb. An HTTP call that never got a response or a gRPC call torn down by the transport previously had *no way* to record a failure and looked green in traces. Deriving a verdict in `describeSpan()` now only escalates: the gRPC exchange no longer paints a recorded failure over with its status-code verdict (the HTTP exchange already behaved this way).

**The commit paths collapse into one.** `commitSpan()` now stamps an event that does not yet carry trace identity, keeps one that does exactly as it is, and leaves ids at zero when no span is bound. `stampAndCommit()` becomes a deprecated delegating alias (`@Deprecated(forRemoval = true)`). The `stampAndCommit`-for-leaves vs `commitSpan`-for-roots split was the #1 documented pitfall — a leaf committed through the wrong verb silently dropped out of every trace — and it carried no information: `stampAndCommit()` was already documented as safe on pre-stamped events, so every documented emit shape reaches identical ids under the single verb. The raw `commit()` remains the deliberate opt-out that neither stamps nor describes.

**Behavior compatibility:** all existing emit shapes are unchanged — `inSpanOf`/`openSpanOf` events and eagerly-stamped deferred events already carry identity (the auto-stamp no-ops), leaves get stamped exactly as before, and unstamped events outside any span still record with zero ids.

**Event documentation and rich examples:**
- `package-info.java` for every event package: full emit patterns for the HTTP root filter and client leaf, the `openSpanOf`/`reenter` gRPC interceptor shape, the guard/begin/end/failed/commitSpan JDBC leaf shape plus the deferred-commit stream case, HikariCP hook sketches for the pool events, and the message/alert instants.
- README grows from a 12-line stub into a real front page: sixty-second tracing quickstart, event catalog, the five rules that make traces assemble, volume control, links to the skills.
- The four instrumentation skills and the docs-site pages (`jeffrey-pages`) teach the single verb, with a version note for applications pinned to 0.13.0.

**Dogfood migration:** `DatabaseClient` and `HeapDumpDatabaseClient` commit through `commitSpan()`; the eagerly-stamped `queryStream` deferred commit keeps its eager `Tracer.stamp`.

**Drive-by fix:** `JdbcDeleteEvent` was labeled "JDBC Insert Statement".

## Tests

- `jeffrey-events`: 50 tests green (JDK 25), including new coverage: transport failure survives `describeSpan()` (HTTP + gRPC), `commitSpan()` stamps a leaf / never re-stamps an own-span / no-ops outside a span, and the deprecated alias behaves identically.
- `mvn javadoc:javadoc` passes (package references resolve).
- `shared/persistence` and `profiles/heap-dump` compile against the reactor-built library.

## Follow-ups in this series

1. *(this PR)* Unified span lifecycle + event documentation
2. `TracedEvents.emit(...)` template killing the ~15-line guard/begin/end/shouldCommit boilerplate, dogfooded in `DatabaseClient`
3. JDBC verb factory + zero-dep `SpanAttributes` JSON builder
4. Executor ergonomics: `fork(Callable)` + a context-propagating `ExecutorService` decorator

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BfGNpXCFpAxW1etXhD8x3v

---
_Generated by [Claude Code](https://claude.ai/code/session_01BfGNpXCFpAxW1etXhD8x3v)_