### PR TITLE
Emit-site conveniences: JdbcStatementEvents verb factory and SpanAttributes JSON builder

### DIFF
--- a/utilities/jeffrey-events/skills/jeffrey-traces-core/SKILL.md
+++ b/utilities/jeffrey-events/skills/jeffrey-traces-core/SKILL.md
@@ -138,6 +138,22 @@ Field notes:
   with `event.failed(throwable)` — never by setting `status` directly.
 - **`TraceSpanEvent`**: no fields of its own; the span shape is all there is.
   You never construct it — `Tracer` does.
+- **`attributes`** (any traced event): operation-specific detail as a JSON
+  object string — per-request values (an entity id, a retry count) that must
+  never go into the span *name*. Build it with `SpanAttributes`
+  (releases after 0.13.0) rather than concatenating JSON by hand — it escapes
+  quotes, backslashes and control characters — and only inside the
+  `shouldCommit()` block, so an event under threshold pays nothing:
+
+  ```java
+  event.attributes = SpanAttributes.create()
+          .put("cache", "miss")
+          .put("retries", 2)
+          .json();
+  ```
+
+  The recording and the profile database contain the values verbatim — scrub
+  anything sensitive.
 
 There are also connection-pool events (`jeffrey.JdbcPoolStatistics`,
 `jeffrey.PooledJdbcConnectionAcquired/Borrowed/Created`,

--- a/utilities/jeffrey-events/skills/jeffrey-traces-mybatis/SKILL.md
+++ b/utilities/jeffrey-events/skills/jeffrey-traces-mybatis/SKILL.md
@@ -33,11 +33,7 @@ picks the event class.
 
 ```java
 import cafe.jeffrey.jfr.events.jdbc.statement.JdbcBaseEvent;
-import cafe.jeffrey.jfr.events.jdbc.statement.JdbcDeleteEvent;
-import cafe.jeffrey.jfr.events.jdbc.statement.JdbcExecuteEvent;
-import cafe.jeffrey.jfr.events.jdbc.statement.JdbcInsertEvent;
-import cafe.jeffrey.jfr.events.jdbc.statement.JdbcQueryEvent;
-import cafe.jeffrey.jfr.events.jdbc.statement.JdbcUpdateEvent;
+import cafe.jeffrey.jfr.events.jdbc.statement.JdbcStatementEvents;
 import org.apache.ibatis.cache.CacheKey;
 import org.apache.ibatis.executor.Executor;
 import org.apache.ibatis.mapping.BoundSql;
@@ -103,13 +99,10 @@ public class JeffreyJfrMyBatisInterceptor implements Interceptor {
         String name = id.substring(mapperDot + 1);            // UserMapper.selectById
         String group = id.substring(mapperDot + 1, methodDot); // UserMapper
 
-        return switch (statement.getSqlCommandType()) {
-            case SELECT -> new JdbcQueryEvent(name, group);
-            case INSERT -> new JdbcInsertEvent(name, group);
-            case UPDATE -> new JdbcUpdateEvent(name, group);
-            case DELETE -> new JdbcDeleteEvent(name, group);
-            default -> new JdbcExecuteEvent(name, group);
-        };
+        // The verb-to-event mapping (SELECT -> JdbcQueryEvent, ..., other ->
+        // JdbcExecuteEvent) is the library's own convention; forVerb applies it.
+        // On 0.13.0, without JdbcStatementEvents, write the switch by hand.
+        return JdbcStatementEvents.forVerb(statement.getSqlCommandType().name(), name, group);
     }
 
     private static long countRows(Object result) {

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/jdbc/statement/JdbcStatementEvents.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/jdbc/statement/JdbcStatementEvents.java
@@ -1,0 +1,128 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.jdbc.statement;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Picks the statement event class for a SQL verb, so an interceptor that sees every statement
+ * through one hook does not have to hand-roll the verb-to-event mapping — the mapping is the
+ * library's own convention, and each emitter re-deriving it is how the conventions drift.
+ *
+ * <pre>{@code
+ * // From a framework that knows the command type (MyBatis SqlCommandType, jOOQ, ...):
+ * JdbcBaseEvent event = JdbcStatementEvents.forVerb(
+ *         statement.getSqlCommandType().name(), name, group);
+ *
+ * // From a plain JDBC interception point that only has the SQL text:
+ * JdbcBaseEvent event = JdbcStatementEvents.forSql(sql, name, group);
+ * }</pre>
+ *
+ * Anything that is not a recognized data verb — DDL, {@code MERGE}, vendor commands — lands on
+ * {@link JdbcExecuteEvent}, the catch-all the Database dashboard shows as "other".
+ */
+public final class JdbcStatementEvents {
+
+    @FunctionalInterface
+    private interface EventConstructor {
+
+        JdbcBaseEvent create(String name, String group);
+    }
+
+    /**
+     * {@code WITH} counts as a query: a common-table expression is how analytical SELECTs are
+     * written, and classifying it as "other" would hide exactly the statements worth watching.
+     */
+    private static final Map<String, EventConstructor> CONSTRUCTORS_BY_VERB = Map.of(
+            "SELECT", JdbcQueryEvent::new,
+            "WITH", JdbcQueryEvent::new,
+            "INSERT", JdbcInsertEvent::new,
+            "UPDATE", JdbcUpdateEvent::new,
+            "DELETE", JdbcDeleteEvent::new);
+
+    private static final char LINE_COMMENT_CHAR = '-';
+    private static final char BLOCK_COMMENT_CHAR = '/';
+    private static final char BLOCK_COMMENT_INNER_CHAR = '*';
+
+    private JdbcStatementEvents() {
+    }
+
+    /**
+     * The event for a known verb — {@code SELECT}, {@code WITH}, {@code INSERT}, {@code UPDATE},
+     * {@code DELETE}, case-insensitively — or a {@link JdbcExecuteEvent} for anything else,
+     * {@code null} included.
+     *
+     * @param verb  the statement's verb, e.g. a MyBatis {@code SqlCommandType} name
+     * @param name  the statement label — stable and low-cardinality, never SQL text
+     * @param group the label statements are grouped under in the Database dashboard
+     */
+    public static JdbcBaseEvent forVerb(String verb, String name, String group) {
+        Objects.requireNonNull(name, "name must not be null");
+
+        EventConstructor constructor = verb == null
+                ? null
+                : CONSTRUCTORS_BY_VERB.get(verb.toUpperCase(Locale.ROOT));
+        return constructor != null ? constructor.create(name, group) : new JdbcExecuteEvent(name, group);
+    }
+
+    /**
+     * The form of {@link #forVerb} for an interception point that only has the SQL text: the verb
+     * is the statement's first keyword, read past leading whitespace, line comments
+     * ({@code -- ...}) and block comments (<code>/&#42; ... &#42;/</code>). The SQL itself is used
+     * for nothing else — the statement's <em>name</em> stays the caller's label, never the text.
+     */
+    public static JdbcBaseEvent forSql(String sql, String name, String group) {
+        return forVerb(sql == null ? null : firstKeyword(sql), name, group);
+    }
+
+    private static String firstKeyword(String sql) {
+        int i = 0;
+        int length = sql.length();
+        while (i < length) {
+            char c = sql.charAt(i);
+            if (Character.isWhitespace(c) || c == '(') {
+                i++;
+            } else if (c == LINE_COMMENT_CHAR && i + 1 < length && sql.charAt(i + 1) == LINE_COMMENT_CHAR) {
+                i = skipLineComment(sql, i);
+            } else if (c == BLOCK_COMMENT_CHAR && i + 1 < length && sql.charAt(i + 1) == BLOCK_COMMENT_INNER_CHAR) {
+                i = skipBlockComment(sql, i);
+            } else {
+                break;
+            }
+        }
+
+        int start = i;
+        while (i < length && Character.isLetter(sql.charAt(i))) {
+            i++;
+        }
+        return sql.substring(start, i);
+    }
+
+    private static int skipLineComment(String sql, int from) {
+        int newline = sql.indexOf('\n', from);
+        return newline < 0 ? sql.length() : newline + 1;
+    }
+
+    private static int skipBlockComment(String sql, int from) {
+        int end = sql.indexOf("*/", from + 2);
+        return end < 0 ? sql.length() : end + 2;
+    }
+}

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/SpanAttributes.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/SpanAttributes.java
@@ -1,0 +1,144 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.trace;
+
+import java.util.Objects;
+
+/**
+ * Builds the JSON object string the {@link AbstractTracedEvent#attributes} field carries, without
+ * pulling a JSON library into instrumentation — this library's zero-dependency promise is exactly
+ * why emitters were hand-concatenating JSON, and hand-concatenated JSON breaks on the first value
+ * containing a quote.
+ *
+ * <pre>{@code
+ * event.attributes = SpanAttributes.create()
+ *         .put("cache", "miss")
+ *         .put("retries", 2)
+ *         .put("fallback", true)
+ *         .json();
+ * }</pre>
+ *
+ * Values are escaped per JSON's rules (quotes, backslashes, control characters), so any string is
+ * safe to record — though what belongs in an attribute is still the emitter's judgement: the
+ * recording and Jeffrey's profile database contain the values verbatim, so scrub anything
+ * sensitive before putting it here.
+ * <p>
+ * Attributes are operation detail, not identity: the span's <em>name</em> stays low-cardinality,
+ * and per-request values (an entity id, a retry count) go here instead. Build the object only
+ * when the event actually commits — inside the {@code shouldCommit()} block or a
+ * {@code TracedEvents.emit} filler — so an event under threshold pays nothing for it.
+ * <p>
+ * Keys are written in the order given and are not de-duplicated; give each key once. This builder
+ * is single-use and not thread-safe, like the event it fills.
+ */
+public final class SpanAttributes {
+
+    private static final String NULL_LITERAL = "null";
+
+    /** Control characters below this code point must be escaped in JSON strings. */
+    private static final char FIRST_PLAIN_CHAR = 0x20;
+
+    private final StringBuilder pairs = new StringBuilder();
+
+    private SpanAttributes() {
+    }
+
+    public static SpanAttributes create() {
+        return new SpanAttributes();
+    }
+
+    /**
+     * Records a string value; {@code null} is recorded as JSON {@code null}.
+     */
+    public SpanAttributes put(String key, String value) {
+        appendKey(key);
+        if (value == null) {
+            pairs.append(NULL_LITERAL);
+        } else {
+            appendQuoted(value);
+        }
+        return this;
+    }
+
+    public SpanAttributes put(String key, long value) {
+        appendKey(key);
+        pairs.append(value);
+        return this;
+    }
+
+    /**
+     * Records a numeric value. JSON has no encoding for {@code NaN} or an infinity, so a
+     * non-finite value is recorded as JSON {@code null}.
+     */
+    public SpanAttributes put(String key, double value) {
+        appendKey(key);
+        if (Double.isFinite(value)) {
+            pairs.append(value);
+        } else {
+            pairs.append(NULL_LITERAL);
+        }
+        return this;
+    }
+
+    public SpanAttributes put(String key, boolean value) {
+        appendKey(key);
+        pairs.append(value);
+        return this;
+    }
+
+    /**
+     * @return the attributes as a JSON object string, {@code "{}"} when nothing was put
+     */
+    public String json() {
+        return "{" + pairs + "}";
+    }
+
+    private void appendKey(String key) {
+        Objects.requireNonNull(key, "key must not be null");
+        if (!pairs.isEmpty()) {
+            pairs.append(',');
+        }
+        appendQuoted(key);
+        pairs.append(':');
+    }
+
+    private void appendQuoted(String value) {
+        pairs.append('"');
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '"' -> pairs.append("\\\"");
+                case '\\' -> pairs.append("\\\\");
+                case '\b' -> pairs.append("\\b");
+                case '\f' -> pairs.append("\\f");
+                case '\n' -> pairs.append("\\n");
+                case '\r' -> pairs.append("\\r");
+                case '\t' -> pairs.append("\\t");
+                default -> {
+                    if (c < FIRST_PLAIN_CHAR) {
+                        pairs.append("\\u%04x".formatted((int) c));
+                    } else {
+                        pairs.append(c);
+                    }
+                }
+            }
+        }
+        pairs.append('"');
+    }
+}

--- a/utilities/jeffrey-events/src/test/java/cafe/jeffrey/jfr/events/jdbc/statement/JdbcStatementEventsTest.java
+++ b/utilities/jeffrey-events/src/test/java/cafe/jeffrey/jfr/events/jdbc/statement/JdbcStatementEventsTest.java
@@ -1,0 +1,112 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.jdbc.statement;
+
+import cafe.jeffrey.jfr.events.trace.SpanKind;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class JdbcStatementEventsTest {
+
+    private static final String NAME = "UserMapper.selectById";
+    private static final String GROUP = "UserMapper";
+
+    @Nested
+    @DisplayName("Picking by verb")
+    class ByVerb {
+
+        @Test
+        @DisplayName("each data verb maps to its own event class, case-insensitively")
+        void dataVerbsMapToTheirClasses() {
+            assertInstanceOf(JdbcQueryEvent.class, JdbcStatementEvents.forVerb("SELECT", NAME, GROUP));
+            assertInstanceOf(JdbcQueryEvent.class, JdbcStatementEvents.forVerb("select", NAME, GROUP));
+            assertInstanceOf(JdbcInsertEvent.class, JdbcStatementEvents.forVerb("INSERT", NAME, GROUP));
+            assertInstanceOf(JdbcUpdateEvent.class, JdbcStatementEvents.forVerb("Update", NAME, GROUP));
+            assertInstanceOf(JdbcDeleteEvent.class, JdbcStatementEvents.forVerb("DELETE", NAME, GROUP));
+        }
+
+        @Test
+        @DisplayName("anything else lands on the execute catch-all")
+        void unknownVerbsAreExecute() {
+            assertInstanceOf(JdbcExecuteEvent.class, JdbcStatementEvents.forVerb("CREATE", NAME, GROUP));
+            assertInstanceOf(JdbcExecuteEvent.class, JdbcStatementEvents.forVerb("MERGE", NAME, GROUP));
+            assertInstanceOf(JdbcExecuteEvent.class, JdbcStatementEvents.forVerb("FLUSH", NAME, GROUP));
+            assertInstanceOf(JdbcExecuteEvent.class, JdbcStatementEvents.forVerb(null, NAME, GROUP));
+        }
+
+        @Test
+        @DisplayName("the event carries the label, group and client kind like a hand-picked one")
+        void eventIsFullyConstructed() {
+            JdbcBaseEvent event = JdbcStatementEvents.forVerb("SELECT", NAME, GROUP);
+
+            assertEquals(NAME, event.name);
+            assertEquals(GROUP, event.group);
+            assertEquals(SpanKind.CLIENT.name(), event.kind);
+        }
+    }
+
+    @Nested
+    @DisplayName("Picking by SQL text")
+    class BySql {
+
+        @Test
+        @DisplayName("the first keyword decides, whatever surrounds it")
+        void firstKeywordDecides() {
+            assertInstanceOf(JdbcQueryEvent.class,
+                    JdbcStatementEvents.forSql("SELECT * FROM users", NAME, GROUP));
+            assertInstanceOf(JdbcInsertEvent.class,
+                    JdbcStatementEvents.forSql("  \n\tinsert into users values (?)", NAME, GROUP));
+            assertInstanceOf(JdbcUpdateEvent.class,
+                    JdbcStatementEvents.forSql("(UPDATE users SET name = ?)", NAME, GROUP));
+        }
+
+        @Test
+        @DisplayName("a common-table expression counts as a query")
+        void withCountsAsAQuery() {
+            assertInstanceOf(JdbcQueryEvent.class, JdbcStatementEvents.forSql(
+                    "WITH active AS (SELECT id FROM users) SELECT count(*) FROM active", NAME, GROUP));
+        }
+
+        @Test
+        @DisplayName("leading comments are read past, not mistaken for the verb")
+        void commentsAreSkipped() {
+            assertInstanceOf(JdbcDeleteEvent.class, JdbcStatementEvents.forSql(
+                    "-- cleanup expired rows\nDELETE FROM sessions WHERE expires_at < ?", NAME, GROUP));
+            assertInstanceOf(JdbcQueryEvent.class, JdbcStatementEvents.forSql(
+                    "/* hint: index scan */ SELECT id FROM users", NAME, GROUP));
+        }
+
+        @Test
+        @DisplayName("DDL, vendor commands, and unreadable text land on the execute catch-all")
+        void everythingElseIsExecute() {
+            assertInstanceOf(JdbcExecuteEvent.class,
+                    JdbcStatementEvents.forSql("CREATE TABLE users (id BIGINT)", NAME, GROUP));
+            assertInstanceOf(JdbcExecuteEvent.class,
+                    JdbcStatementEvents.forSql("FORCE CHECKPOINT;", NAME, GROUP));
+            assertInstanceOf(JdbcExecuteEvent.class, JdbcStatementEvents.forSql("", NAME, GROUP));
+            assertInstanceOf(JdbcExecuteEvent.class, JdbcStatementEvents.forSql(null, NAME, GROUP));
+            assertInstanceOf(JdbcExecuteEvent.class,
+                    JdbcStatementEvents.forSql("/* never closed", NAME, GROUP));
+        }
+    }
+}

--- a/utilities/jeffrey-events/src/test/java/cafe/jeffrey/jfr/events/trace/SpanAttributesTest.java
+++ b/utilities/jeffrey-events/src/test/java/cafe/jeffrey/jfr/events/trace/SpanAttributesTest.java
@@ -1,0 +1,88 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.trace;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SpanAttributesTest {
+
+    @Test
+    @DisplayName("values of every supported type render as one JSON object, in put order")
+    void rendersAllTypes() {
+        String json = SpanAttributes.create()
+                .put("cache", "miss")
+                .put("retries", 2L)
+                .put("ratio", 0.5)
+                .put("fallback", true)
+                .json();
+
+        assertEquals("{\"cache\":\"miss\",\"retries\":2,\"ratio\":0.5,\"fallback\":true}", json);
+    }
+
+    @Test
+    @DisplayName("nothing put renders as an empty object")
+    void emptyRendersAsEmptyObject() {
+        assertEquals("{}", SpanAttributes.create().json());
+    }
+
+    @Test
+    @DisplayName("quotes, backslashes and control characters are escaped, so any string is safe")
+    void escapesStrings() {
+        String json = SpanAttributes.create()
+                .put("sql", "SELECT \"name\" FROM t\nWHERE path = 'C:\\tmp'")
+                .put("nul", "\u0001")
+                .json();
+
+        assertEquals(
+                "{\"sql\":\"SELECT \\\"name\\\" FROM t\\nWHERE path = 'C:\\\\tmp'\",\"nul\":\"\\u0001\"}",
+                json);
+    }
+
+    @Test
+    @DisplayName("a null string value is recorded as JSON null, a null key is refused")
+    void nullHandling() {
+        assertEquals("{\"missing\":null}", SpanAttributes.create().put("missing", (String) null).json());
+        assertThrows(NullPointerException.class, () -> SpanAttributes.create().put(null, "value"));
+    }
+
+    @Test
+    @DisplayName("non-finite numbers, which JSON cannot encode, are recorded as null")
+    void nonFiniteNumbersAreNull() {
+        String json = SpanAttributes.create()
+                .put("nan", Double.NaN)
+                .put("inf", Double.POSITIVE_INFINITY)
+                .json();
+
+        assertEquals("{\"nan\":null,\"inf\":null}", json);
+    }
+
+    @Test
+    @DisplayName("the rendered object lands on the event's attributes field as-is")
+    void fillsTheAttributesField() {
+        TraceSpanEvent event = new TraceSpanEvent();
+
+        event.attributes = SpanAttributes.create().put("chunk", 42L).json();
+
+        assertEquals("{\"chunk\":42}", event.attributes);
+    }
+}


### PR DESCRIPTION
Part 3 of the TraceSpan instrumentation-simplification series. Independent of #177/#178 — based directly on `master` (touching only new files plus two doc sections, so it merges cleanly in any order).

## What changed

**`JdbcStatementEvents`** — the verb-to-event mapping as library API. Every interceptor that sees statements through one hook (a MyBatis plugin, a `DataSource` proxy) had to hand-roll the same switch mapping SQL verbs onto the five statement event classes; each copy is a place for the convention to drift.
- `forVerb(verb, name, group)` applies the mapping from a known command type (e.g. MyBatis `SqlCommandType.name()`), case-insensitively; anything unrecognized — DDL, `MERGE`, vendor commands, `null` — lands on the `JdbcExecuteEvent` catch-all.
- `forSql(sql, name, group)` reads the verb as the statement's first keyword, past leading whitespace, `--` line comments and `/* */` block comments, for interception points that only have the SQL text. `WITH` counts as a query (CTEs are how analytical SELECTs are written). The SQL is used for nothing else — the statement's *name* stays the caller's label.
- The MyBatis skill's interceptor drops its hand-rolled switch for the factory (with a 0.13.0 note).

**`SpanAttributes`** — the `attributes` field without hand-concatenated JSON. The field is "a JSON object as a String" with no support behind it, so emitters either pulled a JSON library into instrumented code (against the zero-dependency promise) or concatenated JSON by hand, which breaks on the first value containing a quote. The builder covers the field's needs: string/long/double/boolean values, JSON escaping (quotes, backslashes, control characters), `null` values as JSON `null`, non-finite doubles (which JSON cannot encode) as `null`. The core skill documents it as the way to fill the field — built only inside the `shouldCommit()` block so an event under threshold pays nothing.

## Tests

13 new tests (60 total green on JDK 25): verb mapping incl. case-insensitivity and the catch-all, SQL sniffing through comments/parens/CTEs and degenerate inputs (`null`, empty, unterminated comment), JSON rendering for all value types, escaping, null-handling, and non-finite numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BfGNpXCFpAxW1etXhD8x3v

---
_Generated by [Claude Code](https://claude.ai/code/session_01BfGNpXCFpAxW1etXhD8x3v)_