### PR TITLE
Executor ergonomics: Tracer.propagating(executor) and Tracer.forkCallable

### DIFF
--- a/utilities/jeffrey-events/skills/jeffrey-traces-core/SKILL.md
+++ b/utilities/jeffrey-events/skills/jeffrey-traces-core/SKILL.md
@@ -196,12 +196,13 @@ They are plain events (not spans); emit them from your pool's hook points
    individual request lives in the trace id, which is already there.
 
 5. **A trace does not cross a plain executor by itself.** `ScopedValue`
-   propagates only through structured concurrency. Before handing work to an
-   `ExecutorService`, `@Async` method, or `CompletableFuture`, capture the
-   context and re-establish it: `Tracer.fork(...)` (capture at call site) or
+   propagates only through structured concurrency. Either wrap the pool once
+   with `Tracer.propagating(executor)` (releases after 0.13.0) so every task
+   submitted inside a span runs inside it, or capture per call site:
+   `Tracer.fork(...)`/`Tracer.forkCallable(...)` (a named child span) or
    `Tracer.current()` + `Tracer.continueIn(parent, ...)` (explicit). Work
-   submitted without this still runs and its leaf events still commit — but as
-   roots of their own single-span traces.
+   submitted without any of this still runs and its leaf events still commit —
+   but as roots of their own single-span traces.
 
 ---
 
@@ -238,13 +239,23 @@ Tracer.run("payment.charge", SpanKind.CLIENT, () -> paymentGateway.charge(order)
 
 ### Crossing threads
 
-`ScopedValue` does not survive a plain executor hand-off. Two tools:
+`ScopedValue` does not survive a plain executor hand-off. Three tools:
 
 ```java
-// fork(): capture here, replay there — for work that IS a separate operation
+// propagating(): wrap the POOL once, and every task submitted inside a span
+// runs inside that span — no per-call-site wrapping, no name, no child span.
+// Leaf events in the task stamp under the submitting span; each activation
+// records a jeffrey.TraceScope naming the thread it ran on.
+ExecutorService executor = Tracer.propagating(Executors.newFixedThreadPool(8));
+executor.submit(() -> parseChunk(file));
+
+// fork()/forkCallable(): capture here, replay there — for work that IS a
+// separate operation deserving its own named span (composes with the above)
 CompletableFuture.runAsync(
         Tracer.fork("report.render", () -> renderChunk(part)),   // capture at call site!
         executor);
+Future<Report> report = executor.submit(
+        Tracer.forkCallable("report.render", () -> render(part)));
 
 // continueIn(): the explicit form when you carry the context yourself
 SpanContext parent = Tracer.current().orElse(null);
@@ -254,9 +265,12 @@ executor.submit(() -> Tracer.continueIn(parent, "chunk.parse", () -> {
 }));
 ```
 
-`fork` captures the parent when *called*, not when the task runs — always call
-it on the thread whose span the work belongs to, then submit the result.
-`@Async` methods and scheduled tasks need the same treatment.
+Pick `propagating` when a whole pool serves traced requests (releases after
+0.13.0), `fork`/`forkCallable` when one task is a distinct operation worth a
+span of its own. `fork` captures the parent when *called*, not when the task
+runs — always call it on the thread whose span the work belongs to, then
+submit the result. `@Async` methods and scheduled tasks need the same
+treatment (a `TaskDecorator`/wrapped executor is the `propagating` shape).
 
 ### Callback-driven work (0.13.0+)
 

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/ContextPropagatingExecutorService.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/ContextPropagatingExecutorService.java
@@ -1,0 +1,143 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.trace;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * The executor decorator behind {@link Tracer#propagating(ExecutorService)}: every task is wrapped
+ * at submission time with the span then in progress on the submitting thread, and re-entered on
+ * whatever thread the delegate runs it on.
+ * <p>
+ * Capture happens per <em>submission</em>, not per decorator: the same wrapped pool serves many
+ * requests, each task carrying the span of the request that submitted it. A task submitted outside
+ * any span is handed to the delegate untouched.
+ *
+ * @see Tracer#propagating(ExecutorService)
+ */
+final class ContextPropagatingExecutorService implements ExecutorService {
+
+    private final ExecutorService delegate;
+
+    ContextPropagatingExecutorService(ExecutorService delegate) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate must not be null");
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        delegate.execute(wrap(command));
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        return delegate.submit(wrap(task));
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        return delegate.submit(wrap(task), result);
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        return delegate.submit(wrap(task));
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        return delegate.invokeAll(wrapAll(tasks));
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(
+            Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
+        return delegate.invokeAll(wrapAll(tasks), timeout, unit);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
+            throws InterruptedException, ExecutionException {
+        return delegate.invokeAny(wrapAll(tasks));
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        return delegate.invokeAny(wrapAll(tasks), timeout, unit);
+    }
+
+    @Override
+    public void shutdown() {
+        delegate.shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return delegate.shutdownNow();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return delegate.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return delegate.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return delegate.awaitTermination(timeout, unit);
+    }
+
+    private static Runnable wrap(Runnable task) {
+        Objects.requireNonNull(task, "task must not be null");
+
+        SpanContext context = Tracer.current().orElse(null);
+        if (context == null) {
+            return task;
+        }
+        return () -> Tracer.reenter(context, task);
+    }
+
+    private static <T> Callable<T> wrap(Callable<T> task) {
+        Objects.requireNonNull(task, "task must not be null");
+
+        SpanContext context = Tracer.current().orElse(null);
+        if (context == null) {
+            return task;
+        }
+        return () -> Tracer.reenter(context, task::call);
+    }
+
+    private static <T> Collection<Callable<T>> wrapAll(Collection<? extends Callable<T>> tasks) {
+        return tasks.stream()
+                .map(task -> (Callable<T>) wrap(task))
+                .toList();
+    }
+}

--- a/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/Tracer.java
+++ b/utilities/jeffrey-events/src/main/java/cafe/jeffrey/jfr/events/trace/Tracer.java
@@ -20,6 +20,8 @@ package cafe.jeffrey.jfr.events.trace;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 
 /**
@@ -386,6 +388,62 @@ public final class Tracer {
      */
     public static <T> Supplier<T> fork(String name, Supplier<T> body) {
         return fork(name, SpanKind.INTERNAL, body);
+    }
+
+    /**
+     * The {@link Callable} form of {@link #fork(String, SpanKind, Runnable)}, shaped for
+     * {@link ExecutorService#submit(Callable)} — the common typed-result hand-off that neither the
+     * {@link Runnable} nor the {@link Supplier} form fits. A distinct name rather than another
+     * {@code fork} overload, because a result-bearing lambda matches {@link Supplier} and
+     * {@link Callable} alike and would make every existing {@code fork} call ambiguous.
+     *
+     * <pre>{@code
+     * Future<Report> report = executor.submit(
+     *         Tracer.forkCallable("report.render", () -> render(part)));
+     * }</pre>
+     */
+    public static <T> Callable<T> forkCallable(String name, SpanKind kind, Callable<T> body) {
+        Objects.requireNonNull(name, "name must not be null");
+        Objects.requireNonNull(kind, "kind must not be null");
+        Objects.requireNonNull(body, "body must not be null");
+
+        SpanContext parent = CURRENT.isBound() ? CURRENT.get() : null;
+        return () -> continueIn(parent, name, kind, body::call);
+    }
+
+    /**
+     * The form of {@link #forkCallable(String, SpanKind, Callable)} with kind
+     * {@link SpanKind#INTERNAL}.
+     */
+    public static <T> Callable<T> forkCallable(String name, Callable<T> body) {
+        return forkCallable(name, SpanKind.INTERNAL, body);
+    }
+
+    /**
+     * Wraps {@code delegate} so that every task submitted to it runs inside the span in progress
+     * on the <em>submitting</em> thread — the executor-wide form of capturing {@link #current}
+     * and re-establishing it per task, for the pool that serves traced requests wholesale.
+     * <p>
+     * Distinct from {@link #fork}: no child span is minted and no name is needed, because the
+     * task is treated as the same operation continuing elsewhere, not a separate one. The context
+     * is re-established with {@link #reenter}, so leaf events emitted inside the task stamp under
+     * the submitting span, and each task activation records a {@link TraceScopeEvent} naming the
+     * thread it actually ran on. A task that wants its own named span in the waterfall still
+     * wraps itself with {@link #fork} or {@link #forkCallable} — submitted through this executor,
+     * the two compose.
+     * <p>
+     * The capture happens per submission, not when the executor is wrapped, so one wrapped pool
+     * serves many requests. A task submitted outside any span is handed to the delegate
+     * untouched and runs exactly as it would have unwrapped.
+     *
+     * <pre>{@code
+     * ExecutorService executor = Tracer.propagating(Executors.newFixedThreadPool(8));
+     * // ... per request:
+     * executor.submit(() -> parseChunk(file));   // nests under the request's span
+     * }</pre>
+     */
+    public static ExecutorService propagating(ExecutorService delegate) {
+        return new ContextPropagatingExecutorService(delegate);
     }
 
     /**

--- a/utilities/jeffrey-events/src/test/java/cafe/jeffrey/jfr/events/trace/TracerTest.java
+++ b/utilities/jeffrey-events/src/test/java/cafe/jeffrey/jfr/events/trace/TracerTest.java
@@ -30,6 +30,13 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -655,6 +662,157 @@ class TracerTest {
                 task.run();
                 return null;
             });
+        }
+
+        @Test
+        @DisplayName("the callable form returns the body's value and reparents like fork")
+        void forkCallableReturnsTheValueAndReparents() throws IOException {
+            Object result = new Object();
+
+            Map<String, RecordedEvent> spans = recordSpans(() -> {
+                Callable<Object> task = Tracer.call("submit", SpanKind.SERVER,
+                        () -> Tracer.forkCallable("handle", SpanKind.INTERNAL, () -> result));
+                runOnAnotherThread(() -> {
+                    assertSame(result, task.call());
+                    return null;
+                });
+            });
+
+            RecordedEvent submit = spans.get("submit");
+            RecordedEvent handle = spans.get("handle");
+            assertEquals(submit.getLong("traceId"), handle.getLong("traceId"));
+            assertEquals(submit.getLong("spanId"), handle.getLong("parentSpanId"));
+        }
+
+        @Test
+        @DisplayName("the kind-less callable form records INTERNAL")
+        void kindLessCallableDefaultsToInternal() throws IOException {
+            Map<String, RecordedEvent> spans = recordSpans(() -> {
+                Callable<String> task = Tracer.forkCallable("handle", () -> "done");
+                try {
+                    assertEquals("done", task.call());
+                } catch (Exception e) {
+                    throw new IllegalStateException(e);
+                }
+            });
+
+            assertEquals(SpanKind.INTERNAL.name(), spans.get("handle").getString("kind"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Propagating executors")
+    class PropagatingExecutors {
+
+        @Test
+        @DisplayName("a submitted task runs inside the submitting span, so nested work reparents to it")
+        void submittedTaskRunsInsideTheSubmittingSpan() throws IOException {
+            Map<String, RecordedEvent> spans = recordSpans(() ->
+                    withExecutor(executor -> {
+                        Future<?> future = Tracer.call("submit", SpanKind.SERVER, () ->
+                                executor.submit(() -> Tracer.run("handle", SpanKind.INTERNAL, () -> {
+                                })));
+                        awaitQuietly(future);
+                    }));
+
+            RecordedEvent submit = spans.get("submit");
+            RecordedEvent handle = spans.get("handle");
+            assertEquals(submit.getLong("traceId"), handle.getLong("traceId"));
+            assertEquals(submit.getLong("spanId"), handle.getLong("parentSpanId"),
+                    "the task is the same operation continuing elsewhere, not a child span");
+        }
+
+        @Test
+        @DisplayName("a leaf event emitted inside a submitted callable stamps under the submitting span")
+        void leafInsideACallableStampsUnderTheSubmittingSpan() {
+            JdbcQueryEvent statement = new JdbcQueryEvent("listSpans", "profile");
+
+            withExecutor(executor -> {
+                // continueIn rather than call: it binds with or without a recording, so the
+                // propagation itself is what this test exercises.
+                SpanContext submitting = Tracer.continueIn(null, "submit", SpanKind.SERVER, () -> {
+                    Future<?> future = executor.submit(() -> {
+                        Tracer.stamp(statement);
+                        return null;
+                    });
+                    awaitQuietly(future);
+                    return Tracer.current().orElseThrow();
+                });
+
+                assertEquals(submitting.traceId(), statement.traceId);
+                assertEquals(submitting.spanId(), statement.parentSpanId);
+            });
+        }
+
+        @Test
+        @DisplayName("each task activation records a scope naming the span it resumed")
+        void eachTaskRecordsAScope() throws IOException {
+            AtomicReference<SpanContext> submitting = new AtomicReference<>();
+
+            List<RecordedEvent> scopes = JfrRecordings.all(TraceScopeEvent.NAME, () ->
+                    withExecutor(executor ->
+                            submitting.set(Tracer.call("submit", SpanKind.SERVER, () -> {
+                                awaitQuietly(executor.submit(() -> null));
+                                awaitQuietly(executor.submit(() -> null));
+                                return Tracer.current().orElseThrow();
+                            }))));
+
+            assertEquals(2, scopes.size(), "one scope per task, recording where each actually ran");
+            for (RecordedEvent scope : scopes) {
+                assertEquals(submitting.get().spanId(), scope.getLong("scopedSpanId"));
+            }
+        }
+
+        @Test
+        @DisplayName("invokeAll carries the span into every task of the batch")
+        void invokeAllCarriesTheSpan() {
+            withExecutor(executor ->
+                    // continueIn rather than run: it binds with or without a recording.
+                    Tracer.continueIn(null, "submit", SpanKind.SERVER, () -> {
+                        try {
+                            List<Future<Boolean>> futures = executor.invokeAll(List.of(
+                                    () -> Tracer.current().isPresent(),
+                                    () -> Tracer.current().isPresent()));
+                            for (Future<Boolean> future : futures) {
+                                assertTrue(future.get(), "every task of the batch runs inside the span");
+                            }
+                        } catch (InterruptedException | ExecutionException e) {
+                            throw new IllegalStateException(e);
+                        }
+                    }));
+        }
+
+        @Test
+        @DisplayName("a task submitted outside any span runs untouched")
+        void taskOutsideASpanRunsUntouched() throws IOException {
+            List<RecordedEvent> scopes = JfrRecordings.all(TraceScopeEvent.NAME, () ->
+                    withExecutor(executor -> {
+                        Future<?> future = executor.submit(() ->
+                                assertTrue(Tracer.current().isEmpty(), "nothing was bound at submission"));
+                        awaitQuietly(future);
+                    }));
+
+            assertTrue(scopes.isEmpty(), "no span was carried, so there is no scope to record");
+        }
+
+        private void withExecutor(Consumer<ExecutorService> body) {
+            ExecutorService executor = Tracer.propagating(Executors.newSingleThreadExecutor());
+            try {
+                body.accept(executor);
+            } finally {
+                executor.shutdown();
+            }
+        }
+
+        private void awaitQuietly(Future<?> future) {
+            try {
+                future.get();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException(e);
+            } catch (ExecutionException e) {
+                throw new IllegalStateException(e.getCause());
+            }
         }
     }
 


### PR DESCRIPTION
Part 4 of the TraceSpan instrumentation-simplification series. Independent of #177/#178/#179 — based directly on `master` (new files plus additive `Tracer` methods and two skill sections; merges cleanly in any order).

## What changed

**`Tracer.propagating(ExecutorService)`** moves cross-thread propagation from every call site to the pool itself. A `ScopedValue` does not survive a plain executor, so every submission into a pool serving traced requests needed a per-call-site `fork()` wrap — and a forgotten wrap silently records the task's events as roots of their own one-span traces (the pitfall tables' second-most-common symptom).

The decorator captures the span in progress at *submission* time (per task, not per decorator — one wrapped pool serves many requests) and re-enters it on whatever thread the delegate runs the task on, across `execute`/`submit`/`invokeAll`/`invokeAny`. Design choices:
- **No child span is minted and no name is needed** — the task is treated as the same operation continuing elsewhere, re-established with `reenter`. Leaf events inside the task stamp under the submitting span, and each activation records a `jeffrey.TraceScope` naming the thread it actually ran on. A task that deserves its own named span composes with `fork`/`forkCallable` on top.
- A task submitted outside any span is handed to the delegate untouched.

**`Tracer.forkCallable(name[, kind], Callable)`** — the `Callable` form of `fork`, shaped for `ExecutorService.submit(Callable)`, the common typed-result hand-off that neither the `Runnable` nor the `Supplier` form fits. It's a distinct name rather than another `fork` overload deliberately: a result-bearing lambda matches `Supplier` and `Callable` alike, so an overload would make every existing `fork` call site ambiguous.

**Docs:** the core skill's "Crossing threads" section now leads with wrapping the pool once, keeps `fork`/`forkCallable` for tasks that are distinct operations, and rule 5 offers the same choice (with a 0.13.0 note).

## Tests

7 new tests (54 total green on JDK 25): a submitted task's spans reparent to the submitting span through a real JFR recording; a leaf stamped inside a submitted `Callable` carries the submitting span's ids; one `TraceScope` per task activation with the right `scopedSpanId`; `invokeAll` carries the span into every task of the batch; a task submitted outside any span runs untouched with no scopes; `forkCallable` returns the body's value, reparents like `fork`, and defaults to `INTERNAL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BfGNpXCFpAxW1etXhD8x3v

---
_Generated by [Claude Code](https://claude.ai/code/session_01BfGNpXCFpAxW1etXhD8x3v)_