### PR TITLE
Simplify notification lane stat display in trace waterfall

### DIFF
--- a/jeffrey-microscope/pages-microscope/src/components/trace/TraceWaterfall.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/trace/TraceWaterfall.vue
@@ -265,12 +265,7 @@
           <i class="rail-glyph ntf" :style="{ background: severityColor(worstNotificationSeverity) }"></i>
           Notifications
         </span>
-        <span class="lane-stat">
-          <template v-if="worstNotificationSeverity !== null">
-            {{ severityLabel(worstNotificationSeverity).toLowerCase() }} &middot;
-          </template>
-          {{ notificationMarks.length }}&times;
-        </span>
+        <span class="lane-stat">{{ notificationMarks.length }}&times;</span>
       </span>
       <span class="lane-track">
         <span class="rail-rule"></span>


### PR DESCRIPTION
## Summary
Simplifies the notification lane statistics display in the trace waterfall component by removing the severity label prefix, showing only the notification count.

## Changes
- Removed the conditional severity label display from the notification lane stat
- The notification count (`notificationMarks.length`) is now the sole content of the stat display
- Maintains the visual severity indicator via the rail glyph color, which already communicates the worst notification severity

## Details
The severity label (e.g., "critical", "warning") was redundant given that:
1. The rail glyph already displays the worst notification severity through color coding
2. The count alone is sufficient for the stat display
3. This reduces visual clutter in the waterfall view

The change simplifies the template while preserving all essential information through the existing color-coded severity indicator.

https://claude.ai/code/session_01NY89xbw4ZDvxzceHp4SBFo