### PR TITLE
Show the span whose allocation forced a collection

### DIFF
--- a/jeffrey-microscope/pages-microscope/src/components/trace/TraceSpanInlineDetail.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/trace/TraceSpanInlineDetail.vue
@@ -129,6 +129,21 @@
                 <b>{{ FormattingService.formatDuration2Units(wait.totalNanos) }}</b>
               </span>
             </p>
+            <!--
+              Instants, counted rather than timed. Kept in their own line so a count is never read
+              as a duration: these happened inside the span without occupying any of it.
+            -->
+            <p v-if="spanMarkers.length > 0" class="sd-waits sd-markers">
+              <span
+                v-for="marker in spanMarkers"
+                :key="marker.category"
+                :title="markerTitle(marker)"
+              >
+                <i :style="{ background: contextColor(marker.category) }"></i>
+                {{ contextLabel(marker.category) }}
+                <b>&times;{{ FormattingService.formatNumber(marker.occurrences) }}</b>
+              </span>
+            </p>
           </div>
         </section>
 
@@ -588,8 +603,37 @@ const meterTitle = computed(
     `${FormattingService.formatDuration2Units(props.span.durationNanos)} total`
 );
 
-/** Anything that came to nothing is dropped: a category with no time is not a finding. */
+/**
+ * What the thread spent time waiting on. A category that came to no time is not a wait.
+ *
+ * Duration is the filter rather than presence, because a wait with nothing in it says nothing —
+ * but see {@link spanMarkers}: some categories are instants and can never pass this test.
+ */
 const spanWaits = computed(() => (props.waits ?? []).filter(wait => wait.totalNanos > 0));
+
+/**
+ * The instant categories: things that happened inside this span without occupying time.
+ *
+ * `jdk.Deoptimization` and `jdk.AllocationRequiringGC` carry no duration at all — they are moments,
+ * not stretches — so they can never clear the duration filter above and were, until now, dropped
+ * everywhere and shown nowhere. They are worth saying: an allocation that forced a collection names
+ * the span responsible for a GC pause the rest of the trace only suffers, and a deoptimisation
+ * explains a span that was fast a moment ago.
+ *
+ * Reported as a count, never as a duration, and kept out of the why-slow panel entirely: that panel
+ * ranks where wall-clock went, and a marker has no wall-clock to contribute.
+ */
+const spanMarkers = computed(() =>
+  (props.waits ?? []).filter(wait => wait.totalNanos === 0 && wait.occurrences > 0)
+);
+
+function markerTitle(marker: TraceContextSlice): string {
+  const events = marker.occurrences === 1 ? '1 event' : `${marker.occurrences} events`;
+  return (
+    `${contextLabel(marker.category)} · ${events} while this span was open, with no duration ` +
+    `of their own`
+  );
+}
 
 function waitTitle(wait: TraceContextSlice): string {
   const events = wait.occurrences === 1 ? '1 event' : `${wait.occurrences} events`;
@@ -845,6 +889,11 @@ function percent(part: number, whole: number): string {
   gap: 0.15rem 0.75rem;
   font-size: 0.78rem;
   color: var(--color-text-muted);
+}
+
+/* Markers are counts, not durations -- set slightly back so the eye reads the waits first. */
+.sd-markers {
+  opacity: 0.85;
 }
 
 .sd-waits span {

--- a/jeffrey-microscope/pages-microscope/src/services/api/model/trace/TraceModels.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/model/trace/TraceModels.ts
@@ -298,6 +298,7 @@ export type TraceContextCategoryName =
   | 'FILE_IO'
   | 'ALLOCATION_STALL'
   | 'DEOPTIMIZATION'
+  | 'ALLOCATION_REQUIRING_GC'
   | 'VT_PINNED'
   | 'CPU_THROTTLED'
   | 'OWN_WORK';

--- a/jeffrey-microscope/pages-microscope/src/services/trace/traceLabels.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/trace/traceLabels.ts
@@ -82,6 +82,13 @@ export const CONTEXT_CATEGORIES: Record<string, { label: string; color: string }
   ALLOCATION_STALL: { label: 'Allocation stall', color: 'var(--flamegraph-color-orange)' },
   DEOPTIMIZATION: { label: 'Deoptimization', color: 'var(--flamegraph-color-peach)' },
   /*
+   * A marker rather than a band, which is why a deep violet is admissible where the ramp is
+   * otherwise crowded with purples: markers are drawn as counted chips inside a span's detail, never
+   * as a lane across the waterfall, so they never share a picture with the lock-wait lavender or the
+   * file-I/O magenta.
+   */
+  ALLOCATION_REQUIRING_GC: { label: 'GC triggered', color: 'var(--chart-series-7)' },
+  /*
    * Crimson-pink rather than another purple: a pin is usually *caused by* a monitor, but drawing it
    * in the lock-wait purple would claim the two rows are the same wait, and the reader's fix — free
    * the carrier — is different from the reader's fix for contention.
@@ -154,6 +161,7 @@ const CONTEXT_EXPLAINING_ROUTES: Record<string, string> = {
   GC_PAUSE: 'profile-garbage-collection',
   SAFEPOINT: 'profile-vm-operations',
   CPU_THROTTLED: 'profile-container-cpu-throttling',
+  ALLOCATION_REQUIRING_GC: 'profile-garbage-collection',
   MONITOR_BLOCKED: 'profile-blocking-operations',
   MONITOR_WAIT: 'profile-blocking-operations',
   PARKED: 'profile-threads-timeline',

--- a/jeffrey-microscope/profiles/profile-persistence-api/src/main/java/cafe/jeffrey/provider/profile/api/TraceContextCategory.java
+++ b/jeffrey-microscope/profiles/profile-persistence-api/src/main/java/cafe/jeffrey/provider/profile/api/TraceContextCategory.java
@@ -97,6 +97,20 @@ public enum TraceContextCategory {
     DEOPTIMIZATION(Scope.THREAD, EventTypeName.DEOPTIMIZATION),
 
     /**
+     * An allocation this thread made could not be satisfied and forced a collection.
+     * <p>
+     * The other direction of the GC story, and the one a waterfall cannot otherwise tell. A
+     * {@link #GC_PAUSE} band says every thread was stopped; this says which span's allocation is why.
+     * Recorded on the allocating thread with the size and the {@code gcId}, so the pause it caused is
+     * identifiable rather than merely nearby.
+     * <p>
+     * Instant, like {@link #DEOPTIMIZATION}: it carries no duration, so it is a marker rather than a
+     * stretch of time. Nothing may add it to a duration total -- see the note on {@link Scope} about
+     * how the two are told apart.
+     */
+    ALLOCATION_REQUIRING_GC(Scope.THREAD, EventTypeName.ALLOCATION_REQUIRING_GC),
+
+    /**
      * A virtual thread pinned to its carrier while it should have unmounted — the wait that
      * {@code jdk.ThreadPark} cannot see, because a parking virtual thread normally unmounts instead
      * of parking the carrier. The complement matters: on virtual threads, a pin is where blocked

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/test/java/cafe/jeffrey/provider/profile/jdbc/JdbcTraceRepositoryTest.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/test/java/cafe/jeffrey/provider/profile/jdbc/JdbcTraceRepositoryTest.java
@@ -67,6 +67,7 @@ import java.sql.Statement;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -1629,6 +1630,21 @@ class JdbcTraceRepositoryTest {
         }
 
         @Test
+        @DisplayName("counts an instant that occupied none of the span it happened in")
+        void countsInstantContext(DataSource dataSource) throws SQLException {
+            Map<TraceContextCategory, TraceSpanContextRecord> waits =
+                    waitsByCategory(withContext(dataSource));
+
+            // jdk.AllocationRequiringGC carries no duration -- it is a moment, not a stretch. It has
+            // to arrive counted rather than be dropped for summing to nothing, because it names the
+            // span responsible for a collection the rest of the trace only suffers.
+            TraceSpanContextRecord allocation = waits.get(TraceContextCategory.ALLOCATION_REQUIRING_GC);
+            assertNotNull(allocation, "an instant must still be attributed to the span it happened in");
+            assertEquals(1, allocation.occurrences());
+            assertEquals(0L, allocation.totalNanos(), "an instant contributes no time");
+        }
+
+        @Test
         @DisplayName("finds pauses recorded on a VM thread, not the span's own")
         void findsGlobalPauses(DataSource dataSource) throws SQLException {
             // The pauses live on thread 3003 while the span ran on 3001. A query that matched the
@@ -1732,9 +1748,15 @@ class JdbcTraceRepositoryTest {
             JdbcTraceRepository repository = withContext(dataSource);
 
             // The monitor and park waits are synthesized leaf spans now; counting them here too
-            // would say the same blocked microsecond twice.
-            assertTrue(waitsByCategory(repository).isEmpty(),
-                    "nothing but promoted categories waited in this trace");
+            // would say the same blocked microsecond twice. Stated as "no promoted category
+            // remains" rather than "nothing remains": a category that was never promoted -- an
+            // instant like an allocation forcing a collection -- legitimately stays in the context,
+            // and an emptiness check would forbid that for no reason.
+            Set<TraceContextCategory> waited = waitsByCategory(repository).keySet();
+            assertFalse(waited.contains(TraceContextCategory.MONITOR_BLOCKED),
+                    "the monitor wait is a span now, so it must not also be counted as a wait");
+            assertFalse(waited.contains(TraceContextCategory.PARKED),
+                    "the park is a span now, so it must not also be counted as a wait");
 
             Map<String, TraceSpanRecord> promoted = promotedOf(repository).stream()
                     .collect(Collectors.toMap(TraceSpanRecord::name, Function.identity()));

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/test/resources/sql/events/insert-trace-context.sql
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/test/resources/sql/events/insert-trace-context.sql
@@ -23,7 +23,9 @@ VALUES
     ('jdk.ThreadPark', 'Thread Park', 23, 'park', '["Java Application"]', '1', NULL, true, NULL, NULL,
      '[{"field":"parkedClass","header":"Class Parked On"}]'),
     ('jdk.GCPhasePauseLevel1', 'GC Phase Pause Level 1', 24, 'gc pause phase', '["Java Virtual Machine","GC"]', '1', NULL, false, NULL, NULL,
-     '[{"field":"name","header":"Name"},{"field":"gcId","header":"GC Identifier"}]');
+     '[{"field":"name","header":"Name"},{"field":"gcId","header":"GC Identifier"}]'),
+    ('jdk.AllocationRequiringGC', 'Allocation Requiring GC', 25, 'allocation forced a collection', '["Java Virtual Machine","GC"]', '1', NULL, true, NULL, NULL,
+     '[{"field":"gcId","header":"GC Identifier"},{"field":"size","header":"Allocation Size"}]');
 
 INSERT INTO events_raw (event_type, start_timestamp, start_timestamp_from_beginning, duration, samples, weight, weight_entity, stacktrace_hash, thread_hash, fields)
 VALUES
@@ -64,6 +66,13 @@ VALUES
      '{"monitorClass":"java.lang.Object","previousOwner":"worker-2"}'),
     ('jdk.ThreadPark', '2025-01-15T10:10:00.250Z', 600250, 20000000, 1, NULL, NULL, NULL, 3001,
      '{"parkedClass":"java.util.concurrent.locks.ReentrantLock"}'),
+
+    -- An allocation the span made that could not be satisfied and forced a collection. It is the
+    -- other direction of the GC story: the GCPhasePause above says every thread was stopped, and
+    -- this says whose allocation is why. Instant -- no duration at all -- so it can only ever be
+    -- counted, never summed into a wait total.
+    ('jdk.AllocationRequiringGC', '2025-01-15T10:10:00.095Z', 600095, NULL, 1, NULL, NULL, NULL, 3001,
+     '{"gcId":42,"size":1048576}'),
 
     -- Waiting on a thread the span never ran on, and outside its window: neither may be attributed.
     ('jdk.JavaMonitorEnter', '2025-01-15T10:10:00.210Z', 600210, 90000000, 1, NULL, NULL, NULL, 3002,

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/EventTypeName.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/EventTypeName.java
@@ -121,6 +121,7 @@ public abstract class EventTypeName {
     public static final String COMPILER_STATISTICS = "jdk.CompilerStatistics";
     public static final String COMPILATION = "jdk.Compilation";
     public static final String DEOPTIMIZATION = "jdk.Deoptimization";
+    public static final String ALLOCATION_REQUIRING_GC = "jdk.AllocationRequiringGC";
     public static final String COMPILER_QUEUE_UTILIZATION = "jdk.CompilerQueueUtilization";
     public static final String CODE_CACHE_STATISTICS = "jdk.CodeCacheStatistics";
     public static final String CODE_CACHE_FULL = "jdk.CodeCacheFull";

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/Type.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/Type.java
@@ -125,6 +125,7 @@ public record Type(String code, boolean calculated) {
     public static final Type COMPILER_STATISTICS = new Type(EventTypeName.COMPILER_STATISTICS);
     public static final Type COMPILATION = new Type(EventTypeName.COMPILATION);
     public static final Type DEOPTIMIZATION = new Type(EventTypeName.DEOPTIMIZATION);
+    public static final Type ALLOCATION_REQUIRING_GC = new Type(EventTypeName.ALLOCATION_REQUIRING_GC);
     public static final Type COMPILER_QUEUE_UTILIZATION = new Type(EventTypeName.COMPILER_QUEUE_UTILIZATION);
     public static final Type CODE_CACHE_STATISTICS = new Type(EventTypeName.CODE_CACHE_STATISTICS);
     public static final Type CODE_CACHE_FULL = new Type(EventTypeName.CODE_CACHE_FULL);
@@ -329,6 +330,7 @@ public record Type(String code, boolean calculated) {
                 COMPILER_STATISTICS,
                 COMPILATION,
                 DEOPTIMIZATION,
+                ALLOCATION_REQUIRING_GC,
                 COMPILER_QUEUE_UTILIZATION,
                 CODE_CACHE_STATISTICS,
                 CODE_CACHE_FULL,


### PR DESCRIPTION
A GC pause band across a waterfall says every thread was stopped. It cannot say *whose allocation is why*, because `jdk.GCPhasePause` is recorded on a VM thread. `jdk.AllocationRequiringGC` is recorded on the allocating thread with the size and the `gcId`, and is the only thing that can point at the span responsible for a pause the rest of the trace merely suffers.

### Probing it first changed the design

It is an **instant** — `gcId`, `size`, thread, stack trace, and no duration at all — and every place the frontend renders a context slice filters on `totalNanos > 0`. Adding the category alone would have shipped something that could never appear.

The same check turned up an existing case of exactly that: `DEOPTIMIZATION` has been in this state since it was added. `jdk.Deoptimization` carries no duration either, so it could never clear the filter and **has never rendered anywhere**.

### So the category arrives with the presentation it needs

A span's detail now reports instants as counted markers — "GC triggered ×3" — on their own line, styled back from the waits above them so a count is never misread as a duration. That makes deoptimisations visible for the first time as well.

Markers stay out of the why-slow panel deliberately: that panel ranks where wall-clock went, and something with no wall-clock has nothing to contribute to it — a zero-length row would sort last behind a bar of no width and say nothing. The distinction is duration versus occurrence, and the two screens answer different questions.

### One test changed

`promotedCategoriesBecomeSpans` asserted the context fixture's waits were empty, which held only because every category in it happened to be promoted into a span. It now states the invariant it meant — that no *promoted* category remains a wait — which is stricter than the emptiness check it replaces, and no longer forbids an instant from staying in the context where it belongs.

### Verification

- `mvn test` on `shared/common` and `profile-sql-persistence` — BUILD SUCCESS, no failures.
- `pages-microscope`: 538 tests pass, typecheck clean, no new lint warnings.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2dZhaw7nFbBoVesUJaUG1)_