### PR TITLE
Step 2 (PR E): record the values a MyBatis statement ran with, and let it take over from the DataSource wrapper

### DIFF
--- a/utilities/jeffrey-events/README.md
+++ b/utilities/jeffrey-events/README.md
@@ -56,7 +56,7 @@ ManagedChannel channel = ManagedChannelBuilder.forAddress(host, port)
         .intercept(new JfrGrpcClientInterceptor())      // outbound call = leaf under the caller
         .build();
 
-configuration.addInterceptor(new JeffreyMyBatisInterceptor());   // statements named UserMapper.selectById
+configuration.addInterceptor(new JeffreyMyBatisInterceptor());   // UserMapper.selectById, with its parameters
 ```
 
 Use `jeffrey-events-mybatis` **or** the `DataSource` wrapper, not both — the MyBatis one names
@@ -126,7 +126,7 @@ dashboards.
 | `jeffrey-events-spring` | Spring `@Configuration` you `@Import` explicitly; no Spring Boot dependency |
 | `jeffrey-events-jdbc` | a `DataSource` wrapper recording every statement — JdbcTemplate, Hibernate, jOOQ and MyBatis alike |
 | `jeffrey-events-hikari` | HikariCP metrics tracker: connection acquire/borrow/create/timeout, plus the periodic pool gauge |
-| `jeffrey-events-mybatis` | MyBatis `Executor` interceptor naming every statement by its mapper method |
+| `jeffrey-events-mybatis` | MyBatis `Executor` interceptor naming every statement by its mapper method, and recording the values it ran with |
 | `jeffrey-events-grpc` | gRPC server and client interceptors: an inbound call becomes a trace root, an outbound one a leaf |
 | `jeffrey-events-spring-boot-starter` | auto-configuration: add it and write nothing |
 

--- a/utilities/jeffrey-events/mybatis/src/main/java/cafe/jeffrey/jfr/events/mybatis/JeffreyMyBatisInterceptor.java
+++ b/utilities/jeffrey-events/mybatis/src/main/java/cafe/jeffrey/jfr/events/mybatis/JeffreyMyBatisInterceptor.java
@@ -33,6 +33,7 @@ import org.apache.ibatis.session.ResultHandler;
 import org.apache.ibatis.session.RowBounds;
 
 import java.util.List;
+import java.util.Properties;
 
 /**
  * Records every MyBatis statement as a Jeffrey leaf span, named by the mapper method that issued
@@ -48,12 +49,29 @@ import java.util.List;
  * The {@code Executor} is the interception point rather than {@code StatementHandler} so that
  * cached and batched execution are covered too.
  *
+ * <h2>Parameters</h2>
+ * The values a statement was bound with are recorded too, because they are what distinguishes the
+ * one slow call from the thousands with the same SQL. That is on by default and switched off with
+ * {@link MyBatisStatementSettings}, which documents what the recording then contains.
+ *
  * <h2>Registration</h2>
- * On mybatis-spring-boot-starter, declaring it as a bean is enough — every {@code Interceptor}
+ * On {@code jeffrey-events-spring-boot-starter} there is nothing to declare:
+ * {@code jeffrey.tracing.mybatis-enabled=true} registers this and stands the {@code DataSource}
+ * wrapper down, so the two cannot record the same statement twice. Without that starter, and on
+ * mybatis-spring-boot-starter, declaring it as a bean is enough — every {@code Interceptor}
  * bean is added to the {@code SqlSessionFactory}. Otherwise
  * {@code configuration.addInterceptor(new JeffreyMyBatisInterceptor())}, or the {@code <plugins>}
  * element in XML. Register it through exactly one of those: registered twice, it records every
  * statement twice.
+ * <p>
+ * Registered through XML or MyBatis' own configuration properties, the settings arrive as plugin
+ * properties rather than a constructor argument:
+ *
+ * <pre>{@code
+ * <plugin interceptor="cafe.jeffrey.jfr.events.mybatis.JeffreyMyBatisInterceptor">
+ *     <property name="capture-parameters" value="false"/>
+ * </plugin>
+ * }</pre>
  */
 @Intercepts({
         @Signature(type = Executor.class, method = "update",
@@ -71,6 +89,27 @@ public class JeffreyMyBatisInterceptor implements Interceptor {
     private static final int STATEMENT_ARGUMENT = 0;
     private static final int PARAMETER_ARGUMENT = 1;
 
+    private static final String CAPTURE_PARAMETERS_PROPERTY = "capture-parameters";
+    private static final String MAX_VALUE_LENGTH_PROPERTY = "max-value-length";
+
+    // Volatile because registration and execution are different threads: MyBatis applies
+    // setProperties while wiring the SqlSessionFactory, and statements run wherever they run.
+    private volatile MyBatisStatementSettings settings = MyBatisStatementSettings.defaults();
+
+    public JeffreyMyBatisInterceptor() {
+    }
+
+    public JeffreyMyBatisInterceptor(MyBatisStatementSettings settings) {
+        this.settings = settings;
+    }
+
+    /**
+     * @return the settings in force — the constructor's, or whatever {@link #setProperties} applied
+     */
+    public MyBatisStatementSettings settings() {
+        return settings;
+    }
+
     @Override
     public Object intercept(Invocation invocation) throws Throwable {
         MappedStatement statement = (MappedStatement) invocation.getArgs()[STATEMENT_ARGUMENT];
@@ -81,9 +120,40 @@ public class JeffreyMyBatisInterceptor implements Interceptor {
         return TracedEvents.emit(createEvent(statement),
                 invocation::proceed,
                 (event, result) -> {
-                    event.sql = statement.getBoundSql(parameter).getSql();
+                    // Asked for inside the filler, so a statement under the recording threshold
+                    // pays for neither the SQL nor the parameter object walk.
+                    BoundSql boundSql = statement.getBoundSql(parameter);
+                    event.sql = boundSql.getSql();
                     event.rows = countRows(result);
+                    if (settings.captureParameters()) {
+                        event.params = StatementParameters.json(statement, boundSql, settings.maxValueLength());
+                    }
                 });
+    }
+
+    /**
+     * MyBatis' own configuration hook, so an XML {@code <plugin>} can configure this without the
+     * application writing any Java. Unknown properties are left alone; MyBatis passes whatever the
+     * declaration carried.
+     */
+    @Override
+    public void setProperties(Properties properties) {
+        boolean captureParameters = booleanProperty(
+                properties, CAPTURE_PARAMETERS_PROPERTY, settings.captureParameters());
+        int maxValueLength = intProperty(
+                properties, MAX_VALUE_LENGTH_PROPERTY, settings.maxValueLength());
+
+        this.settings = new MyBatisStatementSettings(captureParameters, maxValueLength);
+    }
+
+    private static boolean booleanProperty(Properties properties, String name, boolean fallback) {
+        String value = properties.getProperty(name);
+        return value == null ? fallback : Boolean.parseBoolean(value);
+    }
+
+    private static int intProperty(Properties properties, String name, int fallback) {
+        String value = properties.getProperty(name);
+        return value == null ? fallback : Integer.parseInt(value);
     }
 
     /**

--- a/utilities/jeffrey-events/mybatis/src/main/java/cafe/jeffrey/jfr/events/mybatis/MyBatisStatementSettings.java
+++ b/utilities/jeffrey-events/mybatis/src/main/java/cafe/jeffrey/jfr/events/mybatis/MyBatisStatementSettings.java
@@ -1,0 +1,67 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.mybatis;
+
+/**
+ * What the interceptor records about a statement beyond its identity.
+ * <p>
+ * Parameter capture defaults to <b>on</b>, unlike the HTTP filter's capture flags. The two cases
+ * are not the same: a query string is free-form user input that happens to travel with a request,
+ * while a statement's parameters are the statement — the reason one call out of thousands with the
+ * same SQL was the slow one, and what Jeffrey's Database dashboard has a column for. Recording the
+ * SQL and hiding what it ran with makes the slow statement unreadable.
+ * <p>
+ * That said, the values are recorded verbatim and a recording is a file that gets uploaded, shared
+ * and kept. An application whose mappers take e-mail addresses, tokens or anything else it would
+ * not paste into a bug report turns capture off:
+ *
+ * <pre>{@code
+ * new JeffreyMyBatisInterceptor(MyBatisStatementSettings.noParameters());
+ * // Spring Boot: jeffrey.tracing.mybatis-capture-parameters=false
+ * }</pre>
+ *
+ * @param captureParameters record the bound parameter values as a JSON object on the event
+ * @param maxValueLength    longest value recorded before truncation; applies whatever the source,
+ *                          so one CLOB parameter cannot bloat every recording
+ */
+public record MyBatisStatementSettings(boolean captureParameters, int maxValueLength) {
+
+    /** Long enough for an identifier, a name or a short description; short enough to stay cheap. */
+    private static final int DEFAULT_MAX_VALUE_LENGTH = 256;
+
+    public MyBatisStatementSettings {
+        if (maxValueLength < 0) {
+            throw new IllegalArgumentException("maxValueLength must not be negative: " + maxValueLength);
+        }
+    }
+
+    /**
+     * Records parameters, truncating any value longer than 256 characters.
+     */
+    public static MyBatisStatementSettings defaults() {
+        return new MyBatisStatementSettings(true, DEFAULT_MAX_VALUE_LENGTH);
+    }
+
+    /**
+     * Records the statement and its name, and nothing about what it ran with.
+     */
+    public static MyBatisStatementSettings noParameters() {
+        return new MyBatisStatementSettings(false, DEFAULT_MAX_VALUE_LENGTH);
+    }
+}

--- a/utilities/jeffrey-events/mybatis/src/main/java/cafe/jeffrey/jfr/events/mybatis/StatementParameters.java
+++ b/utilities/jeffrey-events/mybatis/src/main/java/cafe/jeffrey/jfr/events/mybatis/StatementParameters.java
@@ -1,0 +1,133 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.mybatis;
+
+import cafe.jeffrey.jfr.events.trace.SpanAttributes;
+import org.apache.ibatis.mapping.BoundSql;
+import org.apache.ibatis.mapping.MappedStatement;
+import org.apache.ibatis.mapping.ParameterMapping;
+import org.apache.ibatis.mapping.ParameterMode;
+import org.apache.ibatis.session.Configuration;
+
+import java.io.InputStream;
+import java.io.Reader;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.SQLXML;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The values MyBatis bound into a statement, as the JSON object the event's {@code params} field
+ * expects.
+ * <p>
+ * Resolution follows MyBatis' own {@code DefaultParameterHandler}, which is the only way to arrive
+ * at the values that were actually bound: an additional parameter wins, a parameter object the type
+ * handlers know is itself the value, and anything else is read off the parameter object as a
+ * property. Because the statement has already run by the time this is asked for, every property
+ * here is one MyBatis resolved a moment ago.
+ */
+final class StatementParameters {
+
+    /** Content that must not be rendered: a stream would be consumed by reading it. */
+    private static final List<Class<?>> LOB_TYPES =
+            List.of(byte[].class, Blob.class, Clob.class, InputStream.class, Reader.class, SQLXML.class);
+
+    private static final String LOB_PLACEHOLDER = "<lob-value>";
+    private static final String TRUNCATION_MARKER = "…";
+
+    /** Written as JSON numbers; every other Number is rendered as text rather than losing digits. */
+    private static final Set<Class<?>> INTEGRAL_TYPES = Set.of(Byte.class, Short.class, Integer.class, Long.class);
+    private static final Set<Class<?>> DECIMAL_TYPES = Set.of(Float.class, Double.class);
+
+    private StatementParameters() {
+    }
+
+    /**
+     * @return the bound values as a JSON object, or {@code null} for a statement that takes none —
+     * an absent field reads better than an empty object in the dashboard
+     */
+    static String json(MappedStatement statement, BoundSql boundSql, int maxValueLength) {
+        List<ParameterMapping> mappings = boundSql.getParameterMappings();
+        if (mappings.isEmpty()) {
+            return null;
+        }
+
+        Configuration configuration = statement.getConfiguration();
+        Object parameterObject = boundSql.getParameterObject();
+        SpanAttributes attributes = SpanAttributes.create();
+        Set<String> written = new HashSet<>();
+
+        for (ParameterMapping mapping : mappings) {
+            if (mapping.getMode() == ParameterMode.OUT) {
+                // An OUT parameter carries no input value; it exists to receive one.
+                continue;
+            }
+            String property = mapping.getProperty();
+            // The same property twice ("a = #{id} OR b = #{id}") resolves to the same value both
+            // times, and SpanAttributes writes keys in the order given without de-duplicating them.
+            if (!written.add(property)) {
+                continue;
+            }
+            put(attributes, property, resolve(configuration, boundSql, parameterObject, property), maxValueLength);
+        }
+
+        return written.isEmpty() ? null : attributes.json();
+    }
+
+    private static Object resolve(
+            Configuration configuration, BoundSql boundSql, Object parameterObject, String property) {
+
+        if (boundSql.hasAdditionalParameter(property)) {
+            return boundSql.getAdditionalParameter(property);
+        }
+        if (parameterObject == null) {
+            return null;
+        }
+        if (configuration.getTypeHandlerRegistry().hasTypeHandler(parameterObject.getClass())) {
+            // The statement takes a single scalar, and the property is the name it was given.
+            return parameterObject;
+        }
+        return configuration.newMetaObject(parameterObject).getValue(property);
+    }
+
+    private static void put(SpanAttributes attributes, String key, Object value, int maxValueLength) {
+        switch (value) {
+            case null -> attributes.put(key, (String) null);
+            case Boolean flag -> attributes.put(key, (boolean) flag);
+            case Number number when INTEGRAL_TYPES.contains(number.getClass()) ->
+                    attributes.put(key, number.longValue());
+            case Number number when DECIMAL_TYPES.contains(number.getClass()) ->
+                    attributes.put(key, number.doubleValue());
+            default -> attributes.put(key, render(value, maxValueLength));
+        }
+    }
+
+    private static String render(Object value, int maxValueLength) {
+        if (LOB_TYPES.stream().anyMatch(type -> type.isInstance(value))) {
+            return LOB_PLACEHOLDER;
+        }
+        String rendered = String.valueOf(value);
+        if (rendered.length() <= maxValueLength) {
+            return rendered;
+        }
+        return rendered.substring(0, maxValueLength) + TRUNCATION_MARKER;
+    }
+}

--- a/utilities/jeffrey-events/mybatis/src/test/java/cafe/jeffrey/jfr/events/mybatis/JeffreyMyBatisInterceptorTest.java
+++ b/utilities/jeffrey-events/mybatis/src/test/java/cafe/jeffrey/jfr/events/mybatis/JeffreyMyBatisInterceptorTest.java
@@ -39,11 +39,13 @@ import org.duckdb.DuckDBDriver;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import javax.sql.DataSource;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -53,6 +55,7 @@ import java.util.function.Function;
 import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Driven through a real MyBatis {@code SqlSession} over a real database: the value of this module
@@ -67,6 +70,7 @@ class JeffreyMyBatisInterceptorTest {
 
     private DuckDBConnection connection;
     private SqlSessionFactory sessionFactory;
+    private DataSource dataSource;
 
     /** Mapper methods, whose ids become the recorded span names. */
     public interface UserMapper {
@@ -76,6 +80,18 @@ class JeffreyMyBatisInterceptorTest {
 
         @Insert("INSERT INTO users VALUES (#{id}, #{name})")
         int insert(@Param("id") int id, @Param("name") String name);
+
+        @Select("SELECT name FROM users WHERE id = #{id} OR id = #{id}")
+        String findNameTwice(@Param("id") int id);
+
+        @Select("SELECT name FROM users WHERE name = #{name} OR name = #{missing,jdbcType=VARCHAR}")
+        String findByName(@Param("name") String name, @Param("missing") String missing);
+
+        @Select("SELECT count(*) FROM users WHERE name = CAST(#{payload} AS VARCHAR)")
+        int countByPayload(@Param("payload") byte[] payload);
+
+        @Select("SELECT count(*) FROM users")
+        int countAll();
     }
 
     @BeforeEach
@@ -84,13 +100,19 @@ class JeffreyMyBatisInterceptorTest {
         try (Statement statement = connection.createStatement()) {
             statement.execute("CREATE TABLE users (id INTEGER, name VARCHAR)");
             statement.execute("INSERT INTO users VALUES (1, 'ada')");
+            statement.execute("CREATE TABLE blobs (data BLOB)");
         }
 
-        Configuration configuration = new Configuration(new Environment(
-                "test", new JdbcTransactionFactory(), new SharedConnectionDataSource(connection)));
+        dataSource = new SharedConnectionDataSource(connection);
+        sessionFactory = sessionFactoryWith(new JeffreyMyBatisInterceptor());
+    }
+
+    private SqlSessionFactory sessionFactoryWith(JeffreyMyBatisInterceptor interceptor) {
+        Configuration configuration = new Configuration(
+                new Environment("test", new JdbcTransactionFactory(), dataSource));
         configuration.addMapper(UserMapper.class);
-        configuration.addInterceptor(new JeffreyMyBatisInterceptor());
-        sessionFactory = new SqlSessionFactoryBuilder().build(configuration);
+        configuration.addInterceptor(interceptor);
+        return new SqlSessionFactoryBuilder().build(configuration);
     }
 
     @AfterEach
@@ -143,8 +165,126 @@ class JeffreyMyBatisInterceptorTest {
                 .hasSpan(SELECT_NAME).nestedUnder("users.show");
     }
 
+    /**
+     * The values a statement ran with are what separates the one slow call from the thousands that
+     * share its SQL, so they are recorded — and everything here is about recording them safely.
+     */
+    @Nested
+    @DisplayName("The parameters a statement ran with")
+    class Parameters {
+
+        @Test
+        @DisplayName("are keyed by the names the mapper method gave them")
+        void namedParametersAreRecorded() throws IOException {
+            RecordedEvent event = JfrRecordings.single(JdbcQueryEvent.NAME, () ->
+                    inSession(mapper -> mapper.findName(1)));
+
+            assertEquals("{\"id\":1}", event.getString("params"),
+                    "a number is written as a number, not as a quoted string");
+        }
+
+        @Test
+        @DisplayName("are escaped, so a value carrying a quote cannot corrupt the field")
+        void valuesAreEscaped() throws IOException {
+            RecordedEvent event = JfrRecordings.single(JdbcInsertEvent.NAME, () ->
+                    inSession(mapper -> mapper.insert(3, "gr\"ace\\")));
+
+            assertEquals("{\"id\":3,\"name\":\"gr\\\"ace\\\\\"}", event.getString("params"));
+        }
+
+        @Test
+        @DisplayName("record a null argument as null rather than dropping it")
+        void nullArgumentIsRecorded() throws IOException {
+            RecordedEvent event = JfrRecordings.single(JdbcQueryEvent.NAME, () ->
+                    inSession(mapper -> mapper.findByName("ada", null)));
+
+            assertEquals("{\"name\":\"ada\",\"missing\":null}", event.getString("params"));
+        }
+
+        @Test
+        @DisplayName("write a property used twice once, because both placeholders resolve alike")
+        void repeatedPropertyIsWrittenOnce() throws IOException {
+            RecordedEvent event = JfrRecordings.single(JdbcQueryEvent.NAME, () ->
+                    inSession(mapper -> mapper.findNameTwice(1)));
+
+            assertEquals("{\"id\":1}", event.getString("params"));
+        }
+
+        @Test
+        @DisplayName("are truncated, so one oversized argument cannot bloat every recording")
+        void longValuesAreTruncated() throws IOException {
+            SqlSessionFactory factory = sessionFactoryWith(
+                    new JeffreyMyBatisInterceptor(new MyBatisStatementSettings(true, 4)));
+
+            RecordedEvent event = JfrRecordings.single(JdbcInsertEvent.NAME, () ->
+                    inSession(factory, mapper -> mapper.insert(4, "abcdefgh")));
+
+            assertEquals("{\"id\":4,\"name\":\"abcd…\"}", event.getString("params"));
+        }
+
+        @Test
+        @DisplayName("stand in for binary content instead of rendering it")
+        void binaryContentIsNotRendered() throws IOException {
+            byte[] payload = "not text".getBytes(StandardCharsets.UTF_8);
+
+            RecordedEvent event = JfrRecordings.single(JdbcQueryEvent.NAME, () ->
+                    assertEquals(0, (int) inSession(mapper -> mapper.countByPayload(payload)),
+                            "the statement still runs — rendering a stream would have consumed it"));
+
+            assertEquals("{\"payload\":\"<lob-value>\"}", event.getString("params"));
+        }
+
+        @Test
+        @DisplayName("are absent for a statement that takes none")
+        void statementWithoutParametersRecordsNone() throws IOException {
+            RecordedEvent event = JfrRecordings.single(JdbcQueryEvent.NAME, () ->
+                    inSession(UserMapper::countAll));
+
+            assertNull(event.getString("params"), "an empty object would only be noise");
+        }
+
+        @Test
+        @DisplayName("can be turned off for an application whose arguments are sensitive")
+        void captureCanBeTurnedOff() throws IOException {
+            SqlSessionFactory factory = sessionFactoryWith(
+                    new JeffreyMyBatisInterceptor(MyBatisStatementSettings.noParameters()));
+
+            RecordedEvent event = JfrRecordings.single(JdbcQueryEvent.NAME, () ->
+                    inSession(factory, mapper -> mapper.findName(1)));
+
+            assertNull(event.getString("params"));
+            assertEquals(SELECT_NAME, event.getString("name"), "the statement itself is still recorded");
+        }
+
+        @Test
+        @DisplayName("are configurable through MyBatis' own plugin properties")
+        void pluginPropertiesConfigureTheSettings() {
+            Properties properties = new Properties();
+            properties.setProperty("capture-parameters", "false");
+            properties.setProperty("max-value-length", "16");
+
+            JeffreyMyBatisInterceptor interceptor = new JeffreyMyBatisInterceptor();
+            interceptor.setProperties(properties);
+
+            assertEquals(new MyBatisStatementSettings(false, 16), interceptor.settings());
+        }
+
+        @Test
+        @DisplayName("keep their defaults when a plugin declaration mentions neither")
+        void unmentionedPropertiesKeepTheirDefaults() {
+            JeffreyMyBatisInterceptor interceptor = new JeffreyMyBatisInterceptor();
+            interceptor.setProperties(new Properties());
+
+            assertEquals(MyBatisStatementSettings.defaults(), interceptor.settings());
+        }
+    }
+
     private <T> T inSession(Function<UserMapper, T> body) {
-        try (SqlSession session = sessionFactory.openSession()) {
+        return inSession(sessionFactory, body);
+    }
+
+    private <T> T inSession(SqlSessionFactory factory, Function<UserMapper, T> body) {
+        try (SqlSession session = factory.openSession()) {
             return body.apply(session.getMapper(UserMapper.class));
         }
     }

--- a/utilities/jeffrey-events/skills/jeffrey-traces-mybatis/SKILL.md
+++ b/utilities/jeffrey-events/skills/jeffrey-traces-mybatis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jeffrey-traces-mybatis
-description: Instrument MyBatis data access with Jeffrey JFR events so every mapper call emits a JdbcQuery/JdbcInsert/JdbcUpdate/JdbcDelete/JdbcExecute event named by its MyBatis statement id, landing as a leaf span in Jeffrey Traces and feeding the Database dashboard. Covers the jeffrey-events-mybatis module (one dependency, one registration line), when to prefer it over the DataSource wrapper in jeffrey-events-jdbc, and the hand-written interceptor for older releases. Requires the jeffrey-traces-core skill for the data model, emit rules, recording setup, and verification.
+description: Instrument MyBatis data access with Jeffrey JFR events so every mapper call emits a JdbcQuery/JdbcInsert/JdbcUpdate/JdbcDelete/JdbcExecute event named by its MyBatis statement id, landing as a leaf span in Jeffrey Traces and feeding the Database dashboard. Covers the jeffrey-events-mybatis module (one dependency, one registration line), recording the parameter values a statement was bound with, when to prefer it over the DataSource wrapper in jeffrey-events-jdbc, and the hand-written interceptor for older releases. Requires the jeffrey-traces-core skill for the data model, emit rules, recording setup, and verification.
 ---
 
 # Jeffrey Traces — MyBatis Instrumentation
@@ -55,6 +55,17 @@ The interceptor is `cafe.jeffrey.jfr.events.mybatis.JeffreyMyBatisInterceptor`. 
 That is the whole integration. MyBatis is intercepted at the `Executor`, so cached and batched
 execution are covered as well.
 
+On the Spring Boot starter there is no bean to declare — one property registers it:
+
+```properties
+jeffrey.tracing.mybatis-enabled=true
+```
+
+It is a property rather than the default because the MyBatis jar on the classpath says nothing
+about whether the application uses it, and turning this on makes the `DataSource` wrapper stand
+down (§2). Guessed from the classpath, that rule would silently stop recording statements in an
+application that has the jar and no mappers.
+
 ## 2. This module or the `DataSource` wrapper — one of the two
 
 `jeffrey-events-jdbc` wraps the `DataSource` and would already record MyBatis statements, because
@@ -67,8 +78,15 @@ statement by parsing its SQL (`SELECT users`); this names it `UserMapper.selectB
 mapper method, stable however the SQL is assembled, and the name a developer would search for.
 
 Do not enable both: each records the same statement, so every mapper call appears twice, once under
-each name. On Spring Boot the `DataSource` wrapper is on by default — turn it off with
-`jeffrey.tracing.jdbc-enabled=false` when you register this interceptor.
+each name. On the Spring Boot starter this is handled for you — `jeffrey.tracing.mybatis-enabled=true`
+registers the interceptor *and* stands the `DataSource` wrapper down, so there is nothing to
+remember and no window where both are recording. Wiring MyBatis by hand (a bean, XML, or
+`@Import(JeffreyMyBatisTracingConfiguration.class)`) leaves that to you: set
+`jeffrey.tracing.jdbc-enabled=false`, or do not import `JeffreyJdbcTracingConfiguration`.
+
+The trade-off is worth seeing before you flip it: an application that uses MyBatis **and** a plain
+`JdbcTemplate` loses the template's statements, because only one recorder runs. Leave the wrapper in
+charge when the mixed coverage matters more than the better names.
 
 ## 3. What it records
 
@@ -78,12 +96,61 @@ each name. On Spring Boot the `DataSource` wrapper is on by default — turn it 
 | `group` | `UserMapper` — the Database dashboard groups on it |
 | event type | picked from `SqlCommandType`: SELECT → `JdbcQueryEvent`, INSERT → `JdbcInsertEvent`, UPDATE → `JdbcUpdateEvent`, DELETE → `JdbcDeleteEvent`, anything else → `JdbcExecuteEvent` |
 | `sql` | the bound SQL, **with its `?` placeholders left in** |
+| `params` | the values it was bound with, as a JSON object — see §4 |
 | `rows` | rows returned for a query, rows affected for everything else |
 
 `sql` keeping its placeholders is the point, not a limitation: identical statements aggregate in the
-dashboard. Parameter values are never recorded — a recording is a file that gets uploaded and kept.
+dashboard, and the values that made one execution slow live in `params` instead.
 
-## 4. Older releases: the hand-written interceptor
+## 4. The values a statement ran with
+
+MyBatis is the one integration that can record them cheaply: it hands the interceptor a `BoundSql`
+carrying the parameter mappings and the parameter object — the same inputs it binds the statement
+from. A `DataSource` proxy would have to intercept every `setXxx` call to know the same thing, and
+`jeffrey-events-jdbc` does not.
+
+```json
+{"id":42,"name":"grace"}
+```
+
+That is what Jeffrey's Database dashboard shows beside the SQL, and it is what separates the one
+slow call from the thousands that share its statement.
+
+**It is on by default**, unlike the HTTP filter's capture flags. The two cases are not alike: a
+query string is free-form user input that happens to travel with a request, while a statement's
+parameters *are* the statement. Recording the SQL and hiding what it ran with makes a slow statement
+unreadable.
+
+Still, the values are recorded verbatim and a recording is a file that gets uploaded, shared and
+kept. An application whose mappers take e-mail addresses, tokens, or anything else you would not
+paste into a bug report turns capture off:
+
+```properties
+jeffrey.tracing.mybatis-capture-parameters=false
+```
+
+```java
+new JeffreyMyBatisInterceptor(MyBatisStatementSettings.noParameters());   // or, wiring by hand
+```
+
+```xml
+<plugin interceptor="cafe.jeffrey.jfr.events.mybatis.JeffreyMyBatisInterceptor">
+    <property name="capture-parameters" value="false"/>
+</plugin>
+```
+
+What the rules are, and why:
+
+| Rule | Reason |
+|---|---|
+| Keys are the property names MyBatis uses — `id` from `@Param("id")`, `arg0` unnamed, `__frch_item_0` inside a `foreach` | the name you can match to the mapper method |
+| A property used twice is written once | `#{id} … #{id}` resolves to the same value both times |
+| Numbers and booleans are JSON numbers and booleans; everything else is a string | `{"id":42}`, not `{"id":"42"}` |
+| `byte[]`, `Blob`, `Clob`, `InputStream`, `Reader`, `SQLXML` record `<lob-value>` | rendering a stream would consume it and break the statement |
+| Values longer than 256 characters are truncated with a `…` | always on, capture flag or not: one CLOB parameter must not bloat every recording. `jeffrey.tracing.mybatis-max-parameter-length` moves the limit |
+| Nothing is computed unless the event commits | a statement under the recording threshold pays for none of this |
+
+## 5. Older releases: the hand-written interceptor
 
 Before the module existed, this was copy-paste. If you are pinned to such a release:
 
@@ -142,25 +209,26 @@ Note what this version does not handle: a mapper declared as a nested interface 
 declared top-level is named `UserMapper.selectById` — two names for one shape. The module drops the
 enclosing class too.
 
-## 5. Correctness notes for the database
+## 6. Correctness notes for the database
 
-- Do not inline parameter values into `sql`. If you want them, serialize them as a JSON object
-  string into `event.params` (`SpanAttributes` builds one with no dependency) — and scrub anything
-  sensitive; the recording and the profile database contain it verbatim.
+- Do not inline parameter values into `sql`; they belong in `params`, which the module fills (§4).
+  Writing them into the SQL text would give every execution its own statement in the dashboard.
 - Batched inserts: set `event.isBatch = true` (and skip `sql`/`params` if the batch is large) when
   you intercept batch execution.
 - Lazy loading and nested selects execute wherever the property is touched. If that happens on the
   request thread inside the span, they nest correctly; if it happens later or on another thread, the
   statement records as its own root — prefer eager fetching in traced paths, or accept the orphan.
 
-## 6. MyBatis-specific pitfalls
+## 7. MyBatis-specific pitfalls
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| Every mapper call appears twice | both this module and the `DataSource` wrapper are active | pick one; on Boot set `jeffrey.tracing.jdbc-enabled=false` |
+| Every mapper call appears twice | both this module and the `DataSource` wrapper are active | on Boot, `jeffrey.tracing.mybatis-enabled=true` does both halves; wiring by hand, also set `jeffrey.tracing.jdbc-enabled=false` |
 | Duplicate events per query | interceptor registered twice (bean *and* XML) | register through exactly one mechanism |
 | Statements named after their SQL, not the mapper | the `DataSource` wrapper is recording them, not this | register the interceptor and disable the wrapper |
 | Statements present in the Database dashboard but not in Traces | committed with `commit()` (hand-written version) | `TracedEvents.emit`, or `commitSpan()` in the `finally` |
 | SQL spans are roots of their own one-span traces | statement ran outside a bound span (no HTTP filter, `@Async`, batch job) | register the root-span filter (`jeffrey-traces-spring-rest-server`); wrap background work with `Tracer.fork`/`continueIn` |
 | One "statement" per parameter combination | parameter values leaked into the event **name** | name from `MappedStatement.getId()` only; values go to `params` at most |
 | Failed statements look green | exception path missing `failed(t)` | `TracedEvents.emit` records it; by hand, catch `Throwable`, call `event.failed(t)`, rethrow |
+| A recording carries values that should not leave the building | parameter capture is on, as it is by default | `jeffrey.tracing.mybatis-capture-parameters=false`, and treat existing recordings as containing them |
+| `params` empty for statements that clearly take arguments | capture turned off somewhere — a settings bean, a plugin property | check `JeffreyMyBatisInterceptor#settings()`; a hand-declared `MyBatisStatementSettings` bean wins over the property |

--- a/utilities/jeffrey-events/skills/jeffrey-traces-spring-rest-server/SKILL.md
+++ b/utilities/jeffrey-events/skills/jeffrey-traces-spring-rest-server/SKILL.md
@@ -47,10 +47,17 @@ Tune it with `jeffrey.tracing.*`:
 | `jeffrey.tracing.order` | `HIGHEST_PRECEDENCE` | Filter order; keep it first so security, routing and data access all happen inside the span |
 | `jeffrey.tracing.jdbc-enabled` | `true` | Wrap every `DataSource` bean so statements are recorded |
 | `jeffrey.tracing.hikari-enabled` | `true` | Give HikariCP pools a Jeffrey metrics tracker |
+| `jeffrey.tracing.mybatis-enabled` | `false` | Name statements by their mapper method instead. Turning it on stands the `DataSource` wrapper down, so nothing is recorded twice — see `jeffrey-traces-mybatis` |
+| `jeffrey.tracing.mybatis-capture-parameters` | `true` | Record the values a MyBatis statement was bound with |
+| `jeffrey.tracing.mybatis-max-parameter-length` | `256` | Truncate longer parameter values |
 | `jeffrey.tracing.capture-query-params` | `false` | Record query-string parameters on the event |
 | `jeffrey.tracing.capture-path-params` | `false` | Record the route's template variables on the event |
 
-**Both capture flags are off by default, deliberately.** A recording is a file that gets uploaded,
+`mybatis-capture-parameters` is the one capture flag that is *on*: a statement's parameters are what
+make a slow statement readable, where a query string is free-form user input. The MyBatis skill
+explains the difference and how to turn it off.
+
+**Both HTTP capture flags are off by default, deliberately.** A recording is a file that gets uploaded,
 shared and kept, and query strings routinely carry access tokens, e-mail addresses and search
 terms. Turn them on for an application whose parameters you know are safe to keep — as Jeffrey does
 for itself.

--- a/utilities/jeffrey-events/spring-boot-starter/pom.xml
+++ b/utilities/jeffrey-events/spring-boot-starter/pom.xml
@@ -69,6 +69,18 @@
             <version>${hikaricp.version}</version>
             <scope>provided</scope>
         </dependency>
+        <!-- Same shape as Hikari: brought along, inert until the application actually uses MyBatis. -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jeffrey-events-mybatis</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mybatis</groupId>
+            <artifactId>mybatis</artifactId>
+            <version>${mybatis.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/utilities/jeffrey-events/spring-boot-starter/src/main/java/cafe/jeffrey/jfr/events/spring/boot/JeffreyJdbcTracingAutoConfiguration.java
+++ b/utilities/jeffrey-events/spring-boot-starter/src/main/java/cafe/jeffrey/jfr/events/spring/boot/JeffreyJdbcTracingAutoConfiguration.java
@@ -22,6 +22,7 @@ import cafe.jeffrey.jfr.events.jdbc.datasource.TracingDataSource;
 import cafe.jeffrey.jfr.events.spring.JeffreyJdbcTracingConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Import;
 
@@ -33,11 +34,21 @@ import javax.sql.DataSource;
  * Separate from the HTTP auto-configuration because the conditions differ: an application can have
  * one, both or neither, and {@code jeffrey.tracing.jdbc-enabled=false} turns this half off without
  * touching request tracing.
+ * <p>
+ * It also backs off entirely once the MyBatis interceptor is registered — which happens only when
+ * an application asks for it with {@code jeffrey.tracing.mybatis-enabled=true}. Both record the
+ * same statements, so running the two would put every mapper call in the dashboard twice, once
+ * under its mapper method and once under a name parsed out of its SQL. The trade-off comes with
+ * that request: an application that uses MyBatis <em>and</em> a plain {@code JdbcTemplate} loses
+ * the template's statements, and gets them back by leaving this half in charge.
  */
 @AutoConfiguration
 @ConditionalOnClass({DataSource.class, TracingDataSource.class})
 @ConditionalOnProperty(prefix = "jeffrey.tracing", name = "enabled", havingValue = "true", matchIfMissing = true)
 @ConditionalOnProperty(prefix = "jeffrey.tracing", name = "jdbc-enabled", havingValue = "true", matchIfMissing = true)
+// Named as a string, not a class literal: the interceptor implements a MyBatis type, so naming it
+// by class would load org.apache.ibatis in an application that has no MyBatis at all.
+@ConditionalOnMissingBean(type = JeffreyMyBatisTracingAutoConfiguration.INTERCEPTOR_TYPE)
 @Import(JeffreyJdbcTracingConfiguration.class)
 public class JeffreyJdbcTracingAutoConfiguration {
 }

--- a/utilities/jeffrey-events/spring-boot-starter/src/main/java/cafe/jeffrey/jfr/events/spring/boot/JeffreyMyBatisTracingAutoConfiguration.java
+++ b/utilities/jeffrey-events/spring-boot-starter/src/main/java/cafe/jeffrey/jfr/events/spring/boot/JeffreyMyBatisTracingAutoConfiguration.java
@@ -1,0 +1,74 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.spring.boot;
+
+import cafe.jeffrey.jfr.events.mybatis.JeffreyMyBatisInterceptor;
+import cafe.jeffrey.jfr.events.mybatis.MyBatisStatementSettings;
+import cafe.jeffrey.jfr.events.spring.JeffreyMyBatisTracingConfiguration;
+import org.apache.ibatis.plugin.Interceptor;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Names every MyBatis statement by the mapper method that issued it, for an application that asks
+ * with {@code jeffrey.tracing.mybatis-enabled=true}.
+ * <p>
+ * Asking is required because the MyBatis jar on the classpath says nothing about whether the
+ * application uses it — a transitive dependency is enough to put it there — while the consequence
+ * of guessing wrong is severe: this configuration is declared <b>before</b>
+ * {@link JeffreyJdbcTracingAutoConfiguration}, which finds the interceptor registered and stands
+ * down. That is what stops an application from recording every mapper call twice, once under
+ * {@code UserMapper.selectById} and once under the name parsed out of its SQL. Guessed from the
+ * classpath, the same rule would silently stop recording statements in an application that has the
+ * jar and no mappers.
+ * <p>
+ * The default is therefore the {@code DataSource} wrapper, which records MyBatis statements too,
+ * just under names read out of their SQL. Turning this on trades that for better names.
+ * <p>
+ * Like the HTTP half, it imports {@link JeffreyMyBatisTracingConfiguration} for the beans that need
+ * no Spring Boot and adds only the {@code jeffrey.tracing.*} binding on top.
+ */
+@AutoConfiguration(before = JeffreyJdbcTracingAutoConfiguration.class)
+@ConditionalOnClass({Interceptor.class, JeffreyMyBatisInterceptor.class})
+@ConditionalOnProperty(prefix = "jeffrey.tracing", name = "enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(prefix = "jeffrey.tracing", name = "mybatis-enabled", havingValue = "true")
+@EnableConfigurationProperties(JeffreyTracingProperties.class)
+@Import(JeffreyMyBatisTracingConfiguration.class)
+public class JeffreyMyBatisTracingAutoConfiguration {
+
+    /**
+     * The interceptor's name, for the condition that makes the JDBC half stand down. A compile-time
+     * constant, so referring to it loads no MyBatis type in an application that has none.
+     */
+    static final String INTERCEPTOR_TYPE = "cafe.jeffrey.jfr.events.mybatis.JeffreyMyBatisInterceptor";
+
+    /**
+     * Replaces the plain configuration's default settings with what {@code jeffrey.tracing.*} says.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public MyBatisStatementSettings jeffreyMyBatisStatementSettings(JeffreyTracingProperties properties) {
+        return properties.toMyBatisSettings();
+    }
+}

--- a/utilities/jeffrey-events/spring-boot-starter/src/main/java/cafe/jeffrey/jfr/events/spring/boot/JeffreyTracingProperties.java
+++ b/utilities/jeffrey-events/spring-boot-starter/src/main/java/cafe/jeffrey/jfr/events/spring/boot/JeffreyTracingProperties.java
@@ -18,6 +18,7 @@
 
 package cafe.jeffrey.jfr.events.spring.boot;
 
+import cafe.jeffrey.jfr.events.mybatis.MyBatisStatementSettings;
 import cafe.jeffrey.jfr.events.servlet.HttpExchangeSettings;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.core.Ordered;
@@ -35,8 +36,23 @@ import java.util.List;
  * @param urlPatterns      which requests the filter sees; {@code /*} covers everything
  * @param order            the filter's order in the chain — first by default, so security, routing
  *                         and data access all happen inside the span
- * @param jdbcEnabled      whether every {@code DataSource} bean is wrapped to record statements
+ * @param jdbcEnabled      whether every {@code DataSource} bean is wrapped to record statements —
+ *                         ignored once {@code mybatisEnabled} is on, since the two would record
+ *                         every mapper call twice
  * @param hikariEnabled    whether HikariCP pools get a Jeffrey metrics tracker
+ * @param mybatisEnabled   whether MyBatis statements are recorded by their mapper method instead of
+ *                         through the {@code DataSource} wrapper. Off by default and asked for
+ *                         explicitly: MyBatis on the classpath is not evidence that the application
+ *                         uses it, and backing the wrapper off on that guess would silently stop
+ *                         recording statements. Turned on, it does take over from {@code
+ *                         jdbcEnabled}, because a mapper method is a better name than one parsed
+ *                         out of SQL
+ * @param mybatisCaptureParameters record the values a MyBatis statement was bound with; on by
+ *                         default, because they are what separates the slow call from the
+ *                         thousands sharing its SQL — turn it off for an application whose mappers
+ *                         take values it would not paste into a bug report, since a recording is a
+ *                         file that gets shared
+ * @param mybatisMaxParameterLength longest parameter value recorded before truncation
  * @param captureQueryParams record query-string parameters on the event; off by default, because
  *                         query strings routinely carry tokens and personal data, and a recording
  *                         is a file that gets shared
@@ -50,6 +66,9 @@ public record JeffreyTracingProperties(
         Integer order,
         Boolean jdbcEnabled,
         Boolean hikariEnabled,
+        Boolean mybatisEnabled,
+        Boolean mybatisCaptureParameters,
+        Integer mybatisMaxParameterLength,
         Boolean captureQueryParams,
         Boolean capturePathParams) {
 
@@ -61,6 +80,11 @@ public record JeffreyTracingProperties(
         order = order == null ? Ordered.HIGHEST_PRECEDENCE : order;
         jdbcEnabled = jdbcEnabled == null || jdbcEnabled;
         hikariEnabled = hikariEnabled == null || hikariEnabled;
+        mybatisEnabled = mybatisEnabled != null && mybatisEnabled;
+        mybatisCaptureParameters = mybatisCaptureParameters == null || mybatisCaptureParameters;
+        mybatisMaxParameterLength = mybatisMaxParameterLength == null
+                ? MyBatisStatementSettings.defaults().maxValueLength()
+                : mybatisMaxParameterLength;
         captureQueryParams = captureQueryParams != null && captureQueryParams;
         capturePathParams = capturePathParams != null && capturePathParams;
     }
@@ -70,5 +94,12 @@ public record JeffreyTracingProperties(
      */
     public HttpExchangeSettings toSettings() {
         return new HttpExchangeSettings(captureQueryParams, capturePathParams);
+    }
+
+    /**
+     * @return the framework-free settings the MyBatis interceptor actually consumes
+     */
+    public MyBatisStatementSettings toMyBatisSettings() {
+        return new MyBatisStatementSettings(mybatisCaptureParameters, mybatisMaxParameterLength);
     }
 }

--- a/utilities/jeffrey-events/spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/utilities/jeffrey-events/spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,3 +1,4 @@
 cafe.jeffrey.jfr.events.spring.boot.JeffreyTracingAutoConfiguration
+cafe.jeffrey.jfr.events.spring.boot.JeffreyMyBatisTracingAutoConfiguration
 cafe.jeffrey.jfr.events.spring.boot.JeffreyJdbcTracingAutoConfiguration
 cafe.jeffrey.jfr.events.spring.boot.JeffreyHikariTracingAutoConfiguration

--- a/utilities/jeffrey-events/spring-boot-starter/src/test/java/cafe/jeffrey/jfr/events/spring/boot/JeffreyTracingAutoConfigurationTest.java
+++ b/utilities/jeffrey-events/spring-boot-starter/src/test/java/cafe/jeffrey/jfr/events/spring/boot/JeffreyTracingAutoConfigurationTest.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import cafe.jeffrey.jfr.events.mybatis.JeffreyMyBatisInterceptor;
+import cafe.jeffrey.jfr.events.mybatis.MyBatisStatementSettings;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -155,6 +157,7 @@ class JeffreyTracingAutoConfigurationTest {
             });
         }
 
+        /** Nested inside this class on purpose: at test-class level the Boot slice would scan it. */
         @Configuration(proxyBeanMethods = false)
         static class PlainDataSource {
 
@@ -162,6 +165,71 @@ class JeffreyTracingAutoConfigurationTest {
             DataSource dataSource() {
                 return Mockito.mock(DataSource.class);
             }
+        }
+    }
+
+    /**
+     * MyBatis names statements better than a {@code DataSource} proxy can, so once an application
+     * asks for it, it takes over — and that hand-over is what keeps a mapper call out of the
+     * dashboard twice.
+     */
+    @Nested
+    @DisplayName("MyBatis")
+    class MyBatis {
+
+        private final WebApplicationContextRunner mybatisRunner = new WebApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        JeffreyMyBatisTracingAutoConfiguration.class, JeffreyJdbcTracingAutoConfiguration.class))
+                .withUserConfiguration(DataSources.PlainDataSource.class)
+                .withPropertyValues("jeffrey.tracing.mybatis-enabled=true");
+
+        @Test
+        @DisplayName("the interceptor is registered as a bean, which is the whole registration")
+        void registersTheInterceptor() {
+            mybatisRunner.run(context -> {
+                assertThat(context).hasSingleBean(JeffreyMyBatisInterceptor.class);
+                assertThat(context.getBean(JeffreyMyBatisInterceptor.class).settings())
+                        .isEqualTo(MyBatisStatementSettings.defaults());
+            });
+        }
+
+        @Test
+        @DisplayName("parameter capture is on by default, because it is what makes a slow statement readable")
+        void capturesParametersByDefault() {
+            mybatisRunner.run(context ->
+                    assertThat(context.getBean(MyBatisStatementSettings.class).captureParameters()).isTrue());
+        }
+
+        @Test
+        @DisplayName("properties reach the interceptor the application actually gets")
+        void propertiesBind() {
+            mybatisRunner.withPropertyValues(
+                            "jeffrey.tracing.mybatis-capture-parameters=false",
+                            "jeffrey.tracing.mybatis-max-parameter-length=16")
+                    .run(context -> assertThat(context.getBean(JeffreyMyBatisInterceptor.class).settings())
+                            .isEqualTo(new MyBatisStatementSettings(false, 16)));
+        }
+
+        @Test
+        @DisplayName("the DataSource is left alone while the interceptor is recording, so nothing is counted twice")
+        void theDataSourceWrapperBacksOff() {
+            mybatisRunner.run(context ->
+                    assertThat(context.getBean(DataSource.class)).isNotInstanceOf(TracingDataSource.class));
+        }
+
+        @Test
+        @DisplayName("having MyBatis on the classpath is not by itself a reason to register anything")
+        void classpathAloneRegistersNothing() {
+            new WebApplicationContextRunner()
+                    .withConfiguration(AutoConfigurations.of(
+                            JeffreyMyBatisTracingAutoConfiguration.class, JeffreyJdbcTracingAutoConfiguration.class))
+                    .withUserConfiguration(DataSources.PlainDataSource.class)
+                    .run(context -> {
+                        assertThat(context).doesNotHaveBean(JeffreyMyBatisInterceptor.class);
+                        assertThat(context.getBean(DataSource.class))
+                                .as("a transitive MyBatis jar must not stop statements being recorded")
+                                .isInstanceOf(TracingDataSource.class);
+                    });
         }
     }
 

--- a/utilities/jeffrey-events/spring/pom.xml
+++ b/utilities/jeffrey-events/spring/pom.xml
@@ -66,9 +66,21 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jeffrey-events-mybatis</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
             <version>${hikaricp.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mybatis</groupId>
+            <artifactId>mybatis</artifactId>
+            <version>${mybatis.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/utilities/jeffrey-events/spring/src/main/java/cafe/jeffrey/jfr/events/spring/JeffreyMyBatisTracingConfiguration.java
+++ b/utilities/jeffrey-events/spring/src/main/java/cafe/jeffrey/jfr/events/spring/JeffreyMyBatisTracingConfiguration.java
@@ -1,0 +1,53 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.spring;
+
+import cafe.jeffrey.jfr.events.mybatis.JeffreyMyBatisInterceptor;
+import cafe.jeffrey.jfr.events.mybatis.MyBatisStatementSettings;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Records every MyBatis statement, wired <em>explicitly</em>.
+ * <p>
+ * Declaring the interceptor as a bean is the whole registration: mybatis-spring adds every
+ * {@code Interceptor} bean to the {@code SqlSessionFactory} it builds.
+ * <p>
+ * Import this <b>or</b> {@link JeffreyJdbcTracingConfiguration}, never both — they would record the
+ * same statement twice, once named by mapper method and once by parsed SQL. Prefer this one
+ * wherever MyBatis is how the application talks to the database, because a statement id is a better
+ * name than anything a {@code DataSource} proxy can derive.
+ *
+ * <pre>{@code
+ * @Import(JeffreyMyBatisTracingConfiguration.class)
+ * }</pre>
+ */
+@Configuration(proxyBeanMethods = false)
+public class JeffreyMyBatisTracingConfiguration {
+
+    /**
+     * Parameter capture is on unless the application declares its own
+     * {@link MyBatisStatementSettings} bean saying otherwise.
+     */
+    @Bean
+    public JeffreyMyBatisInterceptor jeffreyMyBatisInterceptor(ObjectProvider<MyBatisStatementSettings> settings) {
+        return new JeffreyMyBatisInterceptor(settings.getIfAvailable(MyBatisStatementSettings::defaults));
+    }
+}


### PR DESCRIPTION
Stacked on #184 (PR D). Review only the three commits after `1ecf1d1`.

## The gap

`JdbcBaseEvent` has carried a `params` field all along, and Jeffrey consumes it — the parser reads it in `JdbcOverviewEventBuilder.java:136` and carries it into `JdbcSlowStatement`, which is what the "slowest statements" view shows. Exactly one emitter filled it: `DatabaseClient`, for Jeffrey's own internal SQL. Every shipped instrumentation module left it null, so a slow statement in an adopter's recording showed its SQL with bare `?` placeholders and nothing about the call that was actually slow.

MyBatis is the one integration that closes this cheaply: it hands the interceptor a `BoundSql` carrying the parameter mappings and the parameter object — the same inputs it binds the statement from. Resolution follows `DefaultParameterHandler`; no proxy state, no setter interception. Because the statement has already executed by the time the filler runs, every property read is one MyBatis resolved a moment ago.

```json
{"id":42,"name":"grace"}
```

**Capture is on by default**, unlike the HTTP filter's flags — a query string is free-form user input that happens to travel with a request, while a statement's parameters *are* the statement. The risk is real all the same, so it is one property, one constructor argument or one XML `<property>` to turn off, and the javadoc says so where a Boot user will meet it.

Two rules hold whatever the flag says: content that would have to be read to be rendered (`byte[]`, `Blob`, `Clob`, `InputStream`, `Reader`, `SQLXML`) records `<lob-value>`, because reading a stream would consume it and break the statement; and every value is truncated, so one CLOB parameter cannot bloat an entire recording. A property used twice is written once, since both placeholders resolve identically.

## The hand-over, and a plan change worth reading

`jeffrey.tracing.mybatis-enabled=true` registers the interceptor **and** stands the `DataSource` wrapper down. Both record the same statements, so running the two puts every mapper call in the dashboard twice — once under its mapper method, once under a name parsed out of its SQL.

The approved plan had this on by default, keyed on MyBatis being on the classpath. **The starter's own integration test rejected that.** MyBatis reached that test's classpath through this change, the auto-configuration fired for an application with no mappers at all, the wrapper stood down, and `statementsFromTheDataSourceNestUnderTheRequest` went from green to `no span named 'SELECT users' was recorded`. A transitive jar is not evidence of use, and the cost of guessing wrong is silence. So registration is now explicit (`mybatis-enabled` defaults to `false`), the default stays the wrapper — which records MyBatis statements too, just under SQL-derived names — and asking for the interceptor trades that for better names, and with it the statements issued outside MyBatis. That trade-off is stated in the javadoc and the skill rather than left to be discovered.

A regression test pins it: MyBatis on the classpath with no property registers nothing, and the `DataSource` is still wrapped.

## Verification

- `mvn -f utilities/jeffrey-events test` — **BUILD SUCCESS**. 14 MyBatis tests (10 new, each asserting `params` off a live recording: `@Param` keys, escaping, a null argument, a repeated property, truncation, `<lob-value>` with the statement still executing, capture off, plugin properties) and 19 starter tests (5 new for the MyBatis wiring).
- Full reactor `mvn compile -DskipTests -Dexec.skip=true` — **BUILD SUCCESS**.
- Staging pre-flight `-P release deploy` into a scratch repository — 9 modules plus the parent pom, javadoc included, coordinates unchanged.
- No dogfood: Jeffrey does not use MyBatis, so the tests are the only evidence and are written to carry that weight.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BfGNpXCFpAxW1etXhD8x3v)_