### PR TITLE
Improve TraceAttributeStepPicker dropdown layout and scrolling

### DIFF
--- a/jeffrey-microscope/pages-microscope/src/components/trace/TraceAttributeStepPicker.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/trace/TraceAttributeStepPicker.vue
@@ -354,7 +354,7 @@ onBeforeUnmount(() => {
   padding: var(--spacing-1) var(--spacing-3) var(--spacing-1) var(--spacing-1);
   font-size: var(--font-size-base);
   cursor: pointer;
-  max-width: 340px;
+  max-width: 560px;
 }
 
 /*

--- a/jeffrey-microscope/pages-microscope/src/components/trace/TraceAttributeStepPicker.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/trace/TraceAttributeStepPicker.vue
@@ -419,6 +419,8 @@ onBeforeUnmount(() => {
 .chip-label {
   font-size: var(--font-size-sm);
   color: var(--color-text-muted);
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .chip-value {

--- a/jeffrey-microscope/pages-microscope/src/components/trace/TraceAttributeStepPicker.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/trace/TraceAttributeStepPicker.vue
@@ -446,6 +446,11 @@ onBeforeUnmount(() => {
   font-size: var(--font-size-xs);
 }
 
+/*
+ * Capped and scrollable: a profile can carry dozens of event types, and an uncapped list runs past
+ * the bottom of the viewport where the tail is unreachable. The head stays pinned while the rows
+ * scroll under it, so the question the list answers never scrolls away.
+ */
 .picker-pop {
   position: absolute;
   top: calc(100% + var(--spacing-1));
@@ -453,14 +458,18 @@ onBeforeUnmount(() => {
   z-index: 20;
   width: 430px;
   max-width: 82vw;
+  max-height: min(420px, 60vh);
   background: var(--color-white);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-lg);
-  overflow: hidden;
+  overflow-y: auto;
 }
 
 .pop-head {
+  position: sticky;
+  top: 0;
+  z-index: 1;
   display: flex;
   align-items: center;
   gap: var(--spacing-2);


### PR DESCRIPTION
## Summary
Enhanced the trace attribute step picker dropdown to better handle large lists of event types by implementing scrollable content with a sticky header, and improved chip label styling to prevent text overflow.

## Key Changes
- **Increased dropdown width** from 340px to 560px to provide more space for content display
- **Added scrollable dropdown** with `max-height: min(420px, 60vh)` and `overflow-y: auto` to cap the picker popup and allow scrolling when content exceeds viewport
- **Sticky header** on `.pop-head` (position: sticky, top: 0, z-index: 1) to keep the question/header visible while scrolling through event types
- **Improved chip label styling** with `white-space: nowrap` and `flex-shrink: 0` to prevent label text wrapping and maintain consistent layout
- **Added documentation comment** explaining the rationale for capped, scrollable design to handle profiles with dozens of event types

## Implementation Details
The changes address a UX issue where profiles with many event types would cause the picker dropdown to extend beyond the viewport, making the tail unreachable. The sticky header pattern ensures users always see the context of what they're selecting while scrolling through the list.

https://claude.ai/code/session_01C7RrRQuP8pPakGxvPbH4cq