### PR TITLE
Handle absent Class fields in JFR event mapping

### DIFF
--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/jfr/EventFieldsToJsonMapper.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/jfr/EventFieldsToJsonMapper.java
@@ -175,7 +175,7 @@ public class EventFieldsToJsonMapper implements EventFieldsMapper {
         } else if (CLASS_TYPE_NAME.equals(typeName)) {
             return (event, slots) -> {
                 RecordedClass clazz = event.getClass(name);
-                slots.putString(name, RecordedClassMapper.map(clazz.getName()));
+                slots.putString(name, safeClassName(clazz));
             };
         } else if (CLASS_LOADER_TYPE_NAME.equals(typeName)) {
             // The JFR ClassLoader struct ({type: Class, name: String}) has no special
@@ -263,6 +263,16 @@ public class EventFieldsToJsonMapper implements EventFieldsMapper {
 
     private static String safeToString(Object val) {
         return val == null ? null : val.toString();
+    }
+
+    /**
+     * A {@code java.lang.Class} field can legitimately be absent — {@code jdk.ThreadPark.parkedClass}
+     * is null when {@code LockSupport.park()} is called with no blocker, and a monitor event can be
+     * emitted with no monitor class. Such a field lands as an explicit JSON null rather than failing
+     * the whole recording.
+     */
+    private static String safeClassName(RecordedClass clazz) {
+        return clazz == null ? null : RecordedClassMapper.map(clazz.getName());
     }
 
     /**

--- a/shared/common/src/test/java/cafe/jeffrey/shared/common/jfr/EventFieldsToJsonMapperTest.java
+++ b/shared/common/src/test/java/cafe/jeffrey/shared/common/jfr/EventFieldsToJsonMapperTest.java
@@ -278,6 +278,52 @@ class EventFieldsToJsonMapperTest {
     }
 
     @Nested
+    class AbsentClassFields {
+
+        /**
+         * A JFR {@code java.lang.Class} field can be absent — {@code jdk.ThreadPark.parkedClass} is
+         * null whenever {@code LockSupport.park()} is called with no blocker. Reading it used to
+         * dereference the missing class and fail the whole recording.
+         */
+        @Test
+        void mapsAnAbsentClassFieldToNullInsteadOfFailing() throws IOException {
+            Path dumpFile = Files.createTempFile("null-class-mapper-test", ".jfr");
+            List<RecordedEvent> events;
+            List<EventType> eventTypes;
+            try (Recording recording = new Recording()) {
+                recording.enable(MapperProbeEvent.class);
+                recording.start();
+
+                MapperProbeEvent event = new MapperProbeEvent();
+                event.stringValue = "no-class-here";
+                event.classValue = null;
+                event.threadValue = null;
+                event.commit();
+
+                recording.stop();
+                recording.dump(dumpFile);
+            }
+            events = RecordingFile.readAllEvents(dumpFile);
+            eventTypes = events.stream().map(RecordedEvent::getEventType).distinct().toList();
+            Files.deleteIfExists(dumpFile);
+
+            RecordedEvent probe = events.stream()
+                    .filter(e -> PROBE_EVENT_NAME.equals(e.getEventType().getName()))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("Probe event was not recorded"));
+
+            EventFieldsToJsonMapper mapper = new EventFieldsToJsonMapper();
+            mapper.update(eventTypes);
+
+            ObjectNode node = fullTree(mapper.map(probe));
+
+            assertTrue(node.has("classValue"), "an absent class must still be reported as a field");
+            assertTrue(node.get("classValue").isNull(), "an absent class must map to a JSON null");
+            assertEquals("no-class-here", node.get("stringValue").asString());
+        }
+    }
+
+    @Nested
     class G1EvacuationStatisticsStructFields {
 
         @Test


### PR DESCRIPTION
## Summary
Fix a crash when mapping JFR events with absent (null) `java.lang.Class` fields to JSON. Certain JFR events like `jdk.ThreadPark` can have null class fields (e.g., `parkedClass` is null when `LockSupport.park()` is called with no blocker), which previously caused a NullPointerException when dereferencing the missing class.

## Changes
- **EventFieldsToJsonMapper.java**: Replace direct `clazz.getName()` call with a new `safeClassName()` helper method that safely handles null class references
- **EventFieldsToJsonMapper.java**: Add `safeClassName()` utility method that returns null for absent classes instead of throwing an exception
- **EventFieldsToJsonMapperTest.java**: Add comprehensive test case `AbsentClassFields.mapsAnAbsentClassFieldToNullInsteadOfFailing()` that:
  - Creates a JFR recording with a probe event containing a null class field
  - Verifies the mapper produces valid JSON with the field present but mapped to JSON null
  - Confirms other fields are still correctly mapped

## Implementation Details
The fix follows the existing pattern used by `safeToString()` for handling potentially null values. When a `java.lang.Class` field is absent, it now maps to an explicit JSON null rather than failing the entire recording parse, allowing downstream consumers to handle the absence gracefully.

https://claude.ai/code/session_015XA5wb12jgXM8yE1yq84NK