### PR TITLE
Promote traced methods into the trace waterfall

### DIFF
--- a/jeffrey-microscope/pages-microscope/src/components/trace/TraceOperationSummary.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/trace/TraceOperationSummary.vue
@@ -234,6 +234,7 @@ import type {
 import {
   contextColor,
   contextLabel,
+  isMethodEventType,
   operationKey,
   promotedCategory
 } from '@/services/trace/traceLabels';
@@ -517,8 +518,13 @@ const rankedSpans = computed(() =>
 const APPLICATION_SPAN_COLOR = 'var(--color-primary)';
 
 /** Whether the row is a wait the derivation promoted rather than a span the application recorded. */
+/*
+ * Tested by event type rather than by a `synthesized` flag, which this row does not carry: the
+ * breakdown aggregates spans across traces and keeps only what is common to them. A traced method
+ * has to be named explicitly because, unlike every promoted wait, it maps to no context category.
+ */
 function isPromoted(span: TraceOperationSpanRow): boolean {
-  return promotedCategory(span.eventType) !== null;
+  return promotedCategory(span.eventType) !== null || isMethodEventType(span.eventType);
 }
 
 /**
@@ -533,10 +539,13 @@ function spanColor(span: TraceOperationSpanRow): string {
 
 function spanTypeTitle(span: TraceOperationSpanRow): string {
   const category = promotedCategory(span.eventType);
-  if (category === null) {
-    return `Recorded by ${span.eventType}`;
+  if (category !== null) {
+    return `${contextLabel(category)}, promoted from the ${span.eventType} events inside these traces`;
   }
-  return `${contextLabel(category)}, promoted from the ${span.eventType} events inside these traces`;
+  if (isMethodEventType(span.eventType)) {
+    return `Traced method, promoted from the ${span.eventType} events inside these traces`;
+  }
+  return `Recorded by ${span.eventType}`;
 }
 
 /**

--- a/jeffrey-microscope/pages-microscope/src/components/trace/TraceWaterfall.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/trace/TraceWaterfall.vue
@@ -90,6 +90,18 @@
           I/O ops
           <span v-if="promotedIoCount === 0" class="wf-zero">0 events</span>
         </button>
+        <button
+          type="button"
+          class="wf-switch-item"
+          :aria-pressed="showMethodOps && promotedMethodCount > 0"
+          :disabled="promotedMethodCount === 0"
+          :title="methodToggleTitle"
+          @click="showMethodOps = !showMethodOps"
+        >
+          <span class="wf-switch" :class="{ on: showMethodOps && promotedMethodCount > 0 }"></span>
+          Methods
+          <span v-if="promotedMethodCount === 0" class="wf-zero">0 events</span>
+        </button>
         <!--
           The two instant families, each with its own switch for the same reason Blocking ops and
           I/O ops have theirs: they answer different questions, so silencing one must not silence
@@ -898,7 +910,12 @@ import type {
 import { attributeRows } from '@/services/trace/spanAttributes';
 import type { SpanBar } from '@/services/trace/TraceWaterfallLayout';
 import { indentRem, traceWindow, waterfallBars } from '@/services/trace/TraceWaterfallLayout';
-import { descendantCounts, spansWithChildren, visibleSpans } from '@/services/trace/traceTree';
+import {
+  descendantCounts,
+  drawnSpans,
+  spansWithChildren,
+  visibleSpans
+} from '@/services/trace/traceTree';
 import type { ContextBand, ThrottleBand } from '@/services/trace/TraceContextBands';
 import {
   bandAt,
@@ -912,6 +929,7 @@ import {
   contextLabel,
   exceptionColor,
   isIoCategory,
+  isMethodEventType,
   promotedCategory,
   severityColor,
   severityLabel,
@@ -1147,6 +1165,7 @@ watch(
     showContext.value = true;
     showBlockingOps.value = true;
     showIoOps.value = true;
+    showMethodOps.value = true;
   }
 );
 
@@ -1173,6 +1192,16 @@ const showBlockingOps = ref(true);
 /** Whether the promoted file and socket I/O rows are drawn — the other master of the same split. */
 const showIoOps = ref(true);
 
+/**
+ * Whether the promoted traced-method rows are drawn.
+ *
+ * Its own master rather than a share of the blocking one, because it answers a different question:
+ * the other two ask "show me the waiting", this asks "show me my own code". A filter set to trace a
+ * whole class can also put far more rows on the screen than either wait family, and hiding them
+ * must not take the socket read that explains the trace with them.
+ */
+const showMethodOps = ref(true);
+
 /** Whether the global pause bands are drawn — the third master, over what the JVM did to the trace. */
 const showContext = ref(true);
 
@@ -1180,8 +1209,15 @@ const promotedCount = computed(() => props.spans.filter(span => span.synthesized
 
 const promotedIoCount = computed(() => props.spans.filter(isPromotedIo).length);
 
+const promotedMethodCount = computed(() => props.spans.filter(isPromotedMethod).length);
+
+/*
+ * Counted as the complement, so every promoted row belongs to exactly one master and none of them
+ * can fall through the toolbar unswitchable. That makes the subtraction load-bearing: a family added
+ * here without a term in it would be counted as blocking and governed by the wrong switch.
+ */
 const promotedBlockingCount = computed(
-  () => promotedCount.value - promotedIoCount.value
+  () => promotedCount.value - promotedIoCount.value - promotedMethodCount.value
 );
 
 /** Whether a span is a promoted file or socket I/O wait, as opposed to any other promoted wait. */
@@ -1192,6 +1228,22 @@ function isPromotedIo(span: TraceSpanRow): boolean {
   const category = promotedCategory(span.eventType);
   return category !== null && isIoCategory(category);
 }
+
+/** Whether a span is a promoted traced method, as opposed to a promoted wait. */
+function isPromotedMethod(span: TraceSpanRow): boolean {
+  return span.synthesized && isMethodEventType(span.eventType);
+}
+
+const methodToggleTitle = computed(() => {
+  if (promotedMethodCount.value === 0) {
+    return 'No traced methods were promoted in this trace';
+  }
+  const count = promotedMethodCount.value;
+  const ops = count === 1 ? '1 traced method' : `${count} traced methods`;
+  return showMethodOps.value
+    ? `Hide the ${ops} drawn as child spans`
+    : `Show the ${ops} drawn as child spans`;
+});
 
 const blockingToggleTitle = computed(() => {
   if (promotedBlockingCount.value === 0) {
@@ -1341,7 +1393,7 @@ const foldedCounts = computed(() => descendantCounts(props.spans));
  * leaf by construction, so the depth sequence the rendering reads stays intact.
  */
 const rows = computed(() => {
-  const visible = visibleSpans(props.spans, collapsed.value).filter(isSpanDrawn);
+  const visible = drawnSpans(visibleSpans(props.spans, collapsed.value), isSpanDrawn);
   if (!criticalOnly.value) {
     return visible;
   }
@@ -1527,6 +1579,9 @@ function isSpanDrawn(span: TraceSpanRow): boolean {
   if (!span.synthesized) {
     return true;
   }
+  if (isPromotedMethod(span)) {
+    return showMethodOps.value;
+  }
   return isPromotedIo(span) ? showIoOps.value : showBlockingOps.value;
 }
 
@@ -1577,6 +1632,8 @@ function showAllSpans(): void {
   criticalOnly.value = false;
   collapsed.value = new Set();
   showBlockingOps.value = true;
+  showIoOps.value = true;
+  showMethodOps.value = true;
 }
 
 /** In drawn order, so "first" means the first the reader would meet scrolling down. */
@@ -1801,6 +1858,13 @@ function barStyle(span: TraceSpanRow) {
 function barClass(span: TraceSpanRow): string {
   if (span.status === 'ERROR') {
     return 'bar-error';
+  }
+  if (isPromotedMethod(span)) {
+    // Not 'bar-synthesized': that class exists for a promoted *wait*, which is a leaf whose self
+    // time equals its duration and so has no wash worth drawing. A traced method has children, so
+    // its self time is exactly the number the reader came for. It is styled as the internal span it
+    // genuinely is, outlined to show it was derived rather than recorded.
+    return 'bar-internal bar-method';
   }
   if (span.synthesized) {
     return 'bar-synthesized';
@@ -3007,6 +3071,19 @@ function tooltip(span: TraceSpanRow): string {
  */
 .bar-synthesized {
   opacity: 0.9;
+}
+
+/*
+ * Derived, not recorded — said with an outline rather than a hue. A traced method is the
+ * application's own work, so it keeps the internal span's colour instead of taking a fourteenth
+ * one out of a ramp that has no room left; the dashes are what tell it apart from a span the
+ * instrumentation actually recorded. Outline rather than border because the bars are positioned
+ * and sized in percentages, and a border would change what those percentages mean.
+ */
+.bar-method {
+  opacity: 0.9;
+  outline: 1px dashed var(--color-text-soft);
+  outline-offset: -1px;
 }
 
 .bar-synthesized .wf-self {

--- a/jeffrey-microscope/pages-microscope/src/services/api/model/trace/TraceModels.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/model/trace/TraceModels.ts
@@ -98,10 +98,14 @@ export interface TraceSpanRow {
    */
   eventFields: string | null;
   /**
-   * Whether the derivation synthesized this span out of a blocking JDK event (`jdk.SocketRead`,
-   * `jdk.JavaMonitorEnter`, ...) rather than reading it off an instrumented span event. A
-   * synthesized span carries a minted id and is always a leaf — what lets the waterfall style and
-   * filter promoted waits apart from recorded spans.
+   * Whether the derivation synthesized this span out of a JDK event rather than reading it from an
+   * instrumented span event.
+   *
+   * Two kinds of it, and they differ in shape. A promoted *wait* (`jdk.SocketRead`,
+   * `jdk.JavaMonitorEnter`, ...) is always a leaf, and wears its context category's colour. A
+   * promoted *traced method* (`jdk.MethodTrace`) is not: a traced method's duration includes the
+   * methods it calls, so it can hold other method spans and the waits that happened inside it.
+   * Anything that walks the tree has to allow for a synthesized span with children.
    */
   synthesized: boolean;
 }

--- a/jeffrey-microscope/pages-microscope/src/services/trace/traceLabels.test.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/trace/traceLabels.test.ts
@@ -21,6 +21,8 @@ import { describe, expect, it } from 'vitest';
 import {
   errorLabel,
   isIoCategory,
+  isMethodEventType,
+  METHOD_TRACE_EVENT_TYPE,
   operationKey,
   parseOperationName,
   promotedCategory,
@@ -175,5 +177,23 @@ describe('parseOperationName', () => {
     expect(parseOperationName('', 'jeffrey.TraceSpan')).toEqual([
       { kind: 'name', text: '(unnamed)' }
     ]);
+  });
+});
+
+describe('isMethodEventType', () => {
+  it('recognises a promoted traced method', () => {
+    expect(isMethodEventType(METHOD_TRACE_EVENT_TYPE)).toBe(true);
+  });
+
+  it('does not treat a promoted wait as one', () => {
+    expect(isMethodEventType('jdk.SocketRead')).toBe(false);
+    expect(isMethodEventType('jeffrey.TraceSpan')).toBe(false);
+  });
+
+  it('maps to no context category, so its time stays own work', () => {
+    // The why-slow panel rebuilds a promoted category's total from the synthesized spans carrying
+    // it. A traced method is the trace's own work, not a wait, so giving it a category here would
+    // move its time out of OWN_WORK and into a wait total that never happened.
+    expect(promotedCategory(METHOD_TRACE_EVENT_TYPE)).toBeNull();
   });
 });

--- a/jeffrey-microscope/pages-microscope/src/services/trace/traceLabels.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/trace/traceLabels.ts
@@ -50,6 +50,21 @@ import type {
  * the trace's own code running — seen at trace scope instead of span scope.
  */
 /**
+ * The event type the method promotion reads — `jdk.MethodTrace` (JEP 520).
+ *
+ * It is deliberately absent from {@link PROMOTED_CATEGORY_BY_EVENT_TYPE}: that map exists so a
+ * promoted *wait* can borrow its category's colour, and a traced method is not a wait. It is the
+ * trace's own work, which is why its time stays in `OWN_WORK` rather than joining a wait total, and
+ * why it is styled as the internal span it is rather than given a hue of its own.
+ */
+export const METHOD_TRACE_EVENT_TYPE = 'jdk.MethodTrace';
+
+/** Whether a promoted span came from a traced method rather than from a wait. */
+export function isMethodEventType(eventType: string): boolean {
+  return eventType === METHOD_TRACE_EVENT_TYPE;
+}
+
+/**
  * The one context category that is a *window* rather than a measured stretch, named once so the
  * views that must treat it differently agree on which one it is.
  */

--- a/jeffrey-microscope/pages-microscope/src/services/trace/traceTree.test.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/trace/traceTree.test.ts
@@ -17,7 +17,12 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { descendantCounts, spansWithChildren, visibleSpans } from '@/services/trace/traceTree';
+import {
+  descendantCounts,
+  drawnSpans,
+  spansWithChildren,
+  visibleSpans
+} from '@/services/trace/traceTree';
 import type { TraceSpanRow } from '@/services/api/model/trace/TraceModels';
 
 /** A row carrying only what the tree helpers read: its id and its depth. */
@@ -123,5 +128,61 @@ describe('descendantCounts', () => {
 
   it('handles an empty list', () => {
     expect(descendantCounts([]).size).toBe(0);
+  });
+});
+
+/** A parented row, for the subtree filter — `row` alone leaves every parent null. */
+function child(spanId: string, parentSpanId: string, depth: number): TraceSpanRow {
+  return { ...row(spanId, depth), parentSpanId };
+}
+
+describe('drawnSpans', () => {
+  /*
+   *   recorded
+   *     outer      (a traced method, so it can hold children)
+   *       inner    (another traced method)
+   *         read   (a promoted wait, inside the method)
+   *     sibling
+   */
+  const NESTED = [
+    row('recorded', 0),
+    child('outer', 'recorded', 1),
+    child('inner', 'outer', 2),
+    child('read', 'inner', 3),
+    child('sibling', 'recorded', 1)
+  ];
+
+  it('keeps everything when the filter keeps everything', () => {
+    expect(drawnSpans(NESTED, () => true).map(span => span.spanId)).toEqual([
+      'recorded',
+      'outer',
+      'inner',
+      'read',
+      'sibling'
+    ]);
+  });
+
+  it('takes the subtree with a hidden row', () => {
+    // The reason this exists: hiding `outer` row-by-row would leave inner and read indented under a
+    // parent that is no longer drawn.
+    const drawn = drawnSpans(NESTED, span => span.spanId !== 'outer');
+
+    expect(drawn.map(span => span.spanId)).toEqual(['recorded', 'sibling']);
+  });
+
+  it('hides only what hangs under the hidden row', () => {
+    const drawn = drawnSpans(NESTED, span => span.spanId !== 'inner');
+
+    expect(drawn.map(span => span.spanId)).toEqual(['recorded', 'outer', 'sibling']);
+  });
+
+  it('still drops a leaf on its own', () => {
+    const drawn = drawnSpans(NESTED, span => span.spanId !== 'read');
+
+    expect(drawn.map(span => span.spanId)).toEqual(['recorded', 'outer', 'inner', 'sibling']);
+  });
+
+  it('drops a whole tree when its root goes', () => {
+    expect(drawnSpans(NESTED, span => span.spanId !== 'recorded')).toEqual([]);
   });
 });

--- a/jeffrey-microscope/pages-microscope/src/services/trace/traceTree.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/trace/traceTree.ts
@@ -97,3 +97,31 @@ export function descendantCounts(spans: TraceSpanRow[]): Map<string, number> {
   }
   return counts;
 }
+
+/**
+ * The rows that survive a per-row filter, each with whatever hangs under it.
+ *
+ * Filtering row by row is only safe while everything a filter can remove is a leaf. That stopped
+ * being true once traced methods became spans: a method span holds the methods it called and the
+ * waits that happened inside it, so removing one on its own would leave its children indented under
+ * a parent that is no longer drawn.
+ *
+ * Relies on tree order — the caller passes spans with every parent ahead of its children, which is
+ * what {@link visibleSpans} returns — so one pass carries each decision downwards and no parent
+ * chain is ever walked.
+ */
+export function drawnSpans(
+  spans: TraceSpanRow[],
+  isDrawn: (span: TraceSpanRow) => boolean
+): TraceSpanRow[] {
+  const hidden = new Set<string>();
+  const drawn: TraceSpanRow[] = [];
+  for (const span of spans) {
+    if ((span.parentSpanId !== null && hidden.has(span.parentSpanId)) || !isDrawn(span)) {
+      hidden.add(span.spanId);
+      continue;
+    }
+    drawn.push(span);
+  }
+  return drawn;
+}

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/JdbcTraceRepository.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/JdbcTraceRepository.java
@@ -245,7 +245,7 @@ public class JdbcTraceRepository implements TraceRepository {
                 SELECT NULLIF(CAST(json_merge_patch(<<rehydrated>>, '{%s}') AS VARCHAR), '{}') AS payload
                 FROM events_raw e
                 LEFT JOIN field_texts t ON t.text_hash = e.pooled_text_hash
-                WHERE e.event_type IN (:blocking_event_types)
+                WHERE e.event_type IN (:promoted_event_types)
                   AND e.thread_hash IS NOT NULL
             )
             WHERE payload IS NOT NULL
@@ -385,30 +385,112 @@ public class JdbcTraceRepository implements TraceRepository {
                 WHERE e.event_type IN (:blocking_event_types)
                   AND e.thread_hash IS NOT NULL
             ),
-            parented AS (
+            -- jdk.MethodTrace (JEP 520). Unlike a blocking event it names itself -- the name is
+            -- read out of the event rather than taken from a fixed label -- and it NESTS: a traced
+            -- method's duration includes the methods it calls, so one can contain another and a
+            -- blocking wait can happen inside one. `nests` is what carries that difference forward.
+            methods AS (
                 SELECT
-                    b.*,
-                    s.trace_id  AS trace_id,
-                    s.span_id   AS parent_span_id
-                FROM blocking b
+                    e.rowid                                         AS event_row,
+                    e.event_type                                    AS event_type,
+                    e.start_timestamp                               AS start_timestamp,
+                    COALESCE(e.start_timestamp_from_beginning, 0)   AS start_ms,
+                    COALESCE(e.duration, 0)                         AS duration,
+                    e.thread_hash                                   AS thread_hash,
+                    <<rehydrated>>                                  AS fields,
+                    %s
+                    EPOCH_US(e.start_timestamp)                     AS start_us,
+                    TRUE                                            AS nests
+                FROM events_raw e
+                LEFT JOIN field_texts t ON t.text_hash = e.pooled_text_hash
+                WHERE e.event_type = :method_event_type
+                  AND e.thread_hash IS NOT NULL
+            ),
+            candidates AS (
+                SELECT event_row, event_type, start_timestamp, start_ms, duration, thread_hash,
+                       fields, name, kind, start_us, FALSE AS nests
+                FROM blocking
+                UNION ALL
+                SELECT event_row, event_type, start_timestamp, start_ms, duration, thread_hash,
+                       fields, name, kind, start_us, nests
+                FROM methods
+            ),
+            -- Which trace a candidate belongs to, answered by the innermost RECORDED span open on
+            -- its thread. Trace identity comes from instrumentation and only from instrumentation:
+            -- a method span is inside a trace because a recorded span contains it, never because
+            -- another method span does.
+            traced AS (
+                SELECT
+                    c.*,
+                    s.trace_id  AS trace_id
+                FROM candidates c
                 JOIN recorded s
-                  ON s.thread_hash = b.thread_hash
-                 AND b.start_us >= EPOCH_US(s.start_timestamp)
-                 AND b.start_us <= EPOCH_US(s.start_timestamp) + s.duration // 1000
+                  ON s.thread_hash = c.thread_hash
+                 AND c.start_us >= EPOCH_US(s.start_timestamp)
+                 AND c.start_us <= EPOCH_US(s.start_timestamp) + s.duration // 1000
                 QUALIFY ROW_NUMBER() OVER (
-                    PARTITION BY b.event_row
+                    PARTITION BY c.event_row
                     ORDER BY EPOCH_US(s.start_timestamp) DESC,
                              EPOCH_US(s.start_timestamp) + s.duration // 1000 ASC,
                              s.span_id) = 1
             ),
+            -- Minted before parenting, which is what makes nesting possible at all: the id is a pure
+            -- function of columns already in hand, so a method span can be offered as a parent in the
+            -- same statement that creates it, with no recursion and no second insert.
             minted AS (
                 SELECT
-                    p.*,
+                    t.*,
                     1 + CAST(mod(
-                            hash(CONCAT_WS('|', p.trace_id, p.thread_hash, p.event_type,
-                                                p.start_us, p.event_row)),
+                            hash(CONCAT_WS('|', t.trace_id, t.thread_hash, t.event_type,
+                                                t.start_us, t.event_row)),
                             CAST(9223372036854775806 AS UBIGINT)) AS BIGINT) AS span_id
-                FROM parented p
+                FROM traced t
+            ),
+            -- What a promoted span may hang under: every recorded span, plus the method spans just
+            -- minted. Blocking candidates are deliberately absent -- nothing nests inside a wait.
+            parent_candidates AS (
+                SELECT
+                    trace_id, span_id, thread_hash,
+                    EPOCH_US(start_timestamp)                       AS from_us,
+                    EPOCH_US(start_timestamp) + duration // 1000    AS to_us
+                FROM recorded
+                UNION ALL
+                SELECT
+                    trace_id, span_id, thread_hash,
+                    start_us                                        AS from_us,
+                    start_us + duration // 1000                     AS to_us
+                FROM minted
+                WHERE nests
+            ),
+            /*
+             * The parent: the innermost candidate whose window contains the child's start.
+             *
+             * The three-part guard is what keeps this a tree. Two method spans that begin on the
+             * same microsecond each contain the other's start, so containment alone would let them
+             * adopt each other and the tree would close into a cycle. The guard admits a parent only
+             * when it strictly precedes the child in the total order (from ASC, to DESC, span_id
+             * ASC) -- an order in which a container always precedes what it contains -- so a cycle
+             * cannot be expressed. The QUALIFY then reads that same order backwards to pick the
+             * innermost of the candidates that survived.
+             */
+            parented AS (
+                SELECT
+                    m.*,
+                    p.span_id   AS parent_span_id
+                FROM minted m
+                JOIN parent_candidates p
+                  ON p.trace_id = m.trace_id
+                 AND p.thread_hash = m.thread_hash
+                 AND m.start_us >= p.from_us
+                 AND m.start_us <= p.to_us
+                 AND (p.from_us < m.start_us
+                      OR (p.from_us = m.start_us
+                          AND (p.to_us > m.start_us + m.duration // 1000
+                               OR (p.to_us = m.start_us + m.duration // 1000
+                                   AND p.span_id < m.span_id))))
+                QUALIFY ROW_NUMBER() OVER (
+                    PARTITION BY m.event_row
+                    ORDER BY p.from_us DESC, p.to_us ASC, p.span_id) = 1
             ),
             promoted AS (
                 SELECT
@@ -427,7 +509,7 @@ public class JdbcTraceRepository implements TraceRepository {
                     NULL                                                AS attributes,
                     NULLIF(CAST(json_merge_patch(m.fields, '{%s}') AS VARCHAR), '{}') AS payload,
                     TRUE                                                AS synthesized
-                FROM minted m
+                FROM parented m
                 WHERE NOT EXISTS (
                     SELECT 1 FROM recorded t
                     WHERE t.trace_id = m.trace_id AND t.span_id = m.span_id)
@@ -1265,7 +1347,7 @@ public class JdbcTraceRepository implements TraceRepository {
             AND NOT EXISTS (SELECT 1 FROM (%s) scope_types WHERE scope_types.name = e.event_type)
             AND e.event_type NOT IN (%s)
             AND e.event_type NOT IN (%s)"""
-            .formatted(SPAN_EVENT_TYPES, SCOPE_EVENT_TYPES, BlockingLeafSpans.sqlQuotedEventTypes(),
+            .formatted(SPAN_EVENT_TYPES, SCOPE_EVENT_TYPES, PromotedSpans.sqlQuotedEventTypes(),
                     "'" + EventTypeName.NOTIFICATION + "', " + THROW_EVENT_TYPES_SQL));
 
     /*
@@ -1513,10 +1595,12 @@ public class JdbcTraceRepository implements TraceRepository {
         databaseClient.execute(StatementLabel.DERIVE_TRACE_SPANS, DELETE_TRACE_SPANS);
         databaseClient.execute(StatementLabel.DERIVE_TRACE_SPANS, DELETE_SPAN_PAYLOADS);
 
-        MapSqlParameterSource blockingParams = new MapSqlParameterSource()
+        MapSqlParameterSource promotionParams = new MapSqlParameterSource()
                 .addValue("blocking_event_types", BlockingLeafSpans.eventTypes())
                 .addValue("blocking_names", BlockingLeafSpans.names())
-                .addValue("blocking_kinds", BlockingLeafSpans.kinds());
+                .addValue("blocking_kinds", BlockingLeafSpans.kinds())
+                .addValue("method_event_type", MethodSpans.EVENT_TYPE)
+                .addValue("promoted_event_types", List.copyOf(PromotedSpans.EVENT_TYPES));
 
         // Before the spans: the span insert stores payload references, and every reference it
         // computes must have its text row in place.
@@ -1526,15 +1610,16 @@ public class JdbcTraceRepository implements TraceRepository {
                         EVENT_FIELDS_PROJECTION,
                         SPAN_EVENT_TYPES,
                         JDK_EVENT_PLUMBING_KEYS),
-                blockingParams);
+                promotionParams);
 
         // One template per event type -- built-ins overlaid by what the recording declares for
         // itself (@Span, stored in event_types.extras by the parser) -- rendered as one CASE.
         String nameTemplates = SpanNameTemplates.nameCase(databaseClient);
 
         // The placeholders in the order they appear: which event types are spans, the three span
-        // shape projections, the event_fields stripping projection of the recorded branch, and the
-        // narrower plumbing strip of the promoted branch.
+        // shape projections, the event_fields stripping projection of the recorded branch, the
+        // method span's self-naming projection, and the narrower plumbing strip of the promoted
+        // branch.
         databaseClient.insert(
                 StatementLabel.DERIVE_TRACE_SPANS,
                 DERIVE_TRACE_SPANS.formatted(
@@ -1543,8 +1628,9 @@ public class JdbcTraceRepository implements TraceRepository {
                         SpanConventions.kindProjection(),
                         SpanConventions.statusProjection(),
                         EVENT_FIELDS_PROJECTION,
+                        MethodSpans.nameAndKindProjection(),
                         JDK_EVENT_PLUMBING_KEYS),
-                blockingParams);
+                promotionParams);
 
         databaseClient.execute(StatementLabel.DERIVE_TRACES, DERIVE_TRACES);
 

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/MethodSpans.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/MethodSpans.java
@@ -1,0 +1,104 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.provider.profile.jdbc;
+
+import cafe.jeffrey.shared.common.model.EventTypeName;
+
+/**
+ * The promotion of {@code jdk.MethodTrace} (JEP 520) into spans, and how it differs from
+ * {@link BlockingLeafSpans}.
+ * <p>
+ * Three differences, each of which the derivation has to honour:
+ * <ol>
+ *   <li><b>The name is the event's, not ours.</b> A blocking event promotes to a fixed label — every
+ *       {@code jdk.SocketRead} is "Socket read". A traced method promotes to <em>itself</em>, so the
+ *       name is read out of the event's own {@code method} field.</li>
+ *   <li><b>It is not a leaf.</b> A traced method's duration includes the methods it calls, so traced
+ *       methods nest inside one another and a blocking wait can happen inside one. A method span can
+ *       therefore be the parent of another promoted span, which no other promotion can.</li>
+ *   <li><b>It is work, not waiting.</b> It maps to no {@code TraceContextCategory} on purpose: the
+ *       why-slow panel accounts for waits, and a traced method's time is the trace's own work. Giving
+ *       it a category would move that time out of "own work" and into a wait total that never
+ *       happened.</li>
+ * </ol>
+ *
+ * <h2>Reading the method out of the event</h2>
+ * The JFR {@code jdk.types.Method} struct is flattened by {@code EventFieldsToJsonMapper} to the
+ * single string {@code "pkg.Class#method"}, so the traced method is
+ * {@code json_extract_string(fields, '$.method')}.
+ * <p>
+ * It has to be that field and not {@code weight_entity}, which for most events is the same idea.
+ * JEP 520 roots a {@code jdk.MethodTrace} stack trace at the <em>caller</em>, so the leaf frame that
+ * fills {@code weight_entity} names the method that made the call rather than the one being traced.
+ * Verified on a JDK 25 recording: an event with {@code method = Probe.inner()} carries
+ * {@code Probe.outer()} as its leaf frame.
+ */
+final class MethodSpans {
+
+    /** The only event type this promotion reads. */
+    static final String EVENT_TYPE = EventTypeName.METHOD_TRACE;
+
+    /**
+     * Method spans are {@code INTERNAL}: a traced method is the application's own work, not a call
+     * out to anything.
+     */
+    static final String KIND = "INTERNAL";
+
+    /** The flattened {@code "pkg.Class#method"} field the span's name is built from. */
+    static final String METHOD_FIELD = "method";
+
+    /**
+     * The last-resort name. {@code trace_spans.name} is {@code NOT NULL}, so a recording that writes
+     * the method field in a shape this build cannot split still has to produce a span rather than
+     * fail the whole profile's initialisation.
+     */
+    static final String UNNAMED = "Traced method";
+
+    /**
+     * The span name, as a SQL expression over a {@code fields} JSON column.
+     * <p>
+     * {@code "pkg.Class#method"} becomes {@code "Class.method"} — the package is dropped because a
+     * waterfall row is a few centimetres wide and the qualified name pushes the timing off the end of
+     * it. Nothing is lost: the full string stays in the span's payload, which the detail panel shows.
+     * A value that does not split (a shape this build has not seen) falls back to itself rather than
+     * to a null name, since {@code name} is {@code NOT NULL}.
+     */
+    static String nameExpression(String fieldsColumn) {
+        String raw = "json_extract_string(" + fieldsColumn + ", '$." + METHOD_FIELD + "')";
+        String simpleClass = "regexp_extract(split_part(" + raw + ", '#', 1), '([^.]+)$', 1)";
+        String methodName = "split_part(" + raw + ", '#', 2)";
+        return "COALESCE(NULLIF(NULLIF(" + simpleClass + ", '') || '.' || NULLIF(" + methodName
+                + ", ''), '.'), " + raw + ", '" + UNNAMED + "')";
+    }
+
+    /**
+     * The {@code name} and {@code kind} columns of the methods CTE, as the derivation splices them
+     * in.
+     * <p>
+     * Reads the {@code fields} column the same SELECT list defines one line above it — DuckDB
+     * resolves lateral column aliases, so the rehydration is written once rather than three times
+     * inside the name expression.
+     */
+    static String nameAndKindProjection() {
+        return nameExpression("fields") + " AS name,\n                    '" + KIND + "' AS kind,";
+    }
+
+    private MethodSpans() {
+    }
+}

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/PromotedSpans.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/PromotedSpans.java
@@ -1,0 +1,58 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.provider.profile.jdbc;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Every JDK event type the derivation turns into a span, whichever promotion did it.
+ * <p>
+ * The two promotions are described apart because they behave differently — {@link BlockingLeafSpans}
+ * gives fixed names to leaves, {@link MethodSpans} gives an event its own name and lets it nest —
+ * but the queries that have to <em>exclude</em> a promoted event care about none of that. They only
+ * need to know that the event is already drawn as a bar, so this is the union they ask.
+ * <p>
+ * Both exclusions exist for the same reason: an event promoted into a span must not also be counted
+ * or listed as a loose event under the very span it became a child of, or the reader sees it twice
+ * and the totals say the same microsecond twice.
+ */
+final class PromotedSpans {
+
+    /** The promoted event types, for membership tests in the queries that must leave them out. */
+    static final Set<String> EVENT_TYPES = Stream.concat(
+                    BlockingLeafSpans.EVENT_TYPES.stream(),
+                    Stream.of(MethodSpans.EVENT_TYPE))
+            .collect(Collectors.toUnmodifiableSet());
+
+    /**
+     * The promoted event types as a quoted SQL list, for the one statement built as a constant rather
+     * than bound per call. Values come from {@code EventTypeName} constants, never from input.
+     */
+    static String sqlQuotedEventTypes() {
+        return EVENT_TYPES.stream()
+                .sorted()
+                .map(eventType -> "'" + eventType + "'")
+                .collect(Collectors.joining(", "));
+    }
+
+    private PromotedSpans() {
+    }
+}

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/test/java/cafe/jeffrey/provider/profile/jdbc/JdbcTraceRepositoryTest.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/test/java/cafe/jeffrey/provider/profile/jdbc/JdbcTraceRepositoryTest.java
@@ -2612,4 +2612,121 @@ class JdbcTraceRepositoryTest {
             assertTrue(windows.stream().noneMatch(w -> w.throttledSlices() == 6L));
         }
     }
+
+    @Nested
+    @DisplayName("Method trace promotion")
+    class MethodPromotion {
+
+        private static final long METHOD_TRACE = 9003L;
+
+        private static Map<String, TraceSpanRecord> spansByName(DataSource dataSource) throws SQLException {
+            TestUtils.executeSql(dataSource, "sql/events/insert-trace-spans.sql");
+            TestUtils.executeSql(dataSource, "sql/events/insert-trace-method-traces.sql");
+            JdbcTraceRepository repository = new JdbcTraceRepository(new DatabaseClientProvider(dataSource));
+            repository.derive();
+            return repository.spansOf(METHOD_TRACE).stream()
+                    .collect(Collectors.toMap(TraceSpanRecord::name, Function.identity(), (first, _) -> first));
+        }
+
+        @Test
+        @DisplayName("names a method span from the event, not from its leaf stack frame")
+        void namesFromTheMethodField(DataSource dataSource) throws SQLException {
+            Map<String, TraceSpanRecord> spans = spansByName(dataSource);
+
+            // JEP 520 roots the stack trace at the caller, so the fixture's weight_entity values are
+            // the callers: "Probe#main" for the outer event, "Probe#outer" for the inner one. Naming
+            // from that column would produce spans called "Probe.main" and "Probe.outer" -- one name
+            // belonging to a method that was never traced, and neither naming the inner method at all.
+            assertTrue(spans.containsKey("Probe.outer"), "named from fields.method");
+            assertTrue(spans.containsKey("Probe.inner"), "named from fields.method");
+            assertFalse(spans.containsKey("Probe.main"), "that is the caller in weight_entity");
+        }
+
+        @Test
+        @DisplayName("nests a traced method inside the traced method that called it")
+        void nestsMethodInsideMethod(DataSource dataSource) throws SQLException {
+            Map<String, TraceSpanRecord> spans = spansByName(dataSource);
+
+            TraceSpanRecord outer = spans.get("Probe.outer");
+            TraceSpanRecord inner = spans.get("Probe.inner");
+
+            // The point of the whole change: siblings here would claim outer did 214ms of its own
+            // work when 174ms of it was inner.
+            assertEquals(outer.spanId(), inner.parentSpanId(),
+                    "inner hangs under outer, not under the recorded span");
+        }
+
+        @Test
+        @DisplayName("hangs a blocking wait under the traced method it happened in")
+        void nestsBlockingInsideMethod(DataSource dataSource) throws SQLException {
+            Map<String, TraceSpanRecord> spans = spansByName(dataSource);
+
+            assertEquals(spans.get("Probe.inner").spanId(), spans.get("Socket read").parentSpanId(),
+                    "the socket read is inside inner, not a sibling of it");
+        }
+
+        @Test
+        @DisplayName("subtracts a nested method from its parent's self time")
+        void nestedMethodSubtractsFromSelfTime(DataSource dataSource) throws SQLException {
+            Map<String, TraceSpanRecord> spans = spansByName(dataSource);
+
+            TraceSpanRecord outer = spans.get("Probe.outer");
+
+            // 214ms total, 174ms of it in inner.
+            assertEquals(214_000_000L, outer.durationNanos());
+            assertEquals(40_000_000L, outer.selfDurationNanos(),
+                    "outer's own work is what is left once inner is taken out");
+        }
+
+        @Test
+        @DisplayName("promotes a method span as a real span of the trace")
+        void methodSpansAreOrdinarySpans(DataSource dataSource) throws SQLException {
+            TraceSpanRecord inner = spansByName(dataSource).get("Probe.inner");
+
+            assertTrue(inner.synthesized(), "minted, not read from an instrumented span event");
+            assertEquals(EventTypeName.METHOD_TRACE, inner.eventType());
+            assertEquals("INTERNAL", inner.kind(), "a traced method is the application's own work");
+        }
+
+        @Test
+        @DisplayName("leaves a traced method that belongs to no trace alone")
+        void ignoresMethodsOutsideEverySpan(DataSource dataSource) throws SQLException {
+            Map<String, TraceSpanRecord> spans = spansByName(dataSource);
+
+            assertFalse(spans.containsKey("Other.orphan"), "ran on a thread with no span open");
+            assertFalse(spans.containsKey("Probe.afterTheSpan"), "ran after the span closed");
+        }
+
+        @Test
+        @DisplayName("keeps a tree when two traced methods share an interval exactly")
+        void identicalIntervalsCannotCycle(DataSource dataSource) throws SQLException {
+            Map<String, TraceSpanRecord> spans = spansByName(dataSource);
+
+            TraceSpanRecord twinA = spans.get("Probe.twinA");
+            TraceSpanRecord twinB = spans.get("Probe.twinB");
+
+            // Each contains the other's start, so containment alone would let them adopt each other.
+            // Exactly one adoption may survive, and neither may point at itself.
+            assertNotNull(twinA);
+            assertNotNull(twinB);
+            boolean aUnderB = twinA.parentSpanId() != null && twinA.parentSpanId() == twinB.spanId();
+            boolean bUnderA = twinB.parentSpanId() != null && twinB.parentSpanId() == twinA.spanId();
+            assertFalse(aUnderB && bUnderA, "a two-node cycle");
+            assertNotEquals(twinA.spanId(), twinA.parentSpanId(), "self-parent");
+            assertNotEquals(twinB.spanId(), twinB.parentSpanId(), "self-parent");
+        }
+
+        @Test
+        @DisplayName("keeps the recorded span's self time honest about the methods under it")
+        void recordedParentSelfTimeExcludesMethods(DataSource dataSource) throws SQLException {
+            Map<String, TraceSpanRecord> spans = spansByName(dataSource);
+
+            TraceSpanRecord recorded = spans.get("reserveInventory");
+
+            // 300ms of request, 214ms of it inside outer, plus the 10ms twins. The merge means the
+            // nested inner and the socket read are not subtracted a second time.
+            assertEquals(300_000_000L, recorded.durationNanos());
+            assertEquals(76_000_000L, recorded.selfDurationNanos());
+        }
+    }
 }

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/test/resources/sql/events/insert-trace-method-traces.sql
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/test/resources/sql/events/insert-trace-method-traces.sql
@@ -1,0 +1,62 @@
+-- Fixture for JdbcTraceRepositoryTest.MethodPromotion, layered on insert-trace-spans.sql
+-- (which registers jeffrey.TraceSpan as a span type and creates threads 3001 and 3002).
+--
+-- The shape is taken from a real JDK 25 recording rather than invented. A probe with two traced
+-- methods, the outer calling the inner, and a socket read inside the inner one, produced exactly
+-- this nesting:
+--
+--   outer      [533, 747]   method = Probe.outer()   stackTrace leaf = Probe.main
+--     inner    [553, 727]   method = Probe.inner()   stackTrace leaf = Probe.outer   <- the CALLER
+--       read   [603, 724]
+--
+-- Two things that fixture proves and this one reproduces. First, a jdk.MethodTrace duration
+-- INCLUDES the methods it calls, so traced methods nest as intervals -- which is the whole reason
+-- a method span has to be able to parent another span. Second, JEP 520 roots the stack trace at the
+-- CALLER, so weight_entity (the leaf frame) names the wrong method and the name has to come from
+-- the event's own `method` field.
+--
+-- Timings below are the probe's, shifted onto the 10:10:00 span the other trace fixtures use.
+INSERT INTO event_types (name, label, type_id, description, categories, source, subtype, has_stacktrace, extras, settings, columns)
+VALUES
+    ('jdk.MethodTrace', 'Method Trace', 40, 'method tracing', '["Java Virtual Machine","Method Tracing"]', '1', NULL, true, NULL, NULL,
+     '[{"field":"method","header":"Method"}]'),
+    ('jdk.SocketRead', 'Socket Read', 41, 'socket read', '["Java Application"]', '1', NULL, true, NULL, NULL,
+     '[{"field":"host","header":"Remote Host"},{"field":"bytesRead","header":"Bytes Read"}]');
+
+INSERT INTO events_raw (event_type, start_timestamp, start_timestamp_from_beginning, duration, samples, weight, weight_entity, stacktrace_hash, thread_hash, fields)
+VALUES
+    -- The recorded span everything hangs under: 10:10:00.000 .. 10:10:00.300 on thread 3001.
+    ('jeffrey.TraceSpan', '2025-01-15T10:10:00.000Z', 600000, 300000000, 1, NULL, NULL, NULL, 3001,
+     '{"traceId":9003,"spanId":701,"parentSpanId":0,"name":"reserveInventory","kind":"SERVER","status":"UNSET"}'),
+
+    -- outer: 10:10:00.020 .. 10:10:00.234 (214ms). weight_entity is the CALLER, as JFR records it.
+    ('jdk.MethodTrace', '2025-01-15T10:10:00.020Z', 600020, 214000000, 1, 214000000, 'Probe#main', NULL, 3001,
+     '{"method":"cafe.jeffrey.probe.Probe#outer"}'),
+
+    -- inner: 10:10:00.040 .. 10:10:00.214 (174ms), nested inside outer. Its leaf frame is outer,
+    -- so a name taken from weight_entity would call this span "outer" too.
+    ('jdk.MethodTrace', '2025-01-15T10:10:00.040Z', 600040, 174000000, 1, 174000000, 'Probe#outer', NULL, 3001,
+     '{"method":"cafe.jeffrey.probe.Probe#inner"}'),
+
+    -- The socket read inside inner: 10:10:00.090 .. 10:10:00.211 (121ms). Its parent must be the
+    -- inner method, not the recorded span -- which is what promotion into a non-leaf tests.
+    ('jdk.SocketRead', '2025-01-15T10:10:00.090Z', 600090, 121000000, 1, NULL, NULL, NULL, 3001,
+     '{"host":"127.0.0.1","bytesRead":4}'),
+
+    -- A traced method on a thread with no recorded span open: it belongs to no trace and must not
+    -- be promoted at all.
+    ('jdk.MethodTrace', '2025-01-15T10:10:00.100Z', 600100, 5000000, 1, 5000000, 'Other#caller', NULL, 3002,
+     '{"method":"cafe.jeffrey.probe.Other#orphan"}'),
+
+    -- A traced method after the recorded span closed: in range of nothing, promoted nowhere.
+    ('jdk.MethodTrace', '2025-01-15T10:10:00.900Z', 600900, 5000000, 1, 5000000, 'Probe#main', NULL, 3001,
+     '{"method":"cafe.jeffrey.probe.Probe#afterTheSpan"}'),
+
+    -- Two traced methods beginning on the SAME microsecond with the SAME duration. Containment
+    -- alone lets each adopt the other and the tree closes into a cycle; only the strict ordering
+    -- guard keeps this a tree. Which of the two wins does not matter, but it must be one of them
+    -- and it must be stable.
+    ('jdk.MethodTrace', '2025-01-15T10:10:00.250Z', 600250, 10000000, 1, 10000000, 'Probe#main', NULL, 3001,
+     '{"method":"cafe.jeffrey.probe.Probe#twinA"}'),
+    ('jdk.MethodTrace', '2025-01-15T10:10:00.250Z', 600250, 10000000, 1, 10000000, 'Probe#main', NULL, 3001,
+     '{"method":"cafe.jeffrey.probe.Probe#twinB"}');

--- a/jeffrey-pages/src/views/docs/tracing/TracingJdkEventsPage.vue
+++ b/jeffrey-pages/src/views/docs/tracing/TracingJdkEventsPage.vue
@@ -30,6 +30,7 @@ const { setHeadings } = useDocHeadings();
 const headings = [
   { id: 'idea', text: 'The Idea: Promotion, Not Instrumentation', level: 2 },
   { id: 'promoted-set', text: 'Which JDK Events Become Spans', level: 2 },
+  { id: 'traced-methods', text: 'Traced Methods: The Promotion That Nests', level: 2 },
   { id: 'attribution', text: 'How an Event Finds Its Span', level: 2 },
   { id: 'payload', text: 'The Event Payload Survives', level: 2 },
   { id: 'reading', text: 'Reading Promoted Spans in the Waterfall', level: 2 },
@@ -109,6 +110,12 @@ jdk.ZAllocationStall#enabled=true,jdk.ZAllocationStall#threshold=0ms`;
         </thead>
         <tbody>
           <tr>
+            <td><code>jdk.MethodTrace</code></td>
+            <td><em>the method itself</em></td>
+            <td><code>INTERNAL</code></td>
+            <td>Traced methods (<em>Methods</em>)</td>
+          </tr>
+          <tr>
             <td><code>jdk.SocketRead</code></td>
             <td>Socket read</td>
             <td><code>CLIENT</code></td>
@@ -179,9 +186,25 @@ jdk.ZAllocationStall#enabled=true,jdk.ZAllocationStall#threshold=0ms`;
 
       <p>Global stop-the-world events — GC pauses and safepoints — are <em>not</em> promoted into spans; they stopped every thread at once, so they are drawn as lanes across the whole waterfall instead. See <router-link to="/docs/tracing/gc-safepoints">GC Pauses &amp; Safepoints</router-link>.</p>
 
+      <h2 id="traced-methods">Traced Methods: The Promotion That Nests</h2>
+
+      <p><router-link to="/docs/microscope/profiles">JFR method tracing</router-link> (JEP 520, JDK 25) lets you name the methods you care about in the recording configuration — no annotation, no agent, no code change — and <code>jdk.MethodTrace</code> then records each invocation with its duration. Jeffrey promotes those into spans too, which puts your own methods inside the trace waterfall with nothing instrumented: the HTTP span, then <code>OrderService.load</code> under it, then the query under that.</p>
+
+      <p>It differs from every other promotion in three ways, and each one is deliberate.</p>
+
+      <p><strong>It names itself.</strong> A blocking event promotes to a fixed label — every <code>jdk.SocketRead</code> is "Socket read". A traced method promotes to <em>itself</em>, read from the event's own <code>method</code> field and shortened to <code>Class.method</code> for the row (the qualified name stays in the span's payload). It has to be that field: JEP 520 roots a MethodTrace stack trace at the <strong>caller</strong>, so the leaf frame names the method that made the call, not the one being traced.</p>
+
+      <p><strong>It nests.</strong> A traced method's duration includes the methods it calls, so traced methods contain one another and a wait can happen inside one. A method span is therefore the one promoted span that can be a <em>parent</em>: trace two methods where one calls the other and the inner one hangs under the outer one, with the socket read inside it hanging under that. Without this the two would be drawn as siblings and the outer one's self time would claim work its callee did.</p>
+
+      <DocsCallout type="info">
+        <strong>A traced method is work, not waiting</strong> — which is why it maps to no context category and never appears in the why-slow panel. That panel accounts for the time a trace spent <em>not</em> doing its own work; a traced method's time is precisely the trace's own work, and giving it a category would move that time out of "own work" and into a wait total that never happened. The waterfall draws it as the <code>INTERNAL</code> span it is, outlined to show it was derived rather than recorded.
+      </DocsCallout>
+
+      <p>The rows have their own toolbar switch, <strong>Methods</strong>, beside <em>Blocking ops</em> and <em>I/O ops</em> — a filter set to trace a whole class can put far more rows on screen than either wait family, and switching those off must not take the socket read that explains the trace with them. Because method spans have children, switching them off takes their subtrees too.</p>
+
       <h2 id="attribution">How an Event Finds Its Span</h2>
 
-      <p>The attribution rule is: <strong>same thread, innermost open span</strong>. A JDK event is attached to the span that (a) ran on the same thread and (b) was open when the event began, choosing the innermost such span. An event that began outside every span stays an ordinary event and is not promoted. The synthesized span's id is minted deterministically (and guarded against colliding with a recorded id), so promoted spans are ordinary spans everywhere it matters:</p>
+      <p>The attribution rule is: <strong>same thread, innermost open span</strong>. A JDK event is attached to the span that (a) ran on the same thread and (b) was open when the event began, choosing the innermost such span — where "span" means any recorded span <em>or</em> any method span, which is what lets a wait land inside the traced method it happened in. Which trace an event belongs to is still decided by recorded spans alone: a method span is inside a trace because instrumentation put a span around it, never because another method span did. An event that began outside every recorded span stays an ordinary event and is not promoted. The synthesized span's id is minted deterministically (and guarded against colliding with a recorded id), so promoted spans are ordinary spans everywhere it matters:</p>
 
       <ul>
         <li>they count in the trace's span total,</li>


### PR DESCRIPTION
Stacked on #209 — based on that branch so this diff shows only the method-tracing change. GitHub will retarget it to `master` when #209 merges.

## Why

JFR method tracing (JEP 520, JDK 25) lets a recording name the methods it cares about with no annotation, no agent and no code change. Jeffrey already ingests `jdk.MethodTrace` for a flamegraph card and a dashboard, but traces were blind to it. Promoting it into spans puts your own methods inside the waterfall on the same terms: the HTTP span, then `OrderService.load` under it, then the query under that.

## The recording decided the design

I ran a JDK 25 probe — two traced methods, the outer calling the inner, a socket read inside the inner one — rather than working from the event's documentation. It recorded:

```
outer   [533, 747]  method = Probe.outer()  stackTrace leaf = Probe.main
  inner [553, 727]  method = Probe.inner()  stackTrace leaf = Probe.outer
    read[603, 724]
```

Two consequences, both reproduced by the new fixture:

**A traced method names itself, and the name must come from the event's `method` field.** JEP 520 roots the stack trace at the **caller**, so the leaf frame that fills `weight_entity` names the method that made the call, not the one being traced — above, the inner event's leaf frame is `outer`.

> ⚠️ Worth a separate look: the existing **Method Tracing dashboard renders from `weight_entity`**, so its rows appear to be labelled with callers rather than traced methods. Out of scope here; this PR only makes sure the *spans* are named correctly.

**A traced method's duration includes the methods it calls**, so traced methods nest and a wait can happen inside one.

## What changed

- **`MethodSpans`** describes the promotion (self-naming, nesting, no context category); **`PromotedSpans`** is the union both existing exclusions ask, so the drill-down and payload derivation pick MethodTrace up without a second edit.
- **Ids are minted before parenting** rather than after. That is what makes nesting possible in one statement: the id is a pure function of columns already in hand, so a method span can be offered as a parent in the same statement that creates it — no recursion, no second insert.
- **Cycles are made inexpressible.** Two traced methods beginning on the same microsecond each contain the other's start, so containment alone would let them adopt each other. A parent is admitted only when it strictly precedes the child in the total order `(from ASC, to DESC, span_id ASC)` — an order in which a container always precedes what it contains.
- **Trace identity still comes from recorded spans alone.** A method span is inside a trace because instrumentation put a span around it, never because another method span did.
- **No `TraceContextCategory`, deliberately.** The why-slow panel accounts for time a trace spent *not* doing its own work; a traced method's time is precisely its own work. A category would move it out of `OWN_WORK` into a wait total that never happened. It is drawn as the `INTERNAL` span it is, outlined to show it was derived.
- **Frontend**: a fourth **Methods** switch, and `drawnSpans` extracted into `traceTree.ts` — "a promoted span is a leaf by construction" no longer holds, so hiding a method row takes its subtree.

Also fixes `showAllSpans`, which reset only one of the promoted families and so could not actually undo everything that hides a row.

## Testing

- 8 new `@DuckDBTest` cases over a new fixture: naming from the event rather than the caller, method-inside-method, a wait inside a method, self time of both the method and its recorded parent, a method outside every span, and two methods sharing an interval exactly (no cycle, no self-parent).
- 8 new vitest cases for the subtree filter and the method event type.
- Full runs: 4 backend modules `BUILD SUCCESS`, 553 frontend tests pass (was 545), `vue-tsc` clean, lint 0 errors.

## Docs

New "Traced Methods: The Promotion That Nests" section in `TracingJdkEventsPage.vue`, a row in the promoted-set table, and the attribution rule updated to say that a method span can now be the innermost parent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2dZhaw7nFbBoVesUJaUG1)_