### PR TITLE
Lower JFR thresholds for the events traces are drawn from

### DIFF
--- a/jeffrey-pages/src/views/docs/provisioner/ProvisionerConfigurationPage.vue
+++ b/jeffrey-pages/src/views/docs/provisioner/ProvisionerConfigurationPage.vue
@@ -31,6 +31,7 @@ const headings = [
   { id: 'config-file', text: 'Configuration File', level: 2 },
   { id: 'configuration-options', text: 'Configuration Options', level: 2 },
   { id: 'features', text: 'Features', level: 2 },
+  { id: 'tracing-thresholds', text: 'Tracing Event Thresholds', level: 2 },
   { id: 'placeholders', text: 'Placeholders', level: 2 }
 ];
 
@@ -51,6 +52,11 @@ JEFFREY_HEAP_DUMP=crash              # exit | crash | off
 JEFFREY_PERF_COUNTERS=true
 JEFFREY_JVM_LOGGING="jfr*=trace:file=<<JEFFREY:CURRENT_SESSION>>/jfr-jvm.log"
 JEFFREY_ADDITIONAL_JVM_OPTIONS="-Xmx2g"`;
+
+const tracingThresholdsExample = `-XX:StartFlightRecording:name=jeffrey-tracing-thresholds,maxage=15m,\\
+  jdk.SocketRead#enabled=true,jdk.SocketRead#threshold=0ms,jdk.SocketRead#throttle=off,\\
+  jdk.SocketWrite#enabled=true,jdk.SocketWrite#threshold=0ms,jdk.SocketWrite#throttle=off,\\
+  jdk.ThreadPark#enabled=true,jdk.ThreadPark#threshold=1ms,...`;
 
 const minimalConfig = `jeffrey-home = "/opt/jeffrey"
 project {
@@ -269,6 +275,12 @@ additional-jvm-options = "-Xmx2g -Xms2g -Djeffrey.logging.trace-file.path=<<JEFF
               <td><strong>On by default.</strong> Record methods annotated <code>@Traced</code> as spans. Needs Java 25 and <code>jeffrey-events</code> on the application's class path; without them the weaver stays inert. Set <code>JEFFREY_TRACING_ENABLED=false</code> to opt out</td>
             </tr>
             <tr>
+              <td><code>tracing.jfr-event-settings</code></td>
+              <td>No</td>
+              <td><code>JEFFREY_TRACING_JFR_EVENT_SETTINGS</code></td>
+              <td>JFR thresholds for the blocking and I/O events a trace is drawn from. Left empty, the <a href="#tracing-thresholds">built-in list</a> is used. Set to <code>none</code> to opt out while leaving method tracing on. Ignored when <code>tracing.enabled = false</code></td>
+            </tr>
+            <tr>
               <td><code>heap-dump</code></td>
               <td>No</td>
               <td><code>JEFFREY_HEAP_DUMP</code></td>
@@ -348,6 +360,90 @@ additional-jvm-options = "-Xmx2g -Xms2g -Djeffrey.logging.trace-file.path=<<JEFF
             <code>additional-jvm-options = "-Xmx2g -Xms2g"</code>
           </div>
         </div>
+
+        <h2 id="tracing-thresholds">Tracing Event Thresholds</h2>
+        <p>
+          The Tracing view draws a span's blocked time from JDK events — socket and file I/O, lock
+          waits, parks, sleeps. The stock JFR configuration the profiler records with keeps those
+          events well above the durations a trace is read at: 20&nbsp;ms for lock waits and parks,
+          and 1&nbsp;ms for socket and file I/O on Java&nbsp;25. A trace then shows the method that
+          blocked, but not what it blocked on.
+        </p>
+        <p>
+          Whenever <code>tracing.enabled</code> is on, the provisioner adds a second JFR recording
+          that carries nothing but these thresholds:
+        </p>
+        <DocsCodeBlock :code="tracingThresholdsExample" language="bash" />
+        <p>
+          JFR applies the most verbose setting across every recording running in a JVM, and all
+          recordings write into the same repository chunks. So this one recording lowers the
+          thresholds for the profiler's recording as well, and the extra events reach both places
+          they are read from — the dumped <code>.jfr</code> files and the live stream — without the
+          profiler's own configuration being touched. That is why it works the same whether the
+          profiler settings came from the CLI, from the hub, or from the built-in default.
+        </p>
+
+        <table>
+          <thead>
+            <tr>
+              <th>Event</th>
+              <th>Shown as</th>
+              <th>Recorded from</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>jdk.SocketRead</code>, <code>jdk.SocketWrite</code></td>
+              <td>Socket read / Socket write</td>
+              <td>0&nbsp;ms</td>
+            </tr>
+            <tr>
+              <td><code>jdk.FileRead</code>, <code>jdk.FileWrite</code>, <code>jdk.FileForce</code></td>
+              <td>File read / File write / File force</td>
+              <td>0&nbsp;ms</td>
+            </tr>
+            <tr>
+              <td><code>jdk.JavaMonitorEnter</code>, <code>jdk.JavaMonitorWait</code></td>
+              <td>Lock wait / Object.wait</td>
+              <td>1&nbsp;ms</td>
+            </tr>
+            <tr>
+              <td><code>jdk.ThreadPark</code>, <code>jdk.ThreadSleep</code></td>
+              <td>Parked / Sleeping</td>
+              <td>1&nbsp;ms</td>
+            </tr>
+            <tr>
+              <td><code>jdk.VirtualThreadPinned</code></td>
+              <td>VT pinned</td>
+              <td>1&nbsp;ms</td>
+            </tr>
+            <tr>
+              <td><code>jdk.ZAllocationStall</code></td>
+              <td>Allocation stall</td>
+              <td>0&nbsp;ms</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p>
+          I/O is recorded in full, because every socket and file operation is a call the application
+          made on purpose and its duration is what the waterfall exists to show. Blocking starts at
+          1&nbsp;ms, because a parked or waiting thread is also how an idle thread pool spends its
+          life — at 0&nbsp;ms that churn would outweigh the waits worth reading. Set
+          <code>tracing.jfr-event-settings</code> to your own list to change that, or to
+          <code>none</code> to drop the recording while leaving method tracing on.
+        </p>
+
+        <DocsCallout type="warning">
+          <strong>Java 25 rate-limits I/O events.</strong> Its <code>default.jfc</code> caps
+          <code>jdk.SocketRead</code>, <code>jdk.SocketWrite</code>, <code>jdk.FileRead</code> and
+          <code>jdk.FileWrite</code> at 100 events a second. A rate limit resolves to the most
+          restrictive value across the running recordings — the opposite of a threshold — so while
+          the profiler records with that configuration, I/O stays capped at 100/s however low the
+          threshold goes. The threshold still applies within that budget, so short operations do
+          reach the trace; recording every one of them past the cap needs the profiler's own
+          <code>jfrsync</code> configuration changed.
+        </DocsCallout>
 
         <h2 id="placeholders">Placeholders</h2>
         <p>

--- a/jeffrey-pages/src/views/docs/provisioner/ProvisionerConfigurationPage.vue
+++ b/jeffrey-pages/src/views/docs/provisioner/ProvisionerConfigurationPage.vue
@@ -53,7 +53,7 @@ JEFFREY_PERF_COUNTERS=true
 JEFFREY_JVM_LOGGING="jfr*=trace:file=<<JEFFREY:CURRENT_SESSION>>/jfr-jvm.log"
 JEFFREY_ADDITIONAL_JVM_OPTIONS="-Xmx2g"`;
 
-const tracingThresholdsExample = `-XX:StartFlightRecording:name=jeffrey-tracing-thresholds,maxage=15m,\\
+const tracingThresholdsExample = `-XX:StartFlightRecording:name=jeffrey-tracing-thresholds,maxage=30m,\\
   jdk.SocketRead#enabled=true,jdk.SocketRead#threshold=0ms,jdk.SocketRead#throttle=off,\\
   jdk.SocketWrite#enabled=true,jdk.SocketWrite#threshold=0ms,jdk.SocketWrite#throttle=off,\\
   jdk.ThreadPark#enabled=true,jdk.ThreadPark#threshold=1ms,...`;

--- a/jeffrey-provisioner/jeffrey-init.conf
+++ b/jeffrey-provisioner/jeffrey-init.conf
@@ -38,6 +38,29 @@ perf-counters {
 # to keep the agent from installing its class-file transformer at all.
 tracing {
     enabled = true
+
+    # JFR thresholds for the events the Tracing view draws as blocking spans.
+    # The profiler records with a stock JFR configuration where socket I/O, file I/O and
+    # lock waits only fire above 20 ms, so short operations never reach a trace. These
+    # settings are applied by a second, settings-only JFR recording; JFR takes the most
+    # verbose setting across all active recordings, so they also lower the thresholds of
+    # the profiler's own recording — the events land in both the dumped .jfr files and the
+    # streamed session.
+    #
+    # Left empty, the built-in list is used: socket + file I/O at 0ms (every operation) and
+    # JavaMonitorEnter / JavaMonitorWait / ThreadPark / ThreadSleep / VirtualThreadPinned at
+    # 1ms, which keeps idle thread-pool parking out of the traces.
+    #
+    # One caveat on Java 25: its default.jfc rate-limits socket and file I/O to 100 events a
+    # second. A rate limit resolves to the most restrictive value across the running
+    # recordings — the opposite of a threshold — so while the profiler records with that
+    # configuration, I/O stays capped at 100/s however low the threshold goes. Recording
+    # every event past that needs the profiler's own jfrsync configuration changed.
+    #
+    # Ignored when enabled = false. Set to "none" to opt out while leaving method tracing on,
+    # or list your own settings, e.g.:
+    # jfr-event-settings = "jdk.SocketRead#enabled=true,jdk.SocketRead#threshold=0ms"
+    jfr-event-settings = ""
 }
 
 # Heap dump on OutOfMemoryError

--- a/jeffrey-provisioner/src/main/java/cafe/jeffrey/provisioner/InitConfig.java
+++ b/jeffrey-provisioner/src/main/java/cafe/jeffrey/provisioner/InitConfig.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import cafe.jeffrey.provisioner.config.ConfigLayers;
 import cafe.jeffrey.provisioner.config.ConfigPaths;
 import cafe.jeffrey.provisioner.config.EnvironmentLayer;
+import cafe.jeffrey.provisioner.feature.TracingJfrEvents;
 import cafe.jeffrey.provisioner.model.HeapDumpType;
 import cafe.jeffrey.provisioner.placeholder.EnvPlaceholderSource;
 import cafe.jeffrey.provisioner.placeholder.Placeholders;
@@ -119,7 +120,9 @@ public class InitConfig {
             # On by default, unlike the agent's own parameter: a provisioned JVM is one being
             # profiled on purpose, and the weaver is inert without Java 25 and jeffrey-events on
             # the class path. JEFFREY_TRACING_ENABLED=false opts a deployment out.
-            tracing { enabled = true }
+            # jfr-event-settings left empty means the built-in event list
+            # (TracingJfrEvents.DEFAULT_SETTINGS); "none" opts out while leaving tracing on.
+            tracing { enabled = true, jfr-event-settings = "" }
             heap-dump { enabled = false, type = "exit" }
             jvm-logging { enabled = false, command = "" }
             agent-path = ""
@@ -226,6 +229,7 @@ public class InitConfig {
 
     private final boolean perfCountersEnabled;
     private final boolean methodTracingEnabled;
+    private final String tracingJfrEventSettings;
     private final boolean debugNonSafepointsEnabled;
     private final boolean jdkJavaOptionsEnabled;
     private final HeapDumpType heapDumpType;
@@ -275,6 +279,8 @@ public class InitConfig {
 
         this.perfCountersEnabled = resolved.getBoolean(ConfigPaths.PERF_COUNTERS_ENABLED);
         this.methodTracingEnabled = resolved.getBoolean(ConfigPaths.TRACING_ENABLED);
+        this.tracingJfrEventSettings = valueOrDefault(
+                resolved.getString(ConfigPaths.TRACING_JFR_EVENT_SETTINGS), TracingJfrEvents.DEFAULT_SETTINGS);
         this.debugNonSafepointsEnabled = resolved.getBoolean(ConfigPaths.DEBUG_NON_SAFEPOINTS_ENABLED);
         this.jdkJavaOptionsEnabled = resolved.getBoolean(ConfigPaths.JDK_JAVA_OPTIONS_ENABLED);
         this.heapDumpType = resolved.getBoolean(ConfigPaths.HEAP_DUMP_ENABLED)
@@ -372,6 +378,11 @@ public class InitConfig {
         return (value == null || value.isBlank()) ? null : value;
     }
 
+    private static String valueOrDefault(String value, String fallback) {
+        String configured = nullIfBlank(value);
+        return configured != null ? configured : fallback;
+    }
+
     // ==================== Accessors ====================
 
     public String getJeffreyHome() {
@@ -435,6 +446,15 @@ public class InitConfig {
     /** Whether the agent records {@code @Traced} methods as spans. */
     public boolean isMethodTracingEnabled() {
         return methodTracingEnabled;
+    }
+
+    /**
+     * The JFR event settings a traced session lowers its thresholds with, as
+     * {@code -XX:StartFlightRecording} spells them. Never blank: an unset value falls back to
+     * {@link TracingJfrEvents#DEFAULT_SETTINGS}, and {@code "none"} switches the recording off.
+     */
+    public String getTracingJfrEventSettings() {
+        return tracingJfrEventSettings;
     }
 
     public boolean isDebugNonSafepointsEnabled() {

--- a/jeffrey-provisioner/src/main/java/cafe/jeffrey/provisioner/JvmFeatures.java
+++ b/jeffrey-provisioner/src/main/java/cafe/jeffrey/provisioner/JvmFeatures.java
@@ -43,6 +43,8 @@ public record JvmFeatures(List<JvmFeature> features) {
                 new JvmFeature.HeapDump(config.resolveHeapDumpType()),
                 new JvmFeature.JvmLogging(config.getJvmLoggingCommand()),
                 new JvmFeature.Agent(config.getAgentPath(), config.isMethodTracingEnabled(), identity),
+                new JvmFeature.TracingEventThresholds(
+                        config.isMethodTracingEnabled(), config.getTracingJfrEventSettings()),
                 new JvmFeature.AdditionalOptions(config.getAdditionalJvmOptions())));
     }
 

--- a/jeffrey-provisioner/src/main/java/cafe/jeffrey/provisioner/config/ConfigPaths.java
+++ b/jeffrey-provisioner/src/main/java/cafe/jeffrey/provisioner/config/ConfigPaths.java
@@ -45,6 +45,7 @@ public abstract class ConfigPaths {
 
     public static final String PERF_COUNTERS_ENABLED = "perf-counters.enabled";
     public static final String TRACING_ENABLED = "tracing.enabled";
+    public static final String TRACING_JFR_EVENT_SETTINGS = "tracing.jfr-event-settings";
     public static final String JDK_JAVA_OPTIONS_ENABLED = "jdk-java-options.enabled";
     public static final String DEBUG_NON_SAFEPOINTS_ENABLED = "debug-non-safepoints.enabled";
     public static final String HEAP_DUMP_ENABLED = "heap-dump.enabled";

--- a/jeffrey-provisioner/src/main/java/cafe/jeffrey/provisioner/config/EnvironmentLayer.java
+++ b/jeffrey-provisioner/src/main/java/cafe/jeffrey/provisioner/config/EnvironmentLayer.java
@@ -66,6 +66,7 @@ public abstract class EnvironmentLayer {
             new EnvBinding.Flag("JEFFREY_PROVISIONER_VERBOSE", ConfigPaths.PROVISIONER_VERBOSE),
             new EnvBinding.Flag("JEFFREY_PERF_COUNTERS", ConfigPaths.PERF_COUNTERS_ENABLED),
             new EnvBinding.Flag(ENV_TRACING_ENABLED, ConfigPaths.TRACING_ENABLED),
+            new EnvBinding.Value("JEFFREY_TRACING_JFR_EVENT_SETTINGS", ConfigPaths.TRACING_JFR_EVENT_SETTINGS),
             new EnvBinding.Flag("JEFFREY_JDK_JAVA_OPTIONS", ConfigPaths.JDK_JAVA_OPTIONS_ENABLED),
             new EnvBinding.Flag("JEFFREY_DEBUG_NON_SAFEPOINTS", ConfigPaths.DEBUG_NON_SAFEPOINTS_ENABLED),
             new EnvBinding.Attributes("JEFFREY_ATTRIBUTES", ConfigPaths.ATTRIBUTES),

--- a/jeffrey-provisioner/src/main/java/cafe/jeffrey/provisioner/feature/JvmFeature.java
+++ b/jeffrey-provisioner/src/main/java/cafe/jeffrey/provisioner/feature/JvmFeature.java
@@ -164,7 +164,7 @@ public sealed interface JvmFeature {
         static final String DISABLED = "none";
 
         private static final String OPTIONS_PREFIX =
-                "-XX:StartFlightRecording:name=jeffrey-tracing-thresholds,maxage=15m,";
+                "-XX:StartFlightRecording:name=jeffrey-tracing-thresholds,maxage=30m,";
 
         @Override
         public Optional<String> render(Path sessionPath, Placeholders placeholders) {

--- a/jeffrey-provisioner/src/main/java/cafe/jeffrey/provisioner/feature/JvmFeature.java
+++ b/jeffrey-provisioner/src/main/java/cafe/jeffrey/provisioner/feature/JvmFeature.java
@@ -139,6 +139,45 @@ public sealed interface JvmFeature {
         }
     }
 
+    /**
+     * The JFR thresholds a traced session needs, carried by a recording of their own.
+     *
+     * <p>The profiler starts its recording from a stock JFR configuration that keeps these events
+     * above the durations a trace is read at, and that configuration arrives from whichever source
+     * won — the CLI, the hub, or the built-in default — so lowering the thresholds by rewriting it
+     * would have to be done three times over. A second recording sidesteps that: JFR applies the
+     * most verbose setting across every active recording, so this one lowers the thresholds for the
+     * profiler's recording as well without either knowing about the other.
+     *
+     * <p>The events all land in the same repository chunks, which is what puts them in both places
+     * they are read from — the dumped {@code .jfr} files and the stream the agent follows.
+     *
+     * <p>No {@code settings=} is given, which leaves this recording on the JVM's default
+     * configuration — the same one the profiler records with, so the union is unchanged by it.
+     * Naming {@code settings=none} to keep the recording bare is what a reader expects here and is
+     * exactly wrong: it drops the event settings spelled out beside it and the recording carries
+     * nothing at all. {@code maxage} bounds how long this recording pins repository chunks.
+     */
+    record TracingEventThresholds(boolean tracingEnabled, String eventSettings) implements JvmFeature {
+
+        /** Opts a deployment out while leaving tracing itself on. */
+        static final String DISABLED = "none";
+
+        private static final String OPTIONS_PREFIX =
+                "-XX:StartFlightRecording:name=jeffrey-tracing-thresholds,maxage=15m,";
+
+        @Override
+        public Optional<String> render(Path sessionPath, Placeholders placeholders) {
+            if (!tracingEnabled || eventSettings == null || eventSettings.isBlank()) {
+                return Optional.empty();
+            }
+            if (DISABLED.equalsIgnoreCase(eventSettings.trim())) {
+                return Optional.empty();
+            }
+            return Optional.of(OPTIONS_PREFIX + eventSettings.trim());
+        }
+    }
+
     /** Whatever else the deployment asked for. */
     record AdditionalOptions(String options) implements JvmFeature {
 

--- a/jeffrey-provisioner/src/main/java/cafe/jeffrey/provisioner/feature/TracingJfrEvents.java
+++ b/jeffrey-provisioner/src/main/java/cafe/jeffrey/provisioner/feature/TracingJfrEvents.java
@@ -1,0 +1,120 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.provisioner.feature;
+
+import cafe.jeffrey.shared.common.model.EventTypeName;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * The JDK events a traced session needs, and how each one is recorded.
+ *
+ * <p>The stock {@code default.jfc} the profiler records with keeps these events well above the
+ * durations a trace is read at — 20 ms for lock waits and parks, 1 ms for socket and file I/O on
+ * Java 25 — so a trace shows the method that blocked but not what it blocked on. These are the same
+ * event types the Tracing view promotes into leaf spans, named from {@link EventTypeName} so the two
+ * lists cannot drift into disagreeing about an event's spelling.
+ *
+ * <p>I/O is recorded in full ({@code 0ms}): every socket and file operation is a call the
+ * application made on purpose, and its duration is the answer the waterfall exists to show.
+ * Blocking is recorded from {@code 1ms} up, because a parked or waiting thread is also how an idle
+ * thread pool spends its life — at {@code 0ms} that churn would outweigh the waits worth reading.
+ */
+public abstract class TracingJfrEvents {
+
+    private static final String IO_THRESHOLD = "0ms";
+    private static final String BLOCKING_THRESHOLD = "1ms";
+
+    private static final String SETTING_SEPARATOR = ",";
+    private static final String EVENT_SETTING_SEPARATOR = "#";
+    private static final String ASSIGN = "=";
+    private static final String ENABLED_SETTING = "enabled";
+    private static final String THRESHOLD_SETTING = "threshold";
+    private static final String THROTTLE_SETTING = "throttle";
+    private static final String ENABLED_VALUE = "true";
+    private static final String THROTTLE_OFF = "off";
+
+    /**
+     * One event, the threshold it is recorded at, and whether its rate limit is lifted.
+     *
+     * <p>Rendered with an {@code enabled} pair as well: JFR takes the most verbose value across the
+     * active recordings per setting, so a threshold alone would be ignored for an event that a
+     * custom profiler configuration had switched off.
+     */
+    record EventThreshold(String eventType, String threshold, boolean unthrottled) {
+
+        /**
+         * Recorded in full, and its rate limit lifted. Java 25 rate-limits these to 100 events a
+         * second in {@code default.jfc}, which a threshold does not lift.
+         *
+         * <p>The lift only reaches as far as the other recordings allow. Unlike a threshold, where
+         * JFR takes the most verbose value across the active recordings, a rate limit resolves to
+         * the most restrictive one — so while the profiler records with a configuration that
+         * throttles, that cap holds for everyone and this setting has no effect. It applies when
+         * the profiler runs a configuration that does not throttle, which is every JDK before 25.
+         */
+        static EventThreshold io(String eventType) {
+            return new EventThreshold(eventType, IO_THRESHOLD, true);
+        }
+
+        /** Recorded from {@link #BLOCKING_THRESHOLD} up; these carry no rate limit to lift. */
+        static EventThreshold blocking(String eventType) {
+            return new EventThreshold(eventType, BLOCKING_THRESHOLD, false);
+        }
+
+        String render() {
+            StringBuilder settings = new StringBuilder()
+                    .append(setting(ENABLED_SETTING, ENABLED_VALUE))
+                    .append(SETTING_SEPARATOR)
+                    .append(setting(THRESHOLD_SETTING, threshold));
+            if (unthrottled) {
+                settings.append(SETTING_SEPARATOR).append(setting(THROTTLE_SETTING, THROTTLE_OFF));
+            }
+            return settings.toString();
+        }
+
+        private String setting(String name, String value) {
+            return eventType + EVENT_SETTING_SEPARATOR + name + ASSIGN + value;
+        }
+    }
+
+    /**
+     * {@code jdk.FileForce} is I/O but carries no {@code throttle} setting to switch off — naming
+     * one it does not have costs a JFR warning at startup. {@code jdk.ZAllocationStall} is already
+     * unthresholded in {@code default.jfc} and is listed so the settings stand on their own.
+     */
+    static final List<EventThreshold> DEFAULT_EVENTS = List.of(
+            EventThreshold.io(EventTypeName.SOCKET_READ),
+            EventThreshold.io(EventTypeName.SOCKET_WRITE),
+            EventThreshold.io(EventTypeName.FILE_READ),
+            EventThreshold.io(EventTypeName.FILE_WRITE),
+            new EventThreshold(EventTypeName.FILE_FORCE, IO_THRESHOLD, false),
+            EventThreshold.blocking(EventTypeName.JAVA_MONITOR_ENTER),
+            EventThreshold.blocking(EventTypeName.JAVA_MONITOR_WAIT),
+            EventThreshold.blocking(EventTypeName.THREAD_PARK),
+            EventThreshold.blocking(EventTypeName.THREAD_SLEEP),
+            EventThreshold.blocking(EventTypeName.VIRTUAL_THREAD_PINNED),
+            new EventThreshold(EventTypeName.Z_ALLOCATION_STALL, IO_THRESHOLD, false));
+
+    /** The built-in event settings, as the {@code -XX:StartFlightRecording} option spells them. */
+    public static final String DEFAULT_SETTINGS = DEFAULT_EVENTS.stream()
+            .map(EventThreshold::render)
+            .collect(Collectors.joining(SETTING_SEPARATOR));
+}

--- a/jeffrey-provisioner/src/test/java/cafe/jeffrey/provisioner/InitConfigTest.java
+++ b/jeffrey-provisioner/src/test/java/cafe/jeffrey/provisioner/InitConfigTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.jupiter.api.io.TempDir;
+import cafe.jeffrey.provisioner.feature.TracingJfrEvents;
 import cafe.jeffrey.provisioner.model.HeapDumpType;
 import cafe.jeffrey.shared.common.CliConstants;
 import cafe.jeffrey.shared.common.filesystem.FileSystemUtils;
@@ -976,6 +977,48 @@ class InitConfigTest {
                     name -> name.equals("JEFFREY_TRACING_ENABLED") ? "false" : null);
 
             assertFalse(config.isMethodTracingEnabled());
+        }
+
+        @Test
+        void tracingJfrEventSettings_defaultsToTheBuiltInList() throws IOException {
+            Path configFile = tempDir.resolve("config.conf");
+            Files.writeString(configFile, configWithOverrides(
+                    "jeffrey-home = \"/tmp/jeffrey\"",
+                    "project { name = \"my-service\" }"
+            ));
+
+            InitConfig config = InitConfig.fromHoconFile(configFile, null, name -> null);
+
+            assertEquals(TracingJfrEvents.DEFAULT_SETTINGS, config.getTracingJfrEventSettings());
+        }
+
+        @Test
+        void hoconTracingJfrEventSettings_winsOverTheBuiltInList() throws IOException {
+            Path configFile = tempDir.resolve("config.conf");
+            Files.writeString(configFile, configWithOverrides(
+                    "jeffrey-home = \"/tmp/jeffrey\"",
+                    "project { name = \"my-service\" }",
+                    "tracing { jfr-event-settings = \"jdk.SocketRead#threshold=0ms\" }"
+            ));
+
+            InitConfig config = InitConfig.fromHoconFile(configFile, null, name -> null);
+
+            assertEquals("jdk.SocketRead#threshold=0ms", config.getTracingJfrEventSettings());
+        }
+
+        @Test
+        void envTracingJfrEventSettings_winsOverHocon() throws IOException {
+            Path configFile = tempDir.resolve("config.conf");
+            Files.writeString(configFile, configWithOverrides(
+                    "jeffrey-home = \"/tmp/jeffrey\"",
+                    "project { name = \"my-service\" }",
+                    "tracing { jfr-event-settings = \"jdk.SocketRead#threshold=0ms\" }"
+            ));
+
+            InitConfig config = InitConfig.fromHoconFile(configFile, null,
+                    name -> name.equals("JEFFREY_TRACING_JFR_EVENT_SETTINGS") ? "none" : null);
+
+            assertEquals("none", config.getTracingJfrEventSettings());
         }
 
         @Test

--- a/jeffrey-provisioner/src/test/java/cafe/jeffrey/provisioner/feature/JvmFeatureTest.java
+++ b/jeffrey-provisioner/src/test/java/cafe/jeffrey/provisioner/feature/JvmFeatureTest.java
@@ -156,6 +156,112 @@ class JvmFeatureTest {
     }
 
     @Nested
+    class TracingEventThresholds {
+
+        private static final String SETTINGS =
+                "jdk.SocketRead#enabled=true,jdk.SocketRead#threshold=0ms";
+
+        @Test
+        void startsARecordingCarryingTheThresholds() {
+            String options = render(new JvmFeature.TracingEventThresholds(true, SETTINGS));
+
+            assertTrue(options.startsWith("-XX:StartFlightRecording:"), options);
+            assertTrue(options.endsWith(SETTINGS), options);
+        }
+
+        /**
+         * {@code settings=none} reads like the way to keep this recording bare, and instead makes
+         * the JVM discard every event setting given with it — the recording then carries nothing.
+         */
+        @Test
+        void neverNamesASettingsConfiguration() {
+            String options = render(
+                    new JvmFeature.TracingEventThresholds(true, TracingJfrEvents.DEFAULT_SETTINGS));
+
+            assertTrue(!options.contains("settings="), options);
+        }
+
+        /** An unbounded recording would pin repository chunks for the life of the JVM. */
+        @Test
+        void boundsHowLongItPinsChunks() {
+            String options = render(new JvmFeature.TracingEventThresholds(true, SETTINGS));
+
+            assertTrue(options.contains("maxage="), options);
+        }
+
+        /** The default list is what a session gets when nothing overrides it. */
+        @Test
+        void defaultSettingsCoverEveryPromotedEvent() {
+            String options = render(
+                    new JvmFeature.TracingEventThresholds(true, TracingJfrEvents.DEFAULT_SETTINGS));
+
+            assertTrue(options.contains("jdk.SocketRead#threshold=0ms"), options);
+            assertTrue(options.contains("jdk.SocketWrite#threshold=0ms"), options);
+            assertTrue(options.contains("jdk.FileRead#threshold=0ms"), options);
+            assertTrue(options.contains("jdk.FileWrite#threshold=0ms"), options);
+            assertTrue(options.contains("jdk.FileForce#threshold=0ms"), options);
+            assertTrue(options.contains("jdk.JavaMonitorEnter#threshold=1ms"), options);
+            assertTrue(options.contains("jdk.JavaMonitorWait#threshold=1ms"), options);
+            assertTrue(options.contains("jdk.ThreadPark#threshold=1ms"), options);
+            assertTrue(options.contains("jdk.ThreadSleep#threshold=1ms"), options);
+            assertTrue(options.contains("jdk.VirtualThreadPinned#threshold=1ms"), options);
+            assertTrue(options.contains("jdk.ZAllocationStall#threshold=0ms"), options);
+        }
+
+        /** A threshold is ignored for an event a custom profiler configuration switched off. */
+        @Test
+        void everyEventIsEnabledAlongsideItsThreshold() {
+            String options = render(
+                    new JvmFeature.TracingEventThresholds(true, TracingJfrEvents.DEFAULT_SETTINGS));
+
+            for (TracingJfrEvents.EventThreshold event : TracingJfrEvents.DEFAULT_EVENTS) {
+                assertTrue(options.contains(event.eventType() + "#enabled=true"), event.eventType());
+            }
+        }
+
+        /**
+         * Java 25 rate-limits socket and file I/O to 100 events a second, which a threshold does
+         * not lift. {@code jdk.FileForce} has no such limit, and naming a setting an event does not
+         * have costs a JFR warning at startup.
+         */
+        @Test
+        void liftsTheRateLimitOnlyWhereThereIsOneToLift() {
+            String options = render(
+                    new JvmFeature.TracingEventThresholds(true, TracingJfrEvents.DEFAULT_SETTINGS));
+
+            assertTrue(options.contains("jdk.SocketRead#throttle=off"), options);
+            assertTrue(options.contains("jdk.SocketWrite#throttle=off"), options);
+            assertTrue(options.contains("jdk.FileRead#throttle=off"), options);
+            assertTrue(options.contains("jdk.FileWrite#throttle=off"), options);
+            assertTrue(!options.contains("jdk.FileForce#throttle"), options);
+            assertTrue(!options.contains("jdk.ThreadPark#throttle"), options);
+        }
+
+        @Test
+        void rendersNothingWhenTracingIsOff() {
+            assertEquals(Optional.empty(),
+                    new JvmFeature.TracingEventThresholds(false, SETTINGS).render(SESSION, PLACEHOLDERS));
+        }
+
+        @Test
+        void rendersNothingWithoutSettings() {
+            assertEquals(Optional.empty(),
+                    new JvmFeature.TracingEventThresholds(true, null).render(SESSION, PLACEHOLDERS));
+            assertEquals(Optional.empty(),
+                    new JvmFeature.TracingEventThresholds(true, "  ").render(SESSION, PLACEHOLDERS));
+        }
+
+        /** The documented opt-out: keep method tracing, drop the extra recording. */
+        @Test
+        void rendersNothingForTheNoneOptOut() {
+            assertEquals(Optional.empty(),
+                    new JvmFeature.TracingEventThresholds(true, "none").render(SESSION, PLACEHOLDERS));
+            assertEquals(Optional.empty(),
+                    new JvmFeature.TracingEventThresholds(true, " NONE ").render(SESSION, PLACEHOLDERS));
+        }
+    }
+
+    @Nested
     class AdditionalOptions {
 
         @Test


### PR DESCRIPTION
The Tracing view synthesizes a span's blocked time from JDK events, but a
provisioned JVM records with the stock JFR configuration, which keeps those
events above the durations a trace is read at: 20ms for lock waits and parks,
1ms for socket and file I/O on Java 25. A trace showed the method that blocked
but not what it blocked on.

Rewriting the profiler configuration would have to be done once per source --
CLI, hub, built-in -- so instead a traced session starts a second JFR recording
carrying only these thresholds. JFR applies the most verbose setting across
every active recording and they share the same repository chunks, so the
profiler's own recording picks them up too, and the events reach both the
dumped .jfr files and the stream the agent follows.

Two details this cost a JVM to learn:

settings=none reads like the way to keep the extra recording bare, and instead
makes the JVM discard every event setting given with it -- the recording then
carries nothing at all. Naming no configuration is what leaves the settings
standing.

Java 25 also rate-limits socket and file I/O to 100 events a second, which a
threshold does not lift, so those four events switch the limit off. Unlike a
threshold, a rate limit resolves to the most restrictive value across the
running recordings, so the lift only reaches as far as the profiler's own
configuration allows -- documented rather than worked around.

tracing.jfr-event-settings (JEFFREY_TRACING_JFR_EVENT_SETTINGS) overrides the
built-in list, or "none" drops the recording while leaving method tracing on.