### PR TITLE
Handle missing class-typed fields in WeightExtractor

### DIFF
--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/parser/WeightExtractor.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/parser/WeightExtractor.java
@@ -18,6 +18,7 @@
 
 package cafe.jeffrey.profile.parser;
 
+import jdk.jfr.consumer.RecordedClass;
 import jdk.jfr.consumer.RecordedEvent;
 import cafe.jeffrey.shared.common.BytesUtils;
 import cafe.jeffrey.shared.common.DurationUtils;
@@ -53,7 +54,7 @@ public record WeightExtractor(
         return new WeightExtractor(
                 e -> e.getDuration().toNanos(),
                 DurationUtils::formatNanos,
-                e -> e.getClass(entityClassField).getName());
+                classNameOf(entityClassField));
     }
 
     public static WeightExtractor duration(Function<RecordedEvent, String> entityExtractor) {
@@ -78,7 +79,7 @@ public record WeightExtractor(
         return new WeightExtractor(
                 e -> e.getLong(fieldName),
                 BytesUtils::format,
-                e -> e.getClass(entityClassField).getName());
+                classNameOf(entityClassField));
     }
 
     public static WeightExtractor allocation(String fieldName, Function<RecordedEvent, String> entityExtractor) {
@@ -90,5 +91,21 @@ public record WeightExtractor(
 
     public static WeightExtractor allocationEntityOnly(Function<RecordedEvent, String> entityExtractor) {
         return new WeightExtractor(null, null, entityExtractor);
+    }
+
+    /**
+     * Reads the name of a class-typed field. The field is declared on the event type but is not always
+     * populated — {@code jdk.ThreadPark} carries no {@code parkedClass} when the code parks without a
+     * blocker, and {@code jdk.JavaMonitorWait} can omit {@code monitorClass} — so an absent class means
+     * the event has no weight entity rather than a broken recording.
+     */
+    private static Function<RecordedEvent, String> classNameOf(String entityClassField) {
+        return event -> {
+            RecordedClass entityClass = event.getClass(entityClassField);
+            if (entityClass == null) {
+                return null;
+            }
+            return entityClass.getName();
+        };
     }
 }

--- a/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/parser/WeightExtractorTest.java
+++ b/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/parser/WeightExtractorTest.java
@@ -18,16 +18,37 @@
 
 package cafe.jeffrey.profile.parser;
 
+import jdk.jfr.Event;
+import jdk.jfr.FlightRecorder;
+import jdk.jfr.Name;
+import jdk.jfr.Registered;
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.EventStream;
+import jdk.jfr.consumer.RecordedEvent;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.LongFunction;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @DisplayName("WeightExtractor factory methods")
 class WeightExtractorTest {
+
+    private static final String ENTITY_EVENT_NAME = "test.WeightEntityEvent";
+
+    @Name(ENTITY_EVENT_NAME)
+    @Registered(false)
+    static class WeightEntityEvent extends Event {
+        Class<?> monitorClass;
+        long size;
+    }
 
     @Nested
     @DisplayName("duration() no-arg factory method")
@@ -107,5 +128,83 @@ class WeightExtractorTest {
             assertTrue(result.contains("s") || result.contains("ns"),
                     "Expected time string for 1us, but got: " + result);
         }
+    }
+
+    @Nested
+    @DisplayName("Class-typed entity field that the event left empty")
+    class MissingEntityClass {
+
+        @Test
+        @DisplayName("duration(entityClassField) yields no entity instead of failing")
+        void durationYieldsNoEntity(@TempDir Path tempDir) throws Exception {
+            RecordedEvent event = recordEntityEvent(tempDir, null);
+
+            WeightExtractor extractor = WeightExtractor.duration("monitorClass");
+
+            assertNull(extractor.entityExtractor().apply(event));
+        }
+
+        @Test
+        @DisplayName("allocation(fieldName, entityClassField) yields no entity instead of failing")
+        void allocationYieldsNoEntity(@TempDir Path tempDir) throws Exception {
+            RecordedEvent event = recordEntityEvent(tempDir, null);
+
+            WeightExtractor extractor = WeightExtractor.allocation("size", "monitorClass");
+
+            assertNull(extractor.entityExtractor().apply(event));
+            assertEquals(1024L, extractor.extractor().applyAsLong(event));
+        }
+    }
+
+    @Nested
+    @DisplayName("Class-typed entity field that the event populated")
+    class PresentEntityClass {
+
+        @Test
+        @DisplayName("duration(entityClassField) reads the class name")
+        void durationReadsClassName(@TempDir Path tempDir) throws Exception {
+            RecordedEvent event = recordEntityEvent(tempDir, String.class);
+
+            WeightExtractor extractor = WeightExtractor.duration("monitorClass");
+
+            assertEquals("java.lang.String", extractor.entityExtractor().apply(event));
+        }
+
+        @Test
+        @DisplayName("allocation(fieldName, entityClassField) reads the class name")
+        void allocationReadsClassName(@TempDir Path tempDir) throws Exception {
+            RecordedEvent event = recordEntityEvent(tempDir, String.class);
+
+            WeightExtractor extractor = WeightExtractor.allocation("size", "monitorClass");
+
+            assertEquals("java.lang.String", extractor.entityExtractor().apply(event));
+        }
+    }
+
+    private static RecordedEvent recordEntityEvent(Path tempDir, Class<?> monitorClass) throws IOException {
+        Path dumpFile = tempDir.resolve("weight-entity.jfr");
+        FlightRecorder.register(WeightEntityEvent.class);
+
+        try (Recording recording = new Recording()) {
+            recording.enable(ENTITY_EVENT_NAME);
+            recording.start();
+
+            WeightEntityEvent event = new WeightEntityEvent();
+            event.begin();
+            event.monitorClass = monitorClass;
+            event.size = 1024L;
+            event.commit();
+
+            recording.stop();
+            recording.dump(dumpFile);
+        }
+
+        List<RecordedEvent> events = new ArrayList<>();
+        try (EventStream stream = EventStream.openFile(dumpFile)) {
+            stream.onEvent(ENTITY_EVENT_NAME, events::add);
+            stream.start();
+        }
+        assertFalse(events.isEmpty(), "Expected at least one " + ENTITY_EVENT_NAME + " event");
+        return events.getFirst();
     }
 }


### PR DESCRIPTION
## Summary
Fixes a potential `NullPointerException` in `WeightExtractor` when JFR events have class-typed fields that are not populated. Some JFR events (like `jdk.ThreadPark` and `jdk.JavaMonitorWait`) may omit class fields when certain conditions aren't met, and the extractor should gracefully return `null` instead of failing.

## Key Changes
- **WeightExtractor.java**: Added `classNameOf()` helper method that safely handles `null` class fields by checking if `RecordedClass` is `null` before calling `getName()`. Updated `duration(String)` and `allocation(String, String)` factory methods to use this helper.
- **WeightExtractorTest.java**: Added comprehensive test coverage with two nested test classes:
  - `MissingEntityClass`: Verifies that extractors return `null` when the class field is absent
  - `PresentEntityClass`: Verifies that extractors correctly read class names when the field is populated
  - Added `WeightEntityEvent` test event class and `recordEntityEvent()` helper to create actual JFR recordings for testing

## Implementation Details
The fix uses JFR's `EventStream` API to record and playback test events, ensuring the behavior is validated against real JFR event serialization. The `classNameOf()` method returns a `Function<RecordedEvent, String>` that safely extracts class names, allowing the rest of the codebase to treat `null` as a valid "no entity" result rather than an error condition.

https://claude.ai/code/session_017GdZnQk4dMGqqFQC7S54yV