### PR TITLE
TracedEvents.emit: the leaf emit lifecycle written once, dogfooded in DatabaseClient

### DIFF
--- a/shared/persistence/src/main/java/cafe/jeffrey/shared/persistence/client/DatabaseClient.java
+++ b/shared/persistence/src/main/java/cafe/jeffrey/shared/persistence/client/DatabaseClient.java
@@ -19,6 +19,7 @@
 package cafe.jeffrey.shared.persistence.client;
 
 import cafe.jeffrey.jfr.events.jdbc.statement.*;
+import cafe.jeffrey.jfr.events.trace.TracedEvents;
 import tools.jackson.databind.node.ObjectNode;
 import org.springframework.jdbc.core.RowCallbackHandler;
 import org.springframework.jdbc.core.RowMapper;
@@ -64,121 +65,58 @@ public class DatabaseClient {
 
     public int insert(StatementLabel statement, String sql, SqlParameterSource paramSource) {
         JdbcInsertEvent event = new JdbcInsertEvent(statement.name().toLowerCase(), groupLabel);
-        event.begin();
-
-        int rows = 0;
-        try {
-            rows = delegate.update(sql, paramSource);
-            event.end();
-        } catch (Exception e) {
-            event.failed(e);
-            throw e;
-        } finally {
-            if (event.shouldCommit()) {
-                event.sql = sql;
-                event.rows = rows;
-                event.params = paramSourceToJson(paramSource);
-                event.commitSpan();
-            }
-        }
-
-        return rows;
+        return TracedEvents.emit(event,
+                () -> delegate.update(sql, paramSource),
+                (e, rows) -> {
+                    e.sql = sql;
+                    e.rows = rows != null ? rows : 0;
+                    e.params = paramSourceToJson(paramSource);
+                });
     }
 
     public int insertWithLob(StatementLabel statement, String sql, SqlParameterSource paramSource) {
         JdbcInsertEvent event = new JdbcInsertEvent(statement.name().toLowerCase(), groupLabel);
-        event.begin();
-
-        int rows = 0;
-        try {
-            rows = delegate.update(sql, paramSource);
-            event.end();
-        } catch (Exception e) {
-            event.failed(e);
-            throw e;
-        } finally {
-            if (event.shouldCommit()) {
-                event.sql = sql;
-                event.rows = rows;
-                event.isLob = true;
-                event.params = paramSourceToJson(paramSource);
-                event.commitSpan();
-            }
-        }
-
-        return rows;
+        return TracedEvents.emit(event,
+                () -> delegate.update(sql, paramSource),
+                (e, rows) -> {
+                    e.sql = sql;
+                    e.rows = rows != null ? rows : 0;
+                    e.isLob = true;
+                    e.params = paramSourceToJson(paramSource);
+                });
     }
 
     public long batchInsert(StatementLabel statement, String sql, SqlParameterSource[] paramSources) {
         JdbcInsertEvent event = new JdbcInsertEvent(statement.name().toLowerCase(), groupLabel);
-        event.begin();
-
-        long rowsSum = 0;
-        try {
-            int[] rows = delegate.batchUpdate(sql, paramSources);
-            event.end();
-            rowsSum = sumRows(rows);
-        } catch (Exception e) {
-            event.failed(e);
-            throw e;
-        } finally {
-            if (event.shouldCommit()) {
-                event.rows = rowsSum;
-                event.isBatch = true;
-                // Don't populate `params` and `sql` in batch processing
-                // event.sql = sql;
-                // event.params = paramSourceToString(paramSource);
-                event.commitSpan();
-            }
-        }
-
-        return rowsSum;
+        return TracedEvents.emit(event,
+                () -> sumRows(delegate.batchUpdate(sql, paramSources)),
+                (e, rows) -> {
+                    e.rows = rows != null ? rows : 0;
+                    e.isBatch = true;
+                    // Don't populate `params` and `sql` in batch processing
+                });
     }
 
     public int update(StatementLabel statement, String sql, SqlParameterSource paramSource) {
         JdbcUpdateEvent event = new JdbcUpdateEvent(statement.name().toLowerCase(), groupLabel);
-        event.begin();
-
-        int rows = 0;
-        try {
-            rows = delegate.update(sql, paramSource);
-            event.end();
-        } catch (Exception e) {
-            event.failed(e);
-            throw e;
-        } finally {
-            if (event.shouldCommit()) {
-                event.sql = sql;
-                event.rows = rows;
-                event.params = paramSourceToJson(paramSource);
-                event.commitSpan();
-            }
-        }
-
-        return rows;
+        return TracedEvents.emit(event,
+                () -> delegate.update(sql, paramSource),
+                (e, rows) -> {
+                    e.sql = sql;
+                    e.rows = rows != null ? rows : 0;
+                    e.params = paramSourceToJson(paramSource);
+                });
     }
 
     public int delete(StatementLabel statement, String sql, SqlParameterSource paramSource) {
         JdbcDeleteEvent event = new JdbcDeleteEvent(statement.name().toLowerCase(), groupLabel);
-        event.begin();
-
-        int rows = 0;
-        try {
-            rows = delegate.update(sql, paramSource);
-            event.end();
-        } catch (Exception e) {
-            event.failed(e);
-            throw e;
-        } finally {
-            if (event.shouldCommit()) {
-                event.sql = sql;
-                event.rows = rows;
-                event.params = paramSourceToJson(paramSource);
-                event.commitSpan();
-            }
-        }
-
-        return rows;
+        return TracedEvents.emit(event,
+                () -> delegate.update(sql, paramSource),
+                (e, rows) -> {
+                    e.sql = sql;
+                    e.rows = rows != null ? rows : 0;
+                    e.params = paramSourceToJson(paramSource);
+                });
     }
 
     /**
@@ -212,137 +150,67 @@ public class DatabaseClient {
 
     public int delete(StatementLabel statement, String sql) {
         JdbcDeleteEvent event = new JdbcDeleteEvent(statement.name().toLowerCase(), groupLabel);
-        event.begin();
-
-        int rows = 0;
-        try {
-            rows = delegate.getJdbcOperations().update(sql);
-            event.end();
-        } catch (Exception e) {
-            event.failed(e);
-            throw e;
-        } finally {
-            if (event.shouldCommit()) {
-                event.sql = sql;
-                event.rows = rows;
-                event.commitSpan();
-            }
-        }
-
-        return rows;
+        return TracedEvents.emit(event,
+                () -> delegate.getJdbcOperations().update(sql),
+                (e, rows) -> {
+                    e.sql = sql;
+                    e.rows = rows != null ? rows : 0;
+                });
     }
 
     public void execute(StatementLabel statement, String sql) {
         JdbcExecuteEvent event = new JdbcExecuteEvent(statement.name().toLowerCase(), groupLabel);
-        event.begin();
-
-        try {
-            delegate.getJdbcOperations().execute(sql);
-            event.end();
-        } catch (Exception e) {
-            event.failed(e);
-            throw e;
-        } finally {
-            if (event.shouldCommit()) {
-                event.sql = sql;
-                event.commitSpan();
-            }
-        }
+        TracedEvents.emit(event,
+                () -> delegate.getJdbcOperations().execute(sql),
+                e -> e.sql = sql);
     }
 
     public <T> List<T> query(StatementLabel statement, String sql, RowMapper<T> rowMapper) {
         JdbcQueryEvent event = new JdbcQueryEvent(statement.name().toLowerCase(), groupLabel);
-        event.begin();
-
-        List<T> list = null;
-        try {
-            list = delegate.query(sql, rowMapper);
-            event.end();
-        } catch (Exception e) {
-            event.failed(e);
-            throw e;
-        } finally {
-            if (event.shouldCommit()) {
-                event.sql = sql;
-                event.rows = list != null ? list.size() : 0;
-                event.commitSpan();
-            }
-        }
-
-        return list;
+        return TracedEvents.emit(event,
+                () -> delegate.query(sql, rowMapper),
+                (e, list) -> {
+                    e.sql = sql;
+                    e.rows = list != null ? list.size() : 0;
+                });
     }
 
-    public <T> List<T> query(
+    public void query(
             StatementLabel statement, String sql, SqlParameterSource paramSource, RowCallbackHandler callbackHandler) {
 
         CountingRowCallbackHandler handler = new CountingRowCallbackHandler(callbackHandler);
 
         JdbcQueryEvent event = new JdbcQueryEvent(statement.name().toLowerCase(), groupLabel);
-        event.begin();
-
-        List<T> list = null;
-        try {
-            delegate.query(sql, paramSource, handler);
-            event.end();
-        } catch (Exception e) {
-            event.failed(e);
-            throw e;
-        } finally {
-            if (event.shouldCommit()) {
-                event.sql = sql;
-                event.rows = handler.getRowCount();
-                event.commitSpan();
-            }
-        }
-
-        return list;
+        TracedEvents.emit(event,
+                () -> delegate.query(sql, paramSource, handler),
+                e -> {
+                    e.sql = sql;
+                    e.rows = handler.getRowCount();
+                });
     }
 
     public <T> List<T> query(
             StatementLabel statement, String sql, SqlParameterSource paramSource, RowMapper<T> rowMapper) {
 
         JdbcQueryEvent event = new JdbcQueryEvent(statement.name().toLowerCase(), groupLabel);
-        event.begin();
-
-        List<T> list = null;
-        try {
-            list = delegate.query(sql, paramSource, rowMapper);
-            event.end();
-        } catch (Exception e) {
-            event.failed(e);
-            throw e;
-        } finally {
-            if (event.shouldCommit()) {
-                event.sql = sql;
-                event.rows = list != null ? list.size() : 0;
-                event.params = paramSourceToJson(paramSource);
-                event.commitSpan();
-            }
-        }
-
-        return list;
+        return TracedEvents.emit(event,
+                () -> delegate.query(sql, paramSource, rowMapper),
+                (e, list) -> {
+                    e.sql = sql;
+                    e.rows = list != null ? list.size() : 0;
+                    e.params = paramSourceToJson(paramSource);
+                });
     }
 
     public long queryLong(StatementLabel statement, String sql, SqlParameterSource paramSource) {
         JdbcQueryEvent event = new JdbcQueryEvent(statement.name().toLowerCase(), groupLabel);
-        event.begin();
-
-        Long longValue = null;
-        try {
-            longValue = delegate.queryForObject(sql, paramSource, long.class);
-            event.end();
-        } catch (Exception e) {
-            event.failed(e);
-            throw e;
-        } finally {
-            if (event.shouldCommit()) {
-                event.sql = sql;
-                event.rows = longValue != null ? 1 : 0;
-                event.params = paramSourceToJson(paramSource);
-                event.commitSpan();
-            }
-        }
-        return longValue;
+        return TracedEvents.emit(event,
+                () -> delegate.queryForObject(sql, paramSource, long.class),
+                (e, value) -> {
+                    e.sql = sql;
+                    e.rows = value != null ? 1 : 0;
+                    e.params = paramSourceToJson(paramSource);
+                });
     }
 
     public <T> Optional<T> querySingle(
@@ -354,26 +222,16 @@ public class DatabaseClient {
 
     public boolean queryExists(StatementLabel statement, String sql, SqlParameterSource paramSource) {
         JdbcQueryEvent event = new JdbcQueryEvent(statement.name().toLowerCase(), groupLabel);
-        event.begin();
-
-        boolean exists = false;
-        try {
-            Long count = delegate.queryForObject(sql, paramSource, Long.class);
-            exists = count != null && count > 0;
-            event.end();
-        } catch (Exception e) {
-            event.failed(e);
-            throw e;
-        } finally {
-            if (event.shouldCommit()) {
-                event.sql = sql;
-                event.rows = exists ? 1 : 0;
-                event.params = paramSourceToJson(paramSource);
-                event.commitSpan();
-            }
-        }
-
-        return exists;
+        return TracedEvents.emit(event,
+                () -> {
+                    Long count = delegate.queryForObject(sql, paramSource, Long.class);
+                    return count != null && count > 0;
+                },
+                (e, exists) -> {
+                    e.sql = sql;
+                    e.rows = Boolean.TRUE.equals(exists) ? 1 : 0;
+                    e.params = paramSourceToJson(paramSource);
+                });
     }
 
     public <T> void queryStream(
@@ -385,33 +243,24 @@ public class DatabaseClient {
             StatementLabel statement, String sql, SqlParameterSource paramSource, RowMapper<T> mapper, Consumer<T> consumer, Consumer<Object> counter) {
 
         JdbcStreamEvent event = new JdbcStreamEvent(statement.name().toLowerCase(), groupLabel);
-        event.sql = sql;
-        event.begin();
-
-        long rows = 0;
-        long samples = 0;
-        try (Stream<T> queryStream = delegate.queryForStream(sql, paramSource, mapper)) {
-            Stream<T> stream = queryStream;
-            if (counter != null) {
-                stream = stream.peek(counter);
-            }
-            stream.forEach(consumer);
-            if (counter instanceof StreamCounter sc) {
-                rows = sc.rows();
-                samples = sc.samples();
-            }
-        } catch (Exception e) {
-            event.failed(e);
-            throw e;
-        } finally {
-            event.end();
-            if (event.shouldCommit()) {
-                event.rows = rows;
-                event.samples = samples;
-                event.params = paramSourceToJson(paramSource);
-                event.commitSpan();
-            }
-        }
+        TracedEvents.emit(event,
+                () -> {
+                    try (Stream<T> queryStream = delegate.queryForStream(sql, paramSource, mapper)) {
+                        Stream<T> stream = queryStream;
+                        if (counter != null) {
+                            stream = stream.peek(counter);
+                        }
+                        stream.forEach(consumer);
+                    }
+                },
+                e -> {
+                    e.sql = sql;
+                    if (counter instanceof StreamCounter sc) {
+                        e.rows = sc.rows();
+                        e.samples = sc.samples();
+                    }
+                    e.params = paramSourceToJson(paramSource);
+                });
     }
 
     public <T> void queryStream(StatementLabel statement, String sql, RowMapper<T> mapper, Consumer<T> consumer) {

--- a/utilities/jeffrey-events/README.md
+++ b/utilities/jeffrey-events/README.md
@@ -54,21 +54,16 @@ Tracer.run("order.checkout", SpanKind.SERVER, () -> {
     Tracer.run("payment.charge", SpanKind.CLIENT, this::charge);
 });
 
-// 3. A statement (or outbound HTTP call) is a leaf, committed in its own finally
+// 3. A statement (or outbound HTTP call) is a leaf — TracedEvents.emit is the
+//    whole lifecycle: guard, begin, end on success, failed(e) on a throw (the
+//    span shows red), commitSpan() stamping it under the span in progress
 JdbcQueryEvent query = new JdbcQueryEvent("UserMapper.selectById", "UserMapper");
-query.begin();
-try {
-    result = doQuery();
-    query.end();
-} catch (Exception e) {
-    query.failed(e);                               // the span shows red, errorType recorded
-    throw e;
-} finally {
-    if (query.shouldCommit()) {
-        query.sql = sql;
-        query.commitSpan();                        // stamps as a child of the span in progress
-    }
-}
+List<User> users = TracedEvents.emit(query,
+        () -> doQuery(),
+        (e, result) -> {
+            e.sql = sql;
+            e.rows = result != null ? result.size() : 0;
+        });
 ```
 
 Record and verify:
@@ -107,6 +102,8 @@ covers the tracing model itself.
    identity as a child of the span in progress, keeps one that does exactly as it is, and leaves
    the ids at zero when no span is bound (recorded, just untraced). A bare `commit()` skips both
    the stamp and the event's self-description — it is the deliberate opt-out, not the default.
+   For a leaf committed in its own `finally`, `TracedEvents.emit` writes the whole lifecycle in
+   one call (each package's docs show what it expands to).
 3. **Failures are stated with `failed(throwable)`** — on any traced event — then rethrown. Events
    that derive a verdict from their own fields (HTTP status ≥ 400, gRPC status ≠ OK) only ever
    escalate; they never paint over a recorded failure.

--- a/utilities/jeffrey-events/skills/jeffrey-traces-core/SKILL.md
+++ b/utilities/jeffrey-events/skills/jeffrey-traces-core/SKILL.md
@@ -99,9 +99,11 @@ Understand this model first; every rule follows from it.
   0.12.0 — use 0.13.0 or newer for the callback-driven patterns in §5.
 - In releases **after 0.13.0** there is a single commit verb: `commitSpan()`
   stamps an event that does not yet carry identity (`stampAndCommit()` is a
-  deprecated alias), and `failed(Throwable)` exists on **every** traced event.
-  On 0.13.0 itself, commit leaf events with `stampAndCommit()` and note that
-  `failed` exists only on JDBC statement events.
+  deprecated alias), `failed(Throwable)` exists on **every** traced event, and
+  `TracedEvents.emit` writes the whole leaf emit shape in one call.
+  On 0.13.0 itself, commit leaf events with `stampAndCommit()`, note that
+  `failed` exists only on JDBC statement events, and write the emit shape by
+  hand (§4 rule 3 shows the expansion).
 - The library has **zero dependencies** (only `jdk.jfr`) and is safe to leave
   on in production: when no recording is running, every emit path checks
   `event.isEnabled()` and runs the body directly with nothing allocated beyond
@@ -187,7 +189,24 @@ They are plain events (not spans); emit them from your pool's hook points
    identity exactly as it is, and then runs `describeSpan()` + `commit()`. A
    bare `commit()` silently drops the event from every trace.
 
-3. **Always follow the guard/begin/end/shouldCommit shape:**
+3. **Emit leaves through `TracedEvents.emit`** (releases after 0.13.0), which
+   is the whole guard/begin/end/failed/shouldCommit/fill/commitSpan lifecycle
+   in one call — the emit site states only the event, the work, and the
+   fields:
+
+   ```java
+   JdbcQueryEvent event = new JdbcQueryEvent("UserMapper.selectById", "UserMapper");
+   List<User> users = TracedEvents.emit(event,
+           () -> doQuery(),                     // checked exceptions carry through typed
+           (e, result) -> {                     // runs only when actually committing;
+               e.sql = sql;                     // result is null on the failure path
+               e.rows = result != null ? result.size() : 0;
+           });
+   ```
+
+   An exception escaping the body is recorded with `failed(t)` and rethrown
+   unchanged. On 0.13.0, or where the helper does not fit, write what it
+   expands to:
 
    ```java
    SomeEvent event = new SomeEvent(...);
@@ -210,7 +229,8 @@ They are plain events (not spans); emit them from your pool's hook points
    ```
 
    (On the exception path `end()` is intentionally not called — `commit()`
-   closes the interval itself. This mirrors Jeffrey's own `DatabaseClient`.)
+   closes the interval itself. This mirrors Jeffrey's own `DatabaseClient`,
+   which emits every statement through `TracedEvents.emit`.)
 
 4. **Names must be stable and low-cardinality.** Every distinct string enters
    the JFR per-chunk constant pool. Name the *operation*, not the instance:

--- a/utilities/jeffrey-events/skills/jeffrey-traces-http-client/SKILL.md
+++ b/utilities/jeffrey-events/skills/jeffrey-traces-http-client/SKILL.md
@@ -40,40 +40,34 @@ public class JeffreyJfrRestTemplateInterceptor implements ClientHttpRequestInter
     public ClientHttpResponse intercept(
             HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
 
+        // TracedEvents.emit is the whole leaf lifecycle: guard, begin, end on
+        // success, failed(e) on the exception path (a transport failure that
+        // never produced a status code shows red), commitSpan() stamping the
+        // event under the span in progress — usually the server exchange of
+        // the request being served. The IOException propagates through typed.
         HttpClientExchangeEvent event = new HttpClientExchangeEvent();
-        if (!event.isEnabled()) {
-            return execution.execute(request, body);
-        }
-        event.begin();
-        ClientHttpResponse response = null;
-        try {
-            response = execution.execute(request, body);
-            event.end();
-            return response;
-        } catch (IOException e) {
-            // No status code ever arrived - the recorded failure is the
-            // verdict: status=ERROR + the exception's class as errorType.
-            event.failed(e);
-            throw e;
-        } finally {
-            if (event.shouldCommit()) {
-                event.method = request.getMethod().name();
-                // Low-cardinality: host + path with variable segments collapsed,
-                // ideally the URI template you expanded. Never a URL containing
-                // an entity id — one distinct name per endpoint, not per call.
-                event.uri = request.getURI().getHost() + normalizePath(request.getURI().getPath());
-                event.remoteHost = request.getURI().getHost();
-                event.remotePort = request.getURI().getPort();
-                event.requestLength = body.length;
-                event.statusCode = response != null ? response.getStatusCode().value() : 0;
-                // A leaf: commitSpan() stamps it under the span in progress
-                // (usually the server exchange of the request being served).
-                event.commitSpan();
-            }
-        }
+        return TracedEvents.emit(event,
+                () -> execution.execute(request, body),
+                (e, response) -> {
+                    e.method = request.getMethod().name();
+                    // Low-cardinality: host + path with variable segments
+                    // collapsed, ideally the URI template you expanded. Never a
+                    // URL containing an entity id — one distinct name per
+                    // endpoint, not per call.
+                    e.uri = request.getURI().getHost() + normalizePath(request.getURI().getPath());
+                    e.remoteHost = request.getURI().getHost();
+                    e.remotePort = request.getURI().getPort();
+                    e.requestLength = body.length;
+                    // response is null when the call threw before answering.
+                    e.statusCode = response != null ? response.getStatusCode().value() : 0;
+                });
     }
 }
 ```
+
+On 0.13.0, without `TracedEvents`, write the expanded shape from the core
+skill's §4 rule 3 instead (guard, `begin()`, `end()` on success, `commitSpan()`
+in the `finally`).
 
 ## 2. Registration
 

--- a/utilities/jeffrey-events/skills/jeffrey-traces-http-client/SKILL.md
+++ b/utilities/jeffrey-events/skills/jeffrey-traces-http-client/SKILL.md
@@ -17,8 +17,9 @@ exchange of the request being served) — never with `Tracer.inSpanOf`.
 
 Rules recap (from the core skill) that this code embodies:
 
-- Leaf events commit with `commitSpan()` in their own `finally`; a bare
-  `commit()` silently drops the call from every trace.
+- Leaf events commit with `commitSpan()`; a bare `commit()` silently drops
+  the call from every trace. `TracedEvents.emit` below commits that way for
+  you.
 - `uri` must be low-cardinality: the URI template you expanded, or host + path
   with variable segments collapsed — never a URL containing an entity id.
 - `statusCode` drives span status automatically: `describeSpan()` marks
@@ -100,8 +101,8 @@ carries the right identity.
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| Calls in the HTTP Client dashboard but not in Traces | committed with `commit()` | `commitSpan()` in the `finally` |
+| Calls in the HTTP Client dashboard but not in Traces | committed with `commit()` | `TracedEvents.emit`, or `commitSpan()` in the `finally` |
 | Client calls are roots of their own one-span traces | call ran outside a bound span (no server filter, `@Async`, scheduled job) | register the root-span filter (`jeffrey-traces-spring-rest-server`); wrap background work with `Tracer.fork`/`continueIn` |
 | One "endpoint" per entity id | raw expanded URL recorded as `uri` | record the template / normalized path |
-| Connection failures look green | exception path missing `failed(e)` | catch the transport exception, call `event.failed(e)`, rethrow (on 0.13.0, where HTTP events have no `failed`, UNSET ≠ OK is the best available) |
+| Connection failures look green | exception path missing `failed(e)` | `TracedEvents.emit` records it; by hand, catch the transport exception, call `event.failed(e)`, rethrow (on 0.13.0, where HTTP events have no `failed`, UNSET ≠ OK is the best available) |
 | Async call measured as ~0 ms | event ended when the request was *sent*, not when the response arrived | complete the event from the response callback (deferred-commit pattern, §3) |

--- a/utilities/jeffrey-events/skills/jeffrey-traces-mybatis/SKILL.md
+++ b/utilities/jeffrey-events/skills/jeffrey-traces-mybatis/SKILL.md
@@ -34,6 +34,7 @@ picks the event class.
 ```java
 import cafe.jeffrey.jfr.events.jdbc.statement.JdbcBaseEvent;
 import cafe.jeffrey.jfr.events.jdbc.statement.JdbcStatementEvents;
+import cafe.jeffrey.jfr.events.trace.TracedEvents;
 import org.apache.ibatis.cache.CacheKey;
 import org.apache.ibatis.executor.Executor;
 import org.apache.ibatis.mapping.BoundSql;
@@ -62,30 +63,18 @@ public class JeffreyJfrMyBatisInterceptor implements Interceptor {
     @Override
     public Object intercept(Invocation invocation) throws Throwable {
         MappedStatement statement = (MappedStatement) invocation.getArgs()[0];
-        JdbcBaseEvent event = createEvent(statement);
-        if (!event.isEnabled()) {
-            return invocation.proceed();
-        }
-
         Object parameter = invocation.getArgs()[1];
-        event.begin();
-        Object result = null;
-        try {
-            result = invocation.proceed();
-            event.end();
-            return result;
-        } catch (Throwable t) {
-            event.failed(t);        // status=ERROR + errorType; the span shows red
-            throw t;
-        } finally {
-            if (event.shouldCommit()) {
-                event.sql = statement.getBoundSql(parameter).getSql();
-                event.rows = countRows(result);
-                // Leaf span: nested under the HTTP request (or Tracer span)
-                // in progress on this thread; untraced-but-recorded when none.
-                event.commitSpan();
-            }
-        }
+
+        // TracedEvents.emit is the whole leaf lifecycle: guard, begin, end on
+        // success, failed(t) on a throw (the span shows red), commitSpan()
+        // nesting the statement under the HTTP request (or Tracer span) in
+        // progress on this thread — untraced-but-recorded when there is none.
+        return TracedEvents.emit(createEvent(statement),
+                invocation::proceed,
+                (event, result) -> {
+                    event.sql = statement.getBoundSql(parameter).getSql();
+                    event.rows = countRows(result);   // null result on failure -> 0
+                });
     }
 
     /**

--- a/utilities/jeffrey-events/skills/jeffrey-traces-mybatis/SKILL.md
+++ b/utilities/jeffrey-events/skills/jeffrey-traces-mybatis/SKILL.md
@@ -14,15 +14,17 @@ Your mappers need **zero changes**. A MyBatis `Interceptor` (plugin) on the
 
 Rules recap (from the core skill) that this code embodies:
 
-- Every statement event is a **leaf span**: committed with `commitSpan()`
-  in its own `finally`, so it nests under whatever span is in progress on the
-  executing thread (usually the HTTP request), or records as untraced-but-
-  present when there is none. A bare `commit()` would drop it from every trace.
+- Every statement event is a **leaf span**: committed with `commitSpan()`,
+  so it nests under whatever span is in progress on the executing thread
+  (usually the HTTP request), or records as untraced-but-present when there is
+  none. A bare `commit()` would drop it from every trace. `TracedEvents.emit`
+  below commits that way for you.
 - The span name must be low-cardinality: the **MyBatis statement id**
   (`UserMapper.selectById`) — one name per mapper method — never the SQL text
   or anything containing parameter values.
 - Failures are recorded with `event.failed(throwable)` (sets `status=ERROR` +
-  `errorType`), then rethrown.
+  `errorType`), then rethrown — again, what `TracedEvents.emit` does for a
+  body that throws.
 
 ---
 
@@ -145,8 +147,8 @@ public class JeffreyJfrMyBatisInterceptor implements Interceptor {
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| Statements present in the Database dashboard but not in Traces | committed with `commit()` | `commitSpan()` in the `finally` |
+| Statements present in the Database dashboard but not in Traces | committed with `commit()` | `TracedEvents.emit`, or `commitSpan()` in the `finally` |
 | SQL spans are roots of their own one-span traces | statement ran outside a bound span (no HTTP filter, `@Async`, batch job) | register the root-span filter (`jeffrey-traces-spring-rest-server`); wrap background work with `Tracer.fork`/`continueIn` |
 | One "statement" per parameter combination | parameter values leaked into the event **name** | name from `MappedStatement.getId()` only; values go to `params` at most |
-| Failed statements look green | exception path missing `failed(t)` | catch `Throwable`, call `event.failed(t)`, rethrow |
+| Failed statements look green | exception path missing `failed(t)` | `TracedEvents.emit` records it; by hand, catch `Throwable`, call `event.failed(t)`, rethrow |
 | Duplicate events per query | interceptor registered twice (bean + XML) | register through exactly one mechanism |

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/jdbc/statement/package-info.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/jdbc/statement/package-info.java
@@ -42,6 +42,8 @@
  * {@link cafe.jeffrey.jfr.events.trace.AbstractTracedEvent#commitSpan() commitSpan()}, the event
  * nests under whatever span is in progress on the executing thread — usually the request being
  * served — or records untraced-but-present when there is none.
+ * {@link cafe.jeffrey.jfr.events.trace.TracedEvents#emit TracedEvents.emit} writes this whole
+ * shape in one call; spelled out, it is:
  *
  * <pre>{@code
  * JdbcQueryEvent event = new JdbcQueryEvent("UserMapper.selectById", "UserMapper");

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/TracedEvents.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/TracedEvents.java
@@ -1,0 +1,151 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.trace;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * The emit shape of a leaf event, written once: guard, {@code begin}, the work, {@code end} on
+ * success or {@link AbstractTracedEvent#failed(Throwable) failed} on the exception path,
+ * {@code shouldCommit}, fill, {@link AbstractTracedEvent#commitSpan() commitSpan}.
+ * <p>
+ * Every emitter of a statement or client-call event repeats the same ten lines, and each repeat
+ * must remember the same three rules: {@code end()} is not called when the body throws
+ * (committing closes the interval itself), fields are filled only inside the
+ * {@code shouldCommit()} block so an event under threshold pays nothing for them, and the failure
+ * goes through {@code failed(t)} before the rethrow. This class is those rules in one place, so an
+ * emit site says only what is specific to it — which event, which work, which fields:
+ *
+ * <pre>{@code
+ * JdbcQueryEvent event = new JdbcQueryEvent("UserMapper.selectById", "UserMapper");
+ * List<User> users = TracedEvents.emit(event,
+ *         () -> delegate.query(sql, rowMapper),
+ *         (e, result) -> {
+ *             e.sql = sql;
+ *             e.rows = result != null ? result.size() : 0;
+ *         });
+ * }</pre>
+ *
+ * The filler receives the event with its concrete type, so type-specific fields ({@code sql},
+ * {@code statusCode}, {@code isBatch}) assign without casts. On the exception path the filler
+ * still runs — the statement's label and SQL belong on a failed event too — with a {@code null}
+ * result, which is what the result stands for when the work never produced one.
+ * <p>
+ * When nothing is recording, the body runs directly: no {@code begin}, no filler, nothing
+ * allocated beyond the (escape-analysable) event instance itself.
+ * <p>
+ * This is the shape of a <em>leaf</em> committed in its own {@code finally} — the event is stamped
+ * by {@code commitSpan()} as a child of the span in progress. It is not for an event that is its
+ * own span: an inbound exchange keeps the {@link Tracer#inSpanOf} form, whose body runs
+ * <em>inside</em> the span the event opens.
+ */
+public final class TracedEvents {
+
+    /**
+     * The work an emitted event covers. Declared with its own throwable type so a checked
+     * exception propagates through {@link #emit(AbstractTracedEvent, Body, Filler)} unchanged,
+     * exactly as the JDK's {@code ScopedValue.CallableOp} does for {@link Tracer#call}.
+     */
+    @FunctionalInterface
+    public interface Body<R, X extends Throwable> {
+
+        R call() throws X;
+    }
+
+    /**
+     * The {@link Body} of an emit with no result.
+     */
+    @FunctionalInterface
+    public interface VoidBody<X extends Throwable> {
+
+        void run() throws X;
+    }
+
+    /**
+     * Fills the event's type-specific fields immediately before it commits — called only when the
+     * event is actually committing, and on the failure path called with a {@code null} result.
+     */
+    @FunctionalInterface
+    public interface Filler<E extends AbstractTracedEvent, R> {
+
+        void fill(E event, R result);
+    }
+
+    private TracedEvents() {
+    }
+
+    /**
+     * Runs {@code body} inside {@code event}'s interval and commits the event as a leaf span,
+     * returning the body's result.
+     * <p>
+     * An exception escaping {@code body} is recorded with
+     * {@link AbstractTracedEvent#failed(Throwable)} and rethrown unchanged; the filler then
+     * receives a {@code null} result.
+     *
+     * @param event  the event describing the work; freshly constructed, not yet begun
+     * @param body   the work the event covers
+     * @param filler fills the event's fields when — and only when — it commits
+     */
+    public static <E extends AbstractTracedEvent, R, X extends Throwable> R emit(
+            E event, Body<? extends R, X> body, Filler<? super E, ? super R> filler) throws X {
+
+        Objects.requireNonNull(event, "event must not be null");
+        Objects.requireNonNull(body, "body must not be null");
+        Objects.requireNonNull(filler, "filler must not be null");
+
+        if (!event.isEnabled()) {
+            return body.call();
+        }
+
+        event.begin();
+        R result = null;
+        try {
+            result = body.call();
+            // Deliberately only on the success path: when the body throws, commit() closes the
+            // interval itself, and the failure is what failed(t) records below.
+            event.end();
+            return result;
+        } catch (Throwable t) {
+            event.failed(t);
+            throw t;
+        } finally {
+            if (event.shouldCommit()) {
+                filler.fill(event, result);
+                event.commitSpan();
+            }
+        }
+    }
+
+    /**
+     * The form of {@link #emit(AbstractTracedEvent, Body, Filler)} for work with no result; the
+     * filler receives only the event.
+     */
+    public static <E extends AbstractTracedEvent, X extends Throwable> void emit(
+            E event, VoidBody<X> body, Consumer<? super E> filler) throws X {
+
+        Objects.requireNonNull(body, "body must not be null");
+        Objects.requireNonNull(filler, "filler must not be null");
+
+        emit(event, () -> {
+            body.run();
+            return null;
+        }, (e, result) -> filler.accept(e));
+    }
+}

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/package-info.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/package-info.java
@@ -27,6 +27,8 @@
  *       ({@code run}/{@code call}), opens an event as its own span ({@code inSpanOf} /
  *       {@code openSpanOf}), and carries traces across threads ({@code fork}, {@code continueIn},
  *       {@code reenter})</li>
+ *   <li>{@link cafe.jeffrey.jfr.events.trace.TracedEvents} — the leaf emit shape written once:
+ *       guard, begin, the work, failure recording, fill, commit</li>
  *   <li>{@link cafe.jeffrey.jfr.events.trace.TraceSpanEvent} ({@code jeffrey.TraceSpan}) — the
  *       event {@code Tracer} emits for an interval no other instrumentation describes</li>
  *   <li>{@link cafe.jeffrey.jfr.events.trace.TraceScopeEvent} ({@code jeffrey.TraceScope}) — one

--- a/utilities/jeffrey-events/src/test/java/cafe/jeffrey/jfr/events/trace/TracedEventsTest.java
+++ b/utilities/jeffrey-events/src/test/java/cafe/jeffrey/jfr/events/trace/TracedEventsTest.java
@@ -1,0 +1,204 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.trace;
+
+import cafe.jeffrey.jfr.events.jdbc.statement.JdbcQueryEvent;
+import cafe.jeffrey.jfr.events.jdbc.statement.JdbcUpdateEvent;
+import jdk.jfr.consumer.RecordedEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TracedEventsTest {
+
+    private static final String SQL = "SELECT span_id FROM spans WHERE trace_id = ?";
+
+    @Nested
+    @DisplayName("When nothing is recording")
+    class WithoutRecording {
+
+        @Test
+        @DisplayName("the body runs directly and its result is returned")
+        void bodyRunsAndReturns() {
+            Object result = new Object();
+
+            Object emitted = TracedEvents.emit(new JdbcQueryEvent("listSpans", "profile"),
+                    () -> result,
+                    (event, r) -> {
+                    });
+
+            assertSame(result, emitted);
+        }
+
+        @Test
+        @DisplayName("the filler never runs, so field computation costs nothing")
+        void fillerNeverRuns() {
+            AtomicBoolean filled = new AtomicBoolean();
+
+            TracedEvents.emit(new JdbcQueryEvent("listSpans", "profile"),
+                    () -> null,
+                    (event, r) -> filled.set(true));
+
+            assertFalse(filled.get(), "fields are filled only when the event actually commits");
+        }
+
+        @Test
+        @DisplayName("an exception still propagates unchanged")
+        void exceptionPropagates() {
+            IllegalStateException thrown = new IllegalStateException("connection reset");
+
+            IllegalStateException actual = assertThrows(IllegalStateException.class,
+                    () -> TracedEvents.emit(new JdbcQueryEvent("listSpans", "profile"),
+                            () -> {
+                                throw thrown;
+                            },
+                            (event, r) -> {
+                            }));
+
+            assertSame(thrown, actual);
+        }
+    }
+
+    @Nested
+    @DisplayName("When a recording is active")
+    class WithRecording {
+
+        @Test
+        @DisplayName("the event commits with the filler's fields and the body's result comes back")
+        void commitsWithFields() throws IOException {
+            AtomicReference<List<String>> emitted = new AtomicReference<>();
+
+            RecordedEvent recorded = JfrRecordings.single(JdbcQueryEvent.NAME, () -> {
+                JdbcQueryEvent event = new JdbcQueryEvent("listSpans", "profile");
+                List<String> rows = TracedEvents.emit(event,
+                        () -> List.of("a", "b"),
+                        (e, result) -> {
+                            e.sql = SQL;
+                            e.rows = result != null ? result.size() : 0;
+                        });
+                emitted.set(rows);
+            });
+
+            assertEquals(List.of("a", "b"), emitted.get());
+            assertEquals(SQL, recorded.getString("sql"));
+            assertEquals(2, recorded.getLong("rows"));
+            assertEquals("listSpans", recorded.getString("name"));
+            assertEquals(SpanStatus.UNSET.name(), recorded.getString("status"));
+        }
+
+        @Test
+        @DisplayName("emitted inside a span, the event lands as a leaf of it")
+        void nestsUnderTheSpanInProgress() throws IOException {
+            RecordedEvent recorded = JfrRecordings.single(JdbcQueryEvent.NAME, () ->
+                    Tracer.run("request", SpanKind.SERVER, () ->
+                            TracedEvents.emit(new JdbcQueryEvent("listSpans", "profile"),
+                                    () -> null,
+                                    (e, result) -> {
+                                    })));
+
+            assertNotEquals(0, recorded.getLong("traceId"));
+            assertNotEquals(0, recorded.getLong("parentSpanId"),
+                    "commitSpan stamped the leaf under the span in progress");
+        }
+
+        @Test
+        @DisplayName("a throwing body is recorded as a failure and rethrown unchanged")
+        void failureIsRecordedAndRethrown() throws IOException {
+            IllegalStateException thrown = new IllegalStateException("connection reset");
+
+            RecordedEvent recorded = JfrRecordings.single(JdbcQueryEvent.NAME, () -> {
+                IllegalStateException actual = assertThrows(IllegalStateException.class,
+                        () -> TracedEvents.emit(new JdbcQueryEvent("listSpans", "profile"),
+                                () -> {
+                                    throw thrown;
+                                },
+                                (e, result) -> e.sql = SQL));
+                assertSame(thrown, actual);
+            });
+
+            assertEquals(SpanStatus.ERROR.name(), recorded.getString("status"));
+            assertEquals(IllegalStateException.class.getName(), recorded.getString("errorType"));
+            assertEquals(SQL, recorded.getString("sql"),
+                    "the filler still runs on the failure path - a failed statement keeps its label and SQL");
+        }
+
+        @Test
+        @DisplayName("on the failure path the filler sees a null result")
+        void fillerSeesNullResultOnFailure() throws IOException {
+            AtomicReference<Object> seen = new AtomicReference<>(new Object());
+
+            JfrRecordings.single(JdbcQueryEvent.NAME, () ->
+                    assertThrows(IllegalStateException.class,
+                            () -> TracedEvents.emit(new JdbcQueryEvent("listSpans", "profile"),
+                                    () -> {
+                                        throw new IllegalStateException("boom");
+                                    },
+                                    (e, result) -> seen.set(result))));
+
+            assertNull(seen.get(), "the work never produced a result, and null is how the filler learns that");
+        }
+
+        @Test
+        @DisplayName("a checked exception propagates through the declared throwable type")
+        void checkedExceptionPropagatesTyped() throws IOException {
+            JfrRecordings.single(JdbcQueryEvent.NAME, () -> {
+                // No catch of a broad Exception anywhere: the method's signature carries
+                // IOException through, which is the whole point of the Body type variable.
+                IOException actual = assertThrows(IOException.class, this::emitThrowingIo);
+                assertEquals("disk gone", actual.getMessage());
+            });
+        }
+
+        @Test
+        @DisplayName("the void form fills from the event alone")
+        void voidFormFills() throws IOException {
+            RecordedEvent recorded = JfrRecordings.single(JdbcUpdateEvent.NAME, () -> {
+                JdbcUpdateEvent event = new JdbcUpdateEvent("touchSpan", "profile");
+                TracedEvents.emit(event,
+                        () -> {
+                        },
+                        e -> e.sql = SQL);
+            });
+
+            assertEquals(SQL, recorded.getString("sql"));
+            assertEquals("touchSpan", recorded.getString("name"));
+        }
+
+        private void emitThrowingIo() throws IOException {
+            TracedEvents.emit(new JdbcQueryEvent("listSpans", "profile"),
+                    () -> {
+                        throw new IOException("disk gone");
+                    },
+                    (e, result) -> {
+                    });
+        }
+    }
+}


### PR DESCRIPTION
Part 2 of the TraceSpan instrumentation-simplification series. **Rebased onto `master`** now that #177, #179 and #180 have merged — this branch carries only Part 2's own commits, and the diff is 9 files.

## What changed

**`TracedEvents.emit(event, body, filler)`** encodes the ~15-line leaf emit ceremony — guard, `begin()`, the work, `end()` on success, `failed(t)` on the exception path, `shouldCommit()`, fill, `commitSpan()` — in one place. The rules every emitter previously had to remember by hand now live in the library:

- `end()` is skipped when the body throws (committing closes the interval itself),
- fields are filled only inside the `shouldCommit()` block, so an event under threshold pays nothing for computing them,
- failures go through `failed(t)` before the rethrow, unchanged.

The filler is typed to the concrete event (no casts for `sql`/`statusCode`/`isBatch`), checked exceptions carry through a `Body<R, X extends Throwable>` type variable (an interceptor declaring `throws IOException` needs no wrapping), and on the failure path the filler receives a `null` result. When nothing is recording, the body runs directly. A `VoidBody` + `Consumer` overload covers work with no result.

**Dogfood: `DatabaseClient` drops ~150 lines.** Thirteen hand-rolled guard/begin/end/failed/shouldCommit blocks become thirteen emit calls that state only the event, the work, and the fields. Two footnotes: the `RowCallbackHandler` query overload (which always returned `null` and has no callers) is now `void`, and the stream variant no longer calls `end()` on its exception path, matching every other emitter.

**Docs:** the core skill's emit rule leads with the helper and keeps the manual lifecycle as the documented expansion; the RestTemplate and MyBatis interceptor examples shrink onto it (the MyBatis `intercept` becomes 8 lines), and those two skills' rule recaps and pitfall rows now say `emit` is what applies the rules, keeping the by-hand form for emitters that need it. README quickstart and the `trace`/`jdbc.statement` package docs reference it. A version note covers applications pinned to 0.13.0.

The MyBatis example composes with #179's `JdbcStatementEvents.forVerb` — `emit` for the lifecycle, `forVerb` for the event class — which was the one conflict from the rebase.

## Tests

- 9 new `TracedEventsTest` cases: passthrough + no-filler when disabled, fields recorded through a real JFR recording, leaf stamping under a `Tracer` span, failure recorded + rethrown unchanged with the filler still running (`null` result), checked-exception typing, void form.
- **79 tests green** in `jeffrey-events` on JDK 25 — this PR's 9 alongside everything #177/#179/#180 added.
- `shared/persistence` tests green (10), and the full reactor compiles (`mvn compile -Dexec.skip=true`, the skip only avoiding a doc-generator binary missing from the build container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BfGNpXCFpAxW1etXhD8x3v