### PR TITLE
Make the blocking-event set agree with the rest of the codebase

### DIFF
--- a/jeffrey-microscope/pages-microscope/src/services/EventTypeCatalog.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/EventTypeCatalog.ts
@@ -411,6 +411,15 @@ const EVENT_TYPE_CATALOG: EventTypeCategory[] = [
       { name: 'jeffrey.JdbcPoolStatistics', description: 'Connection pool stats' }
     ]
   },
+  // ── Jeffrey: Tracing ──
+  {
+    label: 'Tracing',
+    badge: 'jeffrey',
+    events: [
+      { name: 'jeffrey.TraceSpan', description: 'Hand-written spans from Tracer / @Traced' },
+      { name: 'jeffrey.TraceScope', description: 'Scopes re-entered by Tracer#reenter' }
+    ]
+  },
   // ── Jeffrey: Notifications ──
   {
     label: 'Notifications',

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/parser/WeightExtractorRegistry.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/parser/WeightExtractorRegistry.java
@@ -52,6 +52,12 @@ public class WeightExtractorRegistry {
         registry.put(JAVA_MONITOR_WAIT, WeightExtractor.duration("monitorClass"));
         registry.put(THREAD_PARK, WeightExtractor.duration("parkedClass"));
         registry.put(THREAD_SLEEP, WeightExtractor.duration());
+        // Pinned time is blocked time, and the rest of the codebase already treats it that way --
+        // BlockingLeafSpans promotes it into a span, TraceContextCategory.VT_PINNED explains it as a
+        // wait. Without a weight here it was the one blocking event whose flamegraph could only be
+        // counted, never weighted by the time it cost. No entity: unlike a monitor or a park there
+        // is no class the thread was pinned *on*, only a carrier it could not leave.
+        registry.put(VIRTUAL_THREAD_PINNED, WeightExtractor.duration());
         registry.put(OBJECT_ALLOCATION_IN_NEW_TLAB, WeightExtractor.allocation("tlabSize", "objectClass"));
         registry.put(OBJECT_ALLOCATION_OUTSIDE_TLAB, WeightExtractor.allocation("allocationSize", "objectClass"));
         registry.put(OBJECT_ALLOCATION_SAMPLE, WeightExtractor.allocation("weight", "objectClass"));

--- a/jeffrey-microscope/profiles/profile-threads/src/test/java/cafe/jeffrey/profile/thread/ThreadStateContextPactTest.java
+++ b/jeffrey-microscope/profiles/profile-threads/src/test/java/cafe/jeffrey/profile/thread/ThreadStateContextPactTest.java
@@ -1,0 +1,101 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.thread;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import cafe.jeffrey.provider.profile.api.TraceContextCategory;
+import cafe.jeffrey.shared.common.model.EventTypeName;
+
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The pact between the thread timeline and the trace context lane, which both {@code ThreadState}
+ * and {@code TraceContextCategory} describe in prose and neither could enforce.
+ * <p>
+ * Both classes map JFR event types to "what a thread was doing", for two different pictures: a lane
+ * on the thread timeline, and an explanation of where a span's time went. Their javadocs warn that
+ * the two drift if either is edited alone, and until now nothing checked.
+ * <p>
+ * The invariant is deliberately <b>containment, not equality</b>. Every wait a thread lane can draw
+ * must be a wait the trace lane can explain, or a reader who sees a band on one screen finds nothing
+ * accounting for it on the other. The reverse does not hold and should not: the context side also
+ * carries an {@code fsync}, a ZGC allocation stall, a deoptimisation and a virtual-thread pin, none
+ * of which the timeline draws as a lane of its own.
+ */
+@DisplayName("ThreadState / TraceContextCategory pact")
+class ThreadStateContextPactTest {
+
+    /**
+     * The lifespan states, excluded because they are not waits at all. They are reconstructed from
+     * start/end pairs to bound a lane, and there is no "time spent starting" for a trace to explain.
+     */
+    private static final Set<ThreadState> LIFESPAN = Set.of(ThreadState.STARTED, ThreadState.ENDED);
+
+    @Test
+    @DisplayName("every wait the thread timeline draws is one the trace lane can explain")
+    void everyTimelineWaitHasAContextCategory() {
+        Set<String> unexplained = new TreeSet<>();
+        for (ThreadState state : ThreadState.values()) {
+            if (LIFESPAN.contains(state)) {
+                continue;
+            }
+            String eventType = state.eventType().code();
+            if (TraceContextCategory.fromEventType(eventType).isEmpty()) {
+                unexplained.add(eventType);
+            }
+        }
+
+        assertTrue(unexplained.isEmpty(),
+                "these thread-timeline waits have no TraceContextCategory, so a band on the threads "
+                        + "screen has nothing accounting for it on a trace: " + unexplained);
+    }
+
+    @Test
+    @DisplayName("the context side may carry waits the timeline has no lane for")
+    void containmentIsNotEquality() {
+        // Pins the direction of the invariant, so a future edit that "fixes" the asymmetry by
+        // deleting categories fails here rather than silently narrowing what a trace can explain.
+        Set<String> timelineWaits = new TreeSet<>();
+        for (ThreadState state : ThreadState.values()) {
+            if (!LIFESPAN.contains(state)) {
+                timelineWaits.add(state.eventType().code());
+            }
+        }
+
+        // Every derivation, not just the one this test happened to be written against: a category
+        // recovered by differencing a counter explains a wait exactly as well as one read straight
+        // off an event, and narrowing to a single derivation would let a new one drift in unchecked
+        // -- which is the whole failure mode this test exists to catch.
+        Set<String> contextWaits = new TreeSet<>();
+        for (TraceContextCategory.Derivation derivation : TraceContextCategory.Derivation.values()) {
+            contextWaits.addAll(
+                    TraceContextCategory.eventTypesOf(TraceContextCategory.Scope.THREAD, derivation));
+        }
+
+        assertTrue(contextWaits.containsAll(timelineWaits), "containment must hold");
+        assertTrue(contextWaits.contains(EventTypeName.FILE_FORCE),
+                "fsync is context without being a lane");
+        assertTrue(contextWaits.contains(EventTypeName.VIRTUAL_THREAD_PINNED),
+                "a pin is context without being a lane");
+    }
+}

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/Type.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/Type.java
@@ -230,8 +230,15 @@ public record Type(String code, boolean calculated) {
     // Application notifications
     public static final Type NOTIFICATION = new Type(EventTypeName.NOTIFICATION);
 
-    private static final Set<Type> BLOCKING_EVENTS =
-            Set.of(JAVA_MONITOR_ENTER, JAVA_MONITOR_WAIT, THREAD_PARK, THREAD_SLEEP);
+    /*
+     * VIRTUAL_THREAD_PINNED belongs here for the same reason the other four do: it is a stretch of
+     * time a thread spent not running its own work. It is also where blocked time *hides* on virtual
+     * threads -- a parking virtual thread normally unmounts rather than blocking its carrier, so
+     * jdk.ThreadPark never sees it. The frontend's EventTypes.isBlockingEventType has always
+     * included it; this is the side that was behind.
+     */
+    private static final Set<Type> BLOCKING_EVENTS = Set.of(
+            JAVA_MONITOR_ENTER, JAVA_MONITOR_WAIT, THREAD_PARK, THREAD_SLEEP, VIRTUAL_THREAD_PINNED);
 
     private static final Map<String, Type> KNOWN_TYPES;
 


### PR DESCRIPTION
Three consistency items, each verified against the code rather than assumed from the comment that flagged it.

### `jdk.VirtualThreadPinned` was blocking everywhere except where it counted

It was missing from `Type.BLOCKING_EVENTS` and had no weight extractor at all, while the frontend's `EventTypes.isBlockingEventType` has always counted it. That was not a cosmetic disagreement — everything else in the codebase already treats a pin as blocked time: `BlockingLeafSpans` promotes it into a span, `TraceContextCategory.VT_PINNED` explains it as a wait. It was the one blocking event whose flamegraph could be counted but never weighted by the time it cost.

A pin is also *where blocked time hides* on virtual threads: a parking virtual thread normally unmounts rather than blocking its carrier, so `jdk.ThreadPark` never sees it. This registers a duration weight with no entity — unlike a monitor or a park there is no class the thread was pinned on, only a carrier it could not leave.

### Nothing checked the `ThreadState` ↔ `TraceContextCategory` pact

Both types warn in prose that they drift if either is edited alone. `ThreadStateContextPactTest` now asserts it, as **containment rather than equality**: every wait the thread timeline can draw must be one a trace can explain, while the context side legitimately also carries an fsync, a ZGC allocation stall, a deoptimisation and a pin — none of which are lanes of their own. A second test pins that direction, so a later attempt to "fix" the asymmetry by deleting categories fails rather than silently narrowing what a trace can account for.

### Missing catalog entries

`jeffrey.TraceSpan` and `jeffrey.TraceScope` are emitted by the tracing library but were absent from `EventTypeCatalog.ts`, so they could not be picked in the live/replay stream.

### Verification

- `mvn test` on `shared/common`, `profile-threads`, `profile-management` — BUILD SUCCESS, including the 2 new pact tests.
- `pages-microscope`: 538 tests pass, typecheck clean, no new lint warnings.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2dZhaw7nFbBoVesUJaUG1)_