### PR TITLE
Fix docs index page layout squeezed on mobile viewports

### DIFF
--- a/jeffrey-pages/src/views/docs/DocsLayout.vue
+++ b/jeffrey-pages/src/views/docs/DocsLayout.vue
@@ -297,6 +297,12 @@ onUnmounted(() => {
   .docs-main-container {
     max-width: var(--content-max-width);
   }
+
+  /* The TOC is hidden here, so the index picker no longer needs to reserve
+     its column — regular doc pages don't have it at this width either. */
+  .docs-layout.is-index .docs-main {
+    padding-right: 2rem;
+  }
 }
 
 /* ============================
@@ -331,6 +337,12 @@ onUnmounted(() => {
   .docs-main {
     padding: 1rem;
     margin-left: 0;
+  }
+
+  /* Keep the index picker's right padding in sync with the mobile padding —
+     the desktop-only TOC reservation must never apply on phones. */
+  .docs-layout.is-index .docs-main {
+    padding-right: 1rem;
   }
 
   .mobile-overlay {


### PR DESCRIPTION
The /docs product picker reserved the right TOC column via
padding-right on .docs-layout.is-index .docs-main to mirror regular
doc pages. That rule is more specific than the mobile padding
override, so on phones it kept eating ~284px and squeezed the picker
article into a sliver. Reset the reserved padding at <=1199px (where
the TOC is hidden everywhere) and align it with the 1rem mobile
padding at <=991px.