### PR TITLE
Nest recorded spans under the traced method that wraps them

### DIFF
--- a/jeffrey-microscope/pages-microscope/src/components/trace/TraceWaterfall.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/trace/TraceWaterfall.vue
@@ -1423,8 +1423,9 @@ const foldedCounts = computed(() => descendantCounts(props.spans));
  * The rows actually drawn: folded subtrees removed first, then the promoted rows the reader has
  * switched off, then the off-path spans when the filter is on. That order is what makes them
  * compose — collapsing hides a subtree whether or not its spans are critical, and each filter then
- * narrows whatever survived. Dropping a synthesized row never breaks the tree: a promoted span is a
- * leaf by construction, so the depth sequence the rendering reads stays intact.
+ * narrows whatever survived. Dropping a synthesized row never breaks the tree: drawnSpans takes the
+ * promoted subtree down with it and resurfaces the recorded spans a traced method had adopted, so
+ * no drawn row is ever left under a parent that is not.
  */
 const rows = computed(() => {
   const visible = drawnSpans(visibleSpans(props.spans, collapsed.value), isSpanDrawn);

--- a/jeffrey-microscope/pages-microscope/src/services/trace/traceTree.test.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/trace/traceTree.test.ts
@@ -136,6 +136,11 @@ function child(spanId: string, parentSpanId: string, depth: number): TraceSpanRo
   return { ...row(spanId, depth), parentSpanId };
 }
 
+/** A parented row the derivation minted — a traced method or a promoted wait. */
+function promoted(spanId: string, parentSpanId: string, depth: number): TraceSpanRow {
+  return { ...child(spanId, parentSpanId, depth), synthesized: true };
+}
+
 describe('drawnSpans', () => {
   /*
    *   recorded
@@ -146,9 +151,9 @@ describe('drawnSpans', () => {
    */
   const NESTED = [
     row('recorded', 0),
-    child('outer', 'recorded', 1),
-    child('inner', 'outer', 2),
-    child('read', 'inner', 3),
+    promoted('outer', 'recorded', 1),
+    promoted('inner', 'outer', 2),
+    promoted('read', 'inner', 3),
     child('sibling', 'recorded', 1)
   ];
 
@@ -182,7 +187,32 @@ describe('drawnSpans', () => {
     expect(drawn.map(span => span.spanId)).toEqual(['recorded', 'outer', 'inner', 'sibling']);
   });
 
-  it('drops a whole tree when its root goes', () => {
-    expect(drawnSpans(NESTED, span => span.spanId !== 'recorded')).toEqual([]);
+  it('takes only the promoted subtree down when a root goes', () => {
+    // A recorded span is never taken down by someone else's filter: instrumentation put it there,
+    // and only its own removal — which no toggle performs — could hide it.
+    const drawn = drawnSpans(NESTED, span => span.spanId !== 'recorded');
+
+    expect(drawn.map(span => span.spanId)).toEqual(['sibling']);
+  });
+
+  it('resurfaces a recorded span the hidden method had adopted', () => {
+    /*
+     *   recorded
+     *     method            (a traced method wrapping recorded work)
+     *       adopted         (a recorded span the derivation re-hung under the method)
+     *       write           (a promoted wait, the method's own)
+     */
+    const adopted = [
+      row('recorded', 0),
+      promoted('method', 'recorded', 1),
+      child('adopted', 'method', 2),
+      promoted('write', 'method', 2)
+    ];
+
+    const drawn = drawnSpans(adopted, span => span.spanId !== 'method');
+
+    // Switching Methods off must not take the request's recorded spans with it — before adoption
+    // they drew as the recorded root's children, and hiding the method restores that view.
+    expect(drawn.map(span => span.spanId)).toEqual(['recorded', 'adopted']);
   });
 });

--- a/jeffrey-microscope/pages-microscope/src/services/trace/traceTree.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/trace/traceTree.ts
@@ -99,12 +99,20 @@ export function descendantCounts(spans: TraceSpanRow[]): Map<string, number> {
 }
 
 /**
- * The rows that survive a per-row filter, each with whatever hangs under it.
+ * The rows that survive a per-row filter, each with its promoted subtree.
  *
  * Filtering row by row is only safe while everything a filter can remove is a leaf. That stopped
  * being true once traced methods became spans: a method span holds the methods it called and the
  * waits that happened inside it, so removing one on its own would leave its children indented under
  * a parent that is no longer drawn.
+ *
+ * Hiding carries down to a *synthesized* child only. A promoted span hangs where the derivation
+ * put it, so it goes wherever its parent goes — but a recorded span under a method span was only
+ * ADOPTED there (instrumentation recorded it under a recorded parent, and the derivation re-hung
+ * it under the traced method wrapping it), so switching a promoted family off must resurface it
+ * rather than take the request's real spans down with the toggle. A resurfaced span keeps its
+ * depth; the one-level gap it leaves is the hidden method's, and it closes when the toggle
+ * returns.
  *
  * Relies on tree order — the caller passes spans with every parent ahead of its children, which is
  * what {@link visibleSpans} returns — so one pass carries each decision downwards and no parent
@@ -117,7 +125,8 @@ export function drawnSpans(
   const hidden = new Set<string>();
   const drawn: TraceSpanRow[] = [];
   for (const span of spans) {
-    if ((span.parentSpanId !== null && hidden.has(span.parentSpanId)) || !isDrawn(span)) {
+    const underHidden = span.parentSpanId !== null && hidden.has(span.parentSpanId);
+    if (!isDrawn(span) || (underHidden && span.synthesized)) {
       hidden.add(span.spanId);
       continue;
     }

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/JdbcTraceRepository.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/JdbcTraceRepository.java
@@ -293,7 +293,8 @@ public class JdbcTraceRepository implements TraceRepository {
      *   spans/recorded  -- the recorded span events, deduped, shape projected (as before)
      *   mapping..minted -- the JDK blocking events promoted to leaf spans (as before, joining
      *                      `recorded` where the old statement joined the half-filled table)
-     *   all_spans       -- both, in one relation
+     *   adoptions       -- recorded spans re-hung under the method span that wraps them
+     *   all_spans       -- both, in one relation, recorded parents rewritten where adopted
      *   clipped..covered -- the same-thread-children interval merge (the old SELF_DURATIONS pass)
      *   final SELECT    -- self time subtracted where children covered it, payload hashed into
      *                      its reference (the text itself lives in trace_span_payloads)
@@ -307,6 +308,17 @@ public class JdbcTraceRepository implements TraceRepository {
      * The parent is the *innermost* span whose window contains the event's start on the same
      * thread: latest start wins, smallest window breaks the tie, span id makes it deterministic.
      * An event outside every span is not promoted at all -- there is no trace to hang it on.
+     *
+     * Adoption is the counterpart for recorded spans. A recorded span's parentSpanId names the span
+     * the Tracer's context held when it was created, and jdk.MethodTrace is invisible to that
+     * context -- so a traced method wrapping recorded work (a traced controller method around an
+     * entire request) would land as a SIBLING of the spans it contains, and its self time would
+     * claim the whole request. The adoptions stage re-hangs such a recorded span under the
+     * innermost method span standing between it and its own recorded parent: the method's anchor
+     * (the innermost recorded span open at the method's start -- the same span that decided its
+     * trace) must be exactly the child's recorded parent, and the threads must match. That is what
+     * keeps instrumentation authoritative: a method span only ever slots in between a recorded
+     * parent and its children, never moves a span across recorded ancestry or onto another thread.
      *
      * Its span id is minted, which the derivation otherwise deliberately no longer does: a jdk.*
      * event can never carry a recorded id, so the choice is a minted id or no bar. The id is a hash
@@ -428,11 +440,15 @@ public class JdbcTraceRepository implements TraceRepository {
             -- Which trace a candidate belongs to, answered by the innermost RECORDED span open on
             -- its thread. Trace identity comes from instrumentation and only from instrumentation:
             -- a method span is inside a trace because a recorded span contains it, never because
-            -- another method span does.
+            -- another method span does. That innermost recorded span is kept as the candidate's
+            -- ANCHOR: for a method span it is the recorded span it conceptually runs inside, which
+            -- is what the adoptions stage below checks before letting the method span take over
+            -- that recorded span's children.
             traced AS (
                 SELECT
                     c.*,
-                    s.trace_id  AS trace_id
+                    s.trace_id  AS trace_id,
+                    s.span_id   AS anchor_span_id
                 FROM candidates c
                 JOIN recorded s
                   ON s.thread_hash = c.thread_hash
@@ -526,11 +542,53 @@ public class JdbcTraceRepository implements TraceRepository {
                 QUALIFY ROW_NUMBER() OVER (PARTITION BY m.trace_id, m.span_id
                                            ORDER BY m.start_timestamp) = 1
             ),
+            /*
+             * A recorded span whose start falls inside a method span standing between it and its
+             * own recorded parent is re-hung under that method span -- the innermost one, by the
+             * same order the promotion parenting reads. `anchor_span_id = r.parent_span_id` is the
+             * whole rule: the method span must itself hang (directly or through other method
+             * spans) under exactly the recorded span the child names as its parent, so adoption
+             * only ever interposes a method chain between a recorded parent and its children --
+             * never across recorded ancestry, and never across threads.
+             *
+             * The strict `<` on the start is not a tie-break but a statement of impossibility: a
+             * method span starting in the same microsecond as the recorded span is CONTAINED by
+             * that span as far as the anchor search can see, so its anchor is that span or
+             * something inside it -- never that span's parent -- and the join's anchor equality
+             * already fails. Spelling it strictly also keeps the whole graph provably acyclic:
+             * every adoption edge goes from a strictly earlier start to a later one, and no other
+             * edge kind decreases the start, so no cycle can contain an adoption.
+             */
+            adoptions AS (
+                SELECT
+                    r.trace_id                                          AS trace_id,
+                    r.span_id                                           AS span_id,
+                    m.span_id                                           AS method_parent_span_id
+                FROM recorded r
+                JOIN minted m
+                  ON m.nests
+                 AND m.trace_id = r.trace_id
+                 AND m.anchor_span_id = r.parent_span_id
+                 AND m.thread_hash = r.thread_hash
+                 AND m.start_us < EPOCH_US(r.start_timestamp)
+                 AND EPOCH_US(r.start_timestamp) <= m.start_us + m.duration // 1000
+                QUALIFY ROW_NUMBER() OVER (
+                    PARTITION BY r.trace_id, r.span_id
+                    ORDER BY m.start_us DESC,
+                             m.start_us + m.duration // 1000 ASC,
+                             m.span_id) = 1
+            ),
             all_spans AS (
-                SELECT trace_id, span_id, parent_span_id, name, kind, status, error_type,
-                       start_timestamp, start_ms, duration, thread_hash, event_type,
-                       attributes, payload, synthesized
-                FROM recorded
+                SELECT r.trace_id                                       AS trace_id,
+                       r.span_id                                        AS span_id,
+                       COALESCE(a.method_parent_span_id, r.parent_span_id) AS parent_span_id,
+                       r.name, r.kind, r.status, r.error_type,
+                       r.start_timestamp, r.start_ms, r.duration, r.thread_hash, r.event_type,
+                       r.attributes, r.payload, r.synthesized
+                FROM recorded r
+                LEFT JOIN adoptions a
+                  ON a.trace_id = r.trace_id
+                 AND a.span_id = r.span_id
                 UNION ALL
                 SELECT trace_id, span_id, parent_span_id, name, kind, status, error_type,
                        start_timestamp, start_ms, duration, thread_hash, event_type,

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/MethodSpans.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/MethodSpans.java
@@ -31,7 +31,11 @@ import cafe.jeffrey.shared.common.model.EventTypeName;
  *       name is read out of the event's own {@code method} field.</li>
  *   <li><b>It is not a leaf.</b> A traced method's duration includes the methods it calls, so traced
  *       methods nest inside one another and a blocking wait can happen inside one. A method span can
- *       therefore be the parent of another promoted span, which no other promotion can.</li>
+ *       therefore be the parent of another promoted span, which no other promotion can — and of a
+ *       <em>recorded</em> span: a recorded span that begins inside a method span standing between it
+ *       and its own recorded parent is re-hung under that method span (the derivation's adoption
+ *       stage), so a traced controller method wrapping a request contains the request's recorded
+ *       spans instead of sitting beside them as their sibling.</li>
  *   <li><b>It is work, not waiting.</b> It maps to no {@code TraceContextCategory} on purpose: the
  *       why-slow panel accounts for waits, and a traced method's time is the trace's own work. Giving
  *       it a category would move that time out of "own work" and into a wait total that never

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/test/java/cafe/jeffrey/provider/profile/jdbc/JdbcTraceRepositoryTest.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/test/java/cafe/jeffrey/provider/profile/jdbc/JdbcTraceRepositoryTest.java
@@ -2775,9 +2775,60 @@ class JdbcTraceRepositoryTest {
 
             // 300ms of request, 214ms of it inside outer, plus the 10ms twins and the 10ms method
             // whose name was pooled. The merge means the nested inner and the socket read are not
-            // subtracted a second time.
+            // subtracted a second time. persistOrder does not appear: adopted by inner, its
+            // stretch is charged there, and auditAsync ran on another thread, beside the request
+            // rather than instead of it.
             assertEquals(300_000_000L, recorded.durationNanos());
             assertEquals(66_000_000L, recorded.selfDurationNanos());
+        }
+
+        @Test
+        @DisplayName("adopts a recorded span into the traced method that wraps it")
+        void adoptsRecordedSpansIntoTheWrappingMethod(DataSource dataSource) throws SQLException {
+            Map<String, TraceSpanRecord> spans = spansByName(dataSource);
+
+            // persistOrder was recorded under reserveInventory -- jdk.MethodTrace is invisible to
+            // the Tracer's context, so instrumentation cannot name a method span as a parent.
+            // Without adoption the traced method draws BESIDE the work it wraps, and its self time
+            // claims that work as its own.
+            assertEquals(spans.get("Probe#inner").spanId(), spans.get("persistOrder").parentSpanId(),
+                    "re-hung under the innermost wrapping method, not left beside it");
+        }
+
+        @Test
+        @DisplayName("never moves a recorded span across its recorded ancestry")
+        void adoptionNeverCrossesRecordedAncestry(DataSource dataSource) throws SQLException {
+            Map<String, TraceSpanRecord> spans = spansByName(dataSource);
+
+            // persistOrderIndex starts inside inner's window too, but its recorded parent is
+            // persistOrder while inner anchors at reserveInventory. Adopting it would tear it out
+            // of the parent instrumentation deliberately put around it.
+            assertEquals(spans.get("persistOrder").spanId(), spans.get("persistOrderIndex").parentSpanId(),
+                    "a method span only interposes between a recorded parent and its own children");
+        }
+
+        @Test
+        @DisplayName("never adopts a recorded span onto another thread")
+        void adoptionNeverCrossesThreads(DataSource dataSource) throws SQLException {
+            Map<String, TraceSpanRecord> spans = spansByName(dataSource);
+
+            // auditAsync falls inside outer's time window but ran on the pool thread. A traced
+            // method contains only what ran on its own thread; forked work runs beside it.
+            assertEquals(spans.get("reserveInventory").spanId(), spans.get("auditAsync").parentSpanId(),
+                    "a cross-thread child stays where instrumentation put it");
+        }
+
+        @Test
+        @DisplayName("subtracts an adopted recorded span from the traced method's self time")
+        void adoptedSpansSubtractFromMethodSelfTime(DataSource dataSource) throws SQLException {
+            Map<String, TraceSpanRecord> spans = spansByName(dataSource);
+
+            TraceSpanRecord inner = spans.get("Probe#inner");
+
+            // 174ms total: 121ms on the socket, 20ms inside the adopted persistOrder.
+            assertEquals(174_000_000L, inner.durationNanos());
+            assertEquals(33_000_000L, inner.selfDurationNanos(),
+                    "the adopted span's stretch is no more inner's own work than the socket read's");
         }
     }
 }

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/test/resources/sql/events/insert-trace-method-traces.sql
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/test/resources/sql/events/insert-trace-method-traces.sql
@@ -76,3 +76,24 @@ INSERT INTO events_raw (event_type, start_timestamp, start_timestamp_from_beginn
 VALUES
     ('jdk.MethodTrace', '2025-01-15T10:10:00.270Z', 600270, 10000000, 1, 10000000, 'Probe#main', NULL, 3001,
      '{}', 'method', 7701);
+
+-- Recorded spans for the ADOPTION cases: a traced method that wraps recorded work must contain it.
+-- All three are children the Tracer recorded under span 701 (or under 702) -- jdk.MethodTrace is
+-- invisible to the Tracer's context, so instrumentation can never name a method span as a parent
+-- and the derivation has to re-hang these itself.
+--
+--   persistOrder       [ 60ms ..  80ms]  parent 701, thread 3001 -- starts inside outer AND inner,
+--                                        so the innermost method (inner) must adopt it
+--   persistOrderIndex  [ 65ms ..  70ms]  parent 702, thread 3001 -- inside inner's window too, but
+--                                        inner's anchor is 701, not 702: adoption must never move
+--                                        a span across its recorded ancestry
+--   auditAsync         [180ms .. 220ms]  parent 701, thread 3002 -- inside outer's time window but
+--                                        on another thread: adoption must never cross threads
+INSERT INTO events_raw (event_type, start_timestamp, start_timestamp_from_beginning, duration, samples, weight, weight_entity, stacktrace_hash, thread_hash, fields)
+VALUES
+    ('jeffrey.TraceSpan', '2025-01-15T10:10:00.060Z', 600060, 20000000, 1, NULL, NULL, NULL, 3001,
+     '{"traceId":9003,"spanId":702,"parentSpanId":701,"name":"persistOrder","kind":"INTERNAL","status":"UNSET"}'),
+    ('jeffrey.TraceSpan', '2025-01-15T10:10:00.065Z', 600065, 5000000, 1, NULL, NULL, NULL, 3001,
+     '{"traceId":9003,"spanId":703,"parentSpanId":702,"name":"persistOrderIndex","kind":"INTERNAL","status":"UNSET"}'),
+    ('jeffrey.TraceSpan', '2025-01-15T10:10:00.180Z', 600180, 40000000, 1, NULL, NULL, NULL, 3002,
+     '{"traceId":9003,"spanId":704,"parentSpanId":701,"name":"auditAsync","kind":"INTERNAL","status":"UNSET"}');

--- a/jeffrey-pages/src/views/docs/tracing/TracingJdkEventsPage.vue
+++ b/jeffrey-pages/src/views/docs/tracing/TracingJdkEventsPage.vue
@@ -196,11 +196,13 @@ jdk.ZAllocationStall#enabled=true,jdk.ZAllocationStall#threshold=0ms`;
 
       <p><strong>It nests.</strong> A traced method's duration includes the methods it calls, so traced methods contain one another and a wait can happen inside one. A method span is therefore the one promoted span that can be a <em>parent</em>: trace two methods where one calls the other and the inner one hangs under the outer one, with the socket read inside it hanging under that. Without this the two would be drawn as siblings and the outer one's self time would claim work its callee did.</p>
 
+      <p>Recorded spans nest into it the same way. A recorded span names the span the Tracer's context held when it was created — and <code>jdk.MethodTrace</code> is invisible to that context, so a traced controller method wrapping an entire request would otherwise draw <em>beside</em> the recorded spans it contains, claiming the whole request as its own self time. Jeffrey re-hangs such recorded spans under the traced method instead: a recorded span that began inside a method span standing between it and its own recorded parent becomes that method span's child. The adoption never crosses a thread and never moves a span across the parent instrumentation gave it — a method span only slots in between a recorded parent and its children.</p>
+
       <DocsCallout type="info">
         <strong>A traced method is work, not waiting</strong> — which is why it maps to no context category and never appears in the why-slow panel. That panel accounts for the time a trace spent <em>not</em> doing its own work; a traced method's time is precisely the trace's own work, and giving it a category would move that time out of "own work" and into a wait total that never happened. The waterfall draws it as the <code>INTERNAL</code> span it is, outlined to show it was derived rather than recorded.
       </DocsCallout>
 
-      <p>The rows have their own toolbar switch, <strong>Methods</strong>, beside <em>Blocking ops</em> and <em>I/O ops</em> — a filter set to trace a whole class can put far more rows on screen than either wait family, and switching those off must not take the socket read that explains the trace with them. Because method spans have children, switching them off takes their subtrees too.</p>
+      <p>The rows have their own toolbar switch, <strong>Methods</strong>, beside <em>Blocking ops</em> and <em>I/O ops</em> — a filter set to trace a whole class can put far more rows on screen than either wait family, and switching those off must not take the socket read that explains the trace with them. Because method spans have children, switching them off takes their promoted subtrees too — while the recorded spans a method adopted resurface, back where instrumentation put them.</p>
 
       <h2 id="attribution">How an Event Finds Its Span</h2>
 


### PR DESCRIPTION
A jdk.MethodTrace span promoted around recorded work — a traced controller
method wrapping an entire request — landed as a sibling of the recorded
spans it contains: a recorded span keeps the parent the Tracer's context
held when it was created, and MethodTrace is invisible to that context.
The derivation now re-hangs a recorded span under the innermost method
span standing between it and its own recorded parent: the method's anchor
(the innermost recorded span open at its start) must be exactly the
child's recorded parent, and the threads must match — so a method span
only ever interposes between a recorded parent and its children, never
moves one across recorded ancestry or onto another thread. Self times
follow the new tree: the wrapping method no longer claims the whole
request as its own work.

The waterfall's Methods toggle now resurfaces the recorded spans a hidden
method adopted instead of taking the request's real spans down with the
method's promoted subtree.