### PR TITLE
@Traced: annotate a method, and the agent records it as a span

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,9 @@ jobs:
     - name: Build with Maven
       env:
         JEFFREY_TAG_VERSION: ${{ steps.version.outputs.VERSION }}
-      run: mvn clean package
+      # verify, not package: the agent's integration tests run under a real -javaagent at the
+      # integration-test phase, and package stops short of them.
+      run: mvn clean verify
 
     - name: Upload microscope.jar
       uses: actions/upload-artifact@v7

--- a/build/build-agent-tests/pom.xml
+++ b/build/build-agent-tests/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Jeffrey
+  ~ Copyright (C) 2026 Petr Bouda
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>cafe.jeffrey</groupId>
+        <artifactId>build</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>build-agent-tests</artifactId>
+
+    <!--
+      Proves the agent works as shipped: the real shaded jar, attached with -javaagent, weaving
+      classes that use the real jeffrey-events. Nothing here is published; it exists so that the
+      relocation, the class-loader bridge and the span semantics are exercised together, which no
+      unit test in either module can do on its own.
+    -->
+    <properties>
+        <maven-failsafe-plugin.version>3.5.4</maven-failsafe-plugin.version>
+        <!--
+          The jar the release publishes, by the name build-agent's finalName gives it. Not resolved
+          as a dependency: that resolves to build-agent's main artifact, which is the thin jar
+          without the relocated engine — the one thing these tests must not attach.
+        -->
+        <agent.jar>${project.basedir}/../build-agent/target/jeffrey-agent.jar</agent.jar>
+    </properties>
+
+    <dependencies>
+        <!-- The shaded agent jar itself. Also what orders the reactor: this module cannot build
+             until build-agent has produced the jar the tests attach. -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>build-agent</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>cafe.jeffrey-analyst</groupId>
+            <artifactId>jeffrey-events</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>cafe.jeffrey-analyst</groupId>
+            <artifactId>jeffrey-events-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!--
+              Failsafe rather than surefire, because these tests need the agent jar to exist: they
+              run after package, which is when the shaded jar is built.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${maven-failsafe-plugin.version}</version>
+                <configuration>
+                    <argLine>-javaagent:${agent.jar}=tracing.enabled=true</argLine>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/build/build-agent-tests/src/test/java/cafe/jeffrey/agent/e2e/TracedAgentIT.java
+++ b/build/build-agent-tests/src/test/java/cafe/jeffrey/agent/e2e/TracedAgentIT.java
@@ -23,6 +23,7 @@ import cafe.jeffrey.jfr.events.test.SpansAssert;
 import cafe.jeffrey.jfr.events.trace.SpanKind;
 import cafe.jeffrey.jfr.events.trace.SpanStatus;
 import cafe.jeffrey.jfr.events.trace.TraceSpanEvent;
+import cafe.jeffrey.jfr.events.trace.Tracer;
 import cafe.jeffrey.jfr.events.trace.Traced;
 import jdk.jfr.consumer.RecordedEvent;
 import org.junit.jupiter.api.DisplayName;
@@ -70,7 +71,7 @@ class TracedAgentIT {
     @DisplayName("the span nests under the work that called it, with nothing threaded through")
     void nestsUnderTheCaller() throws IOException {
         List<RecordedEvent> events = JfrRecordings.all(TraceSpanEvent.NAME, () ->
-                cafe.jeffrey.jfr.events.trace.Tracer.run("orders.batch", SpanKind.SERVER, () -> orders.ship("a-1")));
+                Tracer.run("orders.batch", SpanKind.SERVER, () -> orders.ship("a-1")));
 
         SpansAssert.assertThat(events)
                 .hasNoOrphanedSpans()

--- a/build/build-agent-tests/src/test/java/cafe/jeffrey/agent/e2e/TracedAgentIT.java
+++ b/build/build-agent-tests/src/test/java/cafe/jeffrey/agent/e2e/TracedAgentIT.java
@@ -1,0 +1,123 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.agent.e2e;
+
+import cafe.jeffrey.jfr.events.test.JfrRecordings;
+import cafe.jeffrey.jfr.events.test.SpansAssert;
+import cafe.jeffrey.jfr.events.trace.SpanKind;
+import cafe.jeffrey.jfr.events.trace.SpanStatus;
+import cafe.jeffrey.jfr.events.trace.TraceSpanEvent;
+import cafe.jeffrey.jfr.events.trace.Traced;
+import jdk.jfr.consumer.RecordedEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * The agent as it ships: the shaded jar with its relocated bytecode engine, attached with
+ * {@code -javaagent}, weaving classes that use the real {@code jeffrey-events}.
+ * <p>
+ * Everything below crosses the boundary the unit tests each see only one side of — the agent
+ * resolving the library through the instrumented class's own loader, and the library turning that
+ * call into a span in a real recording. A method here is annotated and called normally; nothing
+ * mentions the agent.
+ * <p>
+ * One case cannot live here: an application without {@code jeffrey-events} on its class path. This
+ * module has the library by construction, so that fall-through is proven in the agent's own
+ * {@code TracedWeavingTest} instead.
+ * <p>
+ * The reactor compiles with javac's {@code -parameters}, so captured arguments are keyed by their
+ * real names here — the case an application gets when it does the same.
+ */
+class TracedAgentIT {
+
+    private final Orders orders = new Orders();
+
+    @Test
+    @DisplayName("an annotated method is recorded as a span named after itself")
+    void recordsAnnotatedMethods() throws IOException {
+        RecordedEvent event = JfrRecordings.single(TraceSpanEvent.NAME, () ->
+                assertEquals("shipped:a-1", orders.ship("a-1")));
+
+        assertEquals("Orders.ship", event.getString("name"),
+                "no annotation attribute was needed: the method named itself");
+        assertEquals(SpanKind.INTERNAL.name(), event.getString("kind"));
+    }
+
+    @Test
+    @DisplayName("the span nests under the work that called it, with nothing threaded through")
+    void nestsUnderTheCaller() throws IOException {
+        List<RecordedEvent> events = JfrRecordings.all(TraceSpanEvent.NAME, () ->
+                cafe.jeffrey.jfr.events.trace.Tracer.run("orders.batch", SpanKind.SERVER, () -> orders.ship("a-1")));
+
+        SpansAssert.assertThat(events)
+                .hasNoOrphanedSpans()
+                .hasSpan("Orders.ship").nestedUnder("orders.batch");
+    }
+
+    @Test
+    @DisplayName("the annotation's own name, kind and attributes reach the recording")
+    void recordsWhatTheAnnotationDeclares() throws IOException {
+        RecordedEvent event = JfrRecordings.single(TraceSpanEvent.NAME, () -> orders.charge("a-1", 4200));
+
+        assertEquals("order.charge", event.getString("name"));
+        assertEquals(SpanKind.CLIENT.name(), event.getString("kind"));
+        assertEquals("{\"tier\":\"gold\",\"orderId\":\"a-1\"}", event.getString("attributes"),
+                "the named argument is captured under its real parameter name, the amount is not");
+    }
+
+    @Test
+    @DisplayName("a failing method fails exactly as it would unwoven, and the span says so")
+    void recordsFailures() throws IOException {
+        RecordedEvent event = JfrRecordings.single(TraceSpanEvent.NAME, () -> {
+            IOException thrown = assertThrows(IOException.class, () -> orders.reject("a-1"));
+            assertSame(Orders.REJECTED, thrown, "the caller catches the very exception the method threw");
+        });
+
+        assertEquals(SpanStatus.ERROR.name(), event.getString("status"));
+        assertEquals(IOException.class.getName(), event.getString("errorType"));
+    }
+
+    /** An ordinary class. Nothing here knows it is being traced. */
+    static class Orders {
+
+        static final IOException REJECTED = new IOException("rejected");
+
+        @Traced
+        String ship(String orderId) {
+            return "shipped:" + orderId;
+        }
+
+        @Traced(name = "order.charge", kind = SpanKind.CLIENT,
+                args = {"tier=gold"}, includeMethodArgs = {"orderId"})
+        void charge(String orderId, long amountInCents) {
+        }
+
+        @Traced
+        void reject(String orderId) throws IOException {
+            throw REJECTED;
+        }
+    }
+}

--- a/build/build-agent/pom.xml
+++ b/build/build-agent/pom.xml
@@ -31,6 +31,12 @@
 
     <properties>
         <finalName>jeffrey-agent</finalName>
+        <!--
+          Pinned: unlike the assembly plugin, shade has no version in Maven's super-POM. It also has
+          to be new enough to read ByteBuddy's versioned classes for recent JDKs — 3.6.0 fails on
+          them with "Unsupported class file major version 68".
+        -->
+        <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>
     </properties>
 
     <dependencies>
@@ -42,26 +48,58 @@
 
     <build>
         <plugins>
+            <!--
+              Shaded rather than assembled, because the agent now carries ByteBuddy and the jar is
+              appended to the system class path of every application it attaches to. Unrelocated, it
+              would win parent-first delegation over the ByteBuddy those applications ship with
+              Hibernate, Mockito or Spring — a profiler must never re-version the thing it profiles.
+            -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>${maven-shade-plugin.version}</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
-                            <goal>single</goal>
+                            <goal>shade</goal>
                         </goals>
                         <configuration>
                             <finalName>${finalName}</finalName>
-                            <archive>
-                                <manifestEntries>
-                                    <Premain-Class>cafe.jeffrey.agent.JeffreyAgent</Premain-Class>
-                                </manifestEntries>
-                            </archive>
-                            <descriptorRefs>
-                                <descriptorRef>jar-with-dependencies</descriptorRef>
-                            </descriptorRefs>
-                            <appendAssemblyId>false</appendAssemblyId>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <!--
+                              Left off deliberately: ByteBuddy reaches parts of itself reflectively,
+                              so keeping only what is statically reachable is a correctness risk not
+                              worth a few megabytes.
+                            -->
+                            <minimizeJar>false</minimizeJar>
+                            <relocations>
+                                <relocation>
+                                    <pattern>net.bytebuddy</pattern>
+                                    <shadedPattern>cafe.jeffrey.agent.internal.bytebuddy</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>module-info.class</exclude>
+                                        <exclude>META-INF/maven/**</exclude>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <Premain-Class>cafe.jeffrey.agent.JeffreyAgent</Premain-Class>
+                                        <!-- ByteBuddy ships versioned classes for newer JDKs. -->
+                                        <Multi-Release>true</Multi-Release>
+                                    </manifestEntries>
+                                </transformer>
+                            </transformers>
                         </configuration>
                     </execution>
                 </executions>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -40,6 +40,7 @@
         <module>build-provisioner</module>
         <module>build-provisioner-native</module>
         <module>build-agent</module>
+        <module>build-agent-tests</module>
     </modules>
 
     <build>

--- a/jeffrey-agent/pom.xml
+++ b/jeffrey-agent/pom.xml
@@ -29,7 +29,30 @@
 
     <artifactId>jeffrey-agent</artifactId>
 
+    <properties>
+        <!--
+          Pinned here on purpose, not inherited from Spring's BOM: the agent is shaded into every
+          application it attaches to, so its bytecode engine is a deliberate choice, not whatever a
+          framework happens to manage. Worth keeping in step with what core-hub and core-microscope
+          resolve, but they do not decide it.
+        -->
+        <byte-buddy.version>1.18.10</byte-buddy.version>
+    </properties>
+
     <dependencies>
+        <!-- The weaver. Relocated into the agent jar by build/build-agent so it can never
+             shadow the ByteBuddy of the application being profiled. -->
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>${byte-buddy.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy-agent</artifactId>
+            <version>${byte-buddy.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/jeffrey-agent/src/main/java/cafe/jeffrey/agent/AgentArgs.java
+++ b/jeffrey-agent/src/main/java/cafe/jeffrey/agent/AgentArgs.java
@@ -30,7 +30,9 @@ public record AgentArgs(Path heartbeatDir, Duration heartbeatInterval, boolean h
     private record KeyValue(String key, String value) {
     }
 
-    // Duplicated from HeartbeatConstants — agent must stay zero-dependency for minimal JAR size
+    // Duplicated from HeartbeatConstants rather than shared: the agent depends on none of
+    // Jeffrey's own modules, which is what lets it target an older Java release than they do
+    // and keeps it independent of whatever the profiled application has on its class path.
     private static final String PARAM_DIR = "heartbeat.dir";
     private static final String PARAM_INTERVAL = "heartbeat.interval";
     private static final String PARAM_ENABLED = "heartbeat.enabled";

--- a/jeffrey-agent/src/main/java/cafe/jeffrey/agent/AgentArgs.java
+++ b/jeffrey-agent/src/main/java/cafe/jeffrey/agent/AgentArgs.java
@@ -25,7 +25,7 @@ import java.util.Base64;
 import java.util.Optional;
 
 public record AgentArgs(Path heartbeatDir, Duration heartbeatInterval, boolean heartbeatEnabled,
-                        AppInformation appInfo) {
+                        AppInformation appInfo, boolean tracingEnabled) {
 
     private record KeyValue(String key, String value) {
     }
@@ -36,6 +36,10 @@ public record AgentArgs(Path heartbeatDir, Duration heartbeatInterval, boolean h
     private static final String PARAM_ENABLED = "heartbeat.enabled";
     // Must match HeartbeatConstants.DEFAULT_INTERVAL — both values move together
     private static final Duration DEFAULT_INTERVAL = Duration.ofSeconds(5);
+
+    // Method tracing is off unless asked for: it installs a transformer consulted on every class
+    // the application loads, which is not something to switch on behind an operator's back.
+    private static final String PARAM_TRACING_ENABLED = "tracing.enabled";
 
     // Duplicated from AppInfoConstants — see note above
     private static final String PARAM_WORKSPACE_ID = "app.workspaceId";
@@ -50,12 +54,13 @@ public record AgentArgs(Path heartbeatDir, Duration heartbeatInterval, boolean h
 
     public static AgentArgs parse(String args) {
         if (args == null || args.isBlank()) {
-            return new AgentArgs(null, DEFAULT_INTERVAL, true, null);
+            return new AgentArgs(null, DEFAULT_INTERVAL, true, null, false);
         }
 
         Path heartbeatDir = null;
         Duration interval = DEFAULT_INTERVAL;
         boolean enabled = true;
+        boolean tracingEnabled = false;
 
         String workspaceId = null;
         String projectId = null;
@@ -77,6 +82,7 @@ public record AgentArgs(Path heartbeatDir, Duration heartbeatInterval, boolean h
                 case PARAM_DIR -> heartbeatDir = Path.of(kv.value);
                 case PARAM_INTERVAL -> interval = Duration.ofMillis(Long.parseLong(kv.value));
                 case PARAM_ENABLED -> enabled = Boolean.parseBoolean(kv.value);
+                case PARAM_TRACING_ENABLED -> tracingEnabled = Boolean.parseBoolean(kv.value);
                 case PARAM_WORKSPACE_ID -> workspaceId = kv.value;
                 case PARAM_PROJECT_ID -> projectId = kv.value;
                 case PARAM_PROJECT_NAME -> projectName = kv.value;
@@ -95,7 +101,7 @@ public record AgentArgs(Path heartbeatDir, Duration heartbeatInterval, boolean h
                 workspaceId, projectId, projectName, projectLabel,
                 instanceId, sessionId, sessionOrder, attributes, provisionedAt);
 
-        return new AgentArgs(heartbeatDir, interval, enabled, appInfo);
+        return new AgentArgs(heartbeatDir, interval, enabled, appInfo, tracingEnabled);
     }
 
     private static Optional<KeyValue> parseKeyValue(String part) {

--- a/jeffrey-agent/src/main/java/cafe/jeffrey/agent/AppInformationEvent.java
+++ b/jeffrey-agent/src/main/java/cafe/jeffrey/agent/AppInformationEvent.java
@@ -31,10 +31,10 @@ import jdk.jfr.Timestamp;
  * Application and session identity emitted once at the start of every JFR chunk.
  *
  * <p>This is a self-contained copy of
- * {@code cafe.jeffrey.jfr.events.appinfo.AppInformationEvent}; the agent
- * duplicates it (rather than depending on {@code jeffrey-events}) to remain
- * zero-dependency for minimal JAR size. JFR deduplicates event types by
- * {@link Name}, so the two copies describe the same event type.</p>
+ * {@code cafe.jeffrey.jfr.events.appinfo.AppInformationEvent}. The agent duplicates it rather than
+ * depending on {@code jeffrey-events} because it must not require the profiled application to carry
+ * that library, and because it targets an older Java release than the library does. JFR
+ * deduplicates event types by {@link Name}, so the two copies describe the same event type.</p>
  */
 @Name("jeffrey.AppInformation")
 @Label("Application Information")

--- a/jeffrey-agent/src/main/java/cafe/jeffrey/agent/HeartbeatProducer.java
+++ b/jeffrey-agent/src/main/java/cafe/jeffrey/agent/HeartbeatProducer.java
@@ -36,7 +36,8 @@ public class HeartbeatProducer implements Closeable {
 
     private static final System.Logger LOG = System.getLogger(HeartbeatProducer.class.getName());
 
-    // Duplicated from HeartbeatConstants — agent must stay zero-dependency for minimal JAR size
+    // Duplicated from HeartbeatConstants — see the note in AgentArgs: the agent shares no
+    // module with the rest of Jeffrey, so the constant travels by copy.
     private static final String HEARTBEAT_FILE_NAME = "heartbeat";
     private static final String HEARTBEAT_TMP_FILE_NAME = "heartbeat.tmp";
     private static final String FINISHED_FILE_NAME = "finished";

--- a/jeffrey-agent/src/main/java/cafe/jeffrey/agent/JeffreyAgent.java
+++ b/jeffrey-agent/src/main/java/cafe/jeffrey/agent/JeffreyAgent.java
@@ -18,6 +18,8 @@
 
 package cafe.jeffrey.agent;
 
+import cafe.jeffrey.agent.tracing.TracedWeaver;
+
 import java.lang.System.Logger.Level;
 import java.lang.instrument.Instrumentation;
 import java.nio.file.Files;
@@ -32,6 +34,7 @@ public class JeffreyAgent {
 
         startHeartbeat(agentArgs);
         startAppInformation(agentArgs);
+        startMethodTracing(agentArgs, inst);
     }
 
     // Heartbeat writes a liveness file; AppInformation emits a JFR event. They are
@@ -53,6 +56,14 @@ public class JeffreyAgent {
         producer.start();
 
         LOG.log(Level.INFO, "Heartbeat started: dir=" + heartbeatDir + " interval=" + agentArgs.heartbeatInterval());
+    }
+
+    // Weaves @Traced methods into spans. Off unless asked for, and the only feature that touches
+    // application bytecode, so it is kept apart from the two that merely observe.
+    private static void startMethodTracing(AgentArgs agentArgs, Instrumentation inst) {
+        if (TracedWeaver.install(agentArgs.tracingEnabled(), inst)) {
+            LOG.log(Level.INFO, "Method tracing started, @Traced methods will be recorded as spans");
+        }
     }
 
     private static void startAppInformation(AgentArgs agentArgs) {

--- a/jeffrey-agent/src/main/java/cafe/jeffrey/agent/tracing/TracedInterceptor.java
+++ b/jeffrey-agent/src/main/java/cafe/jeffrey/agent/tracing/TracedInterceptor.java
@@ -1,0 +1,69 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.agent.tracing;
+
+import net.bytebuddy.implementation.bind.annotation.AllArguments;
+import net.bytebuddy.implementation.bind.annotation.Origin;
+import net.bytebuddy.implementation.bind.annotation.RuntimeType;
+import net.bytebuddy.implementation.bind.annotation.SuperCall;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.reflect.Method;
+import java.util.concurrent.Callable;
+
+/**
+ * What a woven {@code @Traced} method calls instead of its own body.
+ * <p>
+ * This is the only agent class the instrumented code links against, which is why it must stay
+ * public and why it deliberately knows nothing about tracing: it hands the method's identity, its
+ * arguments and its original body to the library's runtime, and that runtime decides what a span
+ * is. When there is no runtime to hand them to, it calls the body and the method behaves as if the
+ * agent were not attached.
+ * <p>
+ * The call reaches here because the agent jar sits on the system class path, which every ordinary
+ * class loader delegates to as its parent — including Spring Boot's. A container that refuses to
+ * delegate would fail to link this class instead, which is a documented limitation rather than
+ * something the agent can work around.
+ */
+public final class TracedInterceptor {
+
+    private TracedInterceptor() {
+    }
+
+    /**
+     * @param method    the woven method, cached by ByteBuddy in the instrumented class
+     * @param arguments the values it was called with
+     * @param body      its original body, moved aside by the rebase
+     */
+    @RuntimeType
+    public static Object intercept(
+            @Origin Method method,
+            @AllArguments Object[] arguments,
+            @SuperCall Callable<Object> body) throws Throwable {
+
+        MethodHandle traced = TracedRuntimeBinding.forClass(method.getDeclaringClass());
+        if (traced == null) {
+            return body.call();
+        }
+
+        // invokeExact, not Method#invoke: a method handle propagates whatever the body threw as
+        // itself, so a caller catches the exception its method declared rather than a wrapper.
+        return (Object) traced.invokeExact(method, arguments, body);
+    }
+}

--- a/jeffrey-agent/src/main/java/cafe/jeffrey/agent/tracing/TracedRuntimeBinding.java
+++ b/jeffrey-agent/src/main/java/cafe/jeffrey/agent/tracing/TracedRuntimeBinding.java
@@ -1,0 +1,92 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.agent.tracing;
+
+import java.lang.System.Logger.Level;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
+import java.util.concurrent.Callable;
+
+/**
+ * Finds the tracing runtime that belongs to an instrumented class, or decides once and for all
+ * that there is none.
+ * <p>
+ * The agent cannot link against {@code jeffrey-events}: the agent jar is appended to the system
+ * class path, while the library usually lives in a child loader — a Spring Boot fat jar, a web
+ * application, a plugin container. Linking would also pin the agent to Java 25, which it is not.
+ * So the runtime is resolved through the <em>instrumented class's own</em> loader, which is the one
+ * loader guaranteed to see the library that class was compiled against.
+ * <p>
+ * Resolution can fail for perfectly ordinary reasons — the application does not ship
+ * {@code jeffrey-events}, or runs on Java 21 where the release-25 runtime cannot load. Every one of
+ * those ends the same way: remember that this class has no runtime, say so once, and let its
+ * methods run untouched forever after. An agent that broke an application because a dependency was
+ * missing would be a far worse bug than the missing spans.
+ */
+final class TracedRuntimeBinding {
+
+    private static final System.Logger LOG = System.getLogger(TracedRuntimeBinding.class.getName());
+
+    /** Resolved by name because the agent has no compile-time knowledge of the library. */
+    private static final String RUNTIME_CLASS = "cafe.jeffrey.jfr.events.trace.TracedRuntime";
+    private static final String RUNTIME_METHOD = "traced";
+
+    /** Stands in for "looked, found nothing" so a failed lookup is cached like any other answer. */
+    private static final Object UNAVAILABLE = new Object();
+
+    /**
+     * Keyed by the instrumented class, so an entry is collected with the class that owns it and no
+     * class loader is kept alive by this cache.
+     */
+    private static final ClassValue<Object> BINDINGS = new ClassValue<>() {
+        @Override
+        protected Object computeValue(Class<?> type) {
+            return resolve(type);
+        }
+    };
+
+    private TracedRuntimeBinding() {
+    }
+
+    /**
+     * @return the runtime's {@code traced} method for this class, or {@code null} when the class
+     * has none and its methods should simply run
+     */
+    static MethodHandle forClass(Class<?> instrumented) {
+        Object binding = BINDINGS.get(instrumented);
+        return binding == UNAVAILABLE ? null : (MethodHandle) binding;
+    }
+
+    private static Object resolve(Class<?> instrumented) {
+        try {
+            Class<?> runtime = Class.forName(RUNTIME_CLASS, true, instrumented.getClassLoader());
+            MethodType signature = MethodType.methodType(
+                    Object.class, Method.class, Object[].class, Callable.class);
+
+            return MethodHandles.publicLookup().findStatic(runtime, RUNTIME_METHOD, signature);
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | LinkageError e) {
+            // LinkageError covers the Java 21 case: the runtime is compiled for 25 and cannot load.
+            LOG.log(Level.WARNING, "Method tracing inactive for " + instrumented.getName()
+                    + ": jeffrey-events is missing, older than this agent, or needs Java 25 (" + e + ")");
+            return UNAVAILABLE;
+        }
+    }
+}

--- a/jeffrey-agent/src/main/java/cafe/jeffrey/agent/tracing/TracedWeaver.java
+++ b/jeffrey-agent/src/main/java/cafe/jeffrey/agent/tracing/TracedWeaver.java
@@ -21,6 +21,7 @@ package cafe.jeffrey.agent.tracing;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.agent.builder.ResettableClassFileTransformer;
 import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.implementation.MethodDelegation;
 import net.bytebuddy.utility.JavaModule;
 
@@ -138,7 +139,7 @@ public final class TracedWeaver {
         @Override
         public void onTransformation(
                 TypeDescription type, ClassLoader classLoader, JavaModule module,
-                boolean loaded, net.bytebuddy.dynamic.DynamicType dynamicType) {
+                boolean loaded, DynamicType dynamicType) {
 
             LOG.log(Level.DEBUG, "Instrumented traced methods: " + type.getName());
         }

--- a/jeffrey-agent/src/main/java/cafe/jeffrey/agent/tracing/TracedWeaver.java
+++ b/jeffrey-agent/src/main/java/cafe/jeffrey/agent/tracing/TracedWeaver.java
@@ -1,0 +1,146 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.agent.tracing;
+
+import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.agent.builder.ResettableClassFileTransformer;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.MethodDelegation;
+import net.bytebuddy.utility.JavaModule;
+
+import java.lang.System.Logger.Level;
+import java.lang.instrument.Instrumentation;
+
+import static net.bytebuddy.matcher.ElementMatchers.isAbstract;
+import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
+import static net.bytebuddy.matcher.ElementMatchers.isBridge;
+import static net.bytebuddy.matcher.ElementMatchers.isInterface;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isNative;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.declaresMethod;
+import static net.bytebuddy.matcher.ElementMatchers.not;
+
+/**
+ * Rewrites every {@code @Traced} method so it runs inside a span.
+ * <p>
+ * The annotation is matched <b>by name</b>, never by class: the agent must decide whether to weave
+ * a class without loading anything the application owns, and it has no compile-time knowledge of
+ * {@code jeffrey-events} at all. ByteBuddy reads the annotation out of the class file for exactly
+ * this reason.
+ * <p>
+ * The rewrite is a <em>rebase</em>: the original body moves to a synthetic method and the original
+ * signature is given a new body that hands that method to {@link TracedInterceptor} as a
+ * {@link java.util.concurrent.Callable}. It has to be that shape — a span is bound with a
+ * {@code ScopedValue}, whose binding is structured, so the body must run <em>inside</em> the call
+ * that opens the span rather than between a pair of enter and exit hooks.
+ * <p>
+ * Weaving happens as classes load, which is why the agent belongs on the command line rather than
+ * attached later: a class already loaded when the agent starts keeps its original bodies.
+ */
+public final class TracedWeaver {
+
+    private static final System.Logger LOG = System.getLogger(TracedWeaver.class.getName());
+
+    private static final String TRACED_ANNOTATION = "cafe.jeffrey.jfr.events.trace.Traced";
+
+    /** The release the tracing runtime is compiled for; below it, nothing could ever be recorded. */
+    private static final int REQUIRED_JAVA_VERSION = 25;
+
+    private TracedWeaver() {
+    }
+
+    /**
+     * Installs the weaver when it was asked for and could do anything.
+     *
+     * @return whether the weaver was installed
+     */
+    public static boolean install(boolean tracingEnabled, Instrumentation instrumentation) {
+        return installTransformer(tracingEnabled, instrumentation) != null;
+    }
+
+    /**
+     * @return the installed transformer, or {@code null} when the weaver did not install. Tests use
+     * it to leave the JVM as they found it; the agent itself has nothing to undo.
+     */
+    static ResettableClassFileTransformer installTransformer(
+            boolean tracingEnabled, Instrumentation instrumentation) {
+
+        if (!shouldInstall(tracingEnabled, Runtime.version().feature())) {
+            return null;
+        }
+
+        // ByteBuddy's own ignore set (its classes, JDK reflection internals, synthetic types) is
+        // deliberately left in place: overriding it removes those guards, and there is nothing to
+        // add — a class without an annotated method cannot match, the agent's own classes included.
+        return new AgentBuilder.Default()
+                .assureReadEdgeFromAndTo(instrumentation, TracedInterceptor.class)
+                .with(new WeavingListener())
+                .type(declaresMethod(isAnnotatedWith(named(TRACED_ANNOTATION))).and(not(isInterface())))
+                .transform((builder, type, classLoader, module, protectionDomain) -> builder
+                        .method(isMethod()
+                                .and(isAnnotatedWith(named(TRACED_ANNOTATION)))
+                                .and(not(isAbstract()))
+                                .and(not(isNative()))
+                                .and(not(isBridge())))
+                        .intercept(MethodDelegation.to(TracedInterceptor.class)))
+                .installOn(instrumentation);
+    }
+
+    /**
+     * Below Java 25 the tracing runtime cannot load, so installing a transformer consulted on every
+     * class load would buy an application nothing but the cost of consulting it.
+     */
+    static boolean shouldInstall(boolean tracingEnabled, int javaFeatureVersion) {
+        if (!tracingEnabled) {
+            LOG.log(Level.INFO, "Method tracing is disabled, no classes will be instrumented");
+            return false;
+        }
+        if (javaFeatureVersion < REQUIRED_JAVA_VERSION) {
+            LOG.log(Level.INFO, "Method tracing needs Java " + REQUIRED_JAVA_VERSION
+                    + " and this JVM is " + javaFeatureVersion + ", skipping instrumentation");
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * A class that cannot be woven must not be a class that cannot be loaded, so failures are
+     * reported and the original class file is used unchanged.
+     */
+    private static final class WeavingListener extends AgentBuilder.Listener.Adapter {
+
+        @Override
+        public void onError(
+                String typeName, ClassLoader classLoader, JavaModule module, boolean loaded, Throwable throwable) {
+
+            LOG.log(Level.WARNING, "Failed to instrument traced methods, class left unchanged: "
+                    + typeName + " (" + throwable + ")");
+        }
+
+        @Override
+        public void onTransformation(
+                TypeDescription type, ClassLoader classLoader, JavaModule module,
+                boolean loaded, net.bytebuddy.dynamic.DynamicType dynamicType) {
+
+            LOG.log(Level.DEBUG, "Instrumented traced methods: " + type.getName());
+        }
+    }
+}

--- a/jeffrey-agent/src/test/java/cafe/jeffrey/agent/AgentArgsTest.java
+++ b/jeffrey-agent/src/test/java/cafe/jeffrey/agent/AgentArgsTest.java
@@ -99,6 +99,37 @@ class AgentArgsTest {
     }
 
     @Nested
+    class MethodTracing {
+
+        @Test
+        void offUnlessAskedFor() {
+            AgentArgs args = AgentArgs.parse("heartbeat.dir=/tmp");
+
+            assertFalse(args.tracingEnabled(),
+                    "weaving application bytecode is not something to switch on behind an operator's back");
+        }
+
+        @Test
+        void offForAnEmptyArgumentString() {
+            assertFalse(AgentArgs.parse("").tracingEnabled());
+            assertFalse(AgentArgs.parse(null).tracingEnabled());
+        }
+
+        @Test
+        void enabledExplicitly() {
+            AgentArgs args = AgentArgs.parse("heartbeat.dir=/tmp,tracing.enabled=true");
+
+            assertTrue(args.tracingEnabled());
+            assertEquals(Path.of("/tmp"), args.heartbeatDir(), "the other features are unaffected");
+        }
+
+        @Test
+        void disabledExplicitly() {
+            assertFalse(AgentArgs.parse("tracing.enabled=false").tracingEnabled());
+        }
+    }
+
+    @Nested
     class HeartbeatEnabled {
 
         @Test

--- a/jeffrey-agent/src/test/java/cafe/jeffrey/agent/tracing/FilteringClassLoader.java
+++ b/jeffrey-agent/src/test/java/cafe/jeffrey/agent/tracing/FilteringClassLoader.java
@@ -1,0 +1,79 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.agent.tracing;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Set;
+
+/**
+ * Loads the fixtures itself while hiding chosen classes from them, which is how a test reproduces
+ * the application that has the agent but not {@code jeffrey-events}.
+ * <p>
+ * Defining the fixtures here rather than delegating is the point: a class's tracing runtime is
+ * resolved through the loader that defined it, so only a class defined by this loader is subject to
+ * what this loader refuses to find.
+ */
+final class FilteringClassLoader extends ClassLoader {
+
+    private static final String FIXTURES_PACKAGE = "cafe.jeffrey.agent.tracing.fixtures.";
+
+    private final Set<String> hidden;
+
+    FilteringClassLoader(ClassLoader parent, Set<String> hidden) {
+        super(parent);
+        this.hidden = Set.copyOf(hidden);
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        if (hidden.contains(name)) {
+            throw new ClassNotFoundException(name + " is hidden from " + this);
+        }
+        if (!name.startsWith(FIXTURES_PACKAGE)) {
+            return super.loadClass(name, resolve);
+        }
+
+        synchronized (getClassLoadingLock(name)) {
+            Class<?> alreadyLoaded = findLoadedClass(name);
+            if (alreadyLoaded != null) {
+                return alreadyLoaded;
+            }
+
+            Class<?> defined = define(name);
+            if (resolve) {
+                resolveClass(defined);
+            }
+            return defined;
+        }
+    }
+
+    private Class<?> define(String name) throws ClassNotFoundException {
+        String resource = name.replace('.', '/') + ".class";
+        try (InputStream bytecode = getParent().getResourceAsStream(resource)) {
+            if (bytecode == null) {
+                throw new ClassNotFoundException(name);
+            }
+            byte[] bytes = bytecode.readAllBytes();
+            return defineClass(name, bytes, 0, bytes.length);
+        } catch (IOException e) {
+            throw new ClassNotFoundException(name, e);
+        }
+    }
+}

--- a/jeffrey-agent/src/test/java/cafe/jeffrey/agent/tracing/TracedWeavingTest.java
+++ b/jeffrey-agent/src/test/java/cafe/jeffrey/agent/tracing/TracedWeavingTest.java
@@ -1,0 +1,199 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.agent.tracing;
+
+import cafe.jeffrey.jfr.events.trace.TracedRuntime;
+import net.bytebuddy.agent.ByteBuddyAgent;
+import net.bytebuddy.agent.builder.ResettableClassFileTransformer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.instrument.Instrumentation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Weaves real classes in this JVM and checks what came out.
+ * <p>
+ * The library's runtime is stubbed under its own name, because that name and the signature beside
+ * it <em>are</em> the agent's contract — nothing else about tracing crosses the boundary. What is
+ * being proven here is therefore everything the agent is answerable for: that the right methods are
+ * rewritten, that the method's own behaviour survives the rewrite, and that a missing runtime is
+ * survivable rather than fatal.
+ * <p>
+ * The fixtures are loaded reflectively, after the weaver is installed, because weaving happens as a
+ * class loads and a class named in this file's own code could be loaded too early.
+ */
+class TracedWeavingTest {
+
+    private static final String FIXTURE = "cafe.jeffrey.agent.tracing.fixtures.TracedFixture";
+    private static final String RUNTIME = "cafe.jeffrey.jfr.events.trace.TracedRuntime";
+
+    private static Instrumentation instrumentation;
+    private static ResettableClassFileTransformer installed;
+
+    @BeforeAll
+    static void weave() {
+        instrumentation = ByteBuddyAgent.install();
+        installed = TracedWeaver.installTransformer(true, instrumentation);
+        assertNotNull(installed, "the weaver must install on this JVM");
+    }
+
+    @AfterAll
+    static void unweave() {
+        // Leaves the JVM as it was found: classes loaded from here on are none of this test's
+        // business, and surefire may run other tests in it.
+        instrumentation.removeTransformer(installed);
+    }
+
+    @BeforeEach
+    void forgetPreviousCalls() {
+        TracedRuntime.reset();
+    }
+
+    @Nested
+    @DisplayName("A woven method")
+    class WovenMethods {
+
+        @Test
+        @DisplayName("reaches the runtime with its own identity and arguments, and still returns its result")
+        void handsOverTheCall() throws Exception {
+            Object fixture = newFixture(TracedWeavingTest.class.getClassLoader());
+
+            Object result = invoke(fixture, "returnsAValue", new Class<?>[]{String.class}, "ada");
+
+            assertEquals("body:ada", result, "the method's own body still decides the answer");
+            List<TracedRuntime.Invocation> invocations = TracedRuntime.invocations();
+            assertEquals(1, invocations.size());
+            assertEquals("returnsAValue", invocations.getFirst().method().getName());
+            assertEquals(List.of("ada"), List.of(invocations.getFirst().arguments()));
+        }
+
+        @Test
+        @DisplayName("keeps a primitive return type working through the boxed bridge")
+        void handlesPrimitives() throws Exception {
+            Object fixture = newFixture(TracedWeavingTest.class.getClassLoader());
+
+            assertEquals(42, invoke(fixture, "returnsAPrimitive", new Class<?>[]{int.class}, 21));
+            assertEquals(List.of(21), List.of(TracedRuntime.invocations().getFirst().arguments()));
+        }
+
+        @Test
+        @DisplayName("still performs its side effect when it returns nothing")
+        void handlesVoid() throws Exception {
+            Object fixture = newFixture(TracedWeavingTest.class.getClassLoader());
+            StringBuilder sink = new StringBuilder();
+
+            invoke(fixture, "returnsNothing", new Class<?>[]{StringBuilder.class}, sink);
+
+            assertEquals("ran", sink.toString());
+            assertEquals(1, TracedRuntime.invocations().size());
+        }
+
+        @Test
+        @DisplayName("throws the very exception it threw before weaving, not a wrapper")
+        void keepsExceptionsIntact() throws Exception {
+            Object fixture = newFixture(TracedWeavingTest.class.getClassLoader());
+            Method throwing = fixture.getClass().getMethod("throwsChecked");
+
+            InvocationTargetException reflective =
+                    assertThrows(InvocationTargetException.class, () -> throwing.invoke(fixture));
+
+            assertSame(fixture.getClass().getField("BOOM").get(null), reflective.getCause(),
+                    "a caller must catch the exception its method declared, with its own stack trace");
+            assertEquals(IOException.class, reflective.getCause().getClass());
+            assertEquals(1, TracedRuntime.invocations().size(), "a failed call is still a recorded call");
+        }
+
+        @Test
+        @DisplayName("is woven whether it is static or not")
+        void handlesStaticMethods() throws Exception {
+            Class<?> fixture = Class.forName(FIXTURE, true, TracedWeavingTest.class.getClassLoader());
+
+            assertEquals("static", fixture.getMethod("isStatic").invoke(null));
+            assertEquals(1, TracedRuntime.invocations().size());
+        }
+    }
+
+    @Nested
+    @DisplayName("Everything else")
+    class LeftAlone {
+
+        @Test
+        @DisplayName("an unannotated method beside a traced one is untouched")
+        void ignoresUnannotatedMethods() throws Exception {
+            Object fixture = newFixture(TracedWeavingTest.class.getClassLoader());
+
+            assertEquals("untouched", invoke(fixture, "isNotAnnotated", new Class<?>[0]));
+            assertTrue(TracedRuntime.invocations().isEmpty());
+        }
+
+        @Test
+        @DisplayName("a class whose runtime cannot be found runs exactly as if the agent were absent")
+        void survivesAMissingRuntime() throws Exception {
+            ClassLoader withoutRuntime = new FilteringClassLoader(
+                    TracedWeavingTest.class.getClassLoader(), Set.of(RUNTIME));
+
+            Object fixture = newFixture(withoutRuntime);
+
+            assertEquals("body:ada", invoke(fixture, "returnsAValue", new Class<?>[]{String.class}, "ada"),
+                    "a missing jeffrey-events must cost spans, never the application");
+            assertTrue(TracedRuntime.invocations().isEmpty(), "there was no runtime to reach");
+        }
+    }
+
+    @Nested
+    @DisplayName("Deciding whether to install at all")
+    class Installation {
+
+        @Test
+        @DisplayName("installs only when asked, on a JVM new enough to record anything")
+        void requiresBothConditions() {
+            assertTrue(TracedWeaver.shouldInstall(true, 25));
+            assertTrue(TracedWeaver.shouldInstall(true, 26));
+            assertFalse(TracedWeaver.shouldInstall(false, 25), "tracing is opt-in");
+            assertFalse(TracedWeaver.shouldInstall(true, 21),
+                    "below Java 25 the runtime cannot load, so the transformer would cost without ever paying");
+        }
+    }
+
+    private static Object newFixture(ClassLoader classLoader) throws Exception {
+        return Class.forName(FIXTURE, true, classLoader).getDeclaredConstructor().newInstance();
+    }
+
+    private static Object invoke(Object fixture, String name, Class<?>[] parameterTypes, Object... arguments)
+            throws Exception {
+
+        return fixture.getClass().getMethod(name, parameterTypes).invoke(fixture, arguments);
+    }
+}

--- a/jeffrey-agent/src/test/java/cafe/jeffrey/agent/tracing/fixtures/TracedFixture.java
+++ b/jeffrey-agent/src/test/java/cafe/jeffrey/agent/tracing/fixtures/TracedFixture.java
@@ -1,0 +1,62 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.agent.tracing.fixtures;
+
+import cafe.jeffrey.jfr.events.trace.Traced;
+
+import java.io.IOException;
+
+/**
+ * Loaded only after the weaver is installed, so its methods arrive woven. Every method here exists
+ * to prove that weaving left the method's own behaviour alone.
+ */
+public class TracedFixture {
+
+    /** Thrown by identity, so a test can prove the very same instance reaches the caller. */
+    public static final IOException BOOM = new IOException("boom");
+
+    @Traced
+    public String returnsAValue(String value) {
+        return "body:" + value;
+    }
+
+    @Traced
+    public int returnsAPrimitive(int value) {
+        return value * 2;
+    }
+
+    @Traced
+    public void returnsNothing(StringBuilder sink) {
+        sink.append("ran");
+    }
+
+    @Traced
+    public void throwsChecked() throws IOException {
+        throw BOOM;
+    }
+
+    @Traced
+    public static String isStatic() {
+        return "static";
+    }
+
+    public String isNotAnnotated() {
+        return "untouched";
+    }
+}

--- a/jeffrey-agent/src/test/java/cafe/jeffrey/jfr/events/trace/Traced.java
+++ b/jeffrey-agent/src/test/java/cafe/jeffrey/jfr/events/trace/Traced.java
@@ -1,0 +1,39 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.trace;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Stands in for the real annotation, which lives in {@code jeffrey-events} and cannot be depended
+ * on here: that library is compiled for Java 25 while the agent targets 21, and the agent resolves
+ * everything about tracing by name at runtime rather than by linking.
+ * <p>
+ * That is precisely what makes this stub the right test double. The agent's contract with the
+ * library is a fully-qualified name and a method signature, nothing more, so a stub carrying the
+ * same name and signature exercises the real contract. Its attributes are absent on purpose — the
+ * agent reads none of them; the library does.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Traced {
+}

--- a/jeffrey-agent/src/test/java/cafe/jeffrey/jfr/events/trace/TracedRuntime.java
+++ b/jeffrey-agent/src/test/java/cafe/jeffrey/jfr/events/trace/TracedRuntime.java
@@ -1,0 +1,63 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.trace;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+/**
+ * Stands in for the library's tracing runtime, with the exact signature the agent looks up. It
+ * records what it was handed and runs the body, so a test can assert that the woven method reached
+ * the bridge with the right method, the right arguments and a working body — the whole of what the
+ * agent is responsible for.
+ *
+ * @see Traced
+ */
+public final class TracedRuntime {
+
+    private static final List<Invocation> INVOCATIONS = new ArrayList<>();
+
+    /** What one call through the bridge looked like. */
+    public record Invocation(Method method, Object[] arguments) {
+    }
+
+    private TracedRuntime() {
+    }
+
+    public static Object traced(Method method, Object[] arguments, Callable<Object> body) throws Throwable {
+        synchronized (INVOCATIONS) {
+            INVOCATIONS.add(new Invocation(method, arguments));
+        }
+        return body.call();
+    }
+
+    public static List<Invocation> invocations() {
+        synchronized (INVOCATIONS) {
+            return List.copyOf(INVOCATIONS);
+        }
+    }
+
+    public static void reset() {
+        synchronized (INVOCATIONS) {
+            INVOCATIONS.clear();
+        }
+    }
+}

--- a/jeffrey-hub/core-hub/pom.xml
+++ b/jeffrey-hub/core-hub/pom.xml
@@ -64,10 +64,6 @@
 
         <!-- Third-party -->
         <dependency>
-            <groupId>net.bytebuddy</groupId>
-            <artifactId>byte-buddy</artifactId>
-        </dependency>
-        <dependency>
             <groupId>cafe.jeffrey-analyst</groupId>
             <artifactId>jeffrey-events</artifactId>
         </dependency>

--- a/jeffrey-microscope/core-microscope/pom.xml
+++ b/jeffrey-microscope/core-microscope/pom.xml
@@ -68,10 +68,6 @@
             <artifactId>config</artifactId>
         </dependency>
         <dependency>
-            <groupId>net.bytebuddy</groupId>
-            <artifactId>byte-buddy</artifactId>
-        </dependency>
-        <dependency>
             <groupId>cafe.jeffrey-analyst</groupId>
             <artifactId>jeffrey-events</artifactId>
         </dependency>

--- a/jeffrey-pages/src/views/docs/agent/AgentOverviewPage.vue
+++ b/jeffrey-pages/src/views/docs/agent/AgentOverviewPage.vue
@@ -28,6 +28,7 @@ const headings = [
   { id: 'overview', text: 'Overview', level: 2 },
   { id: 'how-it-works', text: 'How It Works', level: 2 },
   { id: 'configuration', text: 'Configuration', level: 2 },
+  { id: 'method-tracing', text: 'Method Tracing', level: 2 },
   { id: 'server-side-detection', text: 'Server-Side Detection', level: 2 }
 ];
 
@@ -45,7 +46,8 @@ onMounted(() => {
 
       <div class="docs-content">
         <h2 id="overview">Overview</h2>
-        <p><strong>Jeffrey Agent</strong> is a lightweight Java agent (~11 KB, zero external dependencies) that runs inside your Java application's JVM process. Its sole purpose is <strong>heartbeat monitoring</strong> — it periodically writes a timestamp to the filesystem so Jeffrey Hub can detect when a profiled application has stopped.</p>
+        <p><strong>Jeffrey Agent</strong> is a Java agent that runs inside your Java application's JVM process. It does two things: <strong>heartbeat monitoring</strong>, so Jeffrey Hub can detect when a profiled application has stopped, and <strong>method tracing</strong>, which records methods annotated with <code>@Traced</code> as spans without touching their code.</p>
+        <p>Heartbeating is what the agent does by default and costs a daemon thread writing a timestamp. Method tracing rewrites application bytecode as it loads, so it is off until <code>tracing.enabled=true</code> asks for it.</p>
 
         <DocsCallout type="info">
           Jeffrey Agent is automatically configured by <router-link to="/docs/provisioner/overview">Jeffrey Provisioner</router-link> when initializing a profiling session. You do not need to set up the agent manually.
@@ -63,7 +65,14 @@ onMounted(() => {
             <div class="agent-card-icon"><i class="bi bi-feather"></i></div>
             <div class="agent-card-content">
               <h4>Minimal Footprint</h4>
-              <p>Zero external dependencies, single daemon thread, ~11 KB JAR. Designed to add negligible overhead to the profiled application.</p>
+              <p>A single daemon thread, no external dependencies at runtime, and nothing touched in the application unless method tracing is switched on. The JAR is ~4.9 MB, almost all of it the bytecode engine that does the weaving, relocated so it can never clash with the application's own copy.</p>
+            </div>
+          </div>
+          <div class="agent-card">
+            <div class="agent-card-icon"><i class="bi bi-braces"></i></div>
+            <div class="agent-card-content">
+              <h4>Method Tracing</h4>
+              <p>Every method annotated <code>@Traced</code> becomes a span nested under whatever work called it. Opt-in, and it needs Java 25 plus <code>jeffrey-events</code> on the application's class path; without either, the annotated methods simply run.</p>
             </div>
           </div>
           <div class="agent-card">
@@ -134,9 +143,29 @@ onMounted(() => {
                 <td><code>true</code></td>
                 <td>Set to <code>false</code> to disable heartbeating</td>
               </tr>
+              <tr>
+                <td><code>tracing.enabled</code></td>
+                <td><code>false</code></td>
+                <td>Set to <code>true</code> to record <code>@Traced</code> methods as spans</td>
+              </tr>
             </tbody>
           </table>
         </div>
+
+        <h2 id="method-tracing">Method Tracing</h2>
+        <p>Annotate a method and it becomes a span. The method itself is not written around its own tracing — that is the difference from calling <code>Tracer.run</code> by hand, which the <code>jeffrey-events</code> library also offers.</p>
+        <pre class="agent-code"><code>@Traced(name = "order.checkout", args = {"tier=gold"}, includeMethodArgs = {"orderId"})
+public Receipt checkout(String orderId, Card card) { ... }</code></pre>
+        <pre class="agent-code"><code>java -javaagent:/path/to/jeffrey-agent.jar=tracing.enabled=true -jar app.jar</code></pre>
+        <p>The span nests under whatever span is in progress on the thread — an inbound HTTP request, a job, another traced method — and records as its own root when there is none. A method that throws marks its span as failed with the exception's type, and the exception reaches the caller untouched.</p>
+        <p>Arguments are recorded only when asked for. <code>includeMethodArgs</code> names the ones to keep, which is a list of what may be recorded rather than of what may not; <code>captureMethodArgs = true</code> takes all of them. Values are truncated, and the parameter names come from javac's <code>-parameters</code> flag — without it they are <code>arg0</code>, <code>arg1</code>, and so on.</p>
+
+        <DocsCallout type="info">
+          Method tracing needs Java 25 and <code>cafe.jeffrey-analyst:jeffrey-events</code> on the application's class path, because that is where <code>@Traced</code> and the span machinery live. Missing either, the agent says so once in the log and the annotated methods run exactly as if it were not attached — the application is never at risk from a missing dependency.
+        </DocsCallout>
+        <DocsCallout type="warning">
+          Classes are woven as they load, so the agent has to be on the command line at startup. A class already loaded when the agent attaches keeps its original methods.
+        </DocsCallout>
 
         <h2 id="server-side-detection">Server-Side Detection</h2>
         <p>Jeffrey Hub runs a periodic job that polls heartbeat files for all active sessions. When a heartbeat becomes stale (older than a configured threshold, typically ~5 minutes), the server marks the session as finished and uses the last heartbeat timestamp as the session end time. If no heartbeat file exists and the session is old enough, a fallback finish time is used instead.</p>

--- a/jeffrey-pages/src/views/docs/events/TracerApiPage.vue
+++ b/jeffrey-pages/src/views/docs/events/TracerApiPage.vue
@@ -40,6 +40,7 @@ const headings = [
   { id: 'api-fork', text: 'fork', level: 3 },
   { id: 'semantics', text: 'Semantics at a Glance', level: 2 },
   { id: 'choosing', text: 'Choosing the Right Method', level: 2 },
+  { id: 'annotation', text: 'Without the Lambda: @Traced', level: 2 },
   { id: 'composed-tree', text: 'A Complete Tree', level: 2 },
   { id: 'usages', text: 'Where Jeffrey Uses It', level: 2 }
 ];
@@ -527,6 +528,57 @@ const composedTree = `trace a3f9c1d4…                                         
           </tr>
         </tbody>
       </table>
+
+      <h2 id="annotation">Without the Lambda: <code>@Traced</code></h2>
+
+      <p>Every method on this page wraps work in a lambda, which is precise and visible in the code. <code>@Traced</code> declares the same span instead, and the Jeffrey Agent weaves it in — the method is left as it was written.</p>
+
+      <pre><code class="language-java">@Traced(name = "order.checkout", kind = SpanKind.CLIENT,
+        args = {"tier=gold"}, includeMethodArgs = {"orderId"})
+public Receipt checkout(String orderId, Card card) { ... }</code></pre>
+
+      <pre><code class="language-bash">java -javaagent:jeffrey-agent.jar=tracing.enabled=true -jar app.jar</code></pre>
+
+      <p>It emits the same <code>jeffrey.TraceSpan</code> event as <code>Tracer.call</code>, nests under whatever span is in progress on the thread, records as its own root when there is none, and marks the span failed with the exception's type when the method throws — the exception itself reaches the caller untouched.</p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Attribute</th>
+            <th>Default</th>
+            <th>Meaning</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>name</code></td>
+            <td>derived</td>
+            <td>The span name. Empty derives <code>SimpleClassName.methodName</code>, which is low-cardinality by construction</td>
+          </tr>
+          <tr>
+            <td><code>kind</code></td>
+            <td><code>INTERNAL</code></td>
+            <td>What kind of work this is, exactly as the <code>SpanKind</code> passed to <code>Tracer.run</code></td>
+          </tr>
+          <tr>
+            <td><code>args</code></td>
+            <td>none</td>
+            <td>Fixed <code>"key=value"</code> attributes recorded on every call</td>
+          </tr>
+          <tr>
+            <td><code>includeMethodArgs</code></td>
+            <td>none</td>
+            <td>Which parameters to record, by name. Naming one is itself the request to capture it</td>
+          </tr>
+          <tr>
+            <td><code>captureMethodArgs</code></td>
+            <td><code>false</code></td>
+            <td>Records every argument. Prefer <code>includeMethodArgs</code>, which is a list of what may be recorded rather than of what may not</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>Captured values are truncated, and parameter names come from javac's <code>-parameters</code> flag — without it they are <code>arg0</code>, <code>arg1</code>, and so on. The annotation needs Java 25 and the agent attached at startup; without either it is inert and the method runs exactly as written. See the <router-link to="/docs/agent/overview">Jeffrey Agent</router-link> for the rest.</p>
 
       <h2 id="composed-tree">A Complete Tree</h2>
 

--- a/jeffrey-pages/src/views/docs/provisioner/ProvisionerConfigurationPage.vue
+++ b/jeffrey-pages/src/views/docs/provisioner/ProvisionerConfigurationPage.vue
@@ -72,6 +72,7 @@ attributes { cluster = "blue", namespace = "production" }
 
 debug-non-safepoints { enabled = true }
 perf-counters { enabled = true }
+method-tracing { enabled = true }
 heap-dump { enabled = true, type = "crash" }
 jvm-logging {
   enabled = true
@@ -260,6 +261,12 @@ additional-jvm-options = "-Xmx2g -Xms2g -Djeffrey.logging.trace-file.path=<<JEFF
               <td>Save JVM performance counters into the session directory</td>
             </tr>
             <tr>
+              <td><code>method-tracing.enabled</code></td>
+              <td>No</td>
+              <td><code>JEFFREY_METHOD_TRACING</code></td>
+              <td>Record methods annotated <code>@Traced</code> as spans. Needs Java 25 and <code>jeffrey-events</code> on the application's class path</td>
+            </tr>
+            <tr>
               <td><code>heap-dump</code></td>
               <td>No</td>
               <td><code>JEFFREY_HEAP_DUMP</code></td>
@@ -293,6 +300,12 @@ additional-jvm-options = "-Xmx2g -Xms2g -Djeffrey.logging.trace-file.path=<<JEFF
             <h4>Perf Counters</h4>
             <p>Captures JVM performance data via <code>-XX:+UsePerfData</code>. Provides low-level metrics about JVM internals.</p>
             <code>perf-counters { enabled = true }</code>
+          </div>
+          <div class="feature-card trace">
+            <div class="feature-icon"><i class="bi bi-braces"></i></div>
+            <h4>Method Tracing</h4>
+            <p>Tells the Jeffrey Agent to weave methods annotated <code>@Traced</code> into spans. Off by default, since it rewrites application bytecode as it loads.</p>
+            <code>method-tracing { enabled = true }</code>
           </div>
           <div class="feature-card heap">
             <div class="feature-icon"><i class="bi bi-memory"></i></div>

--- a/jeffrey-provisioner/src/main/java/cafe/jeffrey/provisioner/FeatureBuilder.java
+++ b/jeffrey-provisioner/src/main/java/cafe/jeffrey/provisioner/FeatureBuilder.java
@@ -41,6 +41,9 @@ public class FeatureBuilder {
     /* Agent JVM option prefix (passes heartbeat directory as the first agent argument) */
     private static final String AGENT_OPTION_PREFIX = "-javaagent:%s=" + HeartbeatConstants.PARAM_DIR + "=%s";
 
+    /* Turns on @Traced method tracing in the agent; off unless the session asks for it */
+    private static final String AGENT_ARG_METHOD_TRACING = "tracing.enabled=true";
+
     private static final String AGENT_ARG_SEPARATOR = ",";
     private static final String AGENT_ARG_ASSIGN = "=";
 
@@ -49,6 +52,7 @@ public class FeatureBuilder {
 
     private boolean debugNonSafepointsEnabled;
     private boolean perfCountersEnabled;
+    private boolean methodTracingEnabled;
     private HeapDumpType heapDumpType;
     private String jvmLogging;
     private String agentPath;
@@ -62,6 +66,15 @@ public class FeatureBuilder {
 
     public FeatureBuilder setPerfCountersEnabled(boolean enabled) {
         this.perfCountersEnabled = enabled;
+        return this;
+    }
+
+    /**
+     * Records methods annotated {@code @Traced} as spans. It weaves application bytecode as it
+     * loads, so it stays off unless the session asks for it.
+     */
+    public FeatureBuilder setMethodTracingEnabled(boolean enabled) {
+        this.methodTracingEnabled = enabled;
         return this;
     }
 
@@ -126,6 +139,9 @@ public class FeatureBuilder {
         if (agentPath != null && !agentPath.isBlank()) {
             String heartbeatDirPath = currentSessionPath.resolve(HeartbeatConstants.HEARTBEAT_DIR).toString();
             StringBuilder agentOption = new StringBuilder(String.format(AGENT_OPTION_PREFIX, agentPath, heartbeatDirPath));
+            if (methodTracingEnabled) {
+                agentOption.append(AGENT_ARG_SEPARATOR).append(AGENT_ARG_METHOD_TRACING);
+            }
             appendAppIdentity(agentOption);
             options.append(agentOption);
             options.append(" ");

--- a/jeffrey-provisioner/src/main/java/cafe/jeffrey/provisioner/InitConfig.java
+++ b/jeffrey-provisioner/src/main/java/cafe/jeffrey/provisioner/InitConfig.java
@@ -66,6 +66,7 @@ public class InitConfig {
     private static final String ENV_ATTRIBUTES = "JEFFREY_ATTRIBUTES";
     private static final String ENV_HEAP_DUMP = "JEFFREY_HEAP_DUMP";
     private static final String ENV_PERF_COUNTERS = "JEFFREY_PERF_COUNTERS";
+    private static final String ENV_METHOD_TRACING = "JEFFREY_METHOD_TRACING";
     private static final String ENV_JVM_LOGGING = "JEFFREY_JVM_LOGGING";
     private static final String ENV_ADDITIONAL_JVM_OPTIONS = "JEFFREY_ADDITIONAL_JVM_OPTIONS";
 
@@ -117,6 +118,7 @@ public class InitConfig {
             }
             attributes = {}
             perf-counters { enabled = false }
+            method-tracing { enabled = false }
             heap-dump { enabled = false, type = "exit" }
             jvm-logging { enabled = false, command = "" }
             agent-path = ""
@@ -237,6 +239,11 @@ public class InitConfig {
         PerfCountersConfig perfCounters = new PerfCountersConfig();
         perfCounters.setEnabled(resolveBoolWithEnv(perfCfg.getBoolean("enabled"), ENV_PERF_COUNTERS, envLookup));
         config.setPerfCounters(perfCounters);
+
+        Config tracingCfg = resolved.getConfig("method-tracing");
+        MethodTracingConfig methodTracing = new MethodTracingConfig();
+        methodTracing.setEnabled(resolveBoolWithEnv(tracingCfg.getBoolean("enabled"), ENV_METHOD_TRACING, envLookup));
+        config.setMethodTracing(methodTracing);
 
         Config heapCfg = resolved.getConfig("heap-dump");
         HeapDumpConfig heapDump = new HeapDumpConfig();
@@ -392,6 +399,7 @@ public class InitConfig {
     private String agentPath;
     private ProjectConfig project;
     private PerfCountersConfig perfCounters;
+    private MethodTracingConfig methodTracing;
     private HeapDumpConfig heapDump;
     private JvmLoggingConfig jvmLogging;
     private JdkJavaOptionsConfig jdkJavaOptions;
@@ -599,6 +607,19 @@ public class InitConfig {
         this.attributes = attributes;
     }
 
+    /** Whether the agent records {@code @Traced} methods as spans. */
+    public static class MethodTracingConfig {
+        private boolean enabled;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+    }
+
     public static class PerfCountersConfig {
         private boolean enabled;
 
@@ -696,6 +717,18 @@ public class InitConfig {
 
     public boolean isPerfCountersEnabled() {
         return perfCounters != null && perfCounters.isEnabled();
+    }
+
+    public MethodTracingConfig getMethodTracing() {
+        return methodTracing;
+    }
+
+    public void setMethodTracing(MethodTracingConfig methodTracing) {
+        this.methodTracing = methodTracing;
+    }
+
+    public boolean isMethodTracingEnabled() {
+        return methodTracing != null && methodTracing.isEnabled();
     }
 
     public boolean isDebugNonSafepointsEnabled() {

--- a/jeffrey-provisioner/src/main/java/cafe/jeffrey/provisioner/InitExecutor.java
+++ b/jeffrey-provisioner/src/main/java/cafe/jeffrey/provisioner/InitExecutor.java
@@ -149,6 +149,7 @@ public class InitExecutor {
                 .setDebugNonSafepointsEnabled(config.isDebugNonSafepointsEnabled())
                 .setHeapDumpEnabled(config.resolveHeapDumpType())
                 .setPerfCountersEnabled(config.isPerfCountersEnabled())
+                .setMethodTracingEnabled(config.isMethodTracingEnabled())
                 .setJvmLogging(config.getJvmLoggingCommand())
                 .setAgentPath(config.getAgentPath())
                 .setAdditionalJvmOptions(config.getAdditionalJvmOptions())

--- a/jeffrey-provisioner/src/test/java/cafe/jeffrey/provisioner/FeatureBuilderTest.java
+++ b/jeffrey-provisioner/src/test/java/cafe/jeffrey/provisioner/FeatureBuilderTest.java
@@ -187,6 +187,36 @@ class FeatureBuilderTest {
         }
 
         @Test
+        void methodTracingIsAskedForAsAnAgentArgument() {
+            String result = new FeatureBuilder()
+                    .setAgentPath("/path/to/jeffrey-agent.jar")
+                    .setMethodTracingEnabled(true)
+                    .build(SESSION_PATH, PLACEHOLDERS);
+
+            assertTrue(result.contains(",tracing.enabled=true"),
+                    "@Traced is unreachable on a provisioned session unless the agent is told to weave");
+        }
+
+        @Test
+        void methodTracingIsOffUnlessAskedFor() {
+            String result = new FeatureBuilder()
+                    .setAgentPath("/path/to/jeffrey-agent.jar")
+                    .build(SESSION_PATH, PLACEHOLDERS);
+
+            assertTrue(result.contains("-javaagent:"), "the agent still runs, it just does not weave");
+            assertFalse(result.contains("tracing.enabled"));
+        }
+
+        @Test
+        void methodTracingNeedsTheAgentToBeThere() {
+            String result = new FeatureBuilder()
+                    .setMethodTracingEnabled(true)
+                    .build(SESSION_PATH, PLACEHOLDERS);
+
+            assertFalse(result.contains("tracing.enabled"), "there is no agent to carry the argument");
+        }
+
+        @Test
         void noAgentPathProducesNoOptions() {
             String result = new FeatureBuilder()
                     .build(SESSION_PATH, PLACEHOLDERS);

--- a/utilities/jeffrey-events/README.md
+++ b/utilities/jeffrey-events/README.md
@@ -63,6 +63,22 @@ Use `jeffrey-events-mybatis` **or** the `DataSource` wrapper, not both — the M
 statements by mapper method rather than by parsing their SQL, and two of them record every statement
 twice.
 
+## Or annotate the method and write nothing
+
+```java
+@Traced(name = "order.checkout", args = {"tier=gold"}, includeMethodArgs = {"orderId"})
+public Receipt checkout(String orderId, Card card) { ... }
+```
+
+```bash
+java -javaagent:jeffrey-agent.jar=tracing.enabled=true -jar app.jar
+```
+
+The [Jeffrey agent](https://www.jeffrey-analyst.cafe) weaves the same span the explicit form builds,
+so the method is not written around its own tracing. It nests under whatever span is in progress,
+fails with the exception's type, and records only the arguments you name. Needs Java 25; without the
+agent the annotation is inert and the method runs as written.
+
 ## Sixty seconds of tracing
 
 An inbound request becomes the root of a trace, hand-written spans describe the application logic
@@ -140,7 +156,7 @@ dashboards.
 | `jeffrey.GrpcClientExchange` | `grpc.GrpcClientExchangeEvent` | leaf: outbound gRPC call |
 | `jeffrey.JdbcQuery` / `JdbcInsert` / `JdbcUpdate` / `JdbcDelete` / `JdbcExecute` | `jdbc.statement.*` | leaf: one statement per event, split by verb |
 | `jeffrey.JdbcStream` | `jdbc.statement.JdbcStreamEvent` | leaf: query consumed as a stream (deferred commit) |
-| `jeffrey.TraceSpan` | `trace.TraceSpanEvent` | interior span, emitted by `Tracer.run`/`call`/`continueIn` |
+| `jeffrey.TraceSpan` | `trace.TraceSpanEvent` | interior span, emitted by `Tracer.run`/`call`/`continueIn` and by `@Traced` |
 | `jeffrey.TraceScope` | `trace.TraceScopeEvent` | where a re-entered span ran; emitted by `Tracer.reenter` only |
 | `jeffrey.JdbcPoolStatistics` + `PooledJdbcConnection*` | `jdbc.pool.*` | not spans: pool gauges and durations |
 | `jeffrey.Message` / `jeffrey.Alert` | `message.*` | not spans: operational notes and alerts |

--- a/utilities/jeffrey-events/events/src/main/java/cafe/jeffrey/jfr/events/trace/AbstractTracedEvent.java
+++ b/utilities/jeffrey-events/events/src/main/java/cafe/jeffrey/jfr/events/trace/AbstractTracedEvent.java
@@ -168,7 +168,9 @@ public abstract class AbstractTracedEvent extends Event {
 
     /**
      * @deprecated {@link #commitSpan()} now stamps an unstamped event exactly as this method did,
-     * so the two commit paths collapsed into one; this alias only delegates.
+     * so the two commit paths collapsed into one; this alias only delegates. It stays through the
+     * 0.x line — removing published API in a minor release would break call sites for no gain —
+     * and goes at the next major.
      */
     @Deprecated(since = "0.14.0", forRemoval = true)
     public final void stampAndCommit() {

--- a/utilities/jeffrey-events/events/src/main/java/cafe/jeffrey/jfr/events/trace/AttributeValues.java
+++ b/utilities/jeffrey-events/events/src/main/java/cafe/jeffrey/jfr/events/trace/AttributeValues.java
@@ -1,0 +1,86 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.trace;
+
+import java.util.Set;
+
+/**
+ * Writes an arbitrary runtime value onto a span as an attribute, the same way wherever it comes
+ * from.
+ * <p>
+ * Two emitters record values a developer handed the application rather than values the library
+ * chose: {@code @Traced} captures method arguments, and the MyBatis interceptor captures statement
+ * parameters. They write into the same field of the same recording and are read side by side in the
+ * same dashboards, so the rules for turning an object into JSON belong in one place — a number
+ * should not be a number in one and a quoted string in the other because two files drifted apart.
+ * <p>
+ * What is <em>not</em> here is anything domain-specific: only the caller knows that a JDBC
+ * parameter may be a {@code Blob} that must never be read, or what a sensible length limit is for
+ * its own kind of value. Those decisions stay with the caller, which passes the result here.
+ */
+public final class AttributeValues {
+
+    /** Recorded when a value's own {@code toString()} throws — instrumentation never does. */
+    public static final String UNRENDERABLE_VALUE = "<unavailable>";
+
+    private static final String TRUNCATION_MARKER = "…";
+
+    /** Written as JSON numbers; every other Number is rendered as text rather than losing digits. */
+    private static final Set<Class<?>> INTEGRAL_TYPES = Set.of(Byte.class, Short.class, Integer.class, Long.class);
+    private static final Set<Class<?>> DECIMAL_TYPES = Set.of(Float.class, Double.class);
+
+    private AttributeValues() {
+    }
+
+    /**
+     * Records {@code value} under {@code key}, as JSON {@code null}, a number, a boolean, or text.
+     *
+     * @param maxValueLength longest text recorded before it is truncated and marked
+     */
+    public static void put(SpanAttributes attributes, String key, Object value, int maxValueLength) {
+        switch (value) {
+            case null -> attributes.put(key, (String) null);
+            case Boolean flag -> attributes.put(key, (boolean) flag);
+            case Number number when INTEGRAL_TYPES.contains(number.getClass()) ->
+                    attributes.put(key, number.longValue());
+            case Number number when DECIMAL_TYPES.contains(number.getClass()) ->
+                    attributes.put(key, number.doubleValue());
+            default -> attributes.put(key, text(value, maxValueLength));
+        }
+    }
+
+    /**
+     * The value as text, truncated to {@code maxValueLength} and marked when it was cut.
+     */
+    public static String text(Object value, int maxValueLength) {
+        String rendered;
+        try {
+            rendered = String.valueOf(value);
+        } catch (Throwable failure) {
+            // The value's own toString() threw. That is its problem, not the caller's.
+            return UNRENDERABLE_VALUE;
+        }
+
+        if (rendered.length() <= maxValueLength) {
+            return rendered;
+        }
+
+        return rendered.substring(0, maxValueLength) + TRUNCATION_MARKER;
+    }
+}

--- a/utilities/jeffrey-events/events/src/main/java/cafe/jeffrey/jfr/events/trace/Traced.java
+++ b/utilities/jeffrey-events/events/src/main/java/cafe/jeffrey/jfr/events/trace/Traced.java
@@ -1,0 +1,108 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.trace;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Records a method as a span, without the method saying so in its body.
+ * <p>
+ * {@link Tracer#run} and {@link Tracer#call} wrap work in a lambda, which is precise but visible:
+ * the method has to be written around the tracing. This is the declarative half — the Jeffrey
+ * agent weaves the same span around every annotated method, and the method itself is untouched:
+ *
+ * <pre>{@code
+ * @Traced(name = "order.checkout", args = {"tier=gold"}, includeMethodArgs = {"orderId"})
+ * public Receipt checkout(String orderId, Card card) { ... }
+ * }</pre>
+ * <p>
+ * The span behaves exactly like a {@code Tracer.call} one: it nests under whatever span is in
+ * progress on the thread, records as its own root when there is none, and a throw sets the status
+ * to {@code ERROR} with the exception's type.
+ *
+ * <h2>What it takes to work</h2>
+ * The annotation alone records nothing — it is read by the Jeffrey agent, which must be attached
+ * with method tracing switched on:
+ *
+ * <pre>{@code
+ * java -javaagent:jeffrey-agent.jar=tracing.enabled=true -jar app.jar
+ * }</pre>
+ * <p>
+ * The agent weaves classes as they load, so it has to be attached at startup, and it needs Java 25
+ * (the tracing runtime is built on {@code ScopedValue}). Without the agent the annotation is inert
+ * documentation and the method runs exactly as written — nothing fails, nothing is recorded.
+ * <p>
+ * Not to be confused with {@link Span}, which declares the <em>naming convention of an event type</em>
+ * inside the recording's metadata. This one marks a method to record.
+ *
+ * @see Tracer for the explicit form, and for connecting spans across threads
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Traced {
+
+    /**
+     * The span name, which must stay low-cardinality — it is what Jeffrey aggregates on, so it may
+     * never contain an id, a user name or anything else that varies per call.
+     * <p>
+     * Left empty, the name is derived as {@code SimpleClassName.methodName}
+     * ({@code OrderService.checkout}), which is stable by construction.
+     */
+    String name() default "";
+
+    /**
+     * What kind of work this is: {@code INTERNAL} for application logic, {@code CLIENT} for a call
+     * out to something else, {@code SERVER} for handling an inbound request.
+     */
+    SpanKind kind() default SpanKind.INTERNAL;
+
+    /**
+     * Fixed attributes recorded on every call, as {@code "key=value"} entries — the split is on the
+     * first {@code =}, and an entry without one is ignored. Use them for facts about the method
+     * that a reader of the recording would otherwise have to look up in the source.
+     */
+    String[] args() default {};
+
+    /**
+     * Records every argument the method was called with, keyed by parameter name.
+     * <p>
+     * Off by default, and worth leaving off unless the arguments are small and safe: the values are
+     * recorded verbatim through {@code String.valueOf}, and a recording is a file that gets
+     * uploaded, shared and kept. Prefer {@link #includeMethodArgs()}, which records only what you
+     * name.
+     */
+    boolean captureMethodArgs() default false;
+
+    /**
+     * Records only the named parameters — the safe way to capture arguments, because it is a list
+     * of what may be recorded rather than of what may not.
+     * <p>
+     * Naming even one parameter here turns capture on by itself, so {@link #captureMethodArgs()}
+     * does not also have to be set; left empty, {@code captureMethodArgs} decides whether all
+     * arguments are recorded or none are. A name matching no parameter is ignored: the usual cause
+     * is a class compiled without javac's {@code -parameters}, where the real names are
+     * {@code arg0}, {@code arg1} and so on.
+     */
+    String[] includeMethodArgs() default {};
+}

--- a/utilities/jeffrey-events/events/src/main/java/cafe/jeffrey/jfr/events/trace/TracedRuntime.java
+++ b/utilities/jeffrey-events/events/src/main/java/cafe/jeffrey/jfr/events/trace/TracedRuntime.java
@@ -23,7 +23,6 @@ import java.lang.reflect.Parameter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -49,19 +48,10 @@ public final class TracedRuntime {
      */
     private static final int MAX_CAPTURED_VALUE_LENGTH = 256;
 
-    private static final String TRUNCATION_MARKER = "…";
-
-    /** Recorded when an argument's own {@code toString()} throws — instrumentation never does. */
-    private static final String UNRENDERABLE_VALUE = "<unavailable>";
-
     private static final char KEY_VALUE_SEPARATOR = '=';
     private static final char PACKAGE_SEPARATOR = '.';
     private static final char NESTED_CLASS_SEPARATOR = '$';
     private static final String NAME_SEPARATOR = ".";
-
-    /** Written as JSON numbers; every other Number is rendered as text rather than losing digits. */
-    private static final Set<Class<?>> INTEGRAL_TYPES = Set.of(Byte.class, Short.class, Integer.class, Long.class);
-    private static final Set<Class<?>> DECIMAL_TYPES = Set.of(Float.class, Double.class);
 
     /**
      * Keyed by declaring class so an entry dies with the class that owns it, which matters in a
@@ -216,34 +206,6 @@ public final class TracedRuntime {
         return rendered.json();
     }
 
-    private static void put(SpanAttributes attributes, String key, Object value) {
-        switch (value) {
-            case null -> attributes.put(key, (String) null);
-            case Boolean flag -> attributes.put(key, (boolean) flag);
-            case Number number when INTEGRAL_TYPES.contains(number.getClass()) ->
-                    attributes.put(key, number.longValue());
-            case Number number when DECIMAL_TYPES.contains(number.getClass()) ->
-                    attributes.put(key, number.doubleValue());
-            default -> attributes.put(key, text(value));
-        }
-    }
-
-    private static String text(Object value) {
-        String rendered;
-        try {
-            rendered = String.valueOf(value);
-        } catch (Throwable failure) {
-            // The argument's own toString() threw. That is its problem, not the method's.
-            return UNRENDERABLE_VALUE;
-        }
-
-        if (rendered.length() <= MAX_CAPTURED_VALUE_LENGTH) {
-            return rendered;
-        }
-
-        return rendered.substring(0, MAX_CAPTURED_VALUE_LENGTH) + TRUNCATION_MARKER;
-    }
-
     /** Everything about a traced method that does not change between calls. */
     private record TracedMetadata(
             String name,
@@ -265,7 +227,7 @@ public final class TracedRuntime {
                 // Defensive on length: a woven call always passes every argument, but this class is
                 // callable by anyone.
                 Object value = parameter.index() < arguments.length ? arguments[parameter.index()] : null;
-                put(rendered, parameter.name(), value);
+                AttributeValues.put(rendered, parameter.name(), value, MAX_CAPTURED_VALUE_LENGTH);
             }
 
             return rendered.json();

--- a/utilities/jeffrey-events/events/src/main/java/cafe/jeffrey/jfr/events/trace/TracedRuntime.java
+++ b/utilities/jeffrey-events/events/src/main/java/cafe/jeffrey/jfr/events/trace/TracedRuntime.java
@@ -1,0 +1,280 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.trace;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Runs a {@link Traced} method as a span. The Jeffrey agent calls this; applications do not.
+ * <p>
+ * <b>This class is the contract between the agent and the library, and its one public method is
+ * frozen.</b> The agent is compiled against neither this class nor {@link Traced} — it cannot be,
+ * since it loads from the system class path while this loads from the application's, and it
+ * targets an older Java release. It looks this method up reflectively, by name and signature, so
+ * changing either silently disables tracing for every application running an older agent. Add
+ * behaviour by reading more of the annotation here, never by changing the signature.
+ * <p>
+ * Everything a span means lives on this side of that boundary — naming, attributes, the failure
+ * verdict — so it is versioned with the library and an application picks up improvements by
+ * upgrading the dependency, not the agent.
+ */
+public final class TracedRuntime {
+
+    /**
+     * Longer values are truncated: an argument is a fact about a call, not a payload, and one
+     * oversized {@code toString()} must not bloat an entire recording.
+     */
+    private static final int MAX_CAPTURED_VALUE_LENGTH = 256;
+
+    private static final String TRUNCATION_MARKER = "…";
+
+    /** Recorded when an argument's own {@code toString()} throws — instrumentation never does. */
+    private static final String UNRENDERABLE_VALUE = "<unavailable>";
+
+    private static final char KEY_VALUE_SEPARATOR = '=';
+    private static final char PACKAGE_SEPARATOR = '.';
+    private static final char NESTED_CLASS_SEPARATOR = '$';
+    private static final String NAME_SEPARATOR = ".";
+
+    /** Written as JSON numbers; every other Number is rendered as text rather than losing digits. */
+    private static final Set<Class<?>> INTEGRAL_TYPES = Set.of(Byte.class, Short.class, Integer.class, Long.class);
+    private static final Set<Class<?>> DECIMAL_TYPES = Set.of(Float.class, Double.class);
+
+    /**
+     * Keyed by declaring class so an entry dies with the class that owns it, which matters in a
+     * container that loads and discards applications.
+     */
+    private static final ClassValue<Map<Method, TracedMetadata>> METADATA = new ClassValue<>() {
+        @Override
+        protected Map<Method, TracedMetadata> computeValue(Class<?> type) {
+            return new ConcurrentHashMap<>();
+        }
+    };
+
+    private TracedRuntime() {
+    }
+
+    /**
+     * Runs {@code body} as the span described by the method's {@link Traced} annotation, and
+     * returns whatever it returned.
+     * <p>
+     * Anything the body throws propagates unchanged — the same instance, checked or not — after
+     * being recorded as the span's failure.
+     *
+     * @param method    the annotated method being called
+     * @param arguments the values it was called with, in declaration order
+     * @param body      the method's own work
+     * @return the body's result, {@code null} for a void method
+     */
+    public static Object traced(Method method, Object[] arguments, Callable<Object> body) throws Throwable {
+        TracedMetadata metadata = metadataOf(method);
+        if (metadata == null) {
+            // Not annotated after all: run the method and stay out of the way.
+            return body.call();
+        }
+
+        TraceSpanEvent event = new TraceSpanEvent();
+        if (!event.isEnabled()) {
+            // Nothing is recording, so the annotation costs one allocation and a branch.
+            return body.call();
+        }
+
+        event.begin();
+        try {
+            return Tracer.inSpanOf(event, body::call);
+        } catch (Throwable failure) {
+            event.failed(failure);
+            throw failure;
+        } finally {
+            event.end();
+            if (event.shouldCommit()) {
+                event.name = metadata.name();
+                event.kind = metadata.kind();
+                event.attributes = metadata.attributes(arguments);
+                // inSpanOf already stamped the ids, so this commits the span it opened.
+                event.commitSpan();
+            }
+        }
+    }
+
+    private static TracedMetadata metadataOf(Method method) {
+        Map<Method, TracedMetadata> perClass = METADATA.get(method.getDeclaringClass());
+        TracedMetadata cached = perClass.get(method);
+        if (cached != null) {
+            return cached;
+        }
+
+        Traced traced = method.getAnnotation(Traced.class);
+        if (traced == null) {
+            return null;
+        }
+
+        TracedMetadata described = describe(traced, method);
+        perClass.put(method, described);
+        return described;
+    }
+
+    private static TracedMetadata describe(Traced traced, Method method) {
+        List<Attribute> staticAttributes = parseAttributes(traced.args());
+        List<CapturedParameter> captured = selectParameters(traced, method);
+        // An unchanging attribute set is rendered once here rather than on every call.
+        String prebuilt = captured.isEmpty() ? render(staticAttributes) : null;
+
+        return new TracedMetadata(
+                resolveName(traced, method), traced.kind().name(), staticAttributes, captured, prebuilt);
+    }
+
+    /**
+     * The declared name, or {@code OrderService.checkout} derived from the method itself. The
+     * package is dropped because it lengthens every recorded name without distinguishing anything,
+     * and so is any enclosing class, so a nested type reads the same as a top-level one.
+     */
+    private static String resolveName(Traced traced, Method method) {
+        if (!traced.name().isEmpty()) {
+            return traced.name();
+        }
+
+        String qualified = method.getDeclaringClass().getName();
+        int lastSeparator = Math.max(
+                qualified.lastIndexOf(PACKAGE_SEPARATOR), qualified.lastIndexOf(NESTED_CLASS_SEPARATOR));
+        String simpleName = qualified.substring(lastSeparator + 1);
+
+        return simpleName + NAME_SEPARATOR + method.getName();
+    }
+
+    /**
+     * Which arguments to record: the ones named, or all of them when capture is on and nothing is
+     * named, or none. Naming even one parameter is itself the request to capture, so
+     * {@code captureMethodArgs} does not also have to be set.
+     */
+    private static List<CapturedParameter> selectParameters(Traced traced, Method method) {
+        List<String> included = List.of(traced.includeMethodArgs());
+        if (included.isEmpty() && !traced.captureMethodArgs()) {
+            return List.of();
+        }
+
+        Parameter[] parameters = method.getParameters();
+        List<CapturedParameter> selected = new ArrayList<>(parameters.length);
+        for (int index = 0; index < parameters.length; index++) {
+            String parameterName = parameters[index].getName();
+            // A name matching nothing is ignored: usually a class compiled without -parameters,
+            // where the real names are arg0, arg1, and so on.
+            if (included.isEmpty() || included.contains(parameterName)) {
+                selected.add(new CapturedParameter(index, parameterName));
+            }
+        }
+
+        return List.copyOf(selected);
+    }
+
+    private static List<Attribute> parseAttributes(String[] declared) {
+        List<Attribute> parsed = new ArrayList<>(declared.length);
+        for (String entry : declared) {
+            int separator = entry.indexOf(KEY_VALUE_SEPARATOR);
+            if (separator > 0) {
+                parsed.add(new Attribute(entry.substring(0, separator).trim(), entry.substring(separator + 1).trim()));
+            }
+        }
+
+        return List.copyOf(parsed);
+    }
+
+    private static String render(List<Attribute> attributes) {
+        if (attributes.isEmpty()) {
+            // An absent field reads better than an empty object in the dashboard.
+            return null;
+        }
+
+        SpanAttributes rendered = SpanAttributes.create();
+        for (Attribute attribute : attributes) {
+            rendered.put(attribute.key(), attribute.value());
+        }
+
+        return rendered.json();
+    }
+
+    private static void put(SpanAttributes attributes, String key, Object value) {
+        switch (value) {
+            case null -> attributes.put(key, (String) null);
+            case Boolean flag -> attributes.put(key, (boolean) flag);
+            case Number number when INTEGRAL_TYPES.contains(number.getClass()) ->
+                    attributes.put(key, number.longValue());
+            case Number number when DECIMAL_TYPES.contains(number.getClass()) ->
+                    attributes.put(key, number.doubleValue());
+            default -> attributes.put(key, text(value));
+        }
+    }
+
+    private static String text(Object value) {
+        String rendered;
+        try {
+            rendered = String.valueOf(value);
+        } catch (Throwable failure) {
+            // The argument's own toString() threw. That is its problem, not the method's.
+            return UNRENDERABLE_VALUE;
+        }
+
+        if (rendered.length() <= MAX_CAPTURED_VALUE_LENGTH) {
+            return rendered;
+        }
+
+        return rendered.substring(0, MAX_CAPTURED_VALUE_LENGTH) + TRUNCATION_MARKER;
+    }
+
+    /** Everything about a traced method that does not change between calls. */
+    private record TracedMetadata(
+            String name,
+            String kind,
+            List<Attribute> staticAttributes,
+            List<CapturedParameter> capturedParameters,
+            String prebuiltAttributes) {
+
+        String attributes(Object[] arguments) {
+            if (capturedParameters.isEmpty()) {
+                return prebuiltAttributes;
+            }
+
+            SpanAttributes rendered = SpanAttributes.create();
+            for (Attribute attribute : staticAttributes) {
+                rendered.put(attribute.key(), attribute.value());
+            }
+            for (CapturedParameter parameter : capturedParameters) {
+                // Defensive on length: a woven call always passes every argument, but this class is
+                // callable by anyone.
+                Object value = parameter.index() < arguments.length ? arguments[parameter.index()] : null;
+                put(rendered, parameter.name(), value);
+            }
+
+            return rendered.json();
+        }
+    }
+
+    private record Attribute(String key, String value) {
+    }
+
+    private record CapturedParameter(int index, String name) {
+    }
+}

--- a/utilities/jeffrey-events/events/src/test/java/cafe/jeffrey/jfr/events/trace/TracedRuntimeTest.java
+++ b/utilities/jeffrey-events/events/src/test/java/cafe/jeffrey/jfr/events/trace/TracedRuntimeTest.java
@@ -1,0 +1,296 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.jfr.events.trace;
+
+import cafe.jeffrey.jfr.events.test.JfrRecordings;
+import cafe.jeffrey.jfr.events.test.SpansAssert;
+import jdk.jfr.consumer.RecordedEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Drives the bridge the agent calls, without any weaving — every rule about what a {@link Traced}
+ * method records lives on this side, so it can all be asserted against a real recording by calling
+ * {@link TracedRuntime#traced} the way woven bytecode would.
+ * <p>
+ * This module compiles without javac's {@code -parameters}, so the parameter names here are
+ * {@code arg0}, {@code arg1} — which is exactly the case an application that forgets the flag will
+ * hit, and worth pinning.
+ */
+class TracedRuntimeTest {
+
+    @Nested
+    @DisplayName("The span a traced method records")
+    class TheSpan {
+
+        @Test
+        @DisplayName("is named after the method when the annotation does not name it")
+        void derivesItsName() throws IOException {
+            RecordedEvent event = JfrRecordings.single(TraceSpanEvent.NAME, () ->
+                    call("derived", "value"));
+
+            assertEquals("Fixture.derived", event.getString("name"),
+                    "the package and any enclosing class are dropped, so the name stays short and stable");
+            assertEquals(SpanKind.INTERNAL.name(), event.getString("kind"));
+            assertEquals(SpanStatus.UNSET.name(), event.getString("status"),
+                    "a span that simply ran carries no verdict, exactly as Tracer.call leaves it");
+        }
+
+        @Test
+        @DisplayName("takes the declared name and kind when it has them")
+        void usesTheDeclaredName() throws IOException {
+            RecordedEvent event = JfrRecordings.single(TraceSpanEvent.NAME, () ->
+                    call("named"));
+
+            assertEquals("order.checkout", event.getString("name"));
+            assertEquals(SpanKind.CLIENT.name(), event.getString("kind"));
+        }
+
+        @Test
+        @DisplayName("nests under the span in progress, and is a root when there is none")
+        void nestsUnderTheCaller() throws IOException {
+            List<RecordedEvent> events = JfrRecordings.all(TraceSpanEvent.NAME, () -> {
+                Tracer.run("orders.sync", SpanKind.SERVER, () -> call("derived", "value"));
+                call("named");
+            });
+
+            SpansAssert.assertThat(events)
+                    .hasNoOrphanedSpans()
+                    .hasSpan("Fixture.derived").nestedUnder("orders.sync");
+            SpansAssert.assertThat(events).hasSpan("order.checkout").isRoot();
+        }
+
+        @Test
+        @DisplayName("returns what the method returned, and records nothing when nothing is recording")
+        void staysOutOfTheWay() throws Throwable {
+            Object result = TracedRuntime.traced(method("derived", String.class), new Object[]{"value"}, () -> "result");
+
+            assertEquals("result", result);
+        }
+
+        @Test
+        @DisplayName("carries the failure through unchanged, and records it as an error")
+        void recordsAFailure() throws IOException {
+            IOException thrown = new IOException("boom");
+
+            RecordedEvent event = JfrRecordings.single(TraceSpanEvent.NAME, () -> {
+                IOException caught = assertThrows(IOException.class, () ->
+                        TracedRuntime.traced(method("named"), new Object[0], () -> {
+                            throw thrown;
+                        }));
+                assertSame(thrown, caught, "the exception a caller catches must be the one the method threw");
+            });
+
+            assertEquals(SpanStatus.ERROR.name(), event.getString("status"));
+            assertEquals(IOException.class.getName(), event.getString("errorType"));
+        }
+
+        @Test
+        @DisplayName("runs the body even for a method that is not annotated at all")
+        void toleratesAnUnannotatedMethod() throws Throwable {
+            AtomicBoolean ran = new AtomicBoolean();
+
+            Object result = TracedRuntime.traced(method("untraced"), new Object[0], () -> {
+                ran.set(true);
+                return "result";
+            });
+
+            assertTrue(ran.get());
+            assertEquals("result", result);
+        }
+    }
+
+    @Nested
+    @DisplayName("The attributes it records")
+    class Attributes {
+
+        @Test
+        @DisplayName("are absent when the annotation asks for none")
+        void recordsNoneByDefault() throws IOException {
+            RecordedEvent event = JfrRecordings.single(TraceSpanEvent.NAME, () -> call("derived", "value"));
+
+            assertNull(event.getString("attributes"), "an empty object would only be noise");
+        }
+
+        @Test
+        @DisplayName("carry the annotation's own key=value entries")
+        void recordStaticEntries() throws IOException {
+            RecordedEvent event = JfrRecordings.single(TraceSpanEvent.NAME, () -> call("staticOnly"));
+
+            assertEquals("{\"tier\":\"gold\",\"tenant\":\"acme\"}", event.getString("attributes"));
+        }
+
+        @Test
+        @DisplayName("include every argument when capture is on and nothing is named")
+        void captureEveryArgument() throws IOException {
+            RecordedEvent event = JfrRecordings.single(TraceSpanEvent.NAME, () ->
+                    call("captureAll", "ada", 42));
+
+            assertEquals("{\"arg0\":\"ada\",\"arg1\":42}", event.getString("attributes"),
+                    "a number is written as a number, the way the MyBatis module writes its parameters");
+        }
+
+        @Test
+        @DisplayName("include only the named arguments, which is capture enough on its own")
+        void captureOnlyTheNamedArguments() throws IOException {
+            RecordedEvent event = JfrRecordings.single(TraceSpanEvent.NAME, () ->
+                    call("captureSelected", "ada", "secret"));
+
+            assertEquals("{\"arg0\":\"ada\"}", event.getString("attributes"),
+                    "naming a parameter is the request to capture it; captureMethodArgs stays false");
+        }
+
+        @Test
+        @DisplayName("keep the static entries alongside the captured ones")
+        void mergeStaticAndCaptured() throws IOException {
+            RecordedEvent event = JfrRecordings.single(TraceSpanEvent.NAME, () ->
+                    call("staticAndCaptured", "ada"));
+
+            assertEquals("{\"tier\":\"gold\",\"arg0\":\"ada\"}", event.getString("attributes"));
+        }
+
+        @Test
+        @DisplayName("ignore a name that matches no parameter rather than failing")
+        void ignoreAnUnknownName() throws IOException {
+            RecordedEvent event = JfrRecordings.single(TraceSpanEvent.NAME, () ->
+                    call("captureUnknown", "ada"));
+
+            assertNull(event.getString("attributes"),
+                    "nothing matched, so there is nothing to record; the usual cause is a class "
+                            + "compiled without -parameters");
+        }
+
+        @Test
+        @DisplayName("record a null argument as null")
+        void recordNull() throws IOException {
+            RecordedEvent event = JfrRecordings.single(TraceSpanEvent.NAME, () ->
+                    call("captureSelected", null, "secret"));
+
+            assertEquals("{\"arg0\":null}", event.getString("attributes"));
+        }
+
+        @Test
+        @DisplayName("truncate an oversized value instead of bloating the recording")
+        void truncateLongValues() throws IOException {
+            String oversized = "x".repeat(300);
+
+            RecordedEvent event = JfrRecordings.single(TraceSpanEvent.NAME, () ->
+                    call("captureSelected", oversized, "secret"));
+
+            assertEquals("{\"arg0\":\"" + "x".repeat(256) + "…\"}", event.getString("attributes"));
+        }
+
+        @Test
+        @DisplayName("survive an argument whose own toString() throws")
+        void surviveAThrowingArgument() throws IOException {
+            RecordedEvent event = JfrRecordings.single(TraceSpanEvent.NAME, () ->
+                    call("captureSelected", new Unrenderable(), "secret"));
+
+            assertEquals("{\"arg0\":\"<unavailable>\"}", event.getString("attributes"),
+                    "an argument's broken toString() is its problem, not the method's");
+        }
+    }
+
+    private static void call(String methodName, Object... arguments) {
+        Class<?>[] parameterTypes = new Class<?>[arguments.length];
+        for (int index = 0; index < arguments.length; index++) {
+            parameterTypes[index] = declaredType(methodName, index);
+        }
+
+        try {
+            TracedRuntime.traced(method(methodName, parameterTypes), arguments, () -> null);
+        } catch (Throwable e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /** The fixtures take Object/int, so the lookup does not depend on the value passed. */
+    private static Class<?> declaredType(String methodName, int index) {
+        for (Method candidate : Fixture.class.getDeclaredMethods()) {
+            if (candidate.getName().equals(methodName)) {
+                return candidate.getParameterTypes()[index];
+            }
+        }
+        throw new IllegalArgumentException("No such fixture method: " + methodName);
+    }
+
+    private static Method method(String name, Class<?>... parameterTypes) {
+        try {
+            return Fixture.class.getDeclaredMethod(name, parameterTypes);
+        } catch (NoSuchMethodException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    /** Annotated declarations only — the bodies never run, the test supplies them. */
+    @SuppressWarnings("unused")
+    static class Fixture {
+
+        @Traced
+        void derived(String value) {
+        }
+
+        @Traced(name = "order.checkout", kind = SpanKind.CLIENT)
+        void named() {
+        }
+
+        @Traced(args = {"tier=gold", "tenant=acme", "malformed"})
+        void staticOnly() {
+        }
+
+        @Traced(captureMethodArgs = true)
+        void captureAll(String name, int count) {
+        }
+
+        @Traced(includeMethodArgs = {"arg0"})
+        void captureSelected(Object kept, Object dropped) {
+        }
+
+        @Traced(args = {"tier=gold"}, includeMethodArgs = {"arg0"})
+        void staticAndCaptured(String name) {
+        }
+
+        @Traced(includeMethodArgs = {"orderId"})
+        void captureUnknown(String orderId) {
+        }
+
+        void untraced() {
+        }
+    }
+
+    private static final class Unrenderable {
+
+        @Override
+        public String toString() {
+            throw new IllegalStateException("toString is broken");
+        }
+    }
+}

--- a/utilities/jeffrey-events/mybatis/src/main/java/cafe/jeffrey/jfr/events/mybatis/StatementParameters.java
+++ b/utilities/jeffrey-events/mybatis/src/main/java/cafe/jeffrey/jfr/events/mybatis/StatementParameters.java
@@ -18,6 +18,7 @@
 
 package cafe.jeffrey.jfr.events.mybatis;
 
+import cafe.jeffrey.jfr.events.trace.AttributeValues;
 import cafe.jeffrey.jfr.events.trace.SpanAttributes;
 import org.apache.ibatis.mapping.BoundSql;
 import org.apache.ibatis.mapping.MappedStatement;
@@ -51,12 +52,6 @@ final class StatementParameters {
             List.of(byte[].class, Blob.class, Clob.class, InputStream.class, Reader.class, SQLXML.class);
 
     private static final String LOB_PLACEHOLDER = "<lob-value>";
-    private static final String TRUNCATION_MARKER = "…";
-
-    /** Written as JSON numbers; every other Number is rendered as text rather than losing digits. */
-    private static final Set<Class<?>> INTEGRAL_TYPES = Set.of(Byte.class, Short.class, Integer.class, Long.class);
-    private static final Set<Class<?>> DECIMAL_TYPES = Set.of(Float.class, Double.class);
-
     private StatementParameters() {
     }
 
@@ -108,26 +103,16 @@ final class StatementParameters {
         return configuration.newMetaObject(parameterObject).getValue(property);
     }
 
+    /**
+     * Content that would have to be read to be rendered is named rather than read; everything else
+     * is written the way every other emitter writes a captured value.
+     */
     private static void put(SpanAttributes attributes, String key, Object value, int maxValueLength) {
-        switch (value) {
-            case null -> attributes.put(key, (String) null);
-            case Boolean flag -> attributes.put(key, (boolean) flag);
-            case Number number when INTEGRAL_TYPES.contains(number.getClass()) ->
-                    attributes.put(key, number.longValue());
-            case Number number when DECIMAL_TYPES.contains(number.getClass()) ->
-                    attributes.put(key, number.doubleValue());
-            default -> attributes.put(key, render(value, maxValueLength));
-        }
-    }
-
-    private static String render(Object value, int maxValueLength) {
         if (LOB_TYPES.stream().anyMatch(type -> type.isInstance(value))) {
-            return LOB_PLACEHOLDER;
+            attributes.put(key, LOB_PLACEHOLDER);
+            return;
         }
-        String rendered = String.valueOf(value);
-        if (rendered.length() <= maxValueLength) {
-            return rendered;
-        }
-        return rendered.substring(0, maxValueLength) + TRUNCATION_MARKER;
+
+        AttributeValues.put(attributes, key, value, maxValueLength);
     }
 }

--- a/utilities/jeffrey-events/skills/jeffrey-traces-core/SKILL.md
+++ b/utilities/jeffrey-events/skills/jeffrey-traces-core/SKILL.md
@@ -95,7 +95,7 @@ Understand this model first; every rule follows from it.
 <dependency>
     <groupId>cafe.jeffrey-analyst</groupId>
     <artifactId>jeffrey-events</artifactId>
-    <version>0.13.0</version> <!-- latest release on Maven Central -->
+    <version><!-- latest release on Maven Central --></version>
 </dependency>
 ```
 
@@ -105,15 +105,10 @@ Understand this model first; every rule follows from it.
 - On **Java 17–24** you can use the HTTP, gRPC and JDBC events from an earlier
   `jeffrey-events` release (they still light up the HTTP/Database dashboards),
   but not `Tracer` — no hand-written spans and no cross-event trace nesting.
-- `Tracer.openSpanOf` / `Tracer.reenter` / `jeffrey.TraceScope` arrived after
-  0.12.0 — use 0.13.0 or newer for the callback-driven patterns in §5.
-- In releases **after 0.13.0** there is a single commit verb: `commitSpan()`
-  stamps an event that does not yet carry identity (`stampAndCommit()` is a
-  deprecated alias), `failed(Throwable)` exists on **every** traced event, and
+- There is a single commit verb: `commitSpan()` stamps an event that does not
+  yet carry identity, `failed(Throwable)` exists on **every** traced event, and
   `TracedEvents.emit` writes the whole leaf emit shape in one call.
-  On 0.13.0 itself, commit leaf events with `stampAndCommit()`, note that
-  `failed` exists only on JDBC statement events, and write the emit shape by
-  hand (§4 rule 3 shows the expansion).
+  (`stampAndCommit()` is a deprecated alias kept for older call sites.)
 - The library has **zero dependencies** (only `jdk.jfr`) and is safe to leave
   on in production: when no recording is running, every emit path checks
   `event.isEnabled()` and runs the body directly with nothing allocated beyond
@@ -161,8 +156,8 @@ Field notes:
   You never construct it — `Tracer` does.
 - **`attributes`** (any traced event): operation-specific detail as a JSON
   object string — per-request values (an entity id, a retry count) that must
-  never go into the span *name*. Build it with `SpanAttributes`
-  (releases after 0.13.0) rather than concatenating JSON by hand — it escapes
+  never go into the span *name*. Build it with `SpanAttributes` rather than
+  concatenating JSON by hand — it escapes
   quotes, backslashes and control characters — and only inside the
   `shouldCommit()` block, so an event under threshold pays nothing:
 
@@ -201,7 +196,7 @@ They are plain events (not spans); emit them from your pool's hook points
    identity exactly as it is, and then runs `describeSpan()` + `commit()`. A
    bare `commit()` silently drops the event from every trace.
 
-3. **Emit leaves through `TracedEvents.emit`** (releases after 0.13.0), which
+3. **Emit leaves through `TracedEvents.emit`**, which
    is the whole guard/begin/end/failed/shouldCommit/fill/commitSpan lifecycle
    in one call — the emit site states only the event, the work, and the
    fields:
@@ -217,8 +212,7 @@ They are plain events (not spans); emit them from your pool's hook points
    ```
 
    An exception escaping the body is recorded with `failed(t)` and rethrown
-   unchanged. On 0.13.0, or where the helper does not fit, write what it
-   expands to:
+   unchanged. Where the helper does not fit, write what it expands to:
 
    ```java
    SomeEvent event = new SomeEvent(...);
@@ -253,7 +247,7 @@ They are plain events (not spans); emit them from your pool's hook points
 
 5. **A trace does not cross a plain executor by itself.** `ScopedValue`
    propagates only through structured concurrency. Either wrap the pool once
-   with `Tracer.propagating(executor)` (releases after 0.13.0) so every task
+   with `Tracer.propagating(executor)` so every task
    submitted inside a span runs inside it, or capture per call site:
    `Tracer.fork(...)`/`Tracer.forkCallable(...)` (a named child span) or
    `Tracer.current()` + `Tracer.continueIn(parent, ...)` (explicit). Work
@@ -322,13 +316,13 @@ executor.submit(() -> Tracer.continueIn(parent, "chunk.parse", () -> {
 ```
 
 Pick `propagating` when a whole pool serves traced requests (releases after
-0.13.0), `fork`/`forkCallable` when one task is a distinct operation worth a
+`fork`/`forkCallable` when one task is a distinct operation worth a
 span of its own. `fork` captures the parent when *called*, not when the task
 runs — always call it on the thread whose span the work belongs to, then
 submit the result. `@Async` methods and scheduled tasks need the same
 treatment (a `TaskDecorator`/wrapped executor is the `propagating` shape).
 
-### Callback-driven work (0.13.0+)
+### Callback-driven work
 
 For one operation arriving in pieces on threads you don't control (async HTTP
 clients, gRPC listeners): `SpanContext ctx = Tracer.openSpanOf(event)` stamps

--- a/utilities/jeffrey-events/skills/jeffrey-traces-core/SKILL.md
+++ b/utilities/jeffrey-events/skills/jeffrey-traces-core/SKILL.md
@@ -27,6 +27,13 @@ one:
   per inbound call, and the client interceptor that records outbound calls as
   leaf spans.
 
+Application logic in between has two forms. `Tracer.run`/`call` wrap work in a
+lambda — precise, and visible in the method. `@Traced` on a method declares the
+same span and is woven by the Jeffrey agent
+(`-javaagent:jeffrey-agent.jar=tracing.enabled=true`), which leaves the method
+untouched but needs the agent attached at startup and Java 25. Both emit
+`jeffrey.TraceSpan` and nest identically; neither replaces the emit rules below.
+
 There is no separate "send data to Jeffrey" step. The events are ordinary JFR
 events written into the JVM's flight recording; you upload the `.jfr` file to
 Jeffrey (or let a Jeffrey workspace collect it), and Jeffrey parses every event

--- a/utilities/jeffrey-events/skills/jeffrey-traces-http-client/SKILL.md
+++ b/utilities/jeffrey-events/skills/jeffrey-traces-http-client/SKILL.md
@@ -84,7 +84,7 @@ public class JeffreyJfrRestTemplateInterceptor implements ClientHttpRequestInter
 }
 ```
 
-On 0.13.0, without `TracedEvents`, write the expanded shape from the core
+Where `TracedEvents` does not fit, write the expanded shape from the core
 skill's §4 rule 3 instead (guard, `begin()`, `end()` on success, `commitSpan()`
 in the `finally`).
 
@@ -109,7 +109,7 @@ public RestTemplateCustomizer jeffreyJfrRestTemplateCustomizer() {
 
 A blocking interceptor shape does not fit a client whose response arrives via
 callbacks on threads you don't control. Use the callback pattern from the core
-skill instead (0.13.0+): `Tracer.openSpanOf(event)` when the call starts (on
+skill instead: `Tracer.openSpanOf(event)` when the call starts (on
 the thread whose span it belongs to), `Tracer.reenter(ctx, ...)` around each
 callback, and `event.commitSpan()` at completion. `openSpanOf` stamps the ids
 eagerly, so a completion running after the enclosing binding is gone still
@@ -122,5 +122,5 @@ carries the right identity.
 | Calls in the HTTP Client dashboard but not in Traces | committed with `commit()` | `TracedEvents.emit`, or `commitSpan()` in the `finally` |
 | Client calls are roots of their own one-span traces | call ran outside a bound span (no server filter, `@Async`, scheduled job) | register the root-span filter (`jeffrey-traces-spring-rest-server`); wrap background work with `Tracer.fork`/`continueIn` |
 | One "endpoint" per entity id | raw expanded URL recorded as `uri` | record the template / normalized path |
-| Connection failures look green | exception path missing `failed(e)` | `TracedEvents.emit` records it; by hand, catch the transport exception, call `event.failed(e)`, rethrow (on 0.13.0, where HTTP events have no `failed`, UNSET ≠ OK is the best available) |
+| Connection failures look green | exception path missing `failed(e)` | `TracedEvents.emit` records it; by hand, catch the transport exception, call `event.failed(e)`, rethrow |
 | Async call measured as ~0 ms | event ended when the request was *sent*, not when the response arrived | complete the event from the response callback (deferred-commit pattern, §3) |

--- a/utilities/jeffrey-events/skills/jeffrey-traces-mybatis/SKILL.md
+++ b/utilities/jeffrey-events/skills/jeffrey-traces-mybatis/SKILL.md
@@ -190,7 +190,6 @@ public class JeffreyJfrMyBatisInterceptor implements Interceptor {
         String group = id.substring(mapperDot + 1, methodDot);  // UserMapper
 
         // The verb-to-event mapping is the library's own convention; forVerb applies it.
-        // On 0.13.0, without JdbcStatementEvents, write the switch by hand.
         return JdbcStatementEvents.forVerb(statement.getSqlCommandType().name(), name, group);
     }
 


### PR DESCRIPTION
Stacked on #185. Review the nine commits after `ddbe344` — five build `@Traced`, four are a cleanup sweep over the whole stack (bottom section).

```java
@Traced(name = "order.checkout", args = {"tier=gold"}, includeMethodArgs = {"orderId"})
public Receipt checkout(String orderId, Card card) { ... }
```

```bash
java -javaagent:jeffrey-agent.jar=tracing.enabled=true -jar app.jar
```

The integration modules cover the edges — HTTP, gRPC, JDBC, MyBatis — but application logic between them still meant writing the method around its own tracing with `Tracer.run`. This is the declarative half: the same `jeffrey.TraceSpan`, the same nesting, and the method left alone.

## How it is put together

Three parts across two worlds, because the agent **cannot** link against the library: the agent jar loads from the system class path while `jeffrey-events` usually loads from a child (a Boot fat jar, a WAR), and the agent targets Java 21 while `Tracer` needs 25 for `ScopedValue`.

```
woven method ──INVOKESTATIC──▶ TracedInterceptor          [agent, system CL, release 21]
                                 │ ClassValue: MethodHandle, or a sentinel meaning "no runtime"
                                 ▼
                               TracedRuntime.traced(...)  [jeffrey-events, app CL, release 25]
                                 │ reads @Traced, TraceSpanEvent + Tracer.inSpanOf
                                 ▼
                               original body (moved aside by the rebase)
```

The agent matches the annotation **by name** and resolves the runtime through the *instrumented class's own* loader. Everything a span means — naming, attributes, the failure verdict — stays in the library, versioned with it, so applications get improvements by upgrading the dependency rather than the agent. `TracedRuntime.traced` is therefore a frozen contract, and its javadoc says so.

**Why `MethodDelegation` and not `Advice`:** a span is bound with a `ScopedValue`, whose binding is structured — the body must run *inside* the call that opens the span, which a pair of enter/exit hooks cannot express. So the weave is a rebase, handing the original body over as a `Callable`.

**Everything that can go wrong ends with the application running.** No `jeffrey-events`, one too old, a JVM below 25, a class that fails to instrument: each is logged once and those methods run exactly as if the agent were absent. Exceptions pass through as the same instance (`invokeExact`, never `Method#invoke`, so there is no `InvocationTargetException` to unwrap).

## Two decisions worth your eye

**Tracing is off by default** (`tracing.enabled=true`). The agent is attached to every provisioned application under a promise of negligible overhead, and a transformer consulted on every class load is not something to start silently.

**ByteBuddy is shaded and relocated** — `-javaagent` appends the jar to the system class path, which is the *parent* of the application's loaders, so an unrelocated `net.bytebuddy` would win parent-first delegation over the copy the application ships with Hibernate, Mockito or Spring. A profiler must not re-version the thing it profiles. Cost: 11 KB → 4.9 MB, and the docs' zero-dependency claim rewritten.

## Arguments are a list of what may be recorded

`includeMethodArgs` names the parameters to keep and is itself the request to capture them; `captureMethodArgs = true` takes all; the default takes none. Values are truncated at 256 characters, and an argument whose own `toString()` throws is recorded as unavailable rather than breaking the method it was passed to. Keys are parameter names, so `arg0`/`arg1` without javac's `-parameters`.

---

# Cleanup sweep (last four commits)

An audit after the feature landed turned up ten items; nine were done and one was dropped on evidence.

**Two real gaps, not tidying.** A provisioned session could not use `@Traced` at all — the provisioner built `-javaagent:...=heartbeat.dir=...` with nowhere to put a second argument, so the feature was reachable only by hand-writing a JVM line. It is now `method-tracing { enabled = true }` / `JEFFREY_METHOD_TRACING`, beside `perf-counters` and `heap-dump`. And the release workflow ran `mvn clean package` while failsafe binds to `integration-test`, so the one test that runs the shaded agent under a real `-javaagent` could never have failed a release; it runs `verify` now.

**Duplication I introduced across #185 and #186.** `@Traced` and the MyBatis interceptor both record developer-supplied values into the same recording field, and each had grown its own copy of the integral/decimal type sets, the truncation marker and the truncate-and-mark. That is how a number ends up written as a number in one dashboard and a quoted string in the other. Now one `AttributeValues`, with each caller keeping only what is its own — MyBatis the guard that names a `Blob` rather than reading it, `@Traced` its own limit. Both suites pin exact JSON, so they prove the extraction changed nothing.

**Two dead `byte-buddy` declarations** in `core-hub` and `core-microscope`, which no Java file imported — untidy before, actively misleading once the agent started using ByteBuddy for real. Removed, with both test suites green without them.

**Docs that the change made untrue or incomplete:** three comments justifying duplicated constants by a minimal JAR size the agent no longer has (the duplication is still right, for the reason that survived); fourteen `0.13.0` "write it by hand" hedges across three skills, obsolete since 0.14.0; and `@Traced` added to the Tracer API page, which documented every way to open a span except the one that does not appear in the method. Plus two inline fully-qualified names where an import belongs.

**`stampAndCommit()`** now states *when* it goes — the next major, not a minor — rather than carrying an open-ended `forRemoval`.

**Dropped on evidence: the gRPC/HTTP success-verdict split.** gRPC sets `status = OK` where everything else leaves `UNSET`, and aligning them looked right until I read the consumers. `SpanConventions.statusProjection()` makes the derived convention outrank the recorded status except for `ERROR`, and it derives a gRPC span's outcome from gRPC's own `statusCode` — so changing the event would have altered nothing Jeffrey displays. The split that a user actually sees lives in `outcomeArm`, one layer down, and moving it is a dashboard decision with no correctness argument behind it. Left alone deliberately.

## Verification

- `mvn -f utilities/jeffrey-events test` — 94 events tests (15 new for `TracedRuntime`), all modules green.
- `mvn -pl jeffrey-agent test` — 32 green, including weaving through a real `ByteBuddyAgent.install()` against stubs carrying the bridge's exact FQCNs (the stub *is* the contract), and a child-first loader that hides the runtime to prove the fall-through.
- `mvn -pl build/build-agent-tests -am verify` — 4 tests under the **real shaded jar** with `-javaagent`: derived naming, nesting under `Tracer.run`, declared name/kind/attributes, and the error span.
- `mvn -pl jeffrey-provisioner -am test` — 141 green, including three new cases for the agent argument.
- **Full reactor `mvn test`** — the check on the dependency removals. One failure, `core-hub`'s `GrpcDocsControllerTest`, is a 404 from the doc generator skipped via `-Dexec.skip=true` because `protoc` is absent from this container; `core-hub` passes with that one test excluded, and `core-microscope`'s 314 pass outright.
- Shaded jar inspected: **zero** unrelocated `net/bytebuddy/` entries, 3089 relocated, `Premain-Class` + `Multi-Release` in the manifest, and the interceptor's own annotations pointing at the relocated package.
- Staging pre-flight: 9 modules + parent, with `Traced`, `TracedRuntime` and `AttributeValues` in the `jeffrey-events` jar.

Two test failures during development were real bugs, not flakes: my `.ignore(...)` matcher **replaced** ByteBuddy's default ignore set and swallowed the fixtures, so nothing was woven — dropped, since a class with no annotated method cannot match anyway; and the E2E first attached `build-agent`'s *main* artifact, a 2.8 KB thin jar without the engine, because `finalName` makes shade write beside it rather than replace it.

## Limitations, stated

Classes are woven as they load, so the agent must be on the command line. Interface `default` methods are not woven. A container that refuses parent delegation (OSGi-style) would fail to link the interceptor.