### PR TITLE
Name the threads that hold up safepoints

### DIFF
--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/VmOperationController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/VmOperationController.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
 import cafe.jeffrey.profile.manager.VmOperationManager;
 import cafe.jeffrey.profile.manager.model.vmoperation.VmOperationStat;
+import cafe.jeffrey.profile.manager.model.vmoperation.SafepointLatencyData;
 import cafe.jeffrey.profile.manager.model.vmoperation.VmOverview;
 import cafe.jeffrey.timeseries.TimeseriesData;
 
@@ -66,6 +67,12 @@ public class VmOperationController {
     public TimeseriesData safepointTimeline(@PathVariable("profileId") String profileId) {
         LOG.debug("Fetching time-to-safepoint timeline");
         return mgr(profileId).timeToSafepointTimeline();
+    }
+
+    @GetMapping("/safepoint-offenders")
+    public SafepointLatencyData safepointOffenders(@PathVariable("profileId") String profileId) {
+        LOG.debug("Fetching safepoint offenders");
+        return mgr(profileId).safepointOffenders();
     }
 
     private VmOperationManager mgr(String profileId) {

--- a/jeffrey-microscope/pages-microscope/src/services/api/ProfileVmOperationsClient.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/ProfileVmOperationsClient.ts
@@ -18,7 +18,11 @@
 
 import BaseProfileClient from '@/services/api/BaseProfileClient';
 import TimeseriesData from '@/services/timeseries/model/TimeseriesData';
-import type { VmOperationStat, VmOverview } from '@/services/api/model/VmOperationModels';
+import type {
+  SafepointLatencyData,
+  VmOperationStat,
+  VmOverview
+} from '@/services/api/model/VmOperationModels';
 
 export default class ProfileVmOperationsClient extends BaseProfileClient {
   constructor(profileId: string) {
@@ -39,5 +43,10 @@ export default class ProfileVmOperationsClient extends BaseProfileClient {
 
   public getSafepointTimeline(): Promise<TimeseriesData> {
     return this.get<TimeseriesData>('/safepoint-timeline');
+  }
+
+  /** Which threads the JVM waited for on its way into safepoints, ranked. */
+  async getSafepointOffenders(): Promise<SafepointLatencyData> {
+    return this.get<SafepointLatencyData>('/safepoint-offenders');
   }
 }

--- a/jeffrey-microscope/pages-microscope/src/services/api/model/VmOperationModels.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/model/VmOperationModels.ts
@@ -22,7 +22,49 @@ export interface VmOverview {
   longestPauseNanos: number;
   longestPauseOperation: string | null;
   hasVmOperations: boolean;
-  hasSafepointLatency: boolean;
+  /**
+   * Whether `jdk.SafepointStateSynchronization` is present — the per-safepoint view of how long the
+   * JVM spent getting every thread to stop. Was called `hasSafepointLatency`, which read as a claim
+   * about `jdk.SafepointLatency` and never was one.
+   */
+  hasTimeToSafepoint: boolean;
+  /**
+   * Whether `jdk.SafepointLatency` is present — the per-thread view, and the only one that can name
+   * who the JVM was waiting for.
+   */
+  hasSafepointOffenders: boolean;
+}
+
+/**
+ * One thread's record of holding the JVM up on its way into safepoints.
+ *
+ * Aggregated per thread because the event fires once *per thread per safepoint*: a small app across
+ * 16 safepoints already writes 584 of them, so the finding only exists in their distribution.
+ */
+export interface SafepointOffender {
+  threadName: string;
+  /**
+   * What the thread was doing when the safepoint was requested, verbatim (`_thread_in_Java`,
+   * `_thread_in_native`, ...) — the column that turns a number into a diagnosis.
+   */
+  threadState: string;
+  count: number;
+  maxNanos: number;
+  p99Nanos: number;
+  totalNanos: number;
+}
+
+export interface SafepointLatencyData {
+  /** The worst threads, longest first, capped — a page ranks rather than enumerates. */
+  offenders: SafepointOffender[];
+  /** How many distinct threads were measured, so the table's cap is visible rather than silent. */
+  threadCount: number;
+  worstNanos: number;
+  /**
+   * Summed across every thread and safepoint. Not elapsed time: threads reach a safepoint
+   * concurrently, so this is a sum of overlapping waits and is only meaningful as a ranking weight.
+   */
+  totalNanos: number;
 }
 
 export interface VmOperationStat {

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileVmOperations.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/ProfileVmOperations.vue
@@ -85,7 +85,7 @@
         </div>
 
         <DisabledEventsNotice
-          v-if="!overview?.hasSafepointLatency"
+          v-if="!overview?.hasTimeToSafepoint"
           title="Time-to-safepoint data not available"
           action-label="Re-record with the event enabled"
           command="settings=profile,+jdk.SafepointStateSynchronization#enabled=true"
@@ -108,6 +108,100 @@
               :visibleMinutes="60"
             />
           </div>
+        </template>
+
+        <!--
+          Who the JVM waited for. Every other safepoint reading on this page is recorded once per
+          safepoint on a VM thread, so none of them knows whose slowness it measured — which is why
+          the time-to-safepoint chart above can say the wait was long and then stop. jdk.SafepointLatency
+          is recorded on each application thread instead, and is the only thing here that can name a
+          culprit.
+        -->
+        <DisabledEventsNotice
+          v-if="!overview?.hasSafepointOffenders"
+          title="The threads that were waited for are not identified"
+          action-label="Re-record with the event enabled"
+          command="settings=profile,+jdk.SafepointLatency#enabled=true,+jdk.SafepointLatency#stackTrace=true"
+        >
+          Naming the thread that held a safepoint up needs <code>jdk.SafepointLatency</code>, which
+          is disabled in <strong>both</strong> the default and profile JFR configurations. Note the
+          second setting: <code>profile</code> turns its stack trace off even when the event is
+          enabled, so without it you learn which thread was slow but never what it was running.
+        </DisabledEventsNotice>
+        <template v-else-if="offenders.length > 0">
+          <ChartDescription
+            shows="Threads ranked by the total time the JVM spent waiting for them to reach a safepoint."
+            use-case="Names the thread the time-to-safepoint chart above can only measure — and its state says why: compiled Java means a loop with no poll point, native means a call that cannot be interrupted."
+          />
+
+          <DataTable>
+            <template #toolbar>
+              <TableToolbar v-model="offendersView.query" search-placeholder="Filter threads...">
+                <span class="toolbar-info">threads holding up safepoints</span>
+                <template #filters>
+                  <!--
+                    The measured count, not the row count: the table is capped at the worst threads,
+                    and a reader comparing "20 rows" against a 400-thread application should be able
+                    to see that the cap is a cap.
+                  -->
+                  <Badge
+                    key-label="Measured"
+                    :value="safepointLatency?.threadCount ?? 0"
+                    variant="secondary"
+                    size="s"
+                    borderless
+                  />
+                </template>
+              </TableToolbar>
+            </template>
+            <thead>
+              <tr>
+                <th>Thread</th>
+                <th>State when asked to stop</th>
+                <th class="text-end">Safepoints</th>
+                <th class="text-end">Max</th>
+                <th class="text-end">P99</th>
+                <th class="text-end">Total</th>
+                <th class="text-end">Share</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="offender in offendersView.visible" :key="offender.threadName">
+                <td class="thread-name">{{ offender.threadName }}</td>
+                <td>
+                  <Badge
+                    :value="offender.threadState"
+                    :variant="
+                      offender.threadState === '_thread_in_native' ? 'warning' : 'secondary'
+                    "
+                    size="xs"
+                    :title="threadStateHint(offender.threadState)"
+                  />
+                </td>
+                <td class="text-end">{{ FormattingService.formatNumber(offender.count) }}</td>
+                <td class="text-end">
+                  {{ FormattingService.formatDuration2Units(offender.maxNanos) }}
+                </td>
+                <td class="text-end">
+                  {{ FormattingService.formatDuration2Units(offender.p99Nanos) }}
+                </td>
+                <td class="text-end">
+                  {{ FormattingService.formatDuration2Units(offender.totalNanos) }}
+                </td>
+                <td class="text-end">{{ offenderShare(offender).toFixed(1) }}%</td>
+              </tr>
+            </tbody>
+            <template #footer>
+              <TableShowMore
+                :shown="offendersView.visible.length"
+                :match-count="offendersView.matchCount"
+                :total="offendersView.total"
+                :expanded="offendersView.expanded"
+                :page-size="offendersView.pageSize"
+                @toggle="offendersView.toggle"
+              />
+            </template>
+          </DataTable>
         </template>
       </div>
 
@@ -231,7 +325,12 @@ import FormattingService from '@shared/services/FormattingService';
 import AxisFormatType from '@/services/timeseries/AxisFormatType';
 import ProfileVmOperationsClient from '@/services/api/ProfileVmOperationsClient';
 import { useTableView } from '@/composables/useTableView';
-import type { VmOperationStat, VmOverview } from '@/services/api/model/VmOperationModels';
+import type {
+  SafepointLatencyData,
+  SafepointOffender,
+  VmOperationStat,
+  VmOverview
+} from '@/services/api/model/VmOperationModels';
 import type TimeseriesData from '@/services/timeseries/model/TimeseriesData';
 
 const route = useRoute();
@@ -243,12 +342,46 @@ const overview = ref<VmOverview>();
 const vmOperations = ref<VmOperationStat[]>([]);
 const pausesTimeline = ref<TimeseriesData>();
 const safepointTimeline = ref<TimeseriesData>();
+const safepointLatency = ref<SafepointLatencyData>();
 
 const activeTab = ref('operations');
 
 const vmOperationsView = useTableView<VmOperationStat>(vmOperations, {
   searchableText: r => r.operation
 });
+
+const offenders = computed<SafepointOffender[]>(() => safepointLatency.value?.offenders ?? []);
+
+const offendersView = useTableView<SafepointOffender>(offenders, {
+  searchableText: r => `${r.threadName} ${r.threadState}`
+});
+
+/**
+ * The share of the ranking weight one thread accounts for.
+ *
+ * Taken against the summed latency rather than against elapsed time on purpose: threads reach a
+ * safepoint concurrently, so the total is a sum of overlapping waits and means nothing as a
+ * duration. As a denominator for "which thread dominates this list" it is exactly right.
+ */
+function offenderShare(offender: SafepointOffender): number {
+  const total = safepointLatency.value?.totalNanos ?? 0;
+  return total <= 0 ? 0 : (offender.totalNanos / total) * 100;
+}
+
+/**
+ * The thread state in the terms the reader has to act in. `_thread_in_Java` and
+ * `_thread_in_native` are the two that mean something different: the first is a loop the JIT
+ * stripped the safepoint poll out of, the second a call the JVM cannot interrupt at all.
+ */
+function threadStateHint(state: string): string {
+  if (state === '_thread_in_Java') {
+    return 'Running compiled Java — usually a long counted loop with no poll point';
+  }
+  if (state === '_thread_in_native') {
+    return 'Inside a native call, which the JVM cannot interrupt';
+  }
+  return state;
+}
 
 const pauseSeries = computed<number[][]>(() => pausesTimeline.value?.series?.[0]?.data ?? []);
 const safepointSeries = computed<number[][]>(() => safepointTimeline.value?.series?.[0]?.data ?? []);
@@ -304,17 +437,20 @@ onMounted(async () => {
     const profileId = route.params.profileId as string;
     const client = new ProfileVmOperationsClient(profileId);
 
-    const [overviewResult, vmOpsResult, pausesResult, safepointResult] = await Promise.all([
-      client.getOverview(),
-      client.getVmOperations(),
-      client.getPausesTimeline(),
-      client.getSafepointTimeline()
-    ]);
+    const [overviewResult, vmOpsResult, pausesResult, safepointResult, offendersResult] =
+      await Promise.all([
+        client.getOverview(),
+        client.getVmOperations(),
+        client.getPausesTimeline(),
+        client.getSafepointTimeline(),
+        client.getSafepointOffenders()
+      ]);
 
     overview.value = overviewResult;
     vmOperations.value = vmOpsResult;
     pausesTimeline.value = pausesResult;
     safepointTimeline.value = safepointResult;
+    safepointLatency.value = offendersResult;
 
     loading.value = false;
   } catch (e) {

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/VmOperationManager.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/VmOperationManager.java
@@ -19,6 +19,7 @@
 package cafe.jeffrey.profile.manager;
 
 import cafe.jeffrey.profile.manager.model.vmoperation.VmOperationStat;
+import cafe.jeffrey.profile.manager.model.vmoperation.SafepointLatencyData;
 import cafe.jeffrey.profile.manager.model.vmoperation.VmOverview;
 import cafe.jeffrey.shared.common.model.ProfileInfo;
 import cafe.jeffrey.timeseries.TimeseriesData;
@@ -57,4 +58,12 @@ public interface VmOperationManager {
      * Time-to-safepoint per second, in nanoseconds (off by default — usually empty).
      */
     TimeseriesData timeToSafepointTimeline();
+
+    /**
+     * Which threads the JVM waited for on its way into safepoints, ranked.
+     * <p>
+     * The one question the rest of this page cannot answer: every other safepoint event is recorded
+     * once per safepoint on a VM thread, so none of them knows whose slowness it measured.
+     */
+    SafepointLatencyData safepointOffenders();
 }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/VmOperationManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/VmOperationManagerImpl.java
@@ -19,6 +19,8 @@
 package cafe.jeffrey.profile.manager;
 
 import cafe.jeffrey.profile.manager.model.vmoperation.PauseTimeseriesBuilder;
+import cafe.jeffrey.profile.manager.model.vmoperation.SafepointLatencyBuilder;
+import cafe.jeffrey.profile.manager.model.vmoperation.SafepointLatencyData;
 import cafe.jeffrey.profile.manager.model.vmoperation.SafepointSyncTimeseriesBuilder;
 import cafe.jeffrey.profile.manager.model.vmoperation.VmOperationStat;
 import cafe.jeffrey.profile.manager.model.vmoperation.VmOperationStatsBuilder;
@@ -61,7 +63,8 @@ public class VmOperationManagerImpl implements VmOperationManager {
                 .max(Comparator.comparingLong(VmOperationStat::maxNanos))
                 .orElse(null);
 
-        boolean hasSafepointLatency = eventRepository.containsEventType(Type.SAFEPOINT_STATE_SYNCHRONIZATION);
+        boolean hasTimeToSafepoint = eventRepository.containsEventType(Type.SAFEPOINT_STATE_SYNCHRONIZATION);
+        boolean hasSafepointOffenders = eventRepository.containsEventType(Type.SAFEPOINT_LATENCY);
 
         return new VmOverview(
                 vmOperationCount,
@@ -69,7 +72,8 @@ public class VmOperationManagerImpl implements VmOperationManager {
                 longest == null ? 0 : longest.maxNanos(),
                 longest == null ? null : longest.operation(),
                 !vmOperations.isEmpty(),
-                hasSafepointLatency);
+                hasTimeToSafepoint,
+                hasSafepointOffenders);
     }
 
     @Override
@@ -102,5 +106,21 @@ public class VmOperationManagerImpl implements VmOperationManager {
                 .withJsonFields();
 
         return eventStreamRepository.genericStreaming(configurer, new SafepointSyncTimeseriesBuilder(timeRange));
+    }
+
+    @Override
+    public SafepointLatencyData safepointOffenders() {
+        if (!eventRepository.containsEventType(Type.SAFEPOINT_LATENCY)) {
+            return SafepointLatencyData.EMPTY;
+        }
+
+        // withThreads() because the thread is the answer here, not a detail of it; withJsonFields()
+        // for threadState, which is what turns "slow" into "slow for this reason".
+        EventQueryConfigurer configurer = new EventQueryConfigurer()
+                .withEventType(Type.SAFEPOINT_LATENCY)
+                .withThreads()
+                .withJsonFields();
+
+        return eventStreamRepository.genericStreaming(configurer, new SafepointLatencyBuilder());
     }
 }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/vmoperation/SafepointLatencyBuilder.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/vmoperation/SafepointLatencyBuilder.java
@@ -1,0 +1,138 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.vmoperation;
+
+import org.HdrHistogram.Histogram;
+import tools.jackson.databind.node.ObjectNode;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.provider.profile.api.RecordBuilder;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Groups {@code jdk.SafepointLatency} by the thread that was waited for, ranked by summed latency.
+ * <p>
+ * Aggregation is not a presentation choice here, it is forced by the event: JFR writes one of these
+ * per thread per safepoint, so a recording that saw 16 safepoints across a small application
+ * already produced 584 of them, and a real one produces orders of magnitude more. Listing them
+ * would bury the finding in its own evidence.
+ * <p>
+ * Ranked by total rather than by max, because the page is looking for a habit. A thread that is
+ * slow to yield on every one of a thousand safepoints is a tuning problem worth finding; one that
+ * was slow once is usually a scheduler hiccup, and sorting by max would put the hiccup on top. Both
+ * numbers are kept so the reader can tell those apart.
+ */
+public class SafepointLatencyBuilder implements RecordBuilder<GenericRecord, SafepointLatencyData> {
+
+    /** A page ranks rather than enumerates; the thread count travels so the cap is not silent. */
+    private static final int MAX_OFFENDERS = 20;
+
+    private static final String THREAD_STATE_FIELD = "threadState";
+    private static final String UNKNOWN_THREAD = "<unknown>";
+    private static final String UNKNOWN_STATE = "<unknown>";
+
+    /** Three significant digits, matching the other percentile builders in this codebase. */
+    private static final int HISTOGRAM_PRECISION = 3;
+
+    private static final double P99 = 99.0;
+
+    private static final class Accumulator {
+        private final Histogram histogram = new Histogram(HISTOGRAM_PRECISION);
+        private String threadState = UNKNOWN_STATE;
+        private long count;
+        private long totalNanos;
+        private long maxNanos;
+    }
+
+    private final Map<String, Accumulator> byThread = new HashMap<>();
+    private long worstNanos;
+    private long totalNanos;
+
+    @Override
+    public void onRecord(GenericRecord record) {
+        if (record.duration() == null) {
+            return;
+        }
+        long nanos = record.duration().toNanos();
+        if (nanos < 0) {
+            return;
+        }
+
+        String threadName = record.thread() != null && record.thread().name() != null
+                ? record.thread().name()
+                : UNKNOWN_THREAD;
+
+        Accumulator accumulator = byThread.computeIfAbsent(threadName, _ -> new Accumulator());
+        accumulator.count++;
+        accumulator.totalNanos += nanos;
+        accumulator.maxNanos = Math.max(accumulator.maxNanos, nanos);
+        accumulator.histogram.recordValue(nanos);
+
+        /*
+         * The state of the worst sample rather than the most recent one: a thread that is usually
+         * running Java and once blocked in native is described by the sample that actually held the
+         * JVM up, which is the one the reader is being asked to act on.
+         */
+        if (nanos == accumulator.maxNanos) {
+            accumulator.threadState = threadState(record);
+        }
+
+        worstNanos = Math.max(worstNanos, nanos);
+        totalNanos += nanos;
+    }
+
+    private static String threadState(GenericRecord record) {
+        ObjectNode fields = record.jsonFields();
+        if (fields == null || !fields.has(THREAD_STATE_FIELD)) {
+            return UNKNOWN_STATE;
+        }
+        String state = fields.get(THREAD_STATE_FIELD).asString();
+        return state == null || state.isBlank() ? UNKNOWN_STATE : state;
+    }
+
+    @Override
+    public SafepointLatencyData build() {
+        if (byThread.isEmpty()) {
+            return SafepointLatencyData.EMPTY;
+        }
+
+        List<SafepointOffender> offenders = new ArrayList<>(byThread.size());
+        for (Map.Entry<String, Accumulator> entry : byThread.entrySet()) {
+            Accumulator accumulator = entry.getValue();
+            offenders.add(new SafepointOffender(
+                    entry.getKey(),
+                    accumulator.threadState,
+                    accumulator.count,
+                    accumulator.maxNanos,
+                    accumulator.histogram.getValueAtPercentile(P99),
+                    accumulator.totalNanos));
+        }
+        offenders.sort(Comparator.comparingLong(SafepointOffender::totalNanos).reversed());
+
+        return new SafepointLatencyData(
+                List.copyOf(offenders.subList(0, Math.min(MAX_OFFENDERS, offenders.size()))),
+                byThread.size(),
+                worstNanos,
+                totalNanos);
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/vmoperation/SafepointLatencyData.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/vmoperation/SafepointLatencyData.java
@@ -1,0 +1,48 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.vmoperation;
+
+import java.util.List;
+
+/**
+ * Who the JVM waited for on its way into safepoints.
+ * <p>
+ * The pause timeline on the same page says how long the world stood still, and the time-to-safepoint
+ * series says how much of that was spent merely getting there. Neither can say <em>whose</em> fault
+ * the getting-there was, because both are recorded once per safepoint on a VM thread.
+ * {@code jdk.SafepointLatency} is recorded on each application thread instead, which is what makes
+ * naming the culprit possible at all.
+ *
+ * @param offenders     the worst threads, longest first, capped — a page ranks, it does not
+ *                      enumerate
+ * @param threadCount   how many distinct threads were measured, so the table's cap is visible rather
+ *                      than silent
+ * @param worstNanos    the longest single time-to-safepoint anywhere in the recording
+ * @param totalNanos    the summed latency across every thread and safepoint. Deliberately not read
+ *                      as elapsed time: threads reach a safepoint concurrently, so this is a sum of
+ *                      overlapping waits and is only meaningful as a ranking weight
+ */
+public record SafepointLatencyData(
+        List<SafepointOffender> offenders,
+        int threadCount,
+        long worstNanos,
+        long totalNanos) {
+
+    public static final SafepointLatencyData EMPTY = new SafepointLatencyData(List.of(), 0, 0, 0);
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/vmoperation/SafepointOffender.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/vmoperation/SafepointOffender.java
@@ -1,0 +1,50 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.vmoperation;
+
+/**
+ * One thread's record of holding the JVM up on its way into safepoints.
+ * <p>
+ * Aggregated per thread rather than listed per event, and it has to be: {@code jdk.SafepointLatency}
+ * fires once <em>per thread per safepoint</em>, so a recording with a few hundred safepoints and a
+ * few hundred threads writes tens of thousands of events that say almost nothing individually. The
+ * question the page asks — which thread is habitually slow to yield — is a question about their
+ * distribution.
+ *
+ * @param threadName  the thread that had to be waited for
+ * @param threadState what it was doing when the safepoint was requested, verbatim from the event
+ *                    ({@code _thread_in_Java}, {@code _thread_in_native}, ...). This is the column
+ *                    that turns a number into a diagnosis: a thread slow to yield from
+ *                    {@code _thread_in_Java} is running a loop the JIT stripped the safepoint poll
+ *                    out of, while one slow from {@code _thread_in_native} is stuck in a call the
+ *                    JVM cannot interrupt at all
+ * @param count       how many safepoints this thread was measured for
+ * @param maxNanos    its worst single time-to-safepoint
+ * @param p99Nanos    its 99th percentile, so one outlier does not read as a habit
+ * @param totalNanos  the summed latency, which ranks a thread that is always a little slow against
+ *                    one that is occasionally very slow
+ */
+public record SafepointOffender(
+        String threadName,
+        String threadState,
+        long count,
+        long maxNanos,
+        long p99Nanos,
+        long totalNanos) {
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/vmoperation/VmOverview.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/model/vmoperation/VmOverview.java
@@ -27,7 +27,12 @@ package cafe.jeffrey.profile.manager.model.vmoperation;
  * @param longestPauseNanos        duration of the longest single VM operation
  * @param longestPauseOperation    name of that operation (e.g. {@code G1CollectForAllocation})
  * @param hasVmOperations          whether VM-operation events are present
- * @param hasSafepointLatency      whether time-to-safepoint events are present
+ * @param hasTimeToSafepoint       whether {@code jdk.SafepointStateSynchronization} is present — the
+ *                                 per-safepoint view of how long the JVM spent getting every thread
+ *                                 to stop. Renamed from {@code hasSafepointLatency}, which read as a
+ *                                 claim about {@code jdk.SafepointLatency} and was never about it
+ * @param hasSafepointOffenders    whether {@code jdk.SafepointLatency} is present — the per-thread
+ *                                 view, and the only one that can name who was waited for
  */
 public record VmOverview(
         long vmOperationCount,
@@ -35,5 +40,6 @@ public record VmOverview(
         long longestPauseNanos,
         String longestPauseOperation,
         boolean hasVmOperations,
-        boolean hasSafepointLatency) {
+        boolean hasTimeToSafepoint,
+        boolean hasSafepointOffenders) {
 }

--- a/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/VmOperationManagerImplTest.java
+++ b/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/VmOperationManagerImplTest.java
@@ -171,7 +171,8 @@ class VmOperationManagerImplTest {
             var vm = manager().overview();
             assertEquals(0, vm.vmOperationCount());
             assertFalse(vm.hasVmOperations());
-            assertFalse(vm.hasSafepointLatency());
+            assertFalse(vm.hasTimeToSafepoint());
+            assertFalse(vm.hasSafepointOffenders());
         }
     }
 }

--- a/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/vmoperation/SafepointLatencyBuilderTest.java
+++ b/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/model/vmoperation/SafepointLatencyBuilderTest.java
@@ -1,0 +1,139 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.model.vmoperation;
+
+import tools.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import cafe.jeffrey.jfrparser.api.type.JfrThreadImpl;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.shared.common.Json;
+import cafe.jeffrey.shared.common.model.Type;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("SafepointLatencyBuilder")
+class SafepointLatencyBuilderTest {
+
+    private static final String IN_JAVA = "_thread_in_Java";
+    private static final String IN_NATIVE = "_thread_in_native";
+
+    /**
+     * One thread's measurement for one safepoint — the granularity JFR actually writes at. A JDK 26
+     * probe with 16 safepoints emitted 584 of these, which is what makes the aggregation the point
+     * of the builder rather than a convenience.
+     */
+    private static GenericRecord latency(String threadName, String threadState, long nanos) {
+        ObjectNode fields = Json.createObject();
+        fields.put("threadState", threadState);
+        return new GenericRecord(
+                Type.SAFEPOINT_LATENCY, "Safepoint Latency", Instant.EPOCH, Duration.ofMillis(1),
+                Duration.ofNanos(nanos), new JfrThreadImpl(1, 2, threadName, false), null, 0, 0, fields);
+    }
+
+    @Test
+    @DisplayName("aggregates per thread rather than listing every measurement")
+    void aggregatesPerThread() {
+        SafepointLatencyBuilder builder = new SafepointLatencyBuilder();
+        builder.onRecord(latency("laggard", IN_JAVA, 100));
+        builder.onRecord(latency("laggard", IN_JAVA, 300));
+        builder.onRecord(latency("prompt", IN_JAVA, 10));
+
+        SafepointLatencyData data = builder.build();
+
+        assertEquals(2, data.threadCount());
+        assertEquals(2, data.offenders().size());
+        SafepointOffender laggard = data.offenders().getFirst();
+        assertEquals("laggard", laggard.threadName());
+        assertEquals(2, laggard.count());
+        assertEquals(400, laggard.totalNanos());
+        assertEquals(300, laggard.maxNanos());
+    }
+
+    @Test
+    @DisplayName("ranks by summed latency, so a habit outranks a one-off")
+    void ranksByTotalNotMax() {
+        SafepointLatencyBuilder builder = new SafepointLatencyBuilder();
+        // One thread was very slow once; the other is a little slow every single time. The second is
+        // the tuning problem, and sorting by max would bury it under the hiccup.
+        builder.onRecord(latency("hiccup", IN_JAVA, 900));
+        for (int i = 0; i < 20; i++) {
+            builder.onRecord(latency("habit", IN_JAVA, 100));
+        }
+
+        SafepointLatencyData data = builder.build();
+
+        assertEquals("habit", data.offenders().getFirst().threadName());
+        assertEquals(2000, data.offenders().getFirst().totalNanos());
+        assertEquals(900, data.worstNanos(), "the single worst sample is still reported");
+    }
+
+    @Test
+    @DisplayName("describes a thread by the state of its worst measurement")
+    void keepsTheStateOfTheWorstSample() {
+        SafepointLatencyBuilder builder = new SafepointLatencyBuilder();
+        builder.onRecord(latency("mixed", IN_JAVA, 50));
+        builder.onRecord(latency("mixed", IN_NATIVE, 500));
+        builder.onRecord(latency("mixed", IN_JAVA, 60));
+
+        // The sample that actually held the JVM up is the one the reader is being asked to act on.
+        assertEquals(IN_NATIVE, builder.build().offenders().getFirst().threadState());
+    }
+
+    @Test
+    @DisplayName("sums overlapping waits as a ranking weight, not as elapsed time")
+    void totalIsARankingWeight() {
+        SafepointLatencyBuilder builder = new SafepointLatencyBuilder();
+        builder.onRecord(latency("a", IN_JAVA, 100));
+        builder.onRecord(latency("b", IN_JAVA, 100));
+
+        // Both threads waited through the same safepoint concurrently. 200ns of summed latency is
+        // not 200ns of elapsed time, and nothing downstream may read it as such.
+        assertEquals(200, builder.build().totalNanos());
+    }
+
+    @Test
+    @DisplayName("ignores a measurement the recording never made")
+    void ignoresMissingDurations() {
+        SafepointLatencyBuilder builder = new SafepointLatencyBuilder();
+        builder.onRecord(new GenericRecord(
+                Type.SAFEPOINT_LATENCY, "Safepoint Latency", Instant.EPOCH, Duration.ofMillis(1),
+                null, new JfrThreadImpl(1, 2, "unmeasured", false), null, 0, 0, Json.createObject()));
+
+        assertEquals(SafepointLatencyData.EMPTY, builder.build());
+    }
+
+    @Test
+    @DisplayName("falls back rather than dropping a thread with no state recorded")
+    void toleratesMissingThreadState() {
+        SafepointLatencyBuilder builder = new SafepointLatencyBuilder();
+        builder.onRecord(new GenericRecord(
+                Type.SAFEPOINT_LATENCY, "Safepoint Latency", Instant.EPOCH, Duration.ofMillis(1),
+                Duration.ofNanos(70), new JfrThreadImpl(1, 2, "stateless", false), null, 0, 0,
+                Json.createObject()));
+
+        SafepointOffender offender = builder.build().offenders().getFirst();
+        assertEquals("stateless", offender.threadName());
+        assertTrue(offender.threadState() != null && !offender.threadState().isBlank());
+    }
+}

--- a/jeffrey-pages/src/views/docs/microscope/profiles/ProfileVmOperationsPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/profiles/ProfileVmOperationsPage.vue
@@ -29,6 +29,7 @@ const headings = [
   { id: 'overview', text: 'Overview', level: 2 },
   { id: 'operations', text: 'VM Operations', level: 2 },
   { id: 'safepoints', text: 'Safepoints', level: 2 },
+  { id: 'offenders', text: 'Who the JVM Waited For', level: 2 },
   { id: 'types', text: 'Types of VM Operation', level: 2 },
   { id: 'events', text: 'Source Events', level: 2 }
 ];
@@ -58,6 +59,25 @@ onMounted(() => {
       <h2 id="safepoints">Safepoints</h2>
       <p>A per-second timeline of safepoint pause time (the time spent <em>at</em> safepoints, always available) plus — when <code>jdk.SafepointStateSynchronization</code> is enabled — a <em>time-to-safepoint</em> timeline: the wall-clock spent waiting for all threads to reach a safepoint before the operation can begin. High TTSP points at threads slow to poll (long counted loops, JNI), not at the operation itself.</p>
 
+      <h2 id="offenders">Who the JVM Waited For</h2>
+
+      <p>Time-to-safepoint tells you the wait was long. It cannot tell you whose fault it was, and that is not a gap in the page — <code>jdk.SafepointStateSynchronization</code> is recorded once per safepoint on a VM thread, so there is nothing in it that knows which application thread was the slow one.</p>
+
+      <p><code>jdk.SafepointLatency</code> (JDK 25+) is recorded on <em>each application thread</em> instead, once per thread per safepoint. Jeffrey aggregates it per thread and ranks the result: how many safepoints that thread was measured for, its worst and 99th-percentile time-to-safepoint, and the total it accounts for.</p>
+
+      <p>The <strong>state when asked to stop</strong> column is the one that turns a number into a fix:</p>
+
+      <ul>
+        <li><code>_thread_in_Java</code> — running compiled Java, typically a long counted loop the JIT stripped the safepoint poll out of. The loop is the thing to change.</li>
+        <li><code>_thread_in_native</code> — inside a native call, which the JVM cannot interrupt at all; it simply has to wait for the call to return.</li>
+      </ul>
+
+      <DocsCallout type="warning">
+        <strong>The event is off in both configurations, and <code>profile</code> also turns its stack trace off.</strong> Enabling it needs two settings, not one: <code>jdk.SafepointLatency#enabled=true</code> and <code>jdk.SafepointLatency#stackTrace=true</code>. With only the first you learn which thread was slow but never what it was running.
+      </DocsCallout>
+
+      <p>Ranked by summed latency rather than by the worst single sample, deliberately: a thread that is a little slow on every one of a thousand safepoints is a tuning problem worth finding, while one that was slow once is usually a scheduler hiccup — and sorting by max would put the hiccup on top. The total is a ranking weight, not elapsed time: threads reach a safepoint concurrently, so it sums waits that overlapped.</p>
+
       <h2 id="types">Types of VM Operation</h2>
       <ul>
         <li><strong>GC collections</strong> (<code>G1CollectForAllocation</code>, …) — the stop-the-world phases of garbage collection.</li>
@@ -72,6 +92,7 @@ onMounted(() => {
       <ul>
         <li><code>jdk.ExecuteVMOperation</code> — every VM operation with safepoint/blocking flags (enabled by default).</li>
         <li><code>jdk.SafepointStateSynchronization</code> / <code>SafepointBegin</code> / <code>SafepointEnd</code> — time-to-safepoint and safepoint phases (off by default).</li>
+        <li><code>jdk.SafepointLatency</code> — per-thread time-to-safepoint, the only source that names the thread the JVM waited for (JDK 25+, off in both configurations; needs <code>stackTrace=true</code> as well under <code>profile</code>).</li>
       </ul>
     </div>
 

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/EventTypeName.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/EventTypeName.java
@@ -125,6 +125,7 @@ public abstract class EventTypeName {
     public static final String CODE_CACHE_FULL = "jdk.CodeCacheFull";
     public static final String SAFEPOINT_BEGIN = "jdk.SafepointBegin";
     public static final String SAFEPOINT_STATE_SYNCHRONIZATION = "jdk.SafepointStateSynchronization";
+    public static final String SAFEPOINT_LATENCY = "jdk.SafepointLatency";
     public static final String SAFEPOINT_END = "jdk.SafepointEnd";
     public static final String EXECUTE_VM_OPERATION = "jdk.ExecuteVMOperation";
     public static final String JAVA_MONITOR_INFLATE = "jdk.JavaMonitorInflate";

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/Type.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/Type.java
@@ -129,6 +129,7 @@ public record Type(String code, boolean calculated) {
     public static final Type CODE_CACHE_FULL = new Type(EventTypeName.CODE_CACHE_FULL);
     public static final Type SAFEPOINT_BEGIN = new Type(EventTypeName.SAFEPOINT_BEGIN);
     public static final Type SAFEPOINT_STATE_SYNCHRONIZATION = new Type(EventTypeName.SAFEPOINT_STATE_SYNCHRONIZATION);
+    public static final Type SAFEPOINT_LATENCY = new Type(EventTypeName.SAFEPOINT_LATENCY);
     public static final Type SAFEPOINT_END = new Type(EventTypeName.SAFEPOINT_END);
     public static final Type EXECUTE_VM_OPERATION = new Type(EventTypeName.EXECUTE_VM_OPERATION);
     public static final Type JAVA_MONITOR_INFLATE = new Type(EventTypeName.JAVA_MONITOR_INFLATE);
@@ -325,6 +326,7 @@ public record Type(String code, boolean calculated) {
                 EXECUTE_VM_OPERATION,
                 SAFEPOINT_BEGIN,
                 SAFEPOINT_STATE_SYNCHRONIZATION,
+                SAFEPOINT_LATENCY,
                 SAFEPOINT_END,
                 JAVA_MONITOR_INFLATE,
                 VIRTUAL_THREAD_PINNED,


### PR DESCRIPTION
Independent of #209 and #210 — branched off `master`, no file overlap with either, and verified to build and test standing alone.

## Why

The VM Operations page could measure time-to-safepoint and then stop. Its own copy admitted the gap — *"high time-to-safepoint points at threads slow to poll … not the operation itself"* — without being able to say **which** thread. That is not an oversight: `jdk.SafepointStateSynchronization` is recorded once per safepoint on a VM thread, so nothing in it knows whose slowness it measured.

`jdk.SafepointLatency` (JDK 25+) is recorded on **each application thread** instead, and is the only source that can name a culprit.

## What the recording showed

A JDK 26 probe holding the JVM up with a counted loop, so the numbers below are measured rather than assumed:

```
jdk.SafepointLatency {
  duration    = 0.116 ms
  threadState = "_thread_in_Java"
  eventThread = "laggard"
  stackTrace  = [ SafepointProbe.spin() line: 12, ... ]
}
```

**584 events across 16 safepoints** — one per thread per safepoint. That cardinality is why this aggregates per thread rather than listing invocations: the finding only exists in their distribution, and a real application produces orders of magnitude more.

## What changed

- **`SafepointLatencyBuilder`** groups by thread with an HdrHistogram, reporting count, max, P99 and total.
- **Ranked by summed latency, not by the worst sample.** A thread that is a little slow on every one of a thousand safepoints is a tuning problem worth finding; one that was slow once is usually a scheduler hiccup, and sorting by max puts the hiccup on top. Both numbers are kept so the reader can tell them apart. Each thread is described by the state of its *worst* measurement, since that is the sample being acted on.
- **A "Threads Holding Up Safepoints" table** on the Safepoints tab. The **state when asked to stop** column is what turns a number into a fix:
  - `_thread_in_Java` — a loop the JIT stripped the safepoint poll out of. Change the loop.
  - `_thread_in_native` — a call the JVM cannot interrupt at all; it just has to wait.
- **Renames `VmOverview.hasSafepointLatency` → `hasTimeToSafepoint`.** It reports on `jdk.SafepointStateSynchronization` and never did report on `jdk.SafepointLatency`; with the real event now in play the old name was actively misleading. `hasSafepointOffenders` covers the new one.

> ⚠️ **Enabling it takes two settings, not one.** The event is off in **both** the default and profile configurations, and `profile.jfc` additionally sets `stackTrace=false` — so the obvious `settings=profile,+jdk.SafepointLatency#enabled=true` gives you the slow thread without the code that made it slow. Both the in-app notice and the docs now say so.

## One deliberate omission

No `TraceContextCategory` for this event, though an earlier sketch proposed one. The trace context lane explains where a span's time went, and a thread being slow to reach a safepoint is the span **running** (`_thread_in_Java`), not waiting. It is a signal about the pain that thread causes *everyone else* — a different question from the one that panel answers — and at threads × safepoints it would swamp it.

## Testing

- 6 new `SafepointLatencyBuilderTest` cases: per-thread aggregation, ranking by total over max, keeping the worst sample's state, the total being a ranking weight rather than elapsed time (threads reach a safepoint concurrently), and tolerating a missing duration or thread state.
- Full runs: `BUILD SUCCESS` across `common`, `profile-persistence-api`, `profile-sql-persistence`, `profile-management` (268 tests); 553 frontend tests; `vue-tsc` clean; 0 lint errors and zero warnings added to the page touched.

## Docs

New "Who the JVM Waited For" section in `ProfileVmOperationsPage.vue`, plus the event added to Source Events with its two-setting caveat.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2dZhaw7nFbBoVesUJaUG1)_