### PR TITLE
Show what jdk.MethodTiming counted

### DIFF
--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/MethodTracingController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/MethodTracingController.java
@@ -28,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
 import cafe.jeffrey.profile.manager.custom.MethodTracingManager;
 import cafe.jeffrey.profile.manager.custom.model.method.CumulationMode;
+import cafe.jeffrey.profile.manager.custom.model.method.MethodTimingData;
 import cafe.jeffrey.profile.manager.custom.model.method.MethodTracingCumulatedData;
 import cafe.jeffrey.profile.manager.custom.model.method.MethodTracingOverviewData;
 import cafe.jeffrey.profile.manager.custom.model.method.MethodTracingSlowestData;
@@ -62,6 +63,12 @@ public class MethodTracingController {
             @RequestParam("mode") String mode) {
         LOG.debug("Fetching method tracing cumulated: mode={}", mode);
         return mgr(profileId).cumulated(CumulationMode.fromString(mode));
+    }
+
+    @GetMapping("/timing")
+    public MethodTimingData timing(@PathVariable("profileId") String profileId) {
+        LOG.debug("Fetching method timing");
+        return mgr(profileId).methodTiming();
     }
 
     private MethodTracingManager mgr(String profileId) {

--- a/jeffrey-microscope/pages-microscope/src/router/profileChildRoutes.ts
+++ b/jeffrey-microscope/pages-microscope/src/router/profileChildRoutes.ts
@@ -549,6 +549,12 @@ const technologyRoutes = [
     meta: { layout: 'profile' }
   },
   {
+    path: 'technologies/method-tracing/timing',
+    name: 'profile-technologies-method-tracing-timing',
+    component: () => import('@/views/profiles/detail/technologies/ProfileMethodTiming.vue'),
+    meta: { layout: 'profile' }
+  },
+  {
     path: 'technologies/async-profiler/spans',
     name: 'profile-technologies-async-profiler-spans',
     component: () => import('@/views/profiles/detail/technologies/ProfileAsyncProfilerSpans.vue'),

--- a/jeffrey-microscope/pages-microscope/src/services/api/ProfileMethodTracingClient.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/ProfileMethodTracingClient.ts
@@ -20,6 +20,7 @@ import BaseProfileClient from '@/services/api/BaseProfileClient';
 import MethodTracingOverviewData from '@/services/api/model/MethodTracingOverviewData';
 import MethodTracingSlowestData from '@/services/api/model/MethodTracingSlowestData';
 import MethodTracingCumulatedData from '@/services/api/model/MethodTracingCumulatedData';
+import MethodTimingData from '@/services/api/model/MethodTimingData';
 
 export default class ProfileMethodTracingClient extends BaseProfileClient {
   constructor(profileId: string) {
@@ -36,5 +37,13 @@ export default class ProfileMethodTracingClient extends BaseProfileClient {
 
   public getCumulated(mode: 'method' | 'class'): Promise<MethodTracingCumulatedData> {
     return this.get<MethodTracingCumulatedData>('/cumulated', { mode });
+  }
+
+  /**
+   * What `jdk.MethodTiming` counted — exact per-method tallies, as opposed to the traced
+   * invocations every other endpoint here reads.
+   */
+  public getTiming(): Promise<MethodTimingData> {
+    return this.get<MethodTimingData>('/timing');
   }
 }

--- a/jeffrey-microscope/pages-microscope/src/services/api/model/MethodTimingData.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/model/MethodTimingData.ts
@@ -1,0 +1,46 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * One method's timing tally, as `jdk.MethodTiming` counted it.
+ *
+ * Every figure is exact and complete rather than sampled: the JVM instruments the method and keeps
+ * running counters, so it can watch one called millions of times for a fixed price. The trade is
+ * that it keeps no stack, no thread and no individual invocation — it can say a method was called
+ * 4.2 million times averaging 3 µs, and can never say who called it or when the slow one happened.
+ */
+export interface MethodTimingStat {
+  className: string;
+  methodName: string;
+  /** Calls over the whole recording. */
+  invocations: number;
+  minNanos: number;
+  /** The mean across every call, as the JVM computed it — not derivable from the other columns. */
+  avgNanos: number;
+  maxNanos: number;
+}
+
+export default interface MethodTimingData {
+  /** One row per method, most-invoked first. */
+  methods: MethodTimingStat[];
+  /**
+   * Summed across the methods. A scale marker for the header, not a meaningful quantity in itself —
+   * the methods are unrelated and one may sit inside another.
+   */
+  totalInvocations: number;
+}

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/technologies/ProfileMethodTiming.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/technologies/ProfileMethodTiming.vue
@@ -1,0 +1,189 @@
+<!--
+  ~ Jeffrey
+  ~ Copyright (C) 2026 Petr Bouda
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<!--
+  What jdk.MethodTiming counted, as opposed to what jdk.MethodTrace sampled.
+
+  The distinction is the whole reason this view exists beside the others. Method *tracing* writes an
+  event per invocation, so it costs in proportion to how often a method is called and is normally
+  pointed at a handful of them. Method *timing* instruments the method to keep running counters and
+  reports them periodically, so it can watch a method called millions of times for a fixed price --
+  and in exchange keeps no stack, no thread and no individual call.
+-->
+<template>
+  <div>
+    <TracingDisabledFeatureAlert v-if="isTracingDisabled" />
+
+    <div v-else>
+      <LoadingState v-if="loading" message="Loading method timing..." />
+
+      <ErrorState v-else-if="error" :message="error" @retry="loadData" />
+
+      <EmptyState
+        v-else-if="!data || data.methods.length === 0"
+        title="No Method Timing Data"
+        description="No jdk.MethodTiming events were recorded. The event is enabled in both JFR configurations but reports nothing until it is given a filter, e.g. jdk.MethodTiming#filter=com.example.Service::handle"
+        icon="bi-stopwatch"
+      />
+
+      <div v-else>
+        <ChartSection title="Timed Methods" icon="stopwatch" :full-width="true">
+          <template #header-actions>
+            <div class="input-group search-container" style="width: 280px">
+              <span class="input-group-text"><i class="bi bi-search search-icon"></i></span>
+              <input
+                v-model="searchQuery"
+                type="text"
+                class="form-control search-input"
+                placeholder="Filter by class or method..."
+              />
+              <button
+                v-if="searchQuery"
+                class="btn btn-outline-secondary clear-btn"
+                type="button"
+                @click="searchQuery = ''"
+              >
+                <i class="bi bi-x-lg"></i>
+              </button>
+            </div>
+          </template>
+          <DataTable>
+            <thead>
+              <tr>
+                <th>Method</th>
+                <th class="text-end">Invocations</th>
+                <th class="text-end">Min</th>
+                <th class="text-end">Avg</th>
+                <th class="text-end">Max</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="method in filteredMethods" :key="keyOf(method)">
+                <td class="method-cell">
+                  <span class="method-name">{{ method.methodName }}</span>
+                  <span class="class-name">{{ method.className }}</span>
+                </td>
+                <td class="text-end">
+                  {{ FormattingService.formatNumber(method.invocations) }}
+                </td>
+                <td class="text-end">
+                  {{ FormattingService.formatDuration2Units(method.minNanos) }}
+                </td>
+                <td class="text-end">
+                  {{ FormattingService.formatDuration2Units(method.avgNanos) }}
+                </td>
+                <td class="text-end">
+                  {{ FormattingService.formatDuration2Units(method.maxNanos) }}
+                </td>
+              </tr>
+            </tbody>
+          </DataTable>
+        </ChartSection>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import { useRoute } from 'vue-router';
+
+import LoadingState from '@shared/components/LoadingState.vue';
+import ErrorState from '@shared/components/ErrorState.vue';
+import EmptyState from '@shared/components/EmptyState.vue';
+import TracingDisabledFeatureAlert from '@/components/alerts/TracingDisabledFeatureAlert.vue';
+import ChartSection from '@/components/ChartSection.vue';
+import DataTable from '@shared/components/table/DataTable.vue';
+import FormattingService from '@shared/services/FormattingService';
+import ProfileMethodTracingClient from '@/services/api/ProfileMethodTracingClient';
+import '@shared/styles/shared-components.css';
+import type MethodTimingData from '@/services/api/model/MethodTimingData';
+import type { MethodTimingStat } from '@/services/api/model/MethodTimingData';
+import FeatureType from '@/services/api/model/FeatureType';
+
+interface Props {
+  disabledFeatures?: FeatureType[];
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  disabledFeatures: () => []
+});
+
+const route = useRoute();
+const profileId = route.params.profileId as string;
+
+const isTracingDisabled = computed(() =>
+  props.disabledFeatures.includes(FeatureType.METHOD_TRACING_DASHBOARD)
+);
+
+const loading = ref(true);
+const error = ref<string | null>(null);
+const data = ref<MethodTimingData | null>(null);
+const searchQuery = ref('');
+
+const filteredMethods = computed(() => {
+  if (!data.value) {
+    return [];
+  }
+  const query = searchQuery.value.trim().toLowerCase();
+  if (!query) {
+    return data.value.methods;
+  }
+  return data.value.methods.filter(
+    method =>
+      method.className.toLowerCase().includes(query) ||
+      method.methodName.toLowerCase().includes(query)
+  );
+});
+
+function keyOf(method: MethodTimingStat): string {
+  return `${method.className}#${method.methodName}`;
+}
+
+async function loadData() {
+  loading.value = true;
+  error.value = null;
+  try {
+    data.value = await new ProfileMethodTracingClient(profileId).getTiming();
+  } catch (e) {
+    console.error('Failed to load method timing data:', e);
+    error.value = 'Failed to load method timing data';
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(loadData);
+</script>
+
+<style scoped>
+.method-cell {
+  display: flex;
+  flex-direction: column;
+}
+
+.method-name {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.class-name {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+</style>

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/navigation/__tests__/profileNavConfig.spec.ts
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/navigation/__tests__/profileNavConfig.spec.ts
@@ -73,8 +73,8 @@ describe('profileNavConfig', () => {
     // 7 Overview (incl. Dashboards) + 19 JVM (incl. GC/JIT submenu parents + children)
     // + 16 Application (incl. Memory Issues submenu) + 4 Traces (Traces by Operation,
     // Search Traces, Attribute Values, Latency by Attributes) + 4 Visualization
-    // + 17 HeapDump + 4 Tools + 4 Advisor + 34 Technologies
-    expect(allItems.length).toBe(109);
+    // + 17 HeapDump + 4 Tools + 4 Advisor + 35 Technologies
+    expect(allItems.length).toBe(110);
   });
 
   it('every item has a label and a bootstrap icon', () => {

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/navigation/profileNavConfig.ts
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/navigation/profileNavConfig.ts
@@ -195,7 +195,8 @@ export const technologiesNav: Record<string, TechnologyNav> = {
         items: [
           item('Flamegraph', 'bi-fire', '/technologies/method-tracing/flamegraph'),
           item('Slowest Traces', 'bi-hourglass-split', '/technologies/method-tracing/slowest'),
-          item('Cumulated Traces', 'bi-layers', '/technologies/method-tracing/cumulated')
+          item('Cumulated Traces', 'bi-layers', '/technologies/method-tracing/cumulated'),
+          item('Method Timing', 'bi-stopwatch', '/technologies/method-tracing/timing')
         ]
       }
     ]

--- a/jeffrey-microscope/profiles/profile-custom-events/src/main/java/cafe/jeffrey/profile/manager/custom/MethodTracingManager.java
+++ b/jeffrey-microscope/profiles/profile-custom-events/src/main/java/cafe/jeffrey/profile/manager/custom/MethodTracingManager.java
@@ -20,6 +20,7 @@ package cafe.jeffrey.profile.manager.custom;
 
 import cafe.jeffrey.shared.common.model.ProfileInfo;
 import cafe.jeffrey.profile.manager.custom.model.method.CumulationMode;
+import cafe.jeffrey.profile.manager.custom.model.method.MethodTimingData;
 import cafe.jeffrey.profile.manager.custom.model.method.MethodTracingCumulatedData;
 import cafe.jeffrey.profile.manager.custom.model.method.MethodTracingOverviewData;
 import cafe.jeffrey.profile.manager.custom.model.method.MethodTracingSlowestData;
@@ -37,4 +38,13 @@ public interface MethodTracingManager {
     MethodTracingSlowestData slowest();
 
     MethodTracingCumulatedData cumulated(CumulationMode mode);
+
+    /**
+     * What {@code jdk.MethodTiming} counted, one row per method.
+     * <p>
+     * The exact, complete companion to the sampled surfaces beside it: it can watch a method called
+     * millions of times for a fixed price, and in exchange keeps no stack, no thread and no
+     * individual invocation.
+     */
+    MethodTimingData methodTiming();
 }

--- a/jeffrey-microscope/profiles/profile-custom-events/src/main/java/cafe/jeffrey/profile/manager/custom/MethodTracingManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-custom-events/src/main/java/cafe/jeffrey/profile/manager/custom/MethodTracingManagerImpl.java
@@ -21,10 +21,12 @@ package cafe.jeffrey.profile.manager.custom;
 import cafe.jeffrey.shared.common.model.ProfileInfo;
 import cafe.jeffrey.shared.common.model.Type;
 import cafe.jeffrey.shared.common.model.time.RelativeTimeRange;
+import cafe.jeffrey.profile.manager.custom.builder.MethodTimingBuilder;
 import cafe.jeffrey.profile.manager.custom.builder.MethodTracingCumulatedBuilder;
 import cafe.jeffrey.profile.manager.custom.builder.MethodTracingOverviewBuilder;
 import cafe.jeffrey.profile.manager.custom.builder.MethodTracingSlowestBuilder;
 import cafe.jeffrey.profile.manager.custom.model.method.CumulationMode;
+import cafe.jeffrey.profile.manager.custom.model.method.MethodTimingData;
 import cafe.jeffrey.profile.manager.custom.model.method.MethodTracingCumulatedData;
 import cafe.jeffrey.profile.manager.custom.model.method.MethodTracingOverviewData;
 import cafe.jeffrey.profile.manager.custom.model.method.MethodTracingSlowestData;
@@ -73,5 +75,19 @@ public class MethodTracingManagerImpl implements MethodTracingManager {
                 .withTimeRange(timeRange);
 
         return eventStreamRepository.genericStreaming(configurer, new MethodTracingCumulatedBuilder(mode));
+    }
+
+    @Override
+    public MethodTimingData methodTiming() {
+        RelativeTimeRange timeRange = new RelativeTimeRange(profileInfo.profilingStartEnd());
+
+        // No withThreads(): the event has no thread, by design -- it is a counter on the method, not
+        // a record of any one call.
+        EventQueryConfigurer configurer = new EventQueryConfigurer()
+                .withEventType(Type.METHOD_TIMING)
+                .withJsonFields()
+                .withTimeRange(timeRange);
+
+        return eventStreamRepository.genericStreaming(configurer, new MethodTimingBuilder());
     }
 }

--- a/jeffrey-microscope/profiles/profile-custom-events/src/main/java/cafe/jeffrey/profile/manager/custom/builder/MethodTimingBuilder.java
+++ b/jeffrey-microscope/profiles/profile-custom-events/src/main/java/cafe/jeffrey/profile/manager/custom/builder/MethodTimingBuilder.java
@@ -1,0 +1,115 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.custom.builder;
+
+import tools.jackson.databind.node.ObjectNode;
+import cafe.jeffrey.profile.manager.custom.model.method.MethodTimingData;
+import cafe.jeffrey.profile.manager.custom.model.method.MethodTimingStat;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.provider.profile.api.RecordBuilder;
+import cafe.jeffrey.shared.common.Json;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Reads {@code jdk.MethodTiming} into one row per method by keeping the <b>latest tally</b>, never
+ * by summing.
+ *
+ * <h2>Why this must not sum</h2>
+ * The event is periodic — {@code period=endChunk} — and its counters are <b>cumulative over the
+ * whole recording</b>, not per chunk. Measured on a JDK 26 probe calling one method 1000 times a
+ * second: a dump at five seconds carried a single event reading {@code invocations = 5000}, and a
+ * dump at ten seconds carried two events reading {@code 5000} and {@code 11000}. The second event
+ * is the running total, not the second chunk's contribution.
+ * <p>
+ * So a recording with five chunks holds five events per method, each a superset of the last, and
+ * adding them up reports roughly three times the calls that happened. Only the final tally is the
+ * answer, and the same applies to every column: {@code minimum} and {@code maximum} are already the
+ * extremes over everything recorded so far, and {@code average} is the mean over every call, which
+ * is why averaging the averages — or trying to difference them — produces a number that means
+ * nothing.
+ * <p>
+ * The final tally is picked by the largest {@code invocations} rather than by the latest timestamp.
+ * The counter only ever grows, so the largest value <em>is</em> the newest, and reading it that way
+ * does not depend on events arriving in order.
+ */
+public class MethodTimingBuilder implements RecordBuilder<GenericRecord, MethodTimingData> {
+
+    private static final String METHOD_FIELD = "method";
+    private static final String INVOCATIONS_FIELD = "invocations";
+    private static final String MINIMUM_FIELD = "minimum";
+    private static final String AVERAGE_FIELD = "average";
+    private static final String MAXIMUM_FIELD = "maximum";
+
+    /** How {@code EventFieldsToJsonMapper} flattens the JFR method struct. */
+    private static final String METHOD_SEPARATOR = "#";
+
+    private static final String UNKNOWN_CLASS = "<unknown>";
+
+    private final Map<String, MethodTimingStat> latestByMethod = new HashMap<>();
+
+    @Override
+    public void onRecord(GenericRecord record) {
+        ObjectNode fields = record.jsonFields();
+        if (fields == null) {
+            return;
+        }
+        String method = Json.readString(fields, METHOD_FIELD);
+        if (method == null || method.isBlank()) {
+            return;
+        }
+
+        long invocations = Json.readLong(fields, INVOCATIONS_FIELD);
+        MethodTimingStat previous = latestByMethod.get(method);
+        if (previous != null && previous.invocations() >= invocations) {
+            // An earlier chunk's tally, or a repeat of one already seen. The counter never shrinks,
+            // so anything not larger than what is held is not newer than it.
+            return;
+        }
+
+        int separator = method.lastIndexOf(METHOD_SEPARATOR);
+        String className = separator > 0 ? method.substring(0, separator) : UNKNOWN_CLASS;
+        String methodName = separator >= 0 ? method.substring(separator + 1) : method;
+
+        latestByMethod.put(method, new MethodTimingStat(
+                className,
+                methodName,
+                invocations,
+                Json.readLong(fields, MINIMUM_FIELD),
+                Json.readLong(fields, AVERAGE_FIELD),
+                Json.readLong(fields, MAXIMUM_FIELD)));
+    }
+
+    @Override
+    public MethodTimingData build() {
+        if (latestByMethod.isEmpty()) {
+            return MethodTimingData.EMPTY;
+        }
+
+        List<MethodTimingStat> methods = new ArrayList<>(latestByMethod.values());
+        methods.sort(Comparator.comparingLong(MethodTimingStat::invocations).reversed());
+
+        long totalInvocations = methods.stream().mapToLong(MethodTimingStat::invocations).sum();
+        return new MethodTimingData(List.copyOf(methods), totalInvocations);
+    }
+}

--- a/jeffrey-microscope/profiles/profile-custom-events/src/main/java/cafe/jeffrey/profile/manager/custom/model/method/MethodTimingData.java
+++ b/jeffrey-microscope/profiles/profile-custom-events/src/main/java/cafe/jeffrey/profile/manager/custom/model/method/MethodTimingData.java
@@ -1,0 +1,35 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.custom.model.method;
+
+import java.util.List;
+
+/**
+ * What {@code jdk.MethodTiming} counted, one row per method.
+ *
+ * @param methods         the tallies, most-invoked first
+ * @param totalInvocations summed across the methods — a scale marker for the page header, not a
+ *                        meaningful quantity in itself, since the methods are unrelated
+ */
+public record MethodTimingData(
+        List<MethodTimingStat> methods,
+        long totalInvocations) {
+
+    public static final MethodTimingData EMPTY = new MethodTimingData(List.of(), 0);
+}

--- a/jeffrey-microscope/profiles/profile-custom-events/src/main/java/cafe/jeffrey/profile/manager/custom/model/method/MethodTimingStat.java
+++ b/jeffrey-microscope/profiles/profile-custom-events/src/main/java/cafe/jeffrey/profile/manager/custom/model/method/MethodTimingStat.java
@@ -1,0 +1,47 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.custom.model.method;
+
+/**
+ * One method's timing tally, as {@code jdk.MethodTiming} counted it.
+ * <p>
+ * Every figure here is <b>exact and complete</b>, which is what makes this worth showing beside the
+ * sampled surfaces on the same dashboard. {@code jdk.MethodTrace} writes an event per invocation, so
+ * it costs in proportion to how often the method is called and is usually pointed at a handful of
+ * methods; {@code jdk.MethodTiming} instruments the method to keep running counters and reports them
+ * periodically, so it can watch a method called a million times for a fixed price. The trade is that
+ * it keeps no stack, no thread and no individual invocation — it can say a method was called 4.2
+ * million times averaging 3&nbsp;µs, and can never say who called it or when the slow one happened.
+ *
+ * @param className    the declaring class
+ * @param methodName   the method
+ * @param invocations  how many times it was called over the whole recording
+ * @param minNanos     the fastest call
+ * @param avgNanos     the mean across every call, as the JVM computed it. Not derivable from
+ *                     anything else here, and not combinable across recordings
+ * @param maxNanos     the slowest call
+ */
+public record MethodTimingStat(
+        String className,
+        String methodName,
+        long invocations,
+        long minNanos,
+        long avgNanos,
+        long maxNanos) {
+}

--- a/jeffrey-microscope/profiles/profile-custom-events/src/test/java/cafe/jeffrey/profile/manager/custom/builder/MethodTimingBuilderTest.java
+++ b/jeffrey-microscope/profiles/profile-custom-events/src/test/java/cafe/jeffrey/profile/manager/custom/builder/MethodTimingBuilderTest.java
@@ -1,0 +1,121 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.custom.builder;
+
+import tools.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import cafe.jeffrey.profile.manager.custom.model.method.MethodTimingData;
+import cafe.jeffrey.profile.manager.custom.model.method.MethodTimingStat;
+import cafe.jeffrey.provider.profile.api.GenericRecord;
+import cafe.jeffrey.shared.common.Json;
+import cafe.jeffrey.shared.common.model.Type;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("MethodTimingBuilder")
+class MethodTimingBuilderTest {
+
+    /**
+     * One periodic tally. The counters are cumulative over the whole recording, so a later event for
+     * the same method is a superset of the earlier one rather than a new slice of work.
+     */
+    private static GenericRecord timing(String method, long invocations, long min, long avg, long max) {
+        ObjectNode fields = Json.createObject();
+        fields.put("method", method);
+        fields.put("invocations", invocations);
+        fields.put("minimum", min);
+        fields.put("average", avg);
+        fields.put("maximum", max);
+        return new GenericRecord(
+                Type.METHOD_TIMING, "Method Timing", Instant.EPOCH, Duration.ofMillis(1),
+                null, null, null, 0, 0, fields);
+    }
+
+    @Test
+    @DisplayName("keeps the final tally instead of summing the periodic ones")
+    void keepsTheFinalTally() {
+        MethodTimingBuilder builder = new MethodTimingBuilder();
+        // Measured on a JDK 26 probe: a dump at 5s carried invocations=5000, and one at 10s carried
+        // 5000 and 11000 -- the second being the running total, not that chunk's contribution.
+        builder.onRecord(timing("app.Service#handle", 5_000, 10, 20, 90));
+        builder.onRecord(timing("app.Service#handle", 11_000, 10, 21, 140));
+
+        MethodTimingData data = builder.build();
+
+        assertEquals(1, data.methods().size(), "one row per method, however many chunks reported it");
+        MethodTimingStat stat = data.methods().getFirst();
+        assertEquals(11_000, stat.invocations(), "the running total, not 16000");
+        assertEquals(140, stat.maxNanos(), "the extreme over everything recorded so far");
+        assertEquals(21, stat.avgNanos(), "the mean over every call, taken from the final tally");
+    }
+
+    @Test
+    @DisplayName("is not fooled by tallies arriving out of order")
+    void toleratesOutOfOrderTallies() {
+        MethodTimingBuilder builder = new MethodTimingBuilder();
+        builder.onRecord(timing("app.Service#handle", 11_000, 10, 21, 140));
+        builder.onRecord(timing("app.Service#handle", 5_000, 10, 20, 90));
+
+        // The counter only ever grows, so the largest value is the newest whatever order it arrives
+        // in -- which is why the builder selects on it rather than on a timestamp.
+        assertEquals(11_000, builder.build().methods().getFirst().invocations());
+    }
+
+    @Test
+    @DisplayName("splits the flattened method into the class and method columns")
+    void splitsTheMethodName() {
+        MethodTimingBuilder builder = new MethodTimingBuilder();
+        builder.onRecord(timing("cafe.jeffrey.probe.TimingProbe#slow", 10, 3_120_000, 3_140_000, 3_210_000));
+
+        MethodTimingStat stat = builder.build().methods().getFirst();
+        assertEquals("cafe.jeffrey.probe.TimingProbe", stat.className());
+        assertEquals("slow", stat.methodName());
+    }
+
+    @Test
+    @DisplayName("ranks the most-invoked method first")
+    void ranksByInvocations() {
+        MethodTimingBuilder builder = new MethodTimingBuilder();
+        builder.onRecord(timing("app.A#rare", 10, 1, 2, 3));
+        builder.onRecord(timing("app.B#hot", 1_000_000, 1, 2, 3));
+
+        MethodTimingData data = builder.build();
+        assertEquals("hot", data.methods().getFirst().methodName());
+        assertEquals(1_000_010, data.totalInvocations());
+    }
+
+    @Test
+    @DisplayName("ignores a tally with no method to attribute it to")
+    void ignoresNamelessTallies() {
+        MethodTimingBuilder builder = new MethodTimingBuilder();
+        ObjectNode fields = Json.createObject();
+        fields.put("invocations", 5);
+        builder.onRecord(new GenericRecord(
+                Type.METHOD_TIMING, "Method Timing", Instant.EPOCH, Duration.ofMillis(1),
+                null, null, null, 0, 0, fields));
+
+        assertTrue(builder.build().methods().isEmpty());
+        assertEquals(MethodTimingData.EMPTY, builder.build());
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/feature/checker/FeatureCheckers.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/feature/checker/FeatureCheckers.java
@@ -62,8 +62,16 @@ public abstract class FeatureCheckers {
      * JDK method timing and tracing (JEP 520), not distributed tracing — see
      * {@link TracesFeatureChecker} for the Traces section.
      */
+    /*
+     * Either event opens the dashboard. jdk.MethodTiming is enabled in both JFR configurations out
+     * of the box and only needs a filter, while jdk.MethodTrace has to be switched on -- so a
+     * recording carrying timings and no traces is the ordinary case, and gating on MethodTrace
+     * alone hid a populated dashboard from the people most likely to have one.
+     */
     public static final FeatureChecker METHOD_TRACING_DASHBOARD =
-            new SamplesFeatureChecker(FeatureType.METHOD_TRACING_DASHBOARD, Type.METHOD_TRACE);
+            new SamplesFeatureChecker(
+                    FeatureType.METHOD_TRACING_DASHBOARD,
+                    List.of(Type.METHOD_TRACE, Type.METHOD_TIMING));
 
     public static final FeatureChecker ASYNC_PROFILER_SPANS =
             new SamplesFeatureChecker(FeatureType.ASYNC_PROFILER_SPANS, Type.SPAN);

--- a/jeffrey-pages/src/views/docs/microscope/profiles/ProfilesPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/profiles/ProfilesPage.vue
@@ -307,7 +307,7 @@ const folderStructure = `$JEFFREY_HOME/
         <DocsFeatureCard
           icon="bi bi-layers"
           title="Method Tracing"
-          description="Wall-clock flamegraphs from traced methods, slowest traces, cumulated analysis, and per-method drill-down. Each traced method appears as its own frame under its caller, and a call is charged only for the time its traced callees do not already account for."
+          description="Wall-clock flamegraphs from traced methods, slowest traces, cumulated analysis, and per-method drill-down — plus exact per-method tallies from jdk.MethodTiming, which counts every invocation for a fixed price. Each traced method appears as its own frame under its caller, and a call is charged only for the time its traced callees do not already account for."
         />
         <DocsFeatureCard
           icon="bi bi-bounding-box"

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/EventTypeName.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/EventTypeName.java
@@ -30,6 +30,7 @@ public abstract class EventTypeName {
     public static final String CPU_TIME_SAMPLE = "jdk.CPUTimeSample";
     public static final String CPU_TIME_SAMPLES_LOST = "jdk.CPUTimeSamplesLost";
     public static final String METHOD_TRACE = "jdk.MethodTrace";
+    public static final String METHOD_TIMING = "jdk.MethodTiming";
     public static final String WALL_CLOCK_SAMPLE = "profiler.WallClockSample";
     public static final String MALLOC = "profiler.Malloc";
     public static final String FREE = "profiler.Free";

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/Type.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/Type.java
@@ -36,6 +36,7 @@ public record Type(String code, boolean calculated) {
     public static final Type CPU_TIME_SAMPLES_LOST = new Type(EventTypeName.CPU_TIME_SAMPLES_LOST);
     public static final Type WALL_CLOCK_SAMPLE = new Type(EventTypeName.WALL_CLOCK_SAMPLE);
     public static final Type METHOD_TRACE = new Type(EventTypeName.METHOD_TRACE);
+    public static final Type METHOD_TIMING = new Type(EventTypeName.METHOD_TIMING);
     public static final Type MALLOC = new Type(EventTypeName.MALLOC);
     public static final Type FREE = new Type(EventTypeName.FREE);
     public static final Type JAVA_MONITOR_ENTER = new Type(EventTypeName.JAVA_MONITOR_ENTER);
@@ -241,6 +242,7 @@ public record Type(String code, boolean calculated) {
                 CPU_TIME_SAMPLES_LOST,
                 WALL_CLOCK_SAMPLE,
                 METHOD_TRACE,
+                METHOD_TIMING,
                 MALLOC,
                 FREE,
                 NATIVE_LEAK,


### PR DESCRIPTION
Independent of #209 / #210 / #211 / #212 — branched off `master`, verified to build and test standing alone.

## Why

Method timing is the cheap, exact companion to method tracing, and Jeffrey ingested neither.

- `jdk.MethodTrace` writes an event **per invocation**, so it costs in proportion to how often a method is called and is normally pointed at a handful of them.
- `jdk.MethodTiming` instruments the method to keep **running counters** and reports them periodically, so it can watch a method called millions of times for a fixed price — and in exchange keeps no stack, no thread and no individual call.

## The fact that shaped the implementation

I probed a JDK 26 recording rather than reading the field list, because the fact that matters is not in the field list: **the counters are cumulative over the whole recording**, and the event fires once per method per chunk (`period=endChunk`).

Dumping a live JVM calling one method 1000 times a second:

| dump | chunks | `invocations` per event |
|---|---|---|
| at 5 s | 1 | `[5000]` |
| at 10 s | 2 | `[5000, 11000]` |

The second event is the **running total**, not that chunk's ~6000. So a five-chunk recording holds five events per method, each a superset of the last, and **summing them would report roughly three times the calls that happened**.

The builder therefore keeps the final tally and never sums. The same applies to every column: `minimum` and `maximum` are already the extremes over everything recorded so far, and `average` is the mean over every call — which is why averaging the averages, or trying to difference them, produces a number that means nothing.

The final tally is selected by the **largest `invocations`** rather than by the latest timestamp: the counter only ever grows, so the largest value *is* the newest, and reading it that way does not depend on events arriving in order.

## What changed

- `MethodTimingBuilder` + models + manager method + a `/timing` endpoint.
- A **Method Timing** view on the Method Tracing dashboard, with route and nav entry.
- **The dashboard now opens on either event.** `jdk.MethodTiming` is enabled in *both* JFR configurations out of the box and only needs a filter, while `jdk.MethodTrace` has to be switched on — so a recording carrying timings and no traces is the ordinary case, and gating on `MethodTrace` alone hid a populated page from the people most likely to have one. `SamplesFeatureChecker` already supported a list with `anyMatch`, so this is a one-line widening.

The empty state names the filter explicitly (`jdk.MethodTiming#filter=com.example.Service::handle`), since "enabled but reports nothing without a filter" is the state most users will actually be in.

## Testing

5 new `MethodTimingBuilderTest` cases, the first two pinning exactly the behaviour above: keeping the final tally instead of summing (asserting `11000`, not `16000`), and tolerating out-of-order tallies. Plus name splitting, ranking, and ignoring a tally with no method.

`BUILD SUCCESS` across `common`, `profile-custom-events`, `profile-management` (262 tests); 538 frontend tests; `vue-tsc` clean; 0 lint errors.

A nav-config guard test that counts navigation items **caught the new entry** (`expected 110 to be 109`) — working as designed; the count and its breakdown comment are updated rather than weakened.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2dZhaw7nFbBoVesUJaUG1)_