### PR TITLE
Refactor ProjectStorageDrawer layout to grid-based columns

### DIFF
--- a/jeffrey-hub/pages-hub/src/components/ProjectStorageDrawer.vue
+++ b/jeffrey-hub/pages-hub/src/components/ProjectStorageDrawer.vue
@@ -78,9 +78,6 @@
         </div>
       </template>
       <div v-if="groups.length === 0" class="empty-note">No files stored yet</div>
-      <div v-if="absentLabels.length > 0" class="absent-note">
-        <b>Not stored:</b> {{ absentLabels.join(' · ') }}
-      </div>
     </div>
 
     <div v-if="project.largestFiles.length > 0" class="drawer-section">
@@ -108,12 +105,7 @@
 import { computed } from 'vue';
 import FormattingService from '@shared/services/FormattingService';
 import type { ProjectStorage } from '@/services/api/model/StorageOverview';
-import {
-  absentFileTypeLabels,
-  fileTypeMeta,
-  groupUsages,
-  STORAGE_FILE_TYPE_COUNT
-} from '@/services/storage/StorageFileTypes';
+import { fileTypeMeta, groupUsages, STORAGE_FILE_TYPE_COUNT } from '@/services/storage/StorageFileTypes';
 
 const props = defineProps<{
   project: ProjectStorage;
@@ -134,7 +126,6 @@ const displayName = computed(() => {
 });
 
 const groups = computed(() => groupUsages(props.project.fileTypes));
-const absentLabels = computed(() => absentFileTypeLabels(props.project.fileTypes));
 
 const barWidth = (sizeBytes: number) => {
   if (props.project.totalSizeBytes === 0) {
@@ -395,20 +386,6 @@ const barWidth = (sizeBytes: number) => {
   padding: 6px 0;
   font-size: 0.78rem;
   color: var(--color-slate-light);
-}
-
-.absent-note {
-  margin-top: 11px;
-  padding-top: 9px;
-  border-top: 1px dashed var(--color-border);
-  font-size: 0.72rem;
-  color: var(--color-text-light);
-  line-height: 1.6;
-}
-
-.absent-note b {
-  color: var(--color-slate-muted);
-  font-weight: 600;
 }
 
 .file-row {

--- a/jeffrey-hub/pages-hub/src/components/ProjectStorageDrawer.vue
+++ b/jeffrey-hub/pages-hub/src/components/ProjectStorageDrawer.vue
@@ -54,17 +54,27 @@
             :style="{ width: barWidth(usage.sizeBytes), background: usage.group.color }"
         ></span>
       </div>
+      <div v-if="groups.length > 0" class="column-head">
+        <span>Type</span>
+        <span>Size</span>
+        <span>Files</span>
+      </div>
       <template v-for="usage in groups" :key="usage.group.key">
         <div class="group-row">
-          <span class="group-swatch" :style="{ background: usage.group.color }"></span>
-          <span>{{ usage.group.label }}</span>
+          <span class="group-name">
+            <span class="group-swatch" :style="{ background: usage.group.color }"></span>
+            <span class="group-label">{{ usage.group.label }}</span>
+          </span>
           <span class="group-size">{{ formatBytes(usage.sizeBytes) }}</span>
+          <span class="group-count">{{ usage.fileCount.toLocaleString() }}</span>
         </div>
         <div v-for="fileType in usage.fileTypes" :key="fileType.type" class="type-row">
-          <span class="type-label">{{ meta(fileType.type).label }}</span>
-          <span v-if="meta(fileType.type).extension" class="type-ext">{{ meta(fileType.type).extension }}</span>
+          <span class="type-name">
+            <span class="type-label">{{ meta(fileType.type).label }}</span>
+            <span v-if="meta(fileType.type).extension" class="type-ext">{{ meta(fileType.type).extension }}</span>
+          </span>
           <span class="type-size">{{ formatBytes(fileType.sizeBytes) }}</span>
-          <span class="type-count">{{ fileType.fileCount }} {{ fileType.fileCount === 1 ? 'file' : 'files' }}</span>
+          <span class="type-count">{{ fileType.fileCount.toLocaleString() }}</span>
         </div>
       </template>
       <div v-if="groups.length === 0" class="empty-note">No files stored yet</div>
@@ -237,6 +247,7 @@ const barWidth = (sizeBytes: number) => {
 }
 
 .drawer-section {
+  --storage-columns: 1fr 78px 60px;
   padding: 14px 18px;
   border-bottom: 1px solid var(--color-grey-bg);
 }
@@ -269,14 +280,45 @@ const barWidth = (sizeBytes: number) => {
   height: 100%;
 }
 
-.group-row {
-  display: flex;
-  align-items: center;
+.column-head {
+  display: grid;
+  grid-template-columns: var(--storage-columns);
   gap: 8px;
+  padding-bottom: 5px;
+  border-bottom: 1px solid var(--color-border);
+  font-size: 0.62rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-light);
+}
+
+.column-head span:not(:first-child) {
+  text-align: right;
+}
+
+.group-row {
+  display: grid;
+  grid-template-columns: var(--storage-columns);
+  gap: 8px;
+  align-items: center;
   padding: 8px 0 3px;
   font-size: 0.79rem;
   font-weight: 600;
   color: var(--color-heading-dark);
+}
+
+.group-name {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.group-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .group-swatch {
@@ -287,17 +329,39 @@ const barWidth = (sizeBytes: number) => {
 }
 
 .group-size {
-  margin-left: auto;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.group-count {
+  text-align: right;
+  font-size: 0.72rem;
+  color: var(--color-slate-muted);
   font-variant-numeric: tabular-nums;
 }
 
 .type-row {
+  display: grid;
+  grid-template-columns: var(--storage-columns);
+  gap: 8px;
+  align-items: baseline;
+  padding: 3px 0;
+  font-size: 0.76rem;
+  color: var(--color-slate-text);
+}
+
+.type-name {
   display: flex;
   align-items: baseline;
   gap: 8px;
-  padding: 3px 0 3px 17px;
-  font-size: 0.76rem;
-  color: var(--color-slate-text);
+  min-width: 0;
+  padding-left: 17px;
+}
+
+.type-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .type-ext {
@@ -308,10 +372,11 @@ const barWidth = (sizeBytes: number) => {
   padding: 1px 6px;
   border-radius: 4px;
   white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .type-size {
-  margin-left: auto;
+  text-align: right;
   font-weight: 600;
   color: var(--color-heading-dark);
   white-space: nowrap;
@@ -319,10 +384,9 @@ const barWidth = (sizeBytes: number) => {
 }
 
 .type-count {
+  text-align: right;
   color: var(--color-text-light);
   font-size: 0.72rem;
-  min-width: 52px;
-  text-align: right;
   white-space: nowrap;
   font-variant-numeric: tabular-nums;
 }

--- a/jeffrey-hub/pages-hub/src/services/storage/StorageFileTypes.ts
+++ b/jeffrey-hub/pages-hub/src/services/storage/StorageFileTypes.ts
@@ -85,12 +85,4 @@ export function groupUsages(fileTypes: FileTypeUsage[]): GroupUsage[] {
         .filter(usage => usage.fileTypes.length > 0);
 }
 
-/** File types (enum names) not present in the given usages, in registry order. */
-export function absentFileTypeLabels(fileTypes: FileTypeUsage[]): string[] {
-    const present = new Set(fileTypes.map(usage => usage.type));
-    return Object.entries(STORAGE_FILE_TYPES)
-        .filter(([type]) => !present.has(type))
-        .map(([, meta]) => meta.label);
-}
-
 export const STORAGE_FILE_TYPE_COUNT = Object.keys(STORAGE_FILE_TYPES).length;


### PR DESCRIPTION
## Summary
Restructured the ProjectStorageDrawer component to use a consistent grid-based layout with three columns (Type, Size, Files) instead of flexbox, improving alignment and readability of storage information.

## Key Changes
- **Layout restructuring**: Converted `.group-row` and `.type-row` from flexbox to CSS Grid using a `--storage-columns` variable (1fr 78px 60px)
- **Column headers**: Added a new `.column-head` section displaying "Type", "Size", and "Files" headers with proper styling (uppercase, light color, right-aligned for numeric columns)
- **Group rows**: Reorganized to display group name (with swatch and label), size, and file count in aligned columns
- **Type rows**: Updated to show file type name, size, and file count in the same grid structure
- **File count display**: Changed from "N file(s)" text format to numeric-only display with `toLocaleString()` for better consistency
- **Text overflow handling**: Added `.group-name` and `.type-name` wrapper classes with proper text truncation (ellipsis) for long labels
- **Removed "Not stored" section**: Deleted the `.absent-note` UI element and removed the `absentFileTypeLabels()` function from StorageFileTypes.ts

## Implementation Details
- Introduced `--storage-columns` CSS variable in `.drawer-section` for consistent column sizing across all rows
- Right-aligned numeric columns (Size and Files) for better visual scanning
- Added `font-variant-numeric: tabular-nums` to numeric columns for fixed-width digit rendering
- Improved accessibility with proper semantic structure and visual hierarchy
- Removed unused import of `absentFileTypeLabels` from the component

https://claude.ai/code/session_01VaXBfHsA7TnZkfQYAVeubU