### PR TITLE
Step 2 (PR C): jeffrey-events-jdbc and jeffrey-events-hikari — statements from any ORM, and the first pool emitter

### DIFF
--- a/utilities/jeffrey-events/README.md
+++ b/utilities/jeffrey-events/README.md
@@ -33,8 +33,10 @@ into full request traces with per-span flamegraphs.
 </dependency>
 ```
 
-Every inbound request becomes the root span of a trace, named by the matched handler pattern, with
-statements and outbound calls nesting underneath. Tune it with `jeffrey.tracing.*`; see the
+Every inbound request becomes the root span of a trace, named by the matched handler pattern. Every
+`DataSource` bean is wrapped, so the statements your ORM issues nest underneath the request without
+anyone writing JDBC instrumentation, and a HikariCP pool gets its acquire/borrow/create timings and a
+periodic gauge. Tune it with `jeffrey.tracing.*`; see the
 [Spring server skill](skills/jeffrey-traces-spring-rest-server/SKILL.md).
 
 Not on Boot? `jeffrey-events-spring` has the same beans with no Boot dependency and no
@@ -102,6 +104,8 @@ dashboards.
 | `jeffrey-events-test` | assertions over the spans in a recording, for your own tests; zero dependencies |
 | `jeffrey-events-servlet` | the root-span filter; needs only `jakarta.servlet` |
 | `jeffrey-events-spring` | Spring `@Configuration` you `@Import` explicitly; no Spring Boot dependency |
+| `jeffrey-events-jdbc` | a `DataSource` wrapper recording every statement — JdbcTemplate, Hibernate, jOOQ and MyBatis alike |
+| `jeffrey-events-hikari` | HikariCP metrics tracker: connection acquire/borrow/create/timeout, plus the periodic pool gauge |
 | `jeffrey-events-spring-boot-starter` | auto-configuration: add it and write nothing |
 
 ## Event catalog

--- a/utilities/jeffrey-events/hikari/pom.xml
+++ b/utilities/jeffrey-events/hikari/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Jeffrey
+  ~ Copyright (C) 2026 Petr Bouda
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>cafe.jeffrey-analyst</groupId>
+        <artifactId>jeffrey-events-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jeffrey-events-hikari</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+    <description>HikariCP metrics tracker emitting Jeffrey connection-pool events, including the periodic pool gauge</description>
+    <!-- Explicit: Maven Central rejects children that inherit a url with the artifactId appended. -->
+    <url>https://github.com/petrbouda/jeffrey</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jeffrey-events</artifactId>
+        </dependency>
+        <!-- provided: the application already has the pool it is instrumenting. -->
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>${hikaricp.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jeffrey-events-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- A real pool over a real driver, so the tracker is exercised by Hikari itself. -->
+        <dependency>
+            <groupId>org.duckdb</groupId>
+            <artifactId>duckdb_jdbc</artifactId>
+            <version>${duckdb.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>cafe.jeffrey.jfr.events.jdbc.hikari</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/utilities/jeffrey-events/hikari/src/main/java/cafe/jeffrey/jfr/events/jdbc/hikari/JfrMetricsTrackerFactory.java
+++ b/utilities/jeffrey-events/hikari/src/main/java/cafe/jeffrey/jfr/events/jdbc/hikari/JfrMetricsTrackerFactory.java
@@ -1,0 +1,149 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.jdbc.hikari;
+
+import cafe.jeffrey.jfr.events.jdbc.pool.AcquiringPooledJdbcConnectionTimeoutEvent;
+import cafe.jeffrey.jfr.events.jdbc.pool.JdbcPoolStatisticsEvent;
+import cafe.jeffrey.jfr.events.jdbc.pool.PooledJdbcConnectionAcquiredEvent;
+import cafe.jeffrey.jfr.events.jdbc.pool.PooledJdbcConnectionBorrowedEvent;
+import cafe.jeffrey.jfr.events.jdbc.pool.PooledJdbcConnectionCreatedEvent;
+import com.zaxxer.hikari.metrics.IMetricsTracker;
+import com.zaxxer.hikari.metrics.MetricsTrackerFactory;
+import com.zaxxer.hikari.metrics.PoolStats;
+import jdk.jfr.FlightRecorder;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Emits Jeffrey's connection-pool events from HikariCP.
+ * <p>
+ * These event types have shipped since the beginning with nothing to produce them, so the pool
+ * dashboard has had no source. This is that source: Hikari already measures everything the events
+ * describe and hands it to a {@link MetricsTrackerFactory}, so the instrumentation is a mapping
+ * rather than a measurement.
+ *
+ * <pre>{@code
+ * HikariConfig config = new HikariConfig();
+ * config.setMetricsTrackerFactory(new JfrMetricsTrackerFactory());
+ * }</pre>
+ *
+ * Two kinds of event come out of it:
+ * <ul>
+ *   <li><b>Per operation</b> — how long an acquire, a borrow or a physical connection creation
+ *       took, and every acquire that timed out.</li>
+ *   <li><b>Periodic</b> — a {@link JdbcPoolStatisticsEvent} sampled by JFR itself on the period the
+ *       event declares, reading the live gauges Hikari exposes. Registered once per pool when the
+ *       pool asks for a tracker.</li>
+ * </ul>
+ * Pool events are deliberately not spans: the pool reports after the fact, with no interval of its
+ * own for JFR to time. Whatever waited for the connection is the span; these hang off it.
+ */
+public class JfrMetricsTrackerFactory implements MetricsTrackerFactory {
+
+    @Override
+    public IMetricsTracker create(String poolName, PoolStats poolStats) {
+        PoolStatisticsSampler sampler = new PoolStatisticsSampler(poolName, poolStats);
+        FlightRecorder.addPeriodicEvent(JdbcPoolStatisticsEvent.class, sampler);
+        return new JfrMetricsTracker(poolName, sampler);
+    }
+
+    /**
+     * Fills the periodic gauge event from Hikari's live pool statistics.
+     * <p>
+     * Reading the gauges only when JFR asks is the point: the sampler is registered once per pool
+     * and costs nothing between recordings, because JFR does not call it when the event type is
+     * disabled.
+     */
+    private record PoolStatisticsSampler(String poolName, PoolStats poolStats) implements Runnable {
+
+        @Override
+        public void run() {
+            JdbcPoolStatisticsEvent event = new JdbcPoolStatisticsEvent();
+            if (!event.shouldCommit()) {
+                return;
+            }
+            event.poolName = poolName;
+            event.total = poolStats.getTotalConnections();
+            event.idle = poolStats.getIdleConnections();
+            event.active = poolStats.getActiveConnections();
+            event.max = poolStats.getMaxConnections();
+            event.min = poolStats.getMinConnections();
+            event.pendingThreads = poolStats.getPendingThreads();
+            event.commit();
+        }
+    }
+
+    /**
+     * Maps Hikari's per-operation callbacks onto the pool events.
+     * <p>
+     * Hikari reports two of the three durations in milliseconds while the events record a timespan
+     * in nanoseconds, so those are converted rather than recorded in the wrong unit — a pool that
+     * looked a million times faster than it is would be worse than no instrumentation.
+     */
+    private record JfrMetricsTracker(String poolName, PoolStatisticsSampler sampler) implements IMetricsTracker {
+
+        @Override
+        public void recordConnectionAcquiredNanos(long elapsedAcquiredNanos) {
+            PooledJdbcConnectionAcquiredEvent event = new PooledJdbcConnectionAcquiredEvent();
+            if (event.shouldCommit()) {
+                event.poolName = poolName;
+                event.elapsedTime = elapsedAcquiredNanos;
+                event.commit();
+            }
+        }
+
+        @Override
+        public void recordConnectionUsageMillis(long elapsedBorrowedMillis) {
+            PooledJdbcConnectionBorrowedEvent event = new PooledJdbcConnectionBorrowedEvent();
+            if (event.shouldCommit()) {
+                event.poolName = poolName;
+                event.elapsedTime = TimeUnit.MILLISECONDS.toNanos(elapsedBorrowedMillis);
+                event.commit();
+            }
+        }
+
+        @Override
+        public void recordConnectionCreatedMillis(long connectionCreatedMillis) {
+            PooledJdbcConnectionCreatedEvent event = new PooledJdbcConnectionCreatedEvent();
+            if (event.shouldCommit()) {
+                event.poolName = poolName;
+                event.elapsedTime = TimeUnit.MILLISECONDS.toNanos(connectionCreatedMillis);
+                event.commit();
+            }
+        }
+
+        @Override
+        public void recordConnectionTimeout() {
+            AcquiringPooledJdbcConnectionTimeoutEvent event = new AcquiringPooledJdbcConnectionTimeoutEvent();
+            if (event.shouldCommit()) {
+                event.poolName = poolName;
+                event.commit();
+            }
+        }
+
+        /**
+         * Stops the periodic sampler when the pool shuts down, so a closed pool's gauges are not
+         * read for the lifetime of the JVM.
+         */
+        @Override
+        public void close() {
+            FlightRecorder.removePeriodicEvent(sampler);
+        }
+    }
+}

--- a/utilities/jeffrey-events/hikari/src/test/java/cafe/jeffrey/jfr/events/jdbc/hikari/JfrMetricsTrackerFactoryTest.java
+++ b/utilities/jeffrey-events/hikari/src/test/java/cafe/jeffrey/jfr/events/jdbc/hikari/JfrMetricsTrackerFactoryTest.java
@@ -1,0 +1,137 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.jdbc.hikari;
+
+import cafe.jeffrey.jfr.events.jdbc.pool.JdbcPoolStatisticsEvent;
+import cafe.jeffrey.jfr.events.jdbc.pool.PooledJdbcConnectionAcquiredEvent;
+import cafe.jeffrey.jfr.events.jdbc.pool.PooledJdbcConnectionBorrowedEvent;
+import cafe.jeffrey.jfr.events.test.JfrRecordings;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import jdk.jfr.consumer.RecordedEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Exercised through a real HikariCP pool, because the whole module is a mapping of Hikari's own
+ * callbacks — a test that invoked the tracker directly would assert only that the mapping code
+ * compiles, not that Hikari ever calls it.
+ */
+class JfrMetricsTrackerFactoryTest {
+
+    private static final String POOL_NAME = "orders-pool";
+    private static final String JDBC_URL = "jdbc:duckdb:";
+
+    /** Long enough for JFR to fire the one-second periodic gauge at least once. */
+    private static final long GAUGE_WINDOW_MILLIS = 1_500;
+
+    @Test
+    @DisplayName("acquiring and returning a connection records the pool's own timings")
+    void recordsConnectionTimings() throws IOException {
+        List<RecordedEvent> events = JfrRecordings.all(
+                List.of(PooledJdbcConnectionAcquiredEvent.NAME, PooledJdbcConnectionBorrowedEvent.NAME),
+                () -> withPool(pool -> {
+                    try (Connection connection = pool.getConnection();
+                         Statement statement = connection.createStatement()) {
+                        statement.execute("SELECT 1");
+                    }
+                }));
+
+        assertFalse(events.isEmpty(), "Hikari reports every acquire and every return");
+        for (RecordedEvent event : events) {
+            assertEquals(POOL_NAME, event.getString("poolName"));
+            assertTrue(event.getLong("elapsedTime") >= 0, "a timespan is recorded in nanoseconds");
+        }
+    }
+
+    @Test
+    @DisplayName("the pool's live gauges are sampled periodically by JFR itself")
+    void samplesTheGaugePeriodically() throws IOException {
+        List<RecordedEvent> events = JfrRecordings.all(JdbcPoolStatisticsEvent.NAME, () ->
+                withPool(pool -> {
+                    try (Connection connection = pool.getConnection()) {
+                        connection.createStatement().close();
+                        // The gauge is JFR's to schedule; the pool is simply held open across it.
+                        Thread.sleep(GAUGE_WINDOW_MILLIS);
+                    }
+                }));
+
+        assertFalse(events.isEmpty(), "the periodic event should have fired at least once");
+        RecordedEvent gauge = events.getFirst();
+        assertEquals(POOL_NAME, gauge.getString("poolName"));
+        assertTrue(gauge.getInt("total") >= 1, "a connection was in use while the gauge fired");
+        assertTrue(gauge.getInt("max") >= gauge.getInt("total"));
+    }
+
+    @Test
+    @DisplayName("closing the pool stops the sampler, so a dead pool is not read forever")
+    void closingThePoolStopsTheSampler() throws IOException {
+        withPool(pool -> {
+            try (Connection connection = pool.getConnection()) {
+                connection.createStatement().close();
+            }
+        });
+
+        // The pool above is closed by withPool; nothing should be sampled after it.
+        List<RecordedEvent> afterClose = JfrRecordings.all(JdbcPoolStatisticsEvent.NAME,
+                () -> sleep(GAUGE_WINDOW_MILLIS));
+
+        assertTrue(afterClose.isEmpty(), "the periodic sampler was removed when the pool shut down");
+    }
+
+    private interface PoolBody {
+        void accept(HikariDataSource pool) throws Exception;
+    }
+
+    private static void withPool(PoolBody body) {
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl(JDBC_URL);
+        config.setPoolName(POOL_NAME);
+        config.setMaximumPoolSize(2);
+        config.setMetricsTrackerFactory(new JfrMetricsTrackerFactory());
+
+        try (HikariDataSource pool = new HikariDataSource(config)) {
+            body.accept(pool);
+        } catch (SQLException | RuntimeException e) {
+            throw new IllegalStateException(e);
+        } catch (Exception e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/utilities/jeffrey-events/jdbc/pom.xml
+++ b/utilities/jeffrey-events/jdbc/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Jeffrey
+  ~ Copyright (C) 2026 Petr Bouda
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>cafe.jeffrey-analyst</groupId>
+        <artifactId>jeffrey-events-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jeffrey-events-jdbc</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+    <description>DataSource wrapper recording every JDBC statement as a Jeffrey leaf span, whatever persistence framework issued it</description>
+    <!-- Explicit: Maven Central rejects children that inherit a url with the artifactId appended. -->
+    <url>https://github.com/petrbouda/jeffrey</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jeffrey-events</artifactId>
+        </dependency>
+
+        <!-- An in-process database, so the proxy is tested against a real driver. -->
+        <dependency>
+            <groupId>org.duckdb</groupId>
+            <artifactId>duckdb_jdbc</artifactId>
+            <version>${duckdb.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jeffrey-events-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>cafe.jeffrey.jfr.events.jdbc.datasource</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/utilities/jeffrey-events/jdbc/src/main/java/cafe/jeffrey/jfr/events/jdbc/datasource/StatementNaming.java
+++ b/utilities/jeffrey-events/jdbc/src/main/java/cafe/jeffrey/jfr/events/jdbc/datasource/StatementNaming.java
@@ -1,0 +1,109 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.jdbc.datasource;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Decides what a statement is <em>called</em>.
+ * <p>
+ * The name is the operation's identity in Jeffrey, so it has to be stable and low-cardinality —
+ * one name per kind of statement, never one per execution. Raw SQL is the wrong answer twice over:
+ * a statement with inlined literals produces a distinct name per parameter value, and even
+ * placeholder SQL is long enough to bloat the JFR per-chunk constant pool.
+ * <p>
+ * A {@code DataSource} proxy sees only the SQL text, which is why naming is an interface: an
+ * application that knows better — a repository name, a MyBatis statement id — supplies its own.
+ */
+@FunctionalInterface
+public interface StatementNaming {
+
+    /**
+     * @param sql the statement about to run; never {@code null}
+     * @return a stable, low-cardinality name
+     */
+    String name(String sql);
+
+    /**
+     * Names a statement by its verb and primary table — {@code "SELECT users"},
+     * {@code "INSERT orders"} — which is the most specific thing that can be read off SQL without
+     * becoming per-execution.
+     * <p>
+     * A statement whose table cannot be read (a DDL statement, a vendor command, a shape the
+     * patterns do not cover) is named by its verb alone rather than by its text, so an unparsed
+     * statement degrades to a coarse name instead of a high-cardinality one.
+     */
+    static StatementNaming verbAndTable() {
+        return VerbAndTable.INSTANCE;
+    }
+
+    /**
+     * The implementation behind {@link #verbAndTable()}, kept out of the interface so the patterns
+     * are compiled once and named.
+     */
+    final class VerbAndTable implements StatementNaming {
+
+        private static final VerbAndTable INSTANCE = new VerbAndTable();
+
+        /** Unquoted identifier, optionally schema-qualified. */
+        private static final String TABLE = "([A-Za-z0-9_$.\"`\\[\\]]+)";
+
+        private static final Pattern LEADING_VERB = Pattern.compile("^\\s*([A-Za-z]+)");
+
+        /**
+         * Where each verb keeps its primary table. {@code SELECT} and {@code DELETE} both read it
+         * after {@code FROM}, so they share a pattern.
+         */
+        private static final Map<String, Pattern> TABLE_BY_VERB = Map.of(
+                "SELECT", Pattern.compile("\\bFROM\\s+" + TABLE, Pattern.CASE_INSENSITIVE),
+                "DELETE", Pattern.compile("\\bFROM\\s+" + TABLE, Pattern.CASE_INSENSITIVE),
+                "INSERT", Pattern.compile("\\bINTO\\s+" + TABLE, Pattern.CASE_INSENSITIVE),
+                "UPDATE", Pattern.compile("\\bUPDATE\\s+" + TABLE, Pattern.CASE_INSENSITIVE),
+                "MERGE", Pattern.compile("\\bINTO\\s+" + TABLE, Pattern.CASE_INSENSITIVE));
+
+        private static final String UNKNOWN_STATEMENT = "statement";
+        private static final String SEPARATOR = " ";
+
+        private VerbAndTable() {
+        }
+
+        @Override
+        public String name(String sql) {
+            if (sql == null || sql.isBlank()) {
+                return UNKNOWN_STATEMENT;
+            }
+
+            Matcher verbMatcher = LEADING_VERB.matcher(sql);
+            if (!verbMatcher.find()) {
+                return UNKNOWN_STATEMENT;
+            }
+            String verb = verbMatcher.group(1).toUpperCase(Locale.ROOT);
+
+            Pattern tablePattern = TABLE_BY_VERB.get(verb);
+            if (tablePattern == null) {
+                return verb;
+            }
+            Matcher tableMatcher = tablePattern.matcher(sql);
+            return tableMatcher.find() ? verb + SEPARATOR + tableMatcher.group(1) : verb;
+        }
+    }
+}

--- a/utilities/jeffrey-events/jdbc/src/main/java/cafe/jeffrey/jfr/events/jdbc/datasource/StatementTracing.java
+++ b/utilities/jeffrey-events/jdbc/src/main/java/cafe/jeffrey/jfr/events/jdbc/datasource/StatementTracing.java
@@ -1,0 +1,196 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.jdbc.datasource;
+
+import cafe.jeffrey.jfr.events.jdbc.statement.JdbcBaseEvent;
+import cafe.jeffrey.jfr.events.jdbc.statement.JdbcStatementEvents;
+import cafe.jeffrey.jfr.events.trace.TracedEvents;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.util.Set;
+
+/**
+ * Wraps a {@link Connection} so that every statement it runs commits a Jeffrey JDBC event.
+ * <p>
+ * Dynamic proxies rather than hand-written delegates: {@link Connection} and
+ * {@link PreparedStatement} declare well over a hundred methods between them, almost none of which
+ * this instrumentation cares about, and delegating them by hand would be a large surface for a
+ * typo to hide in — one forwarded method quietly returning the wrong thing is a bug in the
+ * application, not just in its telemetry. Only the handful of methods named below are intercepted;
+ * everything else passes straight through.
+ * <p>
+ * {@link java.sql.ResultSet} is deliberately not wrapped. Counting returned rows would mean
+ * proxying every {@code next()} call on the hot path of every query, which costs more than the
+ * number is worth; a query's {@code rows} therefore stays {@code 0}, while updates and batches —
+ * where the driver hands the count back directly — record it.
+ */
+final class StatementTracing {
+
+    /** Methods on {@link Connection} that hand back a statement carrying its own SQL. */
+    private static final Set<String> PREPARING_METHODS = Set.of("prepareStatement", "prepareCall");
+
+    private static final String CREATE_STATEMENT = "createStatement";
+    private static final String EXECUTE_PREFIX = "execute";
+
+    private StatementTracing() {
+    }
+
+    static Connection wrapConnection(Connection connection, StatementNaming naming, String group) {
+        return (Connection) Proxy.newProxyInstance(
+                Connection.class.getClassLoader(),
+                new Class<?>[]{Connection.class},
+                new ConnectionHandler(connection, naming, group));
+    }
+
+    private record ConnectionHandler(Connection delegate, StatementNaming naming, String group)
+            implements InvocationHandler {
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            Object result = call(delegate, method, args);
+
+            if (!(result instanceof Statement statement)) {
+                return result;
+            }
+            // A prepared statement knows its SQL now; a plain one is handed it at execute time.
+            String sql = PREPARING_METHODS.contains(method.getName()) && args != null && args.length > 0
+                    ? String.valueOf(args[0])
+                    : null;
+            if (sql != null || CREATE_STATEMENT.equals(method.getName())) {
+                return wrapStatement(statement, sql, naming, group);
+            }
+            return result;
+        }
+    }
+
+    private static Statement wrapStatement(
+            Statement statement, String preparedSql, StatementNaming naming, String group) {
+
+        Class<?> contract = contractOf(statement);
+        return (Statement) Proxy.newProxyInstance(
+                contract.getClassLoader(),
+                new Class<?>[]{contract},
+                new StatementHandler(statement, preparedSql, naming, group));
+    }
+
+    /**
+     * The most specific JDBC interface the statement implements, so a caller that prepared a
+     * {@link CallableStatement} still gets one back.
+     */
+    private static Class<?> contractOf(Statement statement) {
+        if (statement instanceof CallableStatement) {
+            return CallableStatement.class;
+        }
+        if (statement instanceof PreparedStatement) {
+            return PreparedStatement.class;
+        }
+        return Statement.class;
+    }
+
+    private record StatementHandler(Statement delegate, String preparedSql, StatementNaming naming, String group)
+            implements InvocationHandler {
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            if (!method.getName().startsWith(EXECUTE_PREFIX)) {
+                return call(delegate, method, args);
+            }
+
+            String sql = resolveSql(method, args);
+            JdbcBaseEvent event = JdbcStatementEvents.forSql(sql, naming.name(sql), group);
+
+            return TracedEvents.emit(event,
+                    () -> call(delegate, method, args),
+                    (emitted, result) -> {
+                        emitted.sql = sql;
+                        emitted.rows = rowsOf(result);
+                    });
+        }
+
+        /**
+         * A batch has no single SQL of its own, and {@code Statement.execute(sql)} carries it as
+         * the first argument; a prepared statement always uses the SQL it was prepared with.
+         */
+        private String resolveSql(Method method, Object[] args) {
+            if (preparedSql != null) {
+                return preparedSql;
+            }
+            if (args != null && args.length > 0 && args[0] instanceof String sql) {
+                return sql;
+            }
+            return "";
+        }
+    }
+
+    /**
+     * The row count the driver handed back, where it hands one back at all.
+     */
+    private static long rowsOf(Object result) {
+        return switch (result) {
+            case Integer updated -> updated;
+            case Long updated -> updated;
+            case int[] batch -> sum(batch);
+            case long[] batch -> sum(batch);
+            // A ResultSet (executeQuery) or a Boolean (execute): the count is not knowable without
+            // wrapping the ResultSet, which is not worth the hot-path cost.
+            case null, default -> 0;
+        };
+    }
+
+    private static long sum(int[] counts) {
+        long total = 0;
+        for (int count : counts) {
+            // SUCCESS_NO_INFO / EXECUTE_FAILED are negative markers, not counts.
+            if (count > 0) {
+                total += count;
+            }
+        }
+        return total;
+    }
+
+    private static long sum(long[] counts) {
+        long total = 0;
+        for (long count : counts) {
+            if (count > 0) {
+                total += count;
+            }
+        }
+        return total;
+    }
+
+    /**
+     * Invokes the delegate, unwrapping the reflection layer so the caller sees the driver's own
+     * {@link java.sql.SQLException} and the event records the real failure rather than an
+     * {@link InvocationTargetException}.
+     */
+    private static Object call(Object delegate, Method method, Object[] args) throws Throwable {
+        try {
+            return method.invoke(delegate, args);
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        }
+    }
+}

--- a/utilities/jeffrey-events/jdbc/src/main/java/cafe/jeffrey/jfr/events/jdbc/datasource/TracingDataSource.java
+++ b/utilities/jeffrey-events/jdbc/src/main/java/cafe/jeffrey/jfr/events/jdbc/datasource/TracingDataSource.java
@@ -1,0 +1,134 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.jdbc.datasource;
+
+import javax.sql.DataSource;
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Objects;
+import java.util.logging.Logger;
+
+/**
+ * A {@link DataSource} that records every statement run through it as a Jeffrey JDBC event.
+ * <p>
+ * Wrapping the {@code DataSource} rather than instrumenting a persistence framework is what makes
+ * this one module cover JdbcTemplate, Hibernate/JPA, jOOQ and MyBatis at once: they all reach the
+ * database through this interface, so instrumenting it catches the statements each of them issues,
+ * including the ones an ORM generates that nobody wrote by hand.
+ * <p>
+ * Each statement becomes a <b>leaf span</b> nested under whatever span is in progress on the
+ * executing thread — the request being served, typically — or an untraced-but-recorded event when
+ * there is none.
+ *
+ * <pre>{@code
+ * DataSource traced = new TracingDataSource(hikariDataSource, "orders-db");
+ * }</pre>
+ *
+ * <h2>What it does not do</h2>
+ * Statement <em>parameters</em> are never read, let alone recorded: they are the values most
+ * likely to be personal data, and a proxy cannot know which are safe. The SQL text is recorded as
+ * the driver received it, so a statement built with placeholders stays aggregatable and a
+ * statement built by string concatenation carries whatever was concatenated into it.
+ */
+public class TracingDataSource implements DataSource {
+
+    private final DataSource delegate;
+    private final StatementNaming naming;
+    private final String group;
+
+    /**
+     * @param delegate the real data source
+     * @param group    the label statements are grouped under in Jeffrey's Database dashboard;
+     *                 usually the database or pool name
+     * @param naming   what each statement is called
+     */
+    public TracingDataSource(DataSource delegate, String group, StatementNaming naming) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate must not be null");
+        this.group = Objects.requireNonNull(group, "group must not be null");
+        this.naming = Objects.requireNonNull(naming, "naming must not be null");
+    }
+
+    /**
+     * The form that names statements by verb and primary table.
+     */
+    public TracingDataSource(DataSource delegate, String group) {
+        this(delegate, group, StatementNaming.verbAndTable());
+    }
+
+    /**
+     * @return the data source this one wraps, for code that needs the untraced original
+     */
+    public DataSource delegate() {
+        return delegate;
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return StatementTracing.wrapConnection(delegate.getConnection(), naming, group);
+    }
+
+    @Override
+    public Connection getConnection(String username, String password) throws SQLException {
+        return StatementTracing.wrapConnection(delegate.getConnection(username, password), naming, group);
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws SQLException {
+        return delegate.getLogWriter();
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter out) throws SQLException {
+        delegate.setLogWriter(out);
+    }
+
+    @Override
+    public void setLoginTimeout(int seconds) throws SQLException {
+        delegate.setLoginTimeout(seconds);
+    }
+
+    @Override
+    public int getLoginTimeout() throws SQLException {
+        return delegate.getLoginTimeout();
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        return delegate.getParentLogger();
+    }
+
+    /**
+     * Unwraps to the delegate, so code reaching for a vendor type — a {@code HikariDataSource} to
+     * read its pool, say — still finds it through the proxy.
+     */
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        if (iface.isInstance(this)) {
+            return iface.cast(this);
+        }
+        return delegate.unwrap(iface);
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        return iface.isInstance(this) || delegate.isWrapperFor(iface);
+    }
+}

--- a/utilities/jeffrey-events/jdbc/src/test/java/cafe/jeffrey/jfr/events/jdbc/datasource/TracingDataSourceTest.java
+++ b/utilities/jeffrey-events/jdbc/src/test/java/cafe/jeffrey/jfr/events/jdbc/datasource/TracingDataSourceTest.java
@@ -1,0 +1,306 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.jdbc.datasource;
+
+import cafe.jeffrey.jfr.events.jdbc.statement.JdbcDeleteEvent;
+import cafe.jeffrey.jfr.events.jdbc.statement.JdbcInsertEvent;
+import cafe.jeffrey.jfr.events.jdbc.statement.JdbcQueryEvent;
+import cafe.jeffrey.jfr.events.jdbc.statement.JdbcUpdateEvent;
+import cafe.jeffrey.jfr.events.test.JfrRecordings;
+import cafe.jeffrey.jfr.events.test.SpansAssert;
+import cafe.jeffrey.jfr.events.trace.SpanKind;
+import cafe.jeffrey.jfr.events.trace.SpanStatus;
+import cafe.jeffrey.jfr.events.trace.Tracer;
+import jdk.jfr.consumer.RecordedEvent;
+import org.duckdb.DuckDBConnection;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Runs against a real in-process database rather than a mocked {@link DataSource}: the proxy has to
+ * keep working with a driver's own {@code Statement} implementations and its exceptions, and a mock
+ * would only prove the proxy calls what the test told it to.
+ */
+class TracingDataSourceTest {
+
+    private static final String GROUP = "orders-db";
+    private static final String JDBC_URL = "jdbc:duckdb:";
+
+    private Connection keepAlive;
+    private DataSource traced;
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        // One shared in-memory database: DuckDB drops it when the last connection closes.
+        keepAlive = new org.duckdb.DuckDBDriver().connect(JDBC_URL, new Properties());
+        traced = new TracingDataSource(new SingleConnectionDataSource((DuckDBConnection) keepAlive), GROUP);
+
+        try (Statement statement = keepAlive.createStatement()) {
+            statement.execute("CREATE TABLE users (id INTEGER, name VARCHAR)");
+        }
+    }
+
+    @AfterEach
+    void tearDown() throws SQLException {
+        keepAlive.close();
+    }
+
+    @Nested
+    @DisplayName("Recording statements")
+    class Recording {
+
+        @Test
+        @DisplayName("an insert is recorded as an insert event, named by verb and table")
+        void insertIsRecorded() throws IOException {
+            RecordedEvent event = JfrRecordings.single(JdbcInsertEvent.NAME, () ->
+                    update("INSERT INTO users VALUES (1, 'ada')"));
+
+            assertEquals("INSERT users", event.getString("name"));
+            assertEquals(GROUP, event.getString("group"));
+            assertEquals(SpanKind.CLIENT.name(), event.getString("kind"));
+            assertEquals(1, event.getLong("rows"));
+            assertTrue(event.getString("sql").startsWith("INSERT INTO users"));
+        }
+
+        @Test
+        @DisplayName("each verb picks its own event type")
+        void verbsPickTheirEventTypes() throws IOException {
+            assertEquals("SELECT users", recordOne(JdbcQueryEvent.NAME,
+                    () -> query("SELECT * FROM users")));
+            assertEquals("UPDATE users", recordOne(JdbcUpdateEvent.NAME,
+                    () -> update("UPDATE users SET name = 'grace'")));
+            assertEquals("DELETE users", recordOne(JdbcDeleteEvent.NAME,
+                    () -> update("DELETE FROM users WHERE id = 1")));
+        }
+
+        @Test
+        @DisplayName("a prepared statement records the SQL it was prepared with, not its parameters")
+        void preparedStatementRecordsPlaceholders() throws IOException {
+            RecordedEvent event = JfrRecordings.single(JdbcInsertEvent.NAME, () -> {
+                try (Connection connection = traced.getConnection();
+                     PreparedStatement statement =
+                             connection.prepareStatement("INSERT INTO users VALUES (?, ?)")) {
+                    statement.setInt(1, 7);
+                    statement.setString(2, "hopper");
+                    statement.executeUpdate();
+                } catch (SQLException e) {
+                    throw new IllegalStateException(e);
+                }
+            });
+
+            assertEquals("INSERT INTO users VALUES (?, ?)", event.getString("sql"),
+                    "placeholders keep identical statements aggregatable");
+            assertEquals("INSERT users", event.getString("name"));
+            // Parameters are never read by the proxy, so nothing can leak through them.
+            assertEquals(null, event.getString("params"));
+        }
+
+        @Test
+        @DisplayName("a batch records the rows the driver reports across it")
+        void batchRecordsTotalRows() throws IOException {
+            RecordedEvent event = JfrRecordings.single(JdbcInsertEvent.NAME, () -> {
+                try (Connection connection = traced.getConnection();
+                     PreparedStatement statement =
+                             connection.prepareStatement("INSERT INTO users VALUES (?, ?)")) {
+                    for (int id = 10; id < 13; id++) {
+                        statement.setInt(1, id);
+                        statement.setString(2, "user-" + id);
+                        statement.addBatch();
+                    }
+                    statement.executeBatch();
+                } catch (SQLException e) {
+                    throw new IllegalStateException(e);
+                }
+            });
+
+            assertEquals(3, event.getLong("rows"));
+        }
+    }
+
+    @Nested
+    @DisplayName("When a statement fails")
+    class Failures {
+
+        @Test
+        @DisplayName("the driver's own exception reaches the caller, not a reflection wrapper")
+        void driverExceptionIsUnwrapped() {
+            SQLException thrown = assertThrows(SQLException.class, () -> {
+                try (Connection connection = traced.getConnection();
+                     Statement statement = connection.createStatement()) {
+                    statement.executeUpdate("INSERT INTO nope VALUES (1)");
+                }
+            });
+
+            assertTrue(thrown.getMessage().toLowerCase().contains("nope"), thrown.getMessage());
+        }
+
+        @Test
+        @DisplayName("the failure is recorded on the span, so it shows red in the trace")
+        void failureIsRecorded() throws IOException {
+            RecordedEvent event = JfrRecordings.single(JdbcInsertEvent.NAME, () ->
+                    assertThrows(RuntimeException.class, () -> update("INSERT INTO nope VALUES (1)")));
+
+            assertEquals(SpanStatus.ERROR.name(), event.getString("status"));
+            assertTrue(event.getString("errorType").contains("SQLException"), event.getString("errorType"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Taking part in a trace")
+    class Tracing {
+
+        @Test
+        @DisplayName("a statement nests under the span in progress")
+        void statementNestsUnderTheSpan() throws IOException {
+            List<RecordedEvent> events = JfrRecordings.all(
+                    List.of("jeffrey.TraceSpan", JdbcQueryEvent.NAME),
+                    () -> Tracer.run("orders.list", SpanKind.SERVER, () -> query("SELECT * FROM users")));
+
+            SpansAssert.assertThat(events)
+                    .hasNoUntracedSpans()
+                    .hasNoOrphanedSpans()
+                    .hasSpan("SELECT users").nestedUnder("orders.list");
+        }
+
+        @Test
+        @DisplayName("outside any span the statement is still recorded, just untraced")
+        void statementOutsideASpanIsStillRecorded() throws IOException {
+            RecordedEvent event = JfrRecordings.single(JdbcQueryEvent.NAME, () -> query("SELECT * FROM users"));
+
+            assertEquals(0, event.getLong("traceId"), "recorded and on the dashboard, in no trace");
+        }
+    }
+
+    @Nested
+    @DisplayName("Staying a well-behaved DataSource")
+    class Delegation {
+
+        @Test
+        @DisplayName("the proxy hands back the statement contract the caller asked for")
+        void preservesStatementContracts() throws SQLException {
+            try (Connection connection = traced.getConnection()) {
+                assertInstanceOf(PreparedStatement.class, connection.prepareStatement("SELECT 1"));
+                assertInstanceOf(Statement.class, connection.createStatement());
+            }
+        }
+
+        @Test
+        @DisplayName("unwrap still reaches the vendor type behind the proxy")
+        void unwrapReachesTheDelegate() throws SQLException {
+            assertTrue(traced.isWrapperFor(TracingDataSource.class));
+            assertInstanceOf(TracingDataSource.class, traced.unwrap(TracingDataSource.class));
+        }
+    }
+
+    private String recordOne(String eventType, Runnable body) throws IOException {
+        return JfrRecordings.single(eventType, body).getString("name");
+    }
+
+    private void update(String sql) {
+        try (Connection connection = traced.getConnection();
+             Statement statement = connection.createStatement()) {
+            statement.executeUpdate(sql);
+        } catch (SQLException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private void query(String sql) {
+        try (Connection connection = traced.getConnection();
+             Statement statement = connection.createStatement();
+             ResultSet rows = statement.executeQuery(sql)) {
+            while (rows.next()) {
+                rows.getObject(1);
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /**
+     * Hands out duplicates of one in-memory database connection, so every statement in a test runs
+     * against the same DuckDB instance without a pool being involved.
+     */
+    private record SingleConnectionDataSource(DuckDBConnection connection) implements DataSource {
+
+        @Override
+        public Connection getConnection() throws SQLException {
+            return connection.duplicate();
+        }
+
+        @Override
+        public Connection getConnection(String username, String password) throws SQLException {
+            return getConnection();
+        }
+
+        @Override
+        public PrintWriter getLogWriter() {
+            return null;
+        }
+
+        @Override
+        public void setLogWriter(PrintWriter out) {
+        }
+
+        @Override
+        public void setLoginTimeout(int seconds) {
+        }
+
+        @Override
+        public int getLoginTimeout() {
+            return 0;
+        }
+
+        @Override
+        public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+            throw new SQLFeatureNotSupportedException();
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> iface) {
+            return iface.cast(this);
+        }
+
+        @Override
+        public boolean isWrapperFor(Class<?> iface) {
+            return iface.isInstance(this);
+        }
+    }
+}

--- a/utilities/jeffrey-events/pom.xml
+++ b/utilities/jeffrey-events/pom.xml
@@ -42,6 +42,8 @@
         <module>test</module>
         <module>servlet</module>
         <module>spring</module>
+        <module>jdbc</module>
+        <module>hikari</module>
         <module>spring-boot-starter</module>
     </modules>
 
@@ -77,6 +79,8 @@
           consumer brings its own version and nothing here is imposed on them.
         -->
         <spring-boot.version>4.1.0</spring-boot.version>
+        <hikaricp.version>7.0.2</hikaricp.version>
+        <duckdb.version>1.5.3.0</duckdb.version>
         <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
     </properties>

--- a/utilities/jeffrey-events/skills/jeffrey-traces-spring-rest-server/SKILL.md
+++ b/utilities/jeffrey-events/skills/jeffrey-traces-spring-rest-server/SKILL.md
@@ -45,6 +45,8 @@ Tune it with `jeffrey.tracing.*`:
 | `jeffrey.tracing.enabled` | `true` | Turn the instrumentation off without removing the dependency |
 | `jeffrey.tracing.url-patterns` | `/*` | Which requests the filter sees |
 | `jeffrey.tracing.order` | `HIGHEST_PRECEDENCE` | Filter order; keep it first so security, routing and data access all happen inside the span |
+| `jeffrey.tracing.jdbc-enabled` | `true` | Wrap every `DataSource` bean so statements are recorded |
+| `jeffrey.tracing.hikari-enabled` | `true` | Give HikariCP pools a Jeffrey metrics tracker |
 | `jeffrey.tracing.capture-query-params` | `false` | Record query-string parameters on the event |
 | `jeffrey.tracing.capture-path-params` | `false` | Record the route's template variables on the event |
 

--- a/utilities/jeffrey-events/spring-boot-starter/pom.xml
+++ b/utilities/jeffrey-events/spring-boot-starter/pom.xml
@@ -49,6 +49,28 @@
         </dependency>
 
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jeffrey-events-jdbc</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!--
+          Brought along, but inert unless the application actually uses HikariCP: the
+          auto-configuration is conditional on HikariDataSource being present, and Hikari
+          itself stays provided here.
+        -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jeffrey-events-hikari</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>${hikaricp.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
             <scope>provided</scope>
@@ -84,6 +106,12 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>jeffrey-events-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.duckdb</groupId>
+            <artifactId>duckdb_jdbc</artifactId>
+            <version>${duckdb.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/utilities/jeffrey-events/spring-boot-starter/src/main/java/cafe/jeffrey/jfr/events/spring/boot/JeffreyHikariTracingAutoConfiguration.java
+++ b/utilities/jeffrey-events/spring-boot-starter/src/main/java/cafe/jeffrey/jfr/events/spring/boot/JeffreyHikariTracingAutoConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.spring.boot;
+
+import cafe.jeffrey.jfr.events.jdbc.hikari.JfrMetricsTrackerFactory;
+import cafe.jeffrey.jfr.events.spring.JeffreyHikariTracingConfiguration;
+import com.zaxxer.hikari.HikariDataSource;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Gives HikariCP pools a Jeffrey metrics tracker, which is what makes the connection-pool events
+ * appear — they have shipped since the beginning with nothing to produce them.
+ * <p>
+ * Conditional on HikariCP being the pool in use, so an application on another pool loads none of
+ * these types.
+ */
+@AutoConfiguration
+@ConditionalOnClass({HikariDataSource.class, JfrMetricsTrackerFactory.class})
+@ConditionalOnProperty(prefix = "jeffrey.tracing", name = "enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(prefix = "jeffrey.tracing", name = "hikari-enabled", havingValue = "true", matchIfMissing = true)
+@Import(JeffreyHikariTracingConfiguration.class)
+public class JeffreyHikariTracingAutoConfiguration {
+}

--- a/utilities/jeffrey-events/spring-boot-starter/src/main/java/cafe/jeffrey/jfr/events/spring/boot/JeffreyJdbcTracingAutoConfiguration.java
+++ b/utilities/jeffrey-events/spring-boot-starter/src/main/java/cafe/jeffrey/jfr/events/spring/boot/JeffreyJdbcTracingAutoConfiguration.java
@@ -1,0 +1,43 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.spring.boot;
+
+import cafe.jeffrey.jfr.events.jdbc.datasource.TracingDataSource;
+import cafe.jeffrey.jfr.events.spring.JeffreyJdbcTracingConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Import;
+
+import javax.sql.DataSource;
+
+/**
+ * Records every JDBC statement when the application has a data source at all.
+ * <p>
+ * Separate from the HTTP auto-configuration because the conditions differ: an application can have
+ * one, both or neither, and {@code jeffrey.tracing.jdbc-enabled=false} turns this half off without
+ * touching request tracing.
+ */
+@AutoConfiguration
+@ConditionalOnClass({DataSource.class, TracingDataSource.class})
+@ConditionalOnProperty(prefix = "jeffrey.tracing", name = "enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(prefix = "jeffrey.tracing", name = "jdbc-enabled", havingValue = "true", matchIfMissing = true)
+@Import(JeffreyJdbcTracingConfiguration.class)
+public class JeffreyJdbcTracingAutoConfiguration {
+}

--- a/utilities/jeffrey-events/spring-boot-starter/src/main/java/cafe/jeffrey/jfr/events/spring/boot/JeffreyTracingProperties.java
+++ b/utilities/jeffrey-events/spring-boot-starter/src/main/java/cafe/jeffrey/jfr/events/spring/boot/JeffreyTracingProperties.java
@@ -35,6 +35,8 @@ import java.util.List;
  * @param urlPatterns      which requests the filter sees; {@code /*} covers everything
  * @param order            the filter's order in the chain — first by default, so security, routing
  *                         and data access all happen inside the span
+ * @param jdbcEnabled      whether every {@code DataSource} bean is wrapped to record statements
+ * @param hikariEnabled    whether HikariCP pools get a Jeffrey metrics tracker
  * @param captureQueryParams record query-string parameters on the event; off by default, because
  *                         query strings routinely carry tokens and personal data, and a recording
  *                         is a file that gets shared
@@ -46,6 +48,8 @@ public record JeffreyTracingProperties(
         Boolean enabled,
         List<String> urlPatterns,
         Integer order,
+        Boolean jdbcEnabled,
+        Boolean hikariEnabled,
         Boolean captureQueryParams,
         Boolean capturePathParams) {
 
@@ -55,6 +59,8 @@ public record JeffreyTracingProperties(
         enabled = enabled == null || enabled;
         urlPatterns = urlPatterns == null || urlPatterns.isEmpty() ? ALL_REQUESTS : List.copyOf(urlPatterns);
         order = order == null ? Ordered.HIGHEST_PRECEDENCE : order;
+        jdbcEnabled = jdbcEnabled == null || jdbcEnabled;
+        hikariEnabled = hikariEnabled == null || hikariEnabled;
         captureQueryParams = captureQueryParams != null && captureQueryParams;
         capturePathParams = capturePathParams != null && capturePathParams;
     }

--- a/utilities/jeffrey-events/spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/utilities/jeffrey-events/spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,3 @@
 cafe.jeffrey.jfr.events.spring.boot.JeffreyTracingAutoConfiguration
+cafe.jeffrey.jfr.events.spring.boot.JeffreyJdbcTracingAutoConfiguration
+cafe.jeffrey.jfr.events.spring.boot.JeffreyHikariTracingAutoConfiguration

--- a/utilities/jeffrey-events/spring-boot-starter/src/test/java/cafe/jeffrey/jfr/events/spring/boot/HttpExchangeTracingIntegrationTest.java
+++ b/utilities/jeffrey-events/spring-boot-starter/src/test/java/cafe/jeffrey/jfr/events/spring/boot/HttpExchangeTracingIntegrationTest.java
@@ -34,11 +34,23 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.context.annotation.Bean;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestClient;
 
+import org.duckdb.DuckDBConnection;
+import org.duckdb.DuckDBDriver;
+
+import javax.sql.DataSource;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.List;
+import java.util.Properties;
+import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -51,7 +63,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * what could break, and none of it is exercised by a unit test of the filter class.
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Import(HttpExchangeTracingIntegrationTest.UserController.class)
+@Import({HttpExchangeTracingIntegrationTest.UserController.class,
+        HttpExchangeTracingIntegrationTest.UserQueryController.class,
+        HttpExchangeTracingIntegrationTest.ReportController.class})
 class HttpExchangeTracingIntegrationTest {
 
     private static final String USER_ENDPOINT = "/api/users/{id}";
@@ -62,6 +76,21 @@ class HttpExchangeTracingIntegrationTest {
 
     @SpringBootApplication
     static class TestApplication {
+
+        /**
+         * A plain, untraced data source. The starter is expected to wrap it on its own - that is
+         * precisely what this test is checking, so the test must not wrap it here.
+         */
+        @Bean
+        DataSource dataSource() throws SQLException {
+            DuckDBConnection connection = (DuckDBConnection) new DuckDBDriver()
+                    .connect("jdbc:duckdb:", new Properties());
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("CREATE TABLE users (id INTEGER, name VARCHAR)");
+                statement.execute("INSERT INTO users VALUES (42, 'ada')");
+            }
+            return new SharedConnectionDataSource(connection);
+        }
     }
 
     @RestController
@@ -82,6 +111,90 @@ class HttpExchangeTracingIntegrationTest {
                             event.rows = 1;
                         });
             });
+        }
+    }
+
+    @RestController
+    static class ReportController {
+
+        /**
+         * Exists only for the cardinality test. Test methods share one JVM, and JFR recordings are
+         * process-wide windows, so a request whose server side finishes just after one recording
+         * stops can be counted by the next one. Giving each test its own endpoint means no two of
+         * them can ever contribute the same span name, which keeps the exactly-one assertions
+         * strict rather than making them tolerant.
+         */
+        @GetMapping("/api/reports/{id}")
+        public String report(@PathVariable("id") String id) {
+            return "report-" + id;
+        }
+    }
+
+    @RestController
+    static class UserQueryController {
+
+        private final DataSource dataSource;
+
+        UserQueryController(DataSource dataSource) {
+            this.dataSource = dataSource;
+        }
+
+        /** Ordinary JDBC. No Jeffrey types anywhere in this method - that is the point. */
+        @GetMapping("/api/users/{id}/name")
+        public String name(@PathVariable("id") int id) throws SQLException {
+            try (Connection connection = dataSource.getConnection();
+                 Statement statement = connection.createStatement();
+                 ResultSet rows = statement.executeQuery("SELECT name FROM users WHERE id = " + id)) {
+
+                return rows.next() ? rows.getString(1) : "";
+            }
+        }
+    }
+
+    /** Hands out duplicates of one in-memory DuckDB connection. */
+    record SharedConnectionDataSource(DuckDBConnection connection) implements DataSource {
+
+        @Override
+        public Connection getConnection() throws SQLException {
+            return connection.duplicate();
+        }
+
+        @Override
+        public Connection getConnection(String username, String password) throws SQLException {
+            return getConnection();
+        }
+
+        @Override
+        public PrintWriter getLogWriter() {
+            return null;
+        }
+
+        @Override
+        public void setLogWriter(PrintWriter out) {
+        }
+
+        @Override
+        public void setLoginTimeout(int seconds) {
+        }
+
+        @Override
+        public int getLoginTimeout() {
+            return 0;
+        }
+
+        @Override
+        public Logger getParentLogger() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> iface) {
+            return iface.cast(this);
+        }
+
+        @Override
+        public boolean isWrapperFor(Class<?> iface) {
+            return iface.isInstance(this);
         }
     }
 
@@ -115,12 +228,37 @@ class HttpExchangeTracingIntegrationTest {
     }
 
     @Test
+    @DisplayName("real SQL, through a DataSource nobody instrumented, nests under the request")
+    void statementsFromTheDataSourceNestUnderTheRequest() throws IOException {
+        List<RecordedEvent> events = JfrRecordings.all(
+                List.of(HttpServerExchangeEvent.NAME, JdbcQueryEvent.NAME),
+                () -> {
+                    String body = RestClient.create()
+                            .get()
+                            .uri("http://localhost:" + port + "/api/users/42/name")
+                            .retrieve()
+                            .body(String.class);
+                    assertEquals("ada", body);
+                });
+
+        SpansAssert.assertThat(events)
+                .hasNoUntracedSpans()
+                .hasNoOrphanedSpans()
+                // The application wrote no JDBC instrumentation: the starter wrapped its DataSource,
+                // and the statement is named by verb and table rather than by its SQL text.
+                .hasSpan("SELECT users")
+                .nestedUnder("GET /api/users/{id}/name")
+                .hasKind(SpanKind.CLIENT.name())
+                .hasEventType(JdbcQueryEvent.NAME);
+    }
+
+    @Test
     @DisplayName("one request per endpoint, not one operation name per entity id")
     void spanNamesStayLowCardinality() throws IOException {
         List<RecordedEvent> events = JfrRecordings.all(HttpServerExchangeEvent.NAME, () -> {
             RestClient client = RestClient.create();
             for (int id = 1; id <= 3; id++) {
-                client.get().uri("http://localhost:" + port + "/api/users/" + id).retrieve().body(String.class);
+                client.get().uri("http://localhost:" + port + "/api/reports/" + id).retrieve().body(String.class);
             }
         });
 

--- a/utilities/jeffrey-events/spring-boot-starter/src/test/java/cafe/jeffrey/jfr/events/spring/boot/JeffreyTracingAutoConfigurationTest.java
+++ b/utilities/jeffrey-events/spring-boot-starter/src/test/java/cafe/jeffrey/jfr/events/spring/boot/JeffreyTracingAutoConfigurationTest.java
@@ -18,6 +18,7 @@
 
 package cafe.jeffrey.jfr.events.spring.boot;
 
+import cafe.jeffrey.jfr.events.jdbc.datasource.TracingDataSource;
 import cafe.jeffrey.jfr.events.servlet.HttpExchangeFilter;
 import cafe.jeffrey.jfr.events.servlet.HttpExchangeSettings;
 import cafe.jeffrey.jfr.events.servlet.HttpRequestNaming;
@@ -25,12 +26,16 @@ import cafe.jeffrey.jfr.events.spring.JeffreyTracingConfiguration;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.Ordered;
+
+import javax.sql.DataSource;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -114,6 +119,49 @@ class JeffreyTracingAutoConfigurationTest {
         void canBeDisabled() {
             runner.withPropertyValues("jeffrey.tracing.enabled=false")
                     .run(context -> assertThat(context).doesNotHaveBean(HttpExchangeFilter.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("JDBC and connection pools")
+    class DataSources {
+
+        private final WebApplicationContextRunner jdbcRunner = new WebApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        JeffreyTracingAutoConfiguration.class, JeffreyJdbcTracingAutoConfiguration.class))
+                .withUserConfiguration(PlainDataSource.class);
+
+        @Test
+        @DisplayName("an application's own DataSource is wrapped without it doing anything")
+        void wrapsTheDataSource() {
+            jdbcRunner.run(context ->
+                    assertThat(context.getBean(DataSource.class)).isInstanceOf(TracingDataSource.class));
+        }
+
+        @Test
+        @DisplayName("jdbc-enabled=false leaves the DataSource untouched")
+        void jdbcCanBeDisabled() {
+            jdbcRunner.withPropertyValues("jeffrey.tracing.jdbc-enabled=false")
+                    .run(context ->
+                            assertThat(context.getBean(DataSource.class)).isNotInstanceOf(TracingDataSource.class));
+        }
+
+        @Test
+        @DisplayName("a DataSource is not wrapped twice when the context already has a traced one")
+        void doesNotWrapTwice() {
+            jdbcRunner.run(context -> {
+                DataSource wrapped = context.getBean(DataSource.class);
+                assertThat(((TracingDataSource) wrapped).delegate()).isNotInstanceOf(TracingDataSource.class);
+            });
+        }
+
+        @Configuration(proxyBeanMethods = false)
+        static class PlainDataSource {
+
+            @Bean
+            DataSource dataSource() {
+                return Mockito.mock(DataSource.class);
+            }
         }
     }
 

--- a/utilities/jeffrey-events/spring/pom.xml
+++ b/utilities/jeffrey-events/spring/pom.xml
@@ -52,6 +52,26 @@
             <version>${project.version}</version>
         </dependency>
 
+        <!-- optional: an application without a data source, or without Hikari, uses neither. -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jeffrey-events-jdbc</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jeffrey-events-hikari</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>${hikaricp.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>

--- a/utilities/jeffrey-events/spring/src/main/java/cafe/jeffrey/jfr/events/spring/HikariMetricsBeanPostProcessor.java
+++ b/utilities/jeffrey-events/spring/src/main/java/cafe/jeffrey/jfr/events/spring/HikariMetricsBeanPostProcessor.java
@@ -1,0 +1,49 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.spring;
+
+import cafe.jeffrey.jfr.events.jdbc.hikari.JfrMetricsTrackerFactory;
+import com.zaxxer.hikari.HikariDataSource;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+
+/**
+ * Gives every HikariCP pool a Jeffrey metrics tracker, which is what makes the connection-pool
+ * events appear at all.
+ * <p>
+ * Runs <em>before</em> initialisation, and deliberately: the pool has not started yet, and
+ * {@link TracingDataSourceBeanPostProcessor} replaces the bean with a {@link javax.sql.DataSource}
+ * wrapper afterwards — by then it is no longer a {@link HikariDataSource} to look at.
+ * <p>
+ * A pool that already has a tracker keeps it. An application that configured its own metrics is
+ * making a deliberate choice, and silently replacing it would be the instrumentation deciding
+ * something that is not its to decide.
+ */
+public class HikariMetricsBeanPostProcessor implements BeanPostProcessor {
+
+    @Override
+    public Object postProcessBeforeInitialization(Object bean, String beanName) {
+        if (bean instanceof HikariDataSource pool
+                && !pool.isRunning()
+                && pool.getMetricsTrackerFactory() == null) {
+
+            pool.setMetricsTrackerFactory(new JfrMetricsTrackerFactory());
+        }
+        return bean;
+    }
+}

--- a/utilities/jeffrey-events/spring/src/main/java/cafe/jeffrey/jfr/events/spring/JeffreyHikariTracingConfiguration.java
+++ b/utilities/jeffrey-events/spring/src/main/java/cafe/jeffrey/jfr/events/spring/JeffreyHikariTracingConfiguration.java
@@ -1,0 +1,46 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.spring;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Records connection-pool behaviour from HikariCP, wired <em>explicitly</em>.
+ * <p>
+ * Kept in its own configuration so that its types are loaded only by an application that actually
+ * has HikariCP: referencing {@code HikariDataSource} from a shared configuration would break every
+ * application using a different pool.
+ *
+ * <pre>{@code
+ * @Import(JeffreyHikariTracingConfiguration.class)
+ * }</pre>
+ */
+@Configuration(proxyBeanMethods = false)
+public class JeffreyHikariTracingConfiguration {
+
+    /**
+     * Gives each Hikari pool a Jeffrey metrics tracker, which is the only thing that makes the
+     * pool events - acquire, borrow, create, timeout, and the periodic gauge - appear.
+     */
+    @Bean
+    public static HikariMetricsBeanPostProcessor jeffreyHikariMetricsBeanPostProcessor() {
+        return new HikariMetricsBeanPostProcessor();
+    }
+}

--- a/utilities/jeffrey-events/spring/src/main/java/cafe/jeffrey/jfr/events/spring/JeffreyJdbcTracingConfiguration.java
+++ b/utilities/jeffrey-events/spring/src/main/java/cafe/jeffrey/jfr/events/spring/JeffreyJdbcTracingConfiguration.java
@@ -1,0 +1,53 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.spring;
+
+import cafe.jeffrey.jfr.events.jdbc.datasource.StatementNaming;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Records every JDBC statement, wired <em>explicitly</em>.
+ * <p>
+ * A separate configuration from {@link JeffreyTracingConfiguration} rather than more beans inside
+ * it: an application with no data source must be able to import the HTTP instrumentation without
+ * this one's types being loaded, and a Spring Boot application gets this one only when
+ * {@code javax.sql.DataSource} is actually on the classpath.
+ *
+ * <pre>{@code
+ * @Import(JeffreyJdbcTracingConfiguration.class)
+ * }</pre>
+ */
+@Configuration(proxyBeanMethods = false)
+public class JeffreyJdbcTracingConfiguration {
+
+    /**
+     * Wraps every {@code DataSource} bean so its statements are recorded.
+     * <p>
+     * Statement naming defaults to verb and primary table; an application with better names — a
+     * repository method, a mapper id — declares its own {@link StatementNaming} bean.
+     */
+    @Bean
+    public static TracingDataSourceBeanPostProcessor jeffreyTracingDataSourceBeanPostProcessor(
+            ObjectProvider<StatementNaming> naming) {
+
+        return new TracingDataSourceBeanPostProcessor(naming.getIfAvailable(StatementNaming::verbAndTable));
+    }
+}

--- a/utilities/jeffrey-events/spring/src/main/java/cafe/jeffrey/jfr/events/spring/TracingDataSourceBeanPostProcessor.java
+++ b/utilities/jeffrey-events/spring/src/main/java/cafe/jeffrey/jfr/events/spring/TracingDataSourceBeanPostProcessor.java
@@ -1,0 +1,54 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.spring;
+
+import cafe.jeffrey.jfr.events.jdbc.datasource.StatementNaming;
+import cafe.jeffrey.jfr.events.jdbc.datasource.TracingDataSource;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+
+import javax.sql.DataSource;
+import java.util.Objects;
+
+/**
+ * Wraps every {@link DataSource} bean in a {@link TracingDataSource}, so statements are recorded
+ * whatever issues them — JdbcTemplate, Hibernate, jOOQ or MyBatis all go through this interface.
+ * <p>
+ * A bean post-processor rather than a replacement bean definition: the application keeps declaring
+ * its data source exactly as it did, and everything injected with one transparently gets the traced
+ * view. The bean name becomes the statement group, which is what separates two pools in Jeffrey's
+ * Database dashboard.
+ */
+public class TracingDataSourceBeanPostProcessor implements BeanPostProcessor {
+
+    private final StatementNaming naming;
+
+    public TracingDataSourceBeanPostProcessor(StatementNaming naming) {
+        this.naming = Objects.requireNonNull(naming, "naming must not be null");
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) {
+        // Not a TracingDataSource already: a context refreshed twice, or an application that wrapped
+        // its own, must not end up recording every statement twice.
+        if (bean instanceof DataSource dataSource && !(bean instanceof TracingDataSource)) {
+            return new TracingDataSource(dataSource, beanName, naming);
+        }
+        return bean;
+    }
+}


### PR DESCRIPTION
Third PR of Step 2. **Stacked on #182** (which is stacked on #181); retarget to `master` as those merge.

With this, a Spring Boot application that added one dependency and wrote no code gets **request-rooted traces with its real SQL nested underneath**, whatever ORM issued it — plus connection-pool events that until now had no source at all.

## `jeffrey-events-jdbc` — one module, every persistence framework

Wrapping the `DataSource` is what makes this cover JdbcTemplate, Hibernate/JPA, jOOQ **and** MyBatis at once: they all reach the database through that interface, so instrumenting it catches what each of them issues — including the statements an ORM generates that nobody wrote by hand. Each statement is a leaf span nesting under the span in progress.

Three decisions worth review:

- **Dynamic proxies, not hand-written delegates.** `Connection` and `PreparedStatement` declare well over a hundred methods between them, almost none of which this cares about. A hand-written delegate is a large surface for a typo to hide in, and a forwarded method quietly returning the wrong thing would be a bug in the *application*, not just its telemetry. Only `execute*` is intercepted.
- **`ResultSet` is deliberately not wrapped.** Counting returned rows would mean proxying every `next()` on the hot path of every query. Queries therefore record no row count; updates and batches, where the driver hands the count back, do. Documented rather than silently zero.
- **Naming is `verb + primary table`** (`SELECT users`) — the most specific thing readable off SQL without becoming per-execution — and it's an interface, so an application with better names supplies its own. Parameters are never read, let alone recorded.

## `jeffrey-events-hikari` — the pool events finally have a source

`jeffrey.JdbcPoolStatistics` and the `PooledJdbcConnection*` events have shipped since the beginning with **nothing to produce them**. Hikari already measures what they describe, so this is a mapping: acquire, borrow, create, timeout, plus the periodic gauge registered with `FlightRecorder` and removed when the pool shuts down.

One detail that would have been a silent data bug: two of Hikari's three durations are **milliseconds** while the events record a `@Timespan` in **nanoseconds**. They're converted — a pool that looked a million times faster than it is would be worse than no instrumentation.

## Spring wiring: the same split as PR B

Post-processors live in `jeffrey-events-spring` behind `@Import`; the starter adds only conditions and properties (`jeffrey.tracing.jdbc-enabled`, `jeffrey.tracing.hikari-enabled`). Each gets its **own** `@Configuration` so its types stay unloaded for applications that don't have them — referencing `HikariDataSource` from a shared configuration would break every application on a different pool.

Ordering between the two post-processors is load-bearing: the Hikari one runs *before* initialisation and the `DataSource` wrapper *after*, because once the bean is the wrapper there is no `HikariDataSource` left to configure. A pool that already has a metrics tracker keeps it.

## Verification

- **116 tests green** on JDK 25 across all eight modules (79 events + 10 toolkit + 10 jdbc + 3 hikari + 14 starter).
- **JDBC against a real driver** (in-process DuckDB, not a mock): verb→event-type mapping, prepared statements recording placeholders and never parameters, batch row totals, the driver's own `SQLException` reaching the caller un-wrapped from the reflection layer while the failure is recorded on the span, and nesting under a `Tracer` span.
- **Hikari through a real pool**: timings recorded per operation, and the **periodic gauge actually firing** inside a recording — plus that closing the pool stops the sampler.
- **The headline end-to-end**: an HTTP request whose controller runs ordinary JDBC through an uninstrumented `DataSource` produces `GET /api/users/{id}/name` → `SELECT users`, correctly nested, with no Jeffrey types anywhere in the controller.
- Staging pre-flight stages all seven publishable artifacts; full reactor compiles.

**One flake found and fixed, not papered over.** An integration test failed once on a cold run. It reproduced in neither 5 isolated nor 3 full-suite reruns, so rather than retry-loop it I traced the mechanism: two test methods shared an endpoint, and JFR recordings are process-wide windows, so a request whose server side finishes just after one recording stops can be counted by the next — breaking `hasSpan`'s exactly-one rule. Fixed by giving each test its own endpoint, which removes the coupling instead of loosening the assertion. 3 further full-suite runs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BfGNpXCFpAxW1etXhD8x3v

---
_Generated by [Claude Code](https://claude.ai/code/session_01BfGNpXCFpAxW1etXhD8x3v)_