### PR TITLE
Add a copy button to the span's event-fields statement

### DIFF
--- a/jeffrey-microscope/pages-microscope/src/components/trace/TraceSpanInlineDetail.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/trace/TraceSpanInlineDetail.vue
@@ -195,6 +195,22 @@
         <header>
           Event fields
           <span class="sd-src">{{ span.eventType }}</span>
+          <!--
+            A statement is the one field here nobody reads to the end on screen: it scrolls inside
+            its own block and is usually on its way to an editor or a ticket. The button belongs to
+            the region rather than floating over the text, so it never covers the first line of the
+            very statement it is there to hand over.
+          -->
+          <button
+            v-if="detail.sql"
+            type="button"
+            class="sd-copy"
+            :title="copiedSql ? 'Copied to the clipboard' : 'Copy the statement'"
+            @click="copySql"
+          >
+            <i class="bi" :class="copiedSql ? 'bi-check-lg' : 'bi-clipboard'"></i>
+            {{ copiedSql ? 'Copied' : 'Copy' }}
+          </button>
         </header>
         <div class="sd-region-body">
           <pre v-if="detail.sql" class="sd-sql">{{ detail.sql }}</pre>
@@ -459,6 +475,27 @@ defineEmits<{
 const detail = computed(() =>
   spanDetail(props.span.attributes, props.span.eventFields, props.fields)
 );
+
+const copiedSql = ref(false);
+
+/**
+ * Hands the statement over verbatim — what the block shows, not a re-wrapped copy of it, so what
+ * lands in an editor is the text the recording carried.
+ */
+async function copySql(): Promise<void> {
+  const sql = detail.value.sql;
+  if (sql === null) {
+    return;
+  }
+  try {
+    await navigator.clipboard.writeText(sql);
+    copiedSql.value = true;
+    window.setTimeout(() => (copiedSql.value = false), 1500);
+  } catch {
+    // A denied clipboard is the browser's decision, not a fault to report — the reader can still
+    // select the statement by hand. Leaving the button unchanged says "that did not happen".
+  }
+}
 
 /** A hand-written span has no event view: its own fields are already the span's. */
 const hasEventView = computed(
@@ -942,6 +979,33 @@ function percent(part: number, whole: number): string {
 }
 
 .sd-region.is-evt .sd-table tr:nth-child(even) td {
+  background: var(--color-teal-light);
+}
+
+/*
+ * Scaled to the header it sits in rather than to btn-sm: this row is 0.4rem of padding around a
+ * --font-size-sm label, and a standard small button would set the region's height on its own. It
+ * takes the region's teal by inheritance, so it stays part of the header rather than an object
+ * dropped onto it.
+ */
+.sd-copy {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-left: 0.5rem;
+  padding: 0.05rem 0.35rem;
+  border: 1px solid var(--color-teal-lighter);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-card);
+  color: inherit;
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.sd-copy:hover {
   background: var(--color-teal-light);
 }
 

--- a/jeffrey-microscope/pages-microscope/src/components/trace/TraceSpanInlineDetail.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/trace/TraceSpanInlineDetail.vue
@@ -195,25 +195,41 @@
         <header>
           Event fields
           <span class="sd-src">{{ span.eventType }}</span>
-          <!--
-            A statement is the one field here nobody reads to the end on screen: it scrolls inside
-            its own block and is usually on its way to an editor or a ticket. The button belongs to
-            the region rather than floating over the text, so it never covers the first line of the
-            very statement it is there to hand over.
-          -->
-          <button
-            v-if="detail.sql"
-            type="button"
-            class="sd-copy"
-            :title="copiedSql ? 'Copied to the clipboard' : 'Copy the statement'"
-            @click="copySql"
-          >
-            <i class="bi" :class="copiedSql ? 'bi-check-lg' : 'bi-clipboard'"></i>
-            {{ copiedSql ? 'Copied' : 'Copy' }}
-          </button>
         </header>
         <div class="sd-region-body">
-          <pre v-if="detail.sql" class="sd-sql">{{ detail.sql }}</pre>
+          <!--
+            A statement is the one field here nobody reads to the end on screen: it scrolls inside
+            its own block and is usually on its way to an editor or a ticket. So the block itself
+            hands it over — the whole surface copies, which is a target nobody can miss and costs
+            the panel neither height nor a covered first line.
+
+            A click that lands on a selection is not a copy request: someone who dragged out one
+            clause wants that clause, and taking the whole statement out from under them would be
+            the surface overriding a decision they already made.
+          -->
+          <div
+            v-if="detail.sql"
+            class="sd-stmt"
+            :class="{ 'is-copied': copiedSql }"
+            @click="copyUnlessSelecting"
+          >
+            <pre class="sd-sql">{{ detail.sql }}</pre>
+            <!--
+              A real button rather than a hint painted on the surface: a div that copies is
+              unreachable by keyboard and unnameable to a screen reader, and the accessible name
+              here would otherwise be the entire statement. It doubles as the visible instruction
+              that the block is clickable at all — that is what it says, in words, on hover.
+            -->
+            <button
+              type="button"
+              class="sd-stmt-copy"
+              aria-label="Copy the statement"
+              @click.stop="copySql"
+            >
+              <i class="bi" :class="copiedSql ? 'bi-check-lg' : 'bi-clipboard'"></i>
+              {{ copiedSql ? 'Copied' : 'Click to copy' }}
+            </button>
+          </div>
           <table v-if="detail.eventFields.length > 0" class="sd-table">
             <tbody>
               <tr v-for="row in detail.eventFields" :key="row.key">
@@ -495,6 +511,19 @@ async function copySql(): Promise<void> {
     // A denied clipboard is the browser's decision, not a fault to report — the reader can still
     // select the statement by hand. Leaving the button unchanged says "that did not happen".
   }
+}
+
+/**
+ * The surface's own handler: the block copies on a click that was a click, and stays out of the
+ * way of one that ended a drag. The button beside it calls copySql directly, so the deliberate
+ * control still works while a clause is selected.
+ */
+function copyUnlessSelecting(): void {
+  const selection = window.getSelection();
+  if (selection !== null && selection.toString().length > 0) {
+    return;
+  }
+  copySql();
 }
 
 /** A hand-written span has no event view: its own fields are already the span's. */
@@ -983,30 +1012,75 @@ function percent(part: number, whole: number): string {
 }
 
 /*
- * Scaled to the header it sits in rather than to btn-sm: this row is 0.4rem of padding around a
- * --font-size-sm label, and a standard small button would set the region's height on its own. It
- * takes the region's teal by inheritance, so it stays part of the header rather than an object
- * dropped onto it.
+ * The statement and the control that copies it, as one object. The wrapper exists to anchor the
+ * button over the block -- the block itself scrolls, and a control inside a scroller travels with
+ * the text away from the corner it was placed in.
  */
-.sd-copy {
+.sd-stmt {
+  position: relative;
+  cursor: pointer;
+}
+
+.sd-stmt .sd-sql {
+  transition: all var(--transition-base);
+}
+
+/*
+ * The whole surface answers the hover, not just the corner: that tint is the only thing saying the
+ * block is a target before the button fades in beside it. The copied state holds the same teal at
+ * full strength on the border, so the confirmation is visible even with the pointer already gone.
+ */
+.sd-stmt:hover .sd-sql,
+.sd-stmt:focus-within .sd-sql {
+  border-color: var(--color-teal-lighter);
+  background: var(--color-teal-light);
+}
+
+.sd-stmt.is-copied .sd-sql {
+  border-color: var(--color-teal);
+  background: var(--color-teal-light);
+}
+
+.sd-stmt-copy {
+  position: absolute;
+  top: 0.35rem;
+  right: 0.4rem;
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
-  margin-left: 0.5rem;
-  padding: 0.05rem 0.35rem;
+  padding: 0.1rem 0.35rem;
   border: 1px solid var(--color-teal-lighter);
   border-radius: var(--radius-sm);
   background: var(--color-bg-card);
-  color: inherit;
+  color: var(--color-teal);
   font-size: var(--font-size-xs);
   font-weight: 600;
   letter-spacing: 0.05em;
   text-transform: uppercase;
   cursor: pointer;
+  /*
+   * Hidden until the reader is at the block, because it sits over the end of the first line and a
+   * statement is read far more often than it is copied. Hover, keyboard focus and the moment after
+   * a copy each bring it back -- so it is never the case that a copy happened with nothing saying
+   * so, and never the case that a tabbing reader lands on a control they cannot see.
+   */
+  opacity: 0;
+  transition: all var(--transition-base);
 }
 
-.sd-copy:hover {
+.sd-stmt:hover .sd-stmt-copy,
+.sd-stmt-copy:focus-visible,
+.sd-stmt.is-copied .sd-stmt-copy {
+  opacity: 1;
+}
+
+.sd-stmt-copy:hover {
   background: var(--color-teal-light);
+}
+
+.sd-stmt-copy:focus-visible {
+  outline: 2px solid var(--color-teal);
+  outline-offset: 1px;
 }
 
 .sd-sql {

--- a/jeffrey-microscope/pages-microscope/src/components/trace/TraceStackTrace.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/trace/TraceStackTrace.vue
@@ -350,14 +350,40 @@ async function copy(): Promise<void> {
   white-space: nowrap;
 }
 
-/* Tier one: where the class lives. The quietest thing on any row, application or not. */
+/*
+ * A frame is read in three parts and each one gets its own tier, on every row: the package it
+ * lives in, the class, and the method that ran. The hues are the ones JsonHighlight.vue already
+ * paints code with in this app -- a key in --color-primary-hover, a string value in --color-teal --
+ * because a frame has the same shape: the class is the key, the method is what it holds.
+ *
+ * Weight says which tier leads and colour agrees with it. The class is the heaviest at 700: in a
+ * 253-frame stack a reader scans for OgnlParser before they scan for jjMoveStringLiteralDfa3_0.
+ */
 .st-pkg {
   color: var(--color-text-soft);
+  font-weight: 400;
 }
 
-/* Tier three: the method that ran, which is what a reader opens a fold to find. */
+.st-cls {
+  color: var(--color-primary-hover);
+  font-weight: 700;
+}
+
+.st-sig b {
+  color: var(--color-teal);
+  font-weight: 500;
+}
+
+/*
+ * A library row takes the same two hues pulled back toward the neutral ramp rather than two hues of
+ * its own: mixed, not replaced, so "mine" and "not mine" stay one palette read at two distances.
+ */
+.st-fr:not(.app) .st-cls {
+  color: color-mix(in srgb, var(--color-primary-hover) 62%, var(--color-text-soft));
+}
+
 .st-fr:not(.app) .st-sig b {
-  color: var(--color-text);
+  color: color-mix(in srgb, var(--color-teal) 62%, var(--color-text-soft));
 }
 
 .st-src {
@@ -366,24 +392,13 @@ async function copy(): Promise<void> {
   white-space: nowrap;
 }
 
-/* Application frames carry the ink; everything else recedes. The reader only ever needs
-   "mine" against "not mine", so this is two weights and not a palette. */
+/*
+ * Application frames carry the ink; everything else recedes. With every part of the signature now
+ * painted by tier, this is the row's own colour -- what the separators and anything unlabelled take
+ * -- and the ground the tier hues are read against.
+ */
 .st-fr.app {
   color: var(--color-dark);
-}
-
-.st-fr.app .st-sig {
-  font-weight: 600;
-}
-
-/*
- * The package yields to what it prefixes. An application frame sets its signature at 600 and the
- * package rode along at that weight, which made every row's first 20 characters compete with the
- * class name a reader is actually scanning for. Its colour is the shared one every package takes;
- * only the weight has to be undone here, because only an application row sets one.
- */
-.st-fr.app .st-pkg {
-  font-weight: 400;
 }
 
 .st-fr.app .st-src {
@@ -408,6 +423,17 @@ async function copy(): Promise<void> {
  * splitting it into a bold class and a quiet package would break it into two statements.
  */
 .st-fr.throwing .st-pkg {
+  font-weight: 700;
+}
+
+/*
+ * The one row that is not painted by tier. A stack has exactly one throwing frame and the whole
+ * line is the answer the reader opened it for, so it stays a single red statement rather than a
+ * class and a method in two different hues.
+ */
+.st-fr.throwing .st-cls,
+.st-fr.throwing .st-sig b {
+  color: var(--color-danger);
   font-weight: 700;
 }
 

--- a/jeffrey-microscope/pages-microscope/src/components/trace/TraceStackTrace.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/trace/TraceStackTrace.vue
@@ -94,6 +94,7 @@
             v-if="entry.kind === 'fold'"
             type="button"
             class="st-fold"
+            :class="{ open: opened.has(entry.depth) }"
             @click.stop="toggleFold(entry.depth)"
           >
             <i
@@ -349,15 +350,28 @@ async function copy(): Promise<void> {
 }
 
 /*
- * A run put back by opening a bar stays one run. The band alone would only say "these are related";
- * the rail is what says where the run ends, which a tint cannot once a reader has two bars open in
- * the same stack. Square corners so consecutive rows read as one block rather than a stack of chips.
+ * A run put back by opening a bar keeps the bar's own grey, so the two are one block rather than a
+ * control and some rows that happen to follow it. No rail and no new colour: the bar already says
+ * "this is the folded run", and continuing it downward is the whole statement.
+ *
+ * Square corners in the middle of the run -- rounding every row would read as a stack of chips --
+ * and the block is closed off at both ends by the two rules below.
  */
 .st-fr.opened {
-  background: var(--color-light);
-  border-left: 2px solid var(--color-border-input);
+  background: var(--color-lighter);
   border-radius: 0;
-  padding-left: 0.9rem;
+}
+
+/*
+ * The foot of the block. `:has` rather than a second flag on the entry: the rows a bar restores are
+ * always contiguous and always directly under it, so "the last one" is a fact about the list the
+ * stylesheet can see for itself. The next thing along is another bar or an ordinary frame; where
+ * the run ends the stack, there is no next thing at all.
+ */
+.st-fr.opened:last-child,
+.st-fr.opened:has(+ :not(.opened)) {
+  border-radius: 0 0 var(--radius-xs) var(--radius-xs);
+  margin-bottom: 0.1rem;
 }
 
 /*
@@ -366,7 +380,7 @@ async function copy(): Promise<void> {
  * moment the reader points at it.
  */
 .st-fr.opened:hover {
-  background: color-mix(in srgb, var(--color-primary) 6%, var(--color-light));
+  background: color-mix(in srgb, var(--color-primary) 6%, var(--color-lighter));
 }
 
 .st-sig {
@@ -477,6 +491,15 @@ async function copy(): Promise<void> {
   font-size: var(--font-size-sm);
   text-align: left;
   cursor: pointer;
+}
+
+/*
+ * An open bar is the head of the block its frames form: it gives up the gap and the corners between
+ * itself and the first row it restored, and the run below closes the shape off again.
+ */
+.st-fold.open {
+  margin-bottom: 0;
+  border-radius: var(--radius-xs) var(--radius-xs) 0 0;
 }
 
 .st-fold:hover {

--- a/jeffrey-microscope/pages-microscope/src/components/trace/TraceStackTrace.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/trace/TraceStackTrace.vue
@@ -331,7 +331,13 @@ async function copy(): Promise<void> {
   align-items: baseline;
   padding: 0.09rem 0.4rem;
   border-radius: var(--radius-xs);
-  color: var(--color-text-light);
+  /*
+   * A library frame is read in three tiers, quietest first: the package it lives in, the class, and
+   * the method that actually ran. This is the middle one. It used to be --color-text-light for the
+   * whole row, which at 1.8:1 against the card was a frame a reader could see but not read -- and a
+   * fold is opened precisely to read what is inside it.
+   */
+  color: var(--color-text-muted);
 }
 
 .st-fr:hover {
@@ -344,8 +350,14 @@ async function copy(): Promise<void> {
   white-space: nowrap;
 }
 
+/* Tier one: where the class lives. The quietest thing on any row, application or not. */
 .st-pkg {
-  color: var(--color-text-light);
+  color: var(--color-text-soft);
+}
+
+/* Tier three: the method that ran, which is what a reader opens a fold to find. */
+.st-fr:not(.app) .st-sig b {
+  color: var(--color-text);
 }
 
 .st-src {
@@ -366,12 +378,11 @@ async function copy(): Promise<void> {
 
 /*
  * The package yields to what it prefixes. An application frame sets its signature at 600 and the
- * package rode along at that weight in near-ink, which made every row's first 20 characters compete
- * with the class name a reader is actually scanning for. Back to normal weight and one step down
- * the neutral ramp: still readable when the package is the question, no longer loud when it is not.
+ * package rode along at that weight, which made every row's first 20 characters compete with the
+ * class name a reader is actually scanning for. Its colour is the shared one every package takes;
+ * only the weight has to be undone here, because only an application row sets one.
  */
 .st-fr.app .st-pkg {
-  color: var(--color-text-soft);
   font-weight: 400;
 }
 

--- a/jeffrey-microscope/pages-microscope/src/components/trace/TraceStackTrace.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/trace/TraceStackTrace.vue
@@ -364,8 +364,15 @@ async function copy(): Promise<void> {
   font-weight: 600;
 }
 
+/*
+ * The package yields to what it prefixes. An application frame sets its signature at 600 and the
+ * package rode along at that weight in near-ink, which made every row's first 20 characters compete
+ * with the class name a reader is actually scanning for. Back to normal weight and one step down
+ * the neutral ramp: still readable when the package is the question, no longer loud when it is not.
+ */
 .st-fr.app .st-pkg {
-  color: var(--color-text-muted);
+  color: var(--color-text-soft);
+  font-weight: 400;
 }
 
 .st-fr.app .st-src {
@@ -382,6 +389,15 @@ async function copy(): Promise<void> {
 .st-fr.throwing .st-pkg,
 .st-fr.throwing .st-src {
   color: var(--color-danger);
+}
+
+/*
+ * The one row that keeps its package at full weight. Everywhere else the prefix is what the reader
+ * scans past; on the throwing frame the whole line is the answer they opened the stack for, and
+ * splitting it into a bold class and a quiet package would break it into two statements.
+ */
+.st-fr.throwing .st-pkg {
+  font-weight: 700;
 }
 
 .st-fold {

--- a/jeffrey-microscope/pages-microscope/src/components/trace/TraceStackTrace.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/trace/TraceStackTrace.vue
@@ -427,9 +427,20 @@ async function copy(): Promise<void> {
   font-variant-numeric: tabular-nums;
 }
 
+/*
+ * The packages a bar stands in for are packages like any other, so they take the same neutral the
+ * frame rows give a prefix. The bar's own words keep the darker one: "3 frames in" is what the
+ * control says about itself, and it is the row a reader clicks.
+ */
 .st-pkgs {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  color: var(--color-text-soft);
+}
+
+/* On hover the whole bar goes primary, packages included -- the row lights up as one control. */
+.st-fold:hover .st-pkgs {
+  color: inherit;
 }
 </style>

--- a/jeffrey-microscope/pages-microscope/src/components/trace/TraceStackTrace.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/trace/TraceStackTrace.vue
@@ -106,7 +106,11 @@
             </span>
           </button>
 
-          <div v-else class="st-fr" :class="{ app: entry.application, throwing: entry.throwing }">
+          <div
+            v-else
+            class="st-fr"
+            :class="{ app: entry.application, throwing: entry.throwing, opened: entry.restored }"
+          >
             <span class="st-sig">
               <span v-if="framePkg(entry.frame)" class="st-pkg">{{ framePkg(entry.frame) }}.</span
               ><span class="st-cls">{{ frameSimpleName(entry.frame) }}</span
@@ -342,6 +346,27 @@ async function copy(): Promise<void> {
 
 .st-fr:hover {
   background: var(--color-primary-lighter);
+}
+
+/*
+ * A run put back by opening a bar stays one run. The band alone would only say "these are related";
+ * the rail is what says where the run ends, which a tint cannot once a reader has two bars open in
+ * the same stack. Square corners so consecutive rows read as one block rather than a stack of chips.
+ */
+.st-fr.opened {
+  background: var(--color-light);
+  border-left: 2px solid var(--color-border-input);
+  border-radius: 0;
+  padding-left: 0.9rem;
+}
+
+/*
+ * Hover has to be mixed rather than laid over: --color-primary-lighter is translucent, so on a
+ * banded row it would composite against the card behind it and take the band away at exactly the
+ * moment the reader points at it.
+ */
+.st-fr.opened:hover {
+  background: color-mix(in srgb, var(--color-primary) 6%, var(--color-light));
 }
 
 .st-sig {

--- a/jeffrey-microscope/pages-microscope/src/services/trace/traceStackFolding.test.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/trace/traceStackFolding.test.ts
@@ -115,6 +115,11 @@ describe('foldedStack', () => {
     ]);
   });
 
+  it('leaves the frames it keeps unmarked -- only an opened bar restores anything', () => {
+    const frames = foldedStack(stack).filter(entry => entry.kind === 'frame');
+    expect(frames.some(entry => entry.restored)).toBe(false);
+  });
+
   it('keeps the throwing frame and the thread root even though the root is library code', () => {
     const entries = foldedStack(stack);
     const first = entries[0];
@@ -336,6 +341,10 @@ describe('expandFold', () => {
 
   it('restores each frame at its real depth, not counting from zero again', () => {
     expect(expandFold(onlyFold()).map(entry => entry.depth)).toEqual([1, 2]);
+  });
+
+  it('marks every frame it restores, so the panel can band the run it came from', () => {
+    expect(expandFold(onlyFold()).every(entry => entry.restored)).toBe(true);
   });
 
   it('never announces an expanded frame as the one that threw', () => {

--- a/jeffrey-microscope/pages-microscope/src/services/trace/traceStackFolding.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/trace/traceStackFolding.ts
@@ -75,6 +75,12 @@ export interface StackFrameEntry {
   throwing: boolean;
   /** Whether this frame is the reader's own code, by {@link isApplicationFrame}. */
   application: boolean;
+  /**
+   * True only for a frame that is in view because the reader opened the bar that hid it. The panel
+   * bands these rows together: spread back into the list they would otherwise be indistinguishable
+   * from the library frames the fold rule kept, and the run a bar stands for would lose its edges.
+   */
+  restored: boolean;
 }
 
 /** A collapsed run of consecutive library frames. */
@@ -200,7 +206,8 @@ function frameEntry(
     frame,
     depth,
     throwing: depth === throwingIndex,
-    application: isApplicationFrame(frame)
+    application: isApplicationFrame(frame),
+    restored: false
   };
 }
 
@@ -224,7 +231,10 @@ export function expandFold(fold: StackFoldEntry): StackFrameEntry[] {
   // A bar only ever holds frames the fold rule declined to keep, and the throwing frame is always
   // kept — so nothing inside a bar can be it, whatever the throwing index turns out to be.
   const noneAreThrowing = -1;
-  return fold.frames.map((frame, index) => frameEntry(frame, fold.depth + index, noneAreThrowing));
+  return fold.frames.map((frame, index) => ({
+    ...frameEntry(frame, fold.depth + index, noneAreThrowing),
+    restored: true
+  }));
 }
 
 /**

--- a/shared/ui/common/src/assets/design-tokens.css
+++ b/shared/ui/common/src/assets/design-tokens.css
@@ -303,6 +303,8 @@
   --color-dark: #0b1727;
   --color-text: #5e6e82;
   --color-text-muted: #748194;
+  /* Between muted and light: for text that must stay readable while yielding to what it prefixes. */
+  --color-text-soft: #97a3b4;
   --color-text-light: #b6c1d2;
   
   /* Border Colors */


### PR DESCRIPTION
The trace modal's span detail renders a JdbcQuery-style statement in a scrolling block that nobody reads to the end on screen - it is usually on its way to an editor or a ticket. The Event fields header now carries a copy control beside the event type, so the statement can be lifted verbatim without hand-selecting a scrolled block.

The button sits in the region header rather than floating over the text, so it never covers the first line of the statement it hands over, and it is scaled and coloured to that header instead of using btn-sm, which would set the region's height on its own.