### PR TITLE
Traces: tiers 3-5 of the analysis, plus the All Traces page

### DIFF
--- a/TRACES_ANALYSIS_2026-09-01.md
+++ b/TRACES_ANALYSIS_2026-09-01.md
@@ -7,8 +7,8 @@ the `traces`/`trace_spans`/`trace_*` schema, `TraceManagerImpl`, `TracesControll
 (`jeffrey-pages/src/views/docs/tracing/`).
 
 Every finding carries file:line references and was verified against the current tree. The
-tier-1 fixes (§1.1, §1.2, §1.3) and tier-2 fixes (§1.4, §1.5, §1.6) were subsequently applied
-on this branch — they are marked **[FIXED]** below; everything else remains report-only. It picks up where
+fixes for §1.1–§1.8, §1.10, §2.2, §3.1, §3.2 and §4.1 were subsequently applied on this branch —
+they are marked **[FIXED]** below; everything else remains report-only. It picks up where
 `TRACES_ANALYSIS.md` (2026-08-15) left off: the findings fixed there are not repeated, and where
 that document has gone stale it is called out (§2.1).
 
@@ -115,7 +115,7 @@ false, `TracesFeatureChecker` disables the section, and the orphan spans stay in
 Same for `JdbcTraceAttributeRepository.derive()` (:727-748). Re-running is idempotent (the
 DELETE-first design), so the fix is cheap: wrap each `derive()` in `inTransaction`.
 
-### 1.7 Exception-window arithmetic disagrees with every other window
+### 1.7 Exception-window arithmetic disagrees with every other window — [FIXED]
 
 - `DERIVE_TRACE_SPANS` / `SPAN_CONTEXT` / `OPERATION_INTERVALS` use **integer** division and an
   **inclusive** upper bound: `c.start_us <= EPOCH_US(s.start_timestamp) + s.duration // 1000`
@@ -128,7 +128,7 @@ A span's window can differ by up to 1 µs between exception attribution and ever
 the boundary instant is included in one and excluded in the other. Exceptions near span edges can
 attach to a different span than the notifications/context bands beside them.
 
-### 1.8 `NOT_EQ` is existential, not universal
+### 1.8 `NOT_EQ` is existential, not universal — [FIXED by adding `NONE_EQ`]
 
 `TraceAttributeOperator.NOT_EQ` renders `value_text <> :x`, wrapped as
 `value_id IN (SELECT … WHERE value_text <> :x)` (`TraceAttributeQueries.java:144-150`), and the
@@ -144,7 +144,7 @@ executes. See §5.2 for the suggested resolution.
 as a wildcard. Not SQL injection (the value is bound), but a silently wrong result for values
 containing those characters (URLs with encoded sequences, SQL statements as attribute values).
 
-### 1.10 `threadHash` serialized in two different bases
+### 1.10 `threadHash` serialized in two different bases — [FIXED]
 
 - `TraceSpanRow.threadHash` = `Long.toString(span.threadHash())` → **decimal**
   (`TraceManagerImpl.java:821`)
@@ -189,7 +189,7 @@ caps: `MAX_PAUSE_LOOKBACK_MILLIS = 60_000` (`:1540`) and `MAX_THROTTLE_SAMPLE_GA
 
 ## 2. Dead / stranded surface
 
-### 2.1 The profile-wide trace list has no UI (and `TRACES_ANALYSIS.md` is stale on it)
+### 2.1 The profile-wide trace list has no UI (and `TRACES_ANALYSIS.md` is stale on it) — [MOCKUP DELIVERED, DECISION PENDING]
 
 `GET /api/internal/profiles/{id}/traces` (`TracesController.java:125-151` — a full `TracesPage`
 with `search`, `errorsOnly`, `minDurationNanos`, the operation triple, sort, desc, limit, offset)
@@ -205,7 +205,7 @@ operations and attributes views. Consequently the whole `TraceListQuery` → `TR
 Either ship the page (§5.1) or delete the endpoints deliberately — today it is tested, maintained,
 unserved surface.
 
-### 2.2 Operation-level AI export is implemented but unreachable
+### 2.2 Operation-level AI export is implemented but unreachable — [FIXED]
 
 `TraceAiExportClient.generateOperation()` exists, `GET /operation/ai-export` exists
 (`TracesController.java:277`), and the docs assert it: *"Both the trace waterfall and an
@@ -226,7 +226,7 @@ no export button. The docs are wrong and a finished feature is stranded.
 
 ## 3. UX and feature gaps
 
-### 3.1 Slowest Traces tab fetches 1000, shows 50
+### 3.1 Slowest Traces tab fetches 1000, shows 50 — [FIXED]
 
 `TraceOperationDetail.vue:74-83` passes up to 1000 traces into `TraceCardList` without
 `max-displayed`, so the component default of 50 (`TraceCardList.vue:174`) applies, and there is no
@@ -234,7 +234,7 @@ no export button. The docs are wrong and a finished feature is stranded.
 `:max-displayed="matches.length"` to defeat the same cap, which shows the omission is
 unintentional. Rows 51-1000 are fetched and thrown away.
 
-### 3.2 Attribute Values grid: sort direction and paging
+### 3.2 Attribute Values grid: sort direction and paging — [SORT DIRECTION FIXED; offset paging still open]
 
 `ProfileTraceAttributeValues.vue:38` hardcodes `:descending="true"`; `applySort` sets only the
 field; `getAttributeValues()` has no `desc` parameter. "Which value is *fastest*" and A→Z on
@@ -316,7 +316,13 @@ five times (`:55, :79, :110, :122, :133`) and filters in Java;
 
 ## 4. Convention and test debt
 
-### 4.1 Design-token violations
+### 4.1 Design-token violations — [FIXED]
+
+Fix note: the waterfall's inset hover rules and glyph rings (`box-shadow: inset 0 1px 0 …`,
+`0 0 0 2px …`) are drawn separators over token colors, not elevation shadows — they stay as
+written, the same judgment as a `border-radius: 0` reset. The hairline 1px glyph radii derive
+from the token scale as `calc(var(--radius-xs) / 2)`, since no 1px token exists and
+`--radius-xs` (2px) visibly rounds a 6px glyph.
 
 - `TraceAttributeResults.vue:43-44`: hardcoded `primary-color="#5e64ff"` /
   `secondary-color="#b6c1d2"` — literally the values of `--color-primary` and
@@ -413,8 +419,11 @@ tables, not data grids) but are exactly where ~1,200 lines of bespoke scoped CSS
 2. ~~§1.4/§1.5 race guards + loading affordance in attribute search; guard the `loadPage`
    append~~ — **done on this branch**.
 3. ~~§1.6 transactional `derive()`~~ — **done on this branch**.
-4. §2.2 operation AI-export button (or correct the docs) · §2.1 decision on the trace list.
-5. §1.7 unify window arithmetic · §1.8 add `NONE_EQ` · §1.10 unify `threadHash` base.
-6. §3.1 slowest-traces pagination · §3.2 sort direction end-to-end · §4.1 token cleanup.
+4. ~~§2.2 operation AI-export button~~ — **done on this branch**; §2.1 trace list: interactive
+   mockup delivered, build/delete decision pending.
+5. ~~§1.7 unify window arithmetic · §1.8 add `NONE_EQ` · §1.10 unify `threadHash` base~~ —
+   **done on this branch**.
+6. ~~§3.1 slowest-traces pagination · §3.2 sort direction end-to-end · §4.1 token cleanup~~ —
+   **done on this branch**.
 7. §4.3 controller + component tests (a `TraceAttributesControllerTest` for the `~` parser and a
    mount test of `TraceSpansModal` first — each would have caught a bug in this report).

--- a/TRACES_ANALYSIS_2026-09-01.md
+++ b/TRACES_ANALYSIS_2026-09-01.md
@@ -6,9 +6,9 @@ the `traces`/`trace_spans`/`trace_*` schema, `TraceManagerImpl`, `TracesControll
 `TraceAttributesController`, the four trace views, `components/trace/*`, and the docs site
 (`jeffrey-pages/src/views/docs/tracing/`).
 
-Every finding carries file:line references and was verified against the current tree. The
-fixes for §1.1–§1.8, §1.10, §2.2, §3.1, §3.2 and §4.1 were subsequently applied on this branch —
-they are marked **[FIXED]** below; everything else remains report-only. It picks up where
+Every finding carries file:line references and was verified against the current tree. The fixes for
+§1.1–§1.8, §1.10, §2.1, §2.2, §3.1, §3.2 and §4.1 were subsequently applied on this branch and are
+marked **[FIXED]** below; everything else remains report-only. It picks up where
 `TRACES_ANALYSIS.md` (2026-08-15) left off: the findings fixed there are not repeated, and where
 that document has gone stale it is called out (§2.1).
 
@@ -189,7 +189,7 @@ caps: `MAX_PAUSE_LOOKBACK_MILLIS = 60_000` (`:1540`) and `MAX_THROTTLE_SAMPLE_GA
 
 ## 2. Dead / stranded surface
 
-### 2.1 The profile-wide trace list has no UI (and `TRACES_ANALYSIS.md` is stale on it) — [MOCKUP DELIVERED, DECISION PENDING]
+### 2.1 The profile-wide trace list has no UI (and `TRACES_ANALYSIS.md` is stale on it) — [FIXED]
 
 `GET /api/internal/profiles/{id}/traces` (`TracesController.java:125-151` — a full `TracesPage`
 with `search`, `errorsOnly`, `minDurationNanos`, the operation triple, sort, desc, limit, offset)
@@ -204,6 +204,16 @@ operations and attributes views. Consequently the whole `TraceListQuery` → `TR
 
 Either ship the page (§5.1) or delete the endpoints deliberately — today it is tested, maintained,
 unserved surface.
+
+Fix note: the page was shipped. `views/profiles/detail/traces/ProfileTraces.vue` (route
+`traces/all`, sidebar "All Traces", first in the TRACES group) serves both endpoints — a bucketed
+timeline over the recording, server-side search / errors-only / duration-floor filters, ordering by
+`DURATION | START | SPAN_COUNT | ERROR_COUNT`, fifty-at-a-time paging with `LoadMoreFooter`, filters
+mirrored into the URL, and rows opening the existing `TraceSpansModal`. `TracesPage`,
+`TraceListQuery` and `TraceSortField` now exist in `TraceModels.ts`, with `getTraces` /
+`getTracesTimeline` on `ProfileTracesClient`. The timeline uses the shared `TimeSeriesChart` in the
+same pairing as its two sibling charts rather than a bespoke density strip, which is what the
+"must not disagree" comment in `TraceAttributeResults.vue` asks for.
 
 ### 2.2 Operation-level AI export is implemented but unreachable — [FIXED]
 
@@ -419,8 +429,7 @@ tables, not data grids) but are exactly where ~1,200 lines of bespoke scoped CSS
 2. ~~§1.4/§1.5 race guards + loading affordance in attribute search; guard the `loadPage`
    append~~ — **done on this branch**.
 3. ~~§1.6 transactional `derive()`~~ — **done on this branch**.
-4. ~~§2.2 operation AI-export button~~ — **done on this branch**; §2.1 trace list: interactive
-   mockup delivered, build/delete decision pending.
+4. ~~§2.2 operation AI-export button · §2.1 profile-wide trace list~~ — **done on this branch**.
 5. ~~§1.7 unify window arithmetic · §1.8 add `NONE_EQ` · §1.10 unify `threadHash` base~~ —
    **done on this branch**.
 6. ~~§3.1 slowest-traces pagination · §3.2 sort direction end-to-end · §4.1 token cleanup~~ —

--- a/jeffrey-microscope/pages-microscope/src/components/trace/TraceAttributeResults.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/trace/TraceAttributeResults.vue
@@ -35,13 +35,13 @@
         as the backdrop, because a burst of matches is only a burst if the profile was not equally
         busy everywhere; without it the shape means nothing.
       -->
+      <!-- Default palette, like the drill-down's chart: two "when did traces happen" charts must
+           not disagree on what the primary series looks like. -->
       <TimeSeriesChart
         :primary-data="matchedSeries"
         primary-title="Matched"
         :secondary-data="totalSeries"
         secondary-title="All traces"
-        primary-color="#5e64ff"
-        secondary-color="#b6c1d2"
         time-unit="milliseconds"
         :visible-minutes="60"
         :primary-axis-type="AxisFormatType.NUMBER"

--- a/jeffrey-microscope/pages-microscope/src/components/trace/TraceAttributeSearchBar.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/trace/TraceAttributeSearchBar.vue
@@ -199,6 +199,7 @@ const SOURCE_LABELS: Record<TraceAttributeSource, string> = {
 const OPERATOR_SYMBOLS: Record<TraceAttributeOperator, string> = {
   EQ: '=',
   NOT_EQ: '≠',
+  NONE_EQ: '∄',
   CONTAINS: '⊃',
   GT: '>',
   GTE: '≥',
@@ -210,6 +211,7 @@ const OPERATOR_SYMBOLS: Record<TraceAttributeOperator, string> = {
 const OPERATOR_LABELS: Record<TraceAttributeOperator, string> = {
   EQ: 'is',
   NOT_EQ: 'is not',
+  NONE_EQ: 'is never',
   CONTAINS: 'contains',
   GT: 'greater than',
   GTE: 'at least',
@@ -220,7 +222,9 @@ const OPERATOR_LABELS: Record<TraceAttributeOperator, string> = {
 
 /** Comparisons read the numeric column, which only a numeric value is ever stored in. */
 const NUMERIC_OPERATORS: TraceAttributeOperator[] = ['GT', 'GTE', 'LT', 'LTE'];
-const TEXT_OPERATORS: TraceAttributeOperator[] = ['EQ', 'NOT_EQ', 'CONTAINS'];
+// NOT_EQ and NONE_EQ answer different questions: "some carrier has another value" against
+// "no carrier has this one" -- status ≠ ERROR versus status never ERROR.
+const TEXT_OPERATORS: TraceAttributeOperator[] = ['EQ', 'NOT_EQ', 'NONE_EQ', 'CONTAINS'];
 
 const draftType = ref<string | null>(null);
 const draftKey = ref<TraceAttributeKeyRow | null>(null);
@@ -251,7 +255,7 @@ const availableOperators = computed<TraceAttributeOperator[]>(() => {
     return [...TEXT_OPERATORS, ...NUMERIC_OPERATORS, 'EXISTS'];
   }
   if (kind === 'BOOLEAN') {
-    return ['EQ', 'NOT_EQ', 'EXISTS'];
+    return ['EQ', 'NOT_EQ', 'NONE_EQ', 'EXISTS'];
   }
   return [...TEXT_OPERATORS, 'EXISTS'];
 });

--- a/jeffrey-microscope/pages-microscope/src/components/trace/TraceOperationDetail.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/trace/TraceOperationDetail.vue
@@ -22,7 +22,17 @@
     <ErrorState v-else-if="error" :message="error" @retry="load" />
 
     <template v-else>
-      <TabBar v-model="activeTab" :tabs="tabs" class="mb-3" />
+      <div class="d-flex align-items-center justify-content-between mb-3">
+        <TabBar v-model="activeTab" :tabs="tabs" />
+        <!--
+          Beside the tabs rather than inside one: it exports the whole operation — summary, span
+          ranking, slowest traces — not whichever tab happens to be open.
+        -->
+        <AiExportButton
+          :build-source="buildAiExportSource"
+          tooltip="Export this operation for AI analysis"
+        />
+      </div>
 
       <div v-show="activeTab === 'summary'">
         <TraceOperationSummary
@@ -78,8 +88,20 @@
           :p95-nanos="totals?.p95Nanos"
           :total="totals?.count ?? traces.length"
           :note="capNote"
+          :max-displayed="slowestShown"
           empty-description="No traces for this filter."
           @open="openTrace"
+        />
+        <!--
+          Client-side: the rows are already fetched, this only lifts the list's display cap page by
+          page. Without it the tab fetched up to a thousand traces and silently drew fifty.
+        -->
+        <LoadMoreFooter
+          v-if="rankedByDuration.length > 0"
+          :shown="Math.min(slowestShown, rankedByDuration.length)"
+          :total="rankedByDuration.length"
+          noun="traces"
+          @load-more="slowestShown += SLOWEST_PAGE"
         />
       </div>
 
@@ -104,7 +126,9 @@
 import { computed, onMounted, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 
+import AiExportButton from '@/components/ai-analysis/AiExportButton.vue';
 import ErrorState from '@shared/components/ErrorState.vue';
+import LoadMoreFooter from '@shared/components/LoadMoreFooter.vue';
 import LoadingState from '@shared/components/LoadingState.vue';
 import TabBar from '@shared/components/TabBar.vue';
 import TimeSeriesChart from '@/components/TimeSeriesChart.vue';
@@ -114,7 +138,9 @@ import TraceSpansModal from '@/components/trace/TraceSpansModal.vue';
 import TraceOperationFlamegraphs from '@/components/trace/TraceOperationFlamegraphs.vue';
 import AxisFormatType from '@/services/timeseries/AxisFormatType';
 import ProfileTracesClient from '@/services/api/ProfileTracesClient';
+import TraceAiExportClient from '@/services/api/TraceAiExportClient';
 import { slowestFirst } from '@/services/trace/traceOperationStats';
+import type { AiExportSource } from '@/composables/useAiExport';
 import type { TabBarItem } from '@shared/components/TabBar.vue';
 import type {
   TraceOperationId,
@@ -127,6 +153,8 @@ import type {
 const TIMELINE_BUCKETS = 40;
 /** Matches the backend's default; a type with more traces than this is summarised, not listed. */
 const TRACE_LIMIT = 1000;
+/** How many of the fetched traces the Slowest tab draws at once; Show More lifts it by a page. */
+const SLOWEST_PAGE = 50;
 
 const props = defineProps<{
   profileId: string;
@@ -238,6 +266,8 @@ const samplesAreReachable = computed(() => traces.value.some(trace => trace.hasP
 /** The ranking the Slowest Traces tab is named after; `traces` itself arrives in start order. */
 const rankedByDuration = computed(() => slowestFirst(traces.value));
 
+const slowestShown = ref(SLOWEST_PAGE);
+
 const tabs: TabBarItem[] = [
   { id: 'summary', label: 'Summary', icon: 'grid-1x2' },
   { id: 'flames', label: 'Flamegraphs', icon: 'fire' },
@@ -270,6 +300,20 @@ const capNote = computed<string | undefined>(() => {
   }
   return `First ${TRACE_LIMIT} traces of this operation`;
 });
+
+/**
+ * The rendering happens on the server from the operation's identifying triple alone, and the triple
+ * is a prop — so unlike the trace export, this one is never waiting on anything to load.
+ */
+function buildAiExportSource(): AiExportSource {
+  const client = new TraceAiExportClient(props.profileId);
+  const { name, kind, eventType } = props.operation;
+  return {
+    fetch: () => client.generateOperation(name, kind, eventType),
+    label: 'Operation',
+    filenameStem: `operation-${name}`
+  };
+}
 
 /*
  * Guards against an out-of-order response. Each load claims a number; a response whose number is no

--- a/jeffrey-microscope/pages-microscope/src/components/trace/TraceStackTrace.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/trace/TraceStackTrace.vue
@@ -287,7 +287,7 @@ async function copy(): Promise<void> {
 }
 
 .st-thrown-msg {
-  color: #475569;
+  color: var(--color-slate-text);
 }
 
 .st-head {

--- a/jeffrey-microscope/pages-microscope/src/components/trace/TraceWaterfall.vue
+++ b/jeffrey-microscope/pages-microscope/src/components/trace/TraceWaterfall.vue
@@ -2579,7 +2579,7 @@ function tooltip(span: TraceSpanRow): string {
 }
 
 .rail-glyph.ntf {
-  border-radius: 1px;
+  border-radius: calc(var(--radius-xs) / 2);
   transform: rotate(45deg);
 }
 
@@ -2599,7 +2599,7 @@ function tooltip(span: TraceSpanRow): string {
   bottom: 0;
   width: 1.5px;
   margin-left: -0.75px;
-  border-radius: 1px;
+  border-radius: calc(var(--radius-xs) / 2);
   background: currentColor;
 }
 
@@ -2632,7 +2632,7 @@ function tooltip(span: TraceSpanRow): string {
   width: 0.55rem;
   height: 0.55rem;
   margin: -0.275rem 0 0 -0.275rem;
-  border-radius: 1px;
+  border-radius: calc(var(--radius-xs) / 2);
   background: var(--mark);
   transform: rotate(45deg);
   box-shadow: 0 0 0 2px var(--color-bg-card);
@@ -2653,7 +2653,7 @@ function tooltip(span: TraceSpanRow): string {
   bottom: 0;
   width: 1.5px;
   margin-left: -0.75px;
-  border-radius: 1px;
+  border-radius: calc(var(--radius-xs) / 2);
   background: var(--mark);
 }
 
@@ -2716,7 +2716,7 @@ function tooltip(span: TraceSpanRow): string {
 }
 
 .wf-pin.ntf::after {
-  border-radius: 1px;
+  border-radius: calc(var(--radius-xs) / 2);
   transform: rotate(45deg);
 }
 
@@ -3086,7 +3086,7 @@ function tooltip(span: TraceSpanRow): string {
   width: 2.5px;
   background: currentColor;
   opacity: 0.7;
-  border-radius: 1px 1px 0 0;
+  border-radius: calc(var(--radius-xs) / 2) calc(var(--radius-xs) / 2) 0 0;
 }
 
 .wf-run-detail-row {
@@ -3136,7 +3136,7 @@ function tooltip(span: TraceSpanRow): string {
 
 .wf-run-histogram i {
   width: 22px;
-  border-radius: 2px 2px 0 0;
+  border-radius: var(--radius-xs) var(--radius-xs) 0 0;
   background: var(--span-color);
   opacity: 0.35;
 }

--- a/jeffrey-microscope/pages-microscope/src/router/profileChildRoutes.ts
+++ b/jeffrey-microscope/pages-microscope/src/router/profileChildRoutes.ts
@@ -690,6 +690,14 @@ const advisorRoutes = [
 // Traces — a top-level feature of its own, not one of the technologies
 const traceRoutes = [
   {
+    // The list that is not scoped to anything, which is why it leads: every other trace page starts
+    // by choosing an operation or an attribute.
+    path: 'traces/all',
+    name: 'profile-traces-all',
+    component: () => import('@/views/profiles/detail/traces/ProfileTraces.vue'),
+    meta: { layout: 'profile' }
+  },
+  {
     path: 'traces/operations',
     name: 'profile-traces-operations',
     component: () => import('@/views/profiles/detail/traces/ProfileTraceOperations.vue'),

--- a/jeffrey-microscope/pages-microscope/src/services/api/ProfileTracesClient.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/ProfileTracesClient.ts
@@ -221,6 +221,7 @@ export default class ProfileTracesClient extends BaseProfileClient {
     key: TraceAttributeKeyId,
     eventType: string,
     sort?: TraceAttributeValueSortField,
+    descending?: boolean,
     limit?: number
   ): Promise<TraceAttributeValues> {
     // Scoped to the event type the key was reached through, so the breakdown answers the question
@@ -229,6 +230,7 @@ export default class ProfileTracesClient extends BaseProfileClient {
       ...keyParams(key),
       eventType,
       ...(sort === undefined ? {} : { sort }),
+      ...(descending === undefined ? {} : { desc: descending }),
       ...(limit === undefined ? {} : { limit })
     });
   }

--- a/jeffrey-microscope/pages-microscope/src/services/api/ProfileTracesClient.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/ProfileTracesClient.ts
@@ -34,12 +34,14 @@ import {
 import type {
   TraceContext,
   TraceDetail,
+  TraceListQuery,
   TraceOperationId,
   TraceOperationListQuery,
   TraceOperationsPage,
   TraceOperationSummary,
   TraceOverview,
   TraceRow,
+  TracesPage,
   TraceSpanEvents,
   TraceStacktrace,
   TraceTimelineBucket
@@ -64,7 +66,7 @@ function operationParams(operation: TraceOperationId): Record<string, string> {
  * made before it could be filtered at all.
  */
 function listParams(
-  query: TraceOperationListQuery
+  query: TraceOperationListQuery | TraceListQuery
 ): Record<string, string | number | boolean> {
   const params: Record<string, string | number | boolean> = {};
   for (const [key, value] of Object.entries(query)) {
@@ -99,6 +101,25 @@ export default class ProfileTracesClient extends BaseProfileClient {
    */
   public getTraceContext(traceId: string): Promise<TraceContext> {
     return this.get<TraceContext>(`/${traceId}/context`);
+  }
+
+  /**
+   * A page of the profile's traces, whatever their operation.
+   *
+   * The empty path is the collection itself — `BaseProfileClient` resolves it to the base URL. The
+   * narrowing and the ordering happen on the server because the list is only ever a page of what
+   * can be hundreds of thousands of traces; ranking a page client-side would rank the page, not the
+   * profile.
+   */
+  public getTraces(query: TraceListQuery = {}): Promise<TracesPage> {
+    return this.get<TracesPage>('', listParams(query));
+  }
+
+  /** When the profile's traces happened, bucketed over the recording — the strip above the list. */
+  public getTracesTimeline(buckets?: number): Promise<TraceTimelineBucket[]> {
+    return this.get<TraceTimelineBucket[]>('/timeline', {
+      ...(buckets === undefined ? {} : { buckets })
+    });
   }
 
   /** A page of operations, narrowed and ordered on the server for the same reason traces are. */

--- a/jeffrey-microscope/pages-microscope/src/services/api/model/trace/TraceAttributeModels.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/model/trace/TraceAttributeModels.ts
@@ -58,7 +58,7 @@ export function carrierOf(source: TraceAttributeSource): TraceAttributeCarrier {
 export type TraceAttributeValueKind = 'STRING' | 'NUMBER' | 'BOOLEAN';
 
 export type TraceAttributeOperator =
-  'EQ' | 'NOT_EQ' | 'CONTAINS' | 'GT' | 'GTE' | 'LT' | 'LTE' | 'EXISTS';
+  'EQ' | 'NOT_EQ' | 'NONE_EQ' | 'CONTAINS' | 'GT' | 'GTE' | 'LT' | 'LTE' | 'EXISTS';
 
 /**
  * Whether the conditions have to hold together on one span, or anywhere in the trace.

--- a/jeffrey-microscope/pages-microscope/src/services/api/model/trace/TraceModels.ts
+++ b/jeffrey-microscope/pages-microscope/src/services/api/model/trace/TraceModels.ts
@@ -387,6 +387,32 @@ export interface TraceContext {
   summary: TraceContextSlice[];
 }
 
+/** What a trace list can be ordered by; must match the backend's `TraceSortField`. */
+export type TraceSortField = 'DURATION' | 'START' | 'SPAN_COUNT' | 'ERROR_COUNT';
+
+/**
+ * How the profile-wide trace list should be narrowed, ordered and paged; every field is optional.
+ *
+ * The field names are the wire names, so the client passes them through untranslated. The operation
+ * triple the endpoint also accepts is left out: this list is the one that is not scoped to a type,
+ * and a partial triple is silently ignored by the server anyway.
+ */
+export interface TraceListQuery {
+  search?: string;
+  errorsOnly?: boolean;
+  minDurationNanos?: number;
+  sort?: TraceSortField;
+  desc?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+/** One page of traces, with how many the same filter matched in total. */
+export interface TracesPage {
+  traces: TraceRow[];
+  totalMatching: number;
+}
+
 /** What an operation list can be ordered by; must match the backend's `TraceOperationSortField`. */
 export type TraceOperationSortField =
   'TOTAL_TIME' | 'P50' | 'P95' | 'P99' | 'MAX' | 'COUNT' | 'ERRORS' | 'NAME';

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/traces/ProfileTraceAttributeValues.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/traces/ProfileTraceAttributeValues.vue
@@ -35,7 +35,7 @@
         v-else-if="values"
         :values="values"
         :sort="sort"
-        :descending="true"
+        :descending="descending"
         @sort="applySort(attributeKey, eventType, $event)"
         @pick="filterByValue(attributeKey, $event)"
       />
@@ -75,6 +75,7 @@ const loading = ref(false);
 const error = ref<string | null>(null);
 const values = ref<Values | null>(null);
 const sort = ref<TraceAttributeValueSortField>('TOTAL_TIME');
+const descending = ref(true);
 
 const selectedKey = computed(() => keyFromQuery(route.query));
 const selectedEventType = computed(() => eventTypeFromQuery(route.query));
@@ -90,7 +91,7 @@ async function load(key: TraceAttributeKeyId, eventType: string): Promise<void> 
   loading.value = true;
   error.value = null;
   try {
-    const loaded = await client.getAttributeValues(key, eventType, sort.value);
+    const loaded = await client.getAttributeValues(key, eventType, sort.value, descending.value);
     if (current !== generation) {
       return;
     }
@@ -114,7 +115,14 @@ function applySort(
   eventType: string,
   field: TraceAttributeValueSortField
 ): void {
-  sort.value = field;
+  // Clicking the active column flips the direction; a new column starts from its heavy end, which
+  // is the ranking the page opens with.
+  if (field === sort.value) {
+    descending.value = !descending.value;
+  } else {
+    sort.value = field;
+    descending.value = true;
+  }
   load(key, eventType);
 }
 

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/detail/traces/ProfileTraces.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/detail/traces/ProfileTraces.vue
@@ -1,0 +1,456 @@
+<!--
+  ~ Jeffrey
+  ~ Copyright (C) 2026 Petr Bouda
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<!--
+  All Traces: every trace in the profile, whatever its operation.
+
+  The one entry point that does not start by choosing something. "Which were the slowest" and "what
+  failed" are questions about the profile rather than about a type or an attribute, and answering
+  them through the operations page meant first knowing which operation to open — which is the thing
+  being asked. The narrowing, the ranking and the paging all happen on the server: this list is a
+  page of what can be hundreds of thousands of traces, so ranking what was fetched would rank the
+  page rather than the profile.
+-->
+<template>
+  <div>
+    <TracesDisabledFeatureAlert v-if="featureDisabled" />
+
+    <LoadingState v-else-if="loading" message="Loading traces..." />
+
+    <ErrorState v-else-if="error" :message="error" @retry="loadData" />
+
+    <EmptyState
+      v-else-if="untraced"
+      title="No Traces"
+      description="No trace-carrying events were recorded in this profile."
+      icon="bi-list-ul"
+    />
+
+    <div v-else class="dashboard-container">
+      <TraceOperationStats v-if="overview" :overview="overview" />
+
+      <!--
+        The same chart the operation drill-down and the attribute search draw, over every trace
+        rather than a subset: three pages plot when traces happened, and they must not do it three
+        different ways. Bucketed by the server over the whole recording, so a burst reads as a burst
+        where it happened instead of being folded out of the page that happens to be loaded.
+      -->
+      <MainCard v-if="timeline.length > 0" class="mb-3">
+        <template #header>
+          <MainCardHeader icon="bi-graph-up" title="When Traces Happened" />
+        </template>
+        <TimeSeriesChart
+          :primary-data="primaryData"
+          primary-title="Trace Duration"
+          :secondary-data="secondaryData"
+          secondary-title="Traces"
+          time-unit="milliseconds"
+          :visible-minutes="60"
+          :independent-secondary-axis="true"
+          :primary-axis-type="AxisFormatType.DURATION_IN_NANOS"
+          :secondary-axis-type="AxisFormatType.NUMBER"
+        />
+      </MainCard>
+
+      <!--
+        Rendered above the list and never with it: the controls are how a reader clears a filter, so
+        they must not disappear along with the rows they filtered out.
+      -->
+      <div class="trace-filters">
+        <div class="op-search">
+          <i class="bi bi-search"></i>
+          <input
+            v-model="search"
+            type="text"
+            class="form-control form-control-sm"
+            placeholder="Filter by operation name..."
+          />
+          <button v-if="search" class="btn-clear" @click="search = ''">
+            <i class="bi bi-x-lg"></i>
+          </button>
+        </div>
+
+        <button
+          type="button"
+          class="btn btn-sm"
+          :class="errorsOnly ? 'btn-danger' : 'btn-outline-secondary'"
+          @click="errorsOnly = !errorsOnly"
+        >
+          <i class="bi bi-exclamation-triangle"></i> Errors only
+        </button>
+
+        <select v-model="minDurationNanos" class="form-select form-select-sm trace-select">
+          <option v-for="option in DURATION_FLOORS" :key="option.nanos" :value="option.nanos">
+            {{ option.label }}
+          </option>
+        </select>
+
+        <select v-model="sortKey" class="form-select form-select-sm trace-select">
+          <option v-for="option in SORT_OPTIONS" :key="option.key" :value="option.key">
+            {{ option.label }}
+          </option>
+        </select>
+      </div>
+
+      <LoadingState v-if="listLoading && traces.length === 0" message="Loading traces..." />
+
+      <ErrorState v-else-if="listError" :message="listError" @retry="loadPage(0)" />
+
+      <template v-else>
+        <!--
+          `total` is deliberately not passed: the card list would draw its own "showing X of Y"
+          header on top of the footer's, and the two counts would have to be kept in step for no
+          gain. `max-displayed` defeats the component's own 50-row default, because the page cut
+          already happened on the server.
+        -->
+        <TraceCardList
+          :items="traces"
+          :trace="(trace: TraceRow) => trace"
+          :p50-nanos="overview?.avgNanos"
+          :p95-nanos="overview?.p95Nanos"
+          :max-displayed="traces.length"
+          empty-description="No trace matches the current filter."
+          @open="openTrace"
+        />
+
+        <LoadMoreFooter
+          v-if="traces.length > 0"
+          :shown="traces.length"
+          :total="totalMatching"
+          noun="traces"
+          :loading="listLoading"
+          @load-more="loadMore"
+        />
+      </template>
+    </div>
+
+    <!--
+      A sibling of the content rather than a child of it: GenericModal renders in place, so nested
+      inside a branch that can be hidden it would mount invisibly, lock body scroll, and put its own
+      dismiss handlers out of reach.
+    -->
+    <TraceSpansModal
+      v-model:show="spansShow"
+      :profile-id="profileId"
+      :trace-id="selectedTrace?.traceId ?? ''"
+      :root-name="selectedTrace?.rootName ?? ''"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+
+import EmptyState from '@shared/components/EmptyState.vue';
+import ErrorState from '@shared/components/ErrorState.vue';
+import LoadMoreFooter from '@shared/components/LoadMoreFooter.vue';
+import LoadingState from '@shared/components/LoadingState.vue';
+import MainCard from '@shared/components/MainCard.vue';
+import MainCardHeader from '@shared/components/MainCardHeader.vue';
+import TracesDisabledFeatureAlert from '@/components/alerts/TracesDisabledFeatureAlert.vue';
+import TimeSeriesChart from '@/components/TimeSeriesChart.vue';
+import TraceCardList from '@/components/trace/TraceCardList.vue';
+import TraceOperationStats from '@/components/trace/TraceOperationStats.vue';
+import TraceSpansModal from '@/components/trace/TraceSpansModal.vue';
+import ProfileTracesClient from '@/services/api/ProfileTracesClient';
+import FeatureType from '@/services/api/model/FeatureType';
+import AxisFormatType from '@/services/timeseries/AxisFormatType';
+import type {
+  TraceOverview,
+  TraceRow,
+  TraceSortField,
+  TraceTimelineBucket
+} from '@/services/api/model/trace/TraceModels';
+
+/** One page of traces. Ranked by whatever the sort says, so the cut is always the tail of it. */
+const PAGE_SIZE = 50;
+/** How long to wait for typing to settle before asking the server again. */
+const SEARCH_DEBOUNCE_MILLIS = 250;
+/** Over the whole recording, like every other trace timeline. */
+const TIMELINE_BUCKETS = 60;
+
+const NANOS_PER_MILLI = 1_000_000;
+
+/**
+ * The duration floors offered, as nanoseconds. Coarse on purpose: the filter exists to cut a long
+ * tail of fast traces out of the way, not to express an exact threshold — that is what sorting by
+ * duration and reading from the top already does.
+ */
+const DURATION_FLOORS = [
+  { nanos: 0, label: 'Any duration' },
+  { nanos: 100 * NANOS_PER_MILLI, label: '≥ 100 ms' },
+  { nanos: 500 * NANOS_PER_MILLI, label: '≥ 500 ms' },
+  { nanos: 1_000 * NANOS_PER_MILLI, label: '≥ 1 s' }
+];
+
+/** Keyed by the backend's own `TraceSortField` names, so nothing has to be translated. */
+const SORT_OPTIONS: { key: TraceSortField; label: string }[] = [
+  { key: 'DURATION', label: 'Slowest first' },
+  { key: 'START', label: 'Most recent first' },
+  { key: 'SPAN_COUNT', label: 'Most spans' },
+  { key: 'ERROR_COUNT', label: 'Most errors' }
+];
+
+const SORT_KEYS = new Set<string>(SORT_OPTIONS.map(option => option.key));
+const DEFAULT_SORT: TraceSortField = 'DURATION';
+
+const props = defineProps<{ disabledFeatures: FeatureType[] }>();
+
+const route = useRoute();
+const router = useRouter();
+
+const traces = ref<TraceRow[]>([]);
+const totalMatching = ref(0);
+const timeline = ref<TraceTimelineBucket[]>([]);
+const overview = ref<TraceOverview | null>(null);
+const loading = ref(true);
+const listLoading = ref(false);
+/**
+ * A failed page fetch stays inside the list region: the stats and the timeline above it are still
+ * the profile's, and blanking the page would take a correct answer away to report a failure that
+ * only concerns the rows.
+ */
+const listError = ref<string | null>(null);
+const error = ref<string | null>(null);
+
+/*
+ * The filter lives in the URL, so a filtered list is a link — "the failed traces of this recording"
+ * is something to paste into an issue rather than a set of instructions. The same contract the
+ * sibling trace pages keep. Seeded here, mirrored back by the watcher below.
+ */
+const initialQuery = route.query;
+const search = ref((initialQuery.q as string | undefined) ?? '');
+const errorsOnly = ref(initialQuery.errors === '1');
+const minDurationNanos = ref(Number(initialQuery.min ?? 0) || 0);
+const sortKey = ref<TraceSortField>(
+  SORT_KEYS.has(initialQuery.sort as string) ? (initialQuery.sort as TraceSortField) : DEFAULT_SORT
+);
+
+const profileId = computed(() => route.params.profileId as string);
+const featureDisabled = computed(() => props.disabledFeatures.includes(FeatureType.TRACES));
+const untraced = computed(() => (overview.value?.totalTraces ?? 0) === 0);
+
+const primaryData = computed<number[][]>(() =>
+  timeline.value.map(bucket => [bucket.fromMillisFromBeginning, bucket.maxDurationNanos])
+);
+const secondaryData = computed<number[][]>(() =>
+  timeline.value.map(bucket => [bucket.fromMillisFromBeginning, bucket.count])
+);
+
+const spansShow = ref(false);
+const selectedTrace = ref<TraceRow | null>(null);
+
+function openTrace(trace: TraceRow): void {
+  selectedTrace.value = trace;
+  spansShow.value = true;
+  // The id joins the filter already in the URL, so a waterfall reached from this list is as
+  // linkable as the list itself. Pushed so Back closes the dialog and leaves the reader on their
+  // rows, which is how they got here.
+  router.push({ query: { ...route.query, trace: trace.traceId } });
+}
+
+// Closing takes the trace back out again, so returning to the link does not reopen it.
+watch(spansShow, open => {
+  if (!open && route.query.trace) {
+    const query = { ...route.query };
+    delete query.trace;
+    router.replace({ query });
+  }
+});
+
+/**
+ * Reopens the trace named in the URL once the rows are in. A link can point at a trace beyond the
+ * loaded page, in which case no row is found here — the modal fetches everything it draws from the
+ * id alone, so it still opens, just without the row's own header values.
+ */
+watch([() => route.query.trace, traces], ([traceId]) => {
+  if (!traceId) {
+    spansShow.value = false;
+    return;
+  }
+  const id = traceId as string;
+  selectedTrace.value = traces.value.find(trace => trace.traceId === id) ?? null;
+  spansShow.value = true;
+});
+
+async function loadData(): Promise<void> {
+  loading.value = true;
+  error.value = null;
+  try {
+    const client = new ProfileTracesClient(profileId.value);
+    // The profile's totals and its density, neither of which a page of rows can be folded into.
+    const [profileOverview, buckets] = await Promise.all([
+      client.getOverview(),
+      client.getTracesTimeline(TIMELINE_BUCKETS)
+    ]);
+    overview.value = profileOverview;
+    timeline.value = buckets;
+    await loadPage(0);
+  } catch {
+    error.value = 'Failed to load the traces for this profile.';
+  } finally {
+    loading.value = false;
+  }
+}
+
+/*
+ * Guards against an out-of-order response: a load-more still in flight when a filter change fires a
+ * fresh first page must not append its previous-filter rows onto the new list.
+ */
+let listGeneration = 0;
+
+/** One page of the current filter; an offset of zero replaces the list, anything else appends. */
+async function loadPage(offset: number): Promise<void> {
+  const current = ++listGeneration;
+  listLoading.value = true;
+  listError.value = null;
+  try {
+    const page = await new ProfileTracesClient(profileId.value).getTraces({
+      search: search.value,
+      errorsOnly: errorsOnly.value,
+      minDurationNanos: minDurationNanos.value,
+      sort: sortKey.value,
+      limit: PAGE_SIZE,
+      offset
+    });
+    if (current !== listGeneration) {
+      return;
+    }
+    traces.value = offset === 0 ? page.traces : [...traces.value, ...page.traces];
+    totalMatching.value = page.totalMatching;
+  } catch {
+    if (current !== listGeneration) {
+      return;
+    }
+    listError.value = 'Failed to load the traces for this filter.';
+  } finally {
+    if (current === listGeneration) {
+      listLoading.value = false;
+    }
+  }
+}
+
+function loadMore(): void {
+  loadPage(traces.value.length);
+}
+
+// Debounced because the search box changes on every keystroke; the selects and the toggle do not,
+// but sharing one watcher keeps the refetch in a single place.
+let searchTimer: ReturnType<typeof setTimeout> | undefined;
+watch([search, errorsOnly, minDurationNanos, sortKey], () => {
+  syncFilterQuery();
+  clearTimeout(searchTimer);
+  searchTimer = setTimeout(() => loadPage(0), SEARCH_DEBOUNCE_MILLIS);
+});
+
+/**
+ * Mirrors the filter into the URL. Replaced, not pushed — a filter is view state, and Back should
+ * step out of the page, not backspace through a search term. Defaults are left out so an unfiltered
+ * link stays clean.
+ */
+function syncFilterQuery(): void {
+  const next = { ...route.query };
+  if (search.value) {
+    next.q = search.value;
+  } else {
+    delete next.q;
+  }
+  if (errorsOnly.value) {
+    next.errors = '1';
+  } else {
+    delete next.errors;
+  }
+  if (minDurationNanos.value > 0) {
+    next.min = String(minDurationNanos.value);
+  } else {
+    delete next.min;
+  }
+  if (sortKey.value !== DEFAULT_SORT) {
+    next.sort = sortKey.value;
+  } else {
+    delete next.sort;
+  }
+  router.replace({ query: next });
+}
+
+onUnmounted(() => clearTimeout(searchTimer));
+
+onMounted(() => {
+  if (featureDisabled.value) {
+    loading.value = false;
+  } else {
+    loadData();
+  }
+});
+</script>
+
+<style scoped>
+.trace-filters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-3);
+}
+
+.trace-select {
+  width: auto;
+  font-size: 0.8rem;
+}
+
+/* The toolbar's search affordance, matching the operations page's filter row. */
+.op-search {
+  position: relative;
+}
+
+.op-search i.bi-search {
+  position: absolute;
+  left: 0.6rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--color-text-light);
+  font-size: 0.75rem;
+  pointer-events: none;
+}
+
+.op-search .form-control {
+  padding-left: 1.8rem;
+  padding-right: 1.8rem;
+  font-size: 0.8rem;
+  min-width: 220px;
+}
+
+.btn-clear {
+  position: absolute;
+  right: 0.4rem;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  color: var(--color-text-light);
+  font-size: 0.6rem;
+  cursor: pointer;
+  padding: 2px;
+  line-height: 1;
+}
+
+.btn-clear:hover {
+  color: var(--color-text);
+}
+</style>

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/navigation/__tests__/profileNavConfig.spec.ts
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/navigation/__tests__/profileNavConfig.spec.ts
@@ -71,10 +71,10 @@ describe('profileNavConfig', () => {
 
   it('collects a sane number of nav items', () => {
     // 7 Overview (incl. Dashboards) + 19 JVM (incl. GC/JIT submenu parents + children)
-    // + 16 Application (incl. Memory Issues submenu) + 4 Traces (Traces by Operation,
-    // Search Traces, Attribute Values, Latency by Attributes) + 4 Visualization
+    // + 16 Application (incl. Memory Issues submenu) + 5 Traces (All Traces, Traces by
+    // Operation, Search Traces, Attribute Values, Latency by Attributes) + 4 Visualization
     // + 17 HeapDump + 4 Tools + 4 Advisor + 35 Technologies
-    expect(allItems.length).toBe(110);
+    expect(allItems.length).toBe(111);
   });
 
   it('every item has a label and a bootstrap icon', () => {
@@ -180,6 +180,7 @@ describe('profileNavConfig', () => {
     expect(getModeForPath(profilePath('/string-symbol-tables'))).toBe('JVM');
     expect(getModeForPath(profilePath('/technologies/hub'))).toBe('Technologies');
     // Traces is its own mode now, and `method-tracing` must stay a technology despite the near-name.
+    expect(getModeForPath(profilePath('/traces/all'))).toBe('Traces');
     expect(getModeForPath(profilePath('/traces/operations'))).toBe('Traces');
     expect(getModeForPath(profilePath('/traces/attributes/search'))).toBe('Traces');
     expect(getModeForPath(profilePath('/technologies/method-tracing/slowest'))).toBe('Technologies');

--- a/jeffrey-microscope/pages-microscope/src/views/profiles/navigation/profileNavConfig.ts
+++ b/jeffrey-microscope/pages-microscope/src/views/profiles/navigation/profileNavConfig.ts
@@ -363,6 +363,9 @@ export const profileNavSections: Record<
     {
       title: 'TRACES',
       items: [
+        // First because it is the broadest way in: the other pages answer "is it always like this"
+        // and "which carried this value", both of which presuppose knowing where to look.
+        item('All Traces', 'bi-list-ul', '/traces/all'),
         item('Traces by Operation', 'bi-bar-chart-steps', '/traces/operations'),
         // Sits with the operations rather than under ATTRIBUTES: searching is an everyday way into
         // the traces themselves, not one of the attribute readings.

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/TraceManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/TraceManagerImpl.java
@@ -818,7 +818,10 @@ public class TraceManagerImpl implements TraceManager {
                 span.selfDurationNanos(),
                 criticalPathNanos,
                 depth,
-                Long.toString(span.threadHash()),
+                // Hex like every other id-shaped value on the wire -- the notification and
+                // exception rows already render theirs this way, and a frontend comparing the
+                // three must find one base, not two.
+                toHex(span.threadHash()),
                 span.threadName(),
                 span.isVirtual(),
                 span.eventType(),

--- a/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/TraceManagerImplTest.java
+++ b/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/TraceManagerImplTest.java
@@ -223,12 +223,14 @@ class TraceManagerImplTest {
         }
 
         @Test
-        @DisplayName("ids and thread hash cross the wire as strings")
+        @DisplayName("ids and thread hash cross the wire as hex strings")
         void rendersIdsAsHex() {
             TraceSpanRow root = spansOf(List.of(span(255, null, "root", 0, 10))).getFirst();
 
             assertEquals("00000000000000ff", root.spanId());
-            assertEquals("900", root.threadHash());
+            // The same base as the notification and exception rows' thread hashes -- a span row
+            // rendering decimal here is the bug this pins against.
+            assertEquals("0000000000000384", root.threadHash());
         }
     }
 

--- a/jeffrey-microscope/profiles/profile-persistence-api/src/main/java/cafe/jeffrey/provider/profile/api/TraceAttributeOperator.java
+++ b/jeffrey-microscope/profiles/profile-persistence-api/src/main/java/cafe/jeffrey/provider/profile/api/TraceAttributeOperator.java
@@ -28,7 +28,18 @@ package cafe.jeffrey.provider.profile.api;
 public enum TraceAttributeOperator {
 
     EQ("value_text = :%s"),
+    /**
+     * Some carrier in the group has a different value — true of nearly every trace for a key like
+     * {@code status}. The universal reading ("no carrier has this value") is {@link #NONE_EQ}.
+     */
     NOT_EQ("value_text <> :%s"),
+    /**
+     * No carrier in the group has this value: the row predicate is {@link #EQ}'s, and the query
+     * builder counts the matches to zero instead of above it. A group with no rows of the key's
+     * carrier at all (a trace with no notifications, for a notification key) is not matched — the
+     * search runs over the carriers the trace recorded, not over their absence.
+     */
+    NONE_EQ("value_text = :%s"),
     CONTAINS("lower(value_text) LIKE '%%' || lower(:%s) || '%%'"),
     /**
      * The four ordering comparisons read {@code value_num}, which is filled only where the value is
@@ -73,6 +84,15 @@ public enum TraceAttributeOperator {
      * {@link #EXISTS} reads nothing at all.
      */
     public boolean readsText() {
-        return this == EQ || this == NOT_EQ || this == CONTAINS;
+        return this == EQ || this == NOT_EQ || this == NONE_EQ || this == CONTAINS;
+    }
+
+    /**
+     * Whether the condition holds when its row predicate matches <em>nothing</em> in the group —
+     * the query builder counts the matching rows to zero instead of above it, and the hit lookup
+     * skips the condition, there being no matching row to point at.
+     */
+    public boolean negatedAggregate() {
+        return this == NONE_EQ;
     }
 }

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/JdbcTraceAttributeRepository.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/JdbcTraceAttributeRepository.java
@@ -909,7 +909,7 @@ public class JdbcTraceAttributeRepository implements TraceAttributeRepository {
 
         List<Hit> hits = new ArrayList<>();
         for (TraceAttributeCarrier carrier : TraceAttributeCarrier.values()) {
-            List<String> carrierPredicates = predicates.of(carrier);
+            List<String> carrierPredicates = predicates.highlightable(carrier);
             if (!carrierPredicates.isEmpty()) {
                 hits.addAll(hitsOfCarrier(carrier, carrierPredicates, params));
             }

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/JdbcTraceRepository.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/JdbcTraceRepository.java
@@ -1043,7 +1043,11 @@ public class JdbcTraceRepository implements TraceRepository {
                 JOIN trace_spans s
                   ON s.thread_hash = x.thread_hash
                  AND EPOCH_US(s.start_timestamp) <= x.start_us
-                 AND x.start_us < EPOCH_US(s.start_timestamp) + (s.duration / 1000)
+                 -- Integer division and an inclusive bound, the same window arithmetic as the span
+                 -- derivation and the context slices: `/` on integers yields DOUBLE in DuckDB, so
+                 -- the float form gave a throw a window up to 1 microsecond wider than every other
+                 -- reading of the same span.
+                 AND x.start_us <= EPOCH_US(s.start_timestamp) + s.duration // 1000
                 -- The innermost containing span: shortest window first, latest start to break a tie.
                 QUALIFY ROW_NUMBER() OVER (PARTITION BY x.exception_id
                                            ORDER BY s.duration, s.start_timestamp DESC) = 1

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/TraceAttributeQueries.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/TraceAttributeQueries.java
@@ -62,6 +62,13 @@ final class TraceAttributeQueries {
     }
 
     /**
+     * One condition's row predicate, with how the aggregate reads it: an ordinary condition holds
+     * where the count of matching rows is above zero, a negated one where it is exactly zero.
+     */
+    record Predicate(String sql, boolean negated) {
+    }
+
+    /**
      * The predicates of one search, split by the carrier their keys belong to.
      * <p>
      * They are split rather than listed together because the two live in different tables and are
@@ -71,18 +78,29 @@ final class TraceAttributeQueries {
      * @param spans         predicates over {@code trace_span_attributes}
      * @param notifications predicates over {@code trace_notification_attributes}
      */
-    record Predicates(List<String> spans, List<String> notifications) {
+    record Predicates(List<Predicate> spans, List<Predicate> notifications) {
 
         boolean isEmpty() {
             return spans.isEmpty() && notifications.isEmpty();
         }
 
-        /** Every predicate, for the hit lookup, which ORs them across rows of one table. */
-        List<String> of(TraceAttributeCarrier carrier) {
+        private List<Predicate> of(TraceAttributeCarrier carrier) {
             return switch (carrier) {
                 case SPAN -> spans;
                 case NOTIFICATION -> notifications;
             };
+        }
+
+        /**
+         * The predicates whose satisfied rows exist, for the hit lookup, which ORs them across rows
+         * of one table. A negated condition holds precisely where nothing matches, so it has no row
+         * to point at and is left out.
+         */
+        List<String> highlightable(TraceAttributeCarrier carrier) {
+            return of(carrier).stream()
+                    .filter(predicate -> !predicate.negated())
+                    .map(Predicate::sql)
+                    .toList();
         }
     }
 
@@ -99,8 +117,8 @@ final class TraceAttributeQueries {
     static Predicates predicates(
             List<TraceAttributeCondition> conditions, MapSqlParameterSource params) {
 
-        List<String> spanPredicates = new ArrayList<>();
-        List<String> notificationPredicates = new ArrayList<>();
+        List<Predicate> spanPredicates = new ArrayList<>();
+        List<Predicate> notificationPredicates = new ArrayList<>();
         for (int i = 0; i < conditions.size(); i++) {
             TraceAttributeCondition condition = conditions.get(i);
             TraceAttributeKeyId key = condition.key();
@@ -124,8 +142,9 @@ final class TraceAttributeQueries {
                 params.addValue("attr_value_" + i, condition.value());
             }
 
-            String predicate = "(source = '%s' AND %s AND attr_key = :%s AND %s)"
+            String sql = "(source = '%s' AND %s AND attr_key = :%s AND %s)"
                     .formatted(key.source().name(), ownerClause, keyParam, valueClause);
+            Predicate predicate = new Predicate(sql, condition.operator().negatedAggregate());
 
             switch (key.source().carrier()) {
                 case SPAN -> spanPredicates.add(predicate);
@@ -176,7 +195,7 @@ final class TraceAttributeQueries {
 
         List<String> branches = new ArrayList<>(2);
         for (TraceAttributeCarrier carrier : TraceAttributeCarrier.values()) {
-            List<String> carrierPredicates = predicates.of(carrier);
+            List<Predicate> carrierPredicates = predicates.of(carrier);
             if (!carrierPredicates.isEmpty()) {
                 branches.add(branch(carrier, carrierPredicates, query.scope()));
             }
@@ -184,12 +203,17 @@ final class TraceAttributeQueries {
         return String.join("\nINTERSECT\n", branches);
     }
 
-    /** One carrier's half of the match: the traces where every condition of that carrier held. */
+    /**
+     * One carrier's half of the match: the traces where every condition of that carrier held.
+     * An ordinary condition holds where some row of the group matches; a negated one
+     * ({@link TraceAttributeOperator#negatedAggregate()}) where none does.
+     */
     private static String branch(
-            TraceAttributeCarrier carrier, List<String> predicates, TraceAttributeScope scope) {
+            TraceAttributeCarrier carrier, List<Predicate> predicates, TraceAttributeScope scope) {
 
         String having = predicates.stream()
-                .map(predicate -> "COUNT(*) FILTER (WHERE %s) > 0".formatted(predicate))
+                .map(predicate -> "COUNT(*) FILTER (WHERE %s) %s"
+                        .formatted(predicate.sql(), predicate.negated() ? "= 0" : "> 0"))
                 .collect(Collectors.joining("\n   AND "));
 
         return """

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/test/java/cafe/jeffrey/provider/profile/jdbc/JdbcTraceAttributeRepositoryTest.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/test/java/cafe/jeffrey/provider/profile/jdbc/JdbcTraceAttributeRepositoryTest.java
@@ -78,6 +78,9 @@ class JdbcTraceAttributeRepositoryTest {
     /** The same name as the attribute above, declared by the span shape rather than attached. */
     private static final TraceAttributeKeyId SHAPE_EVENT_TYPE =
             new TraceAttributeKeyId(TraceAttributeSource.SPAN_SHAPE, null, "eventType");
+    /** Every span carries one, which is what makes the universal operator testable per trace. */
+    private static final TraceAttributeKeyId SHAPE_STATUS =
+            new TraceAttributeKeyId(TraceAttributeSource.SPAN_SHAPE, null, "status");
     private static final TraceAttributeKeyId JDBC_ROWS =
             new TraceAttributeKeyId(TraceAttributeSource.EVENT_FIELD, JDBC_QUERY, "rows");
     private static final TraceAttributeKeyId HTTP_STATUS_CODE =
@@ -316,6 +319,58 @@ class JdbcTraceAttributeRepositoryTest {
                     new TraceAttributeCondition(JDBC_ROWS, TraceAttributeOperator.GT, "9"))).total());
             assertEquals(0, repository.search(search(TraceAttributeScope.TRACE,
                     new TraceAttributeCondition(JDBC_ROWS, TraceAttributeOperator.GT, "99"))).total());
+        }
+
+        /**
+         * The two negative operators answer different questions. Both fixture traces contain an
+         * ERROR span, but only the slow one also has spans that are not — so the existential
+         * {@code NOT_EQ} finds it, while the universal {@code NONE_EQ} correctly finds neither.
+         */
+        @Test
+        @DisplayName("NOT_EQ is existential, NONE_EQ is universal")
+        void noneEqIsUniversal(DataSource dataSource) throws SQLException {
+            JdbcTraceAttributeRepository repository = derived(dataSource);
+
+            assertEquals(1, repository.search(search(TraceAttributeScope.TRACE,
+                    new TraceAttributeCondition(SHAPE_STATUS, TraceAttributeOperator.NOT_EQ, "ERROR")))
+                    .total(), "the slow trace has spans that are not ERROR");
+            assertEquals(0, repository.search(search(TraceAttributeScope.TRACE,
+                    new TraceAttributeCondition(SHAPE_STATUS, TraceAttributeOperator.NONE_EQ, "ERROR")))
+                    .total(), "both traces contain an ERROR span, so neither is free of them");
+            assertEquals(1, repository.search(search(TraceAttributeScope.TRACE,
+                    new TraceAttributeCondition(SHAPE_STATUS, TraceAttributeOperator.NONE_EQ, "UNSET")))
+                    .total(), "only the failed trace's single span never reports UNSET");
+        }
+
+        @Test
+        @DisplayName("a NONE_EQ match has no row to point at, so it produces no hit")
+        void noneEqProducesNoHits(DataSource dataSource) throws SQLException {
+            TraceAttributeRepository.SearchPage page = derived(dataSource)
+                    .search(search(TraceAttributeScope.TRACE, new TraceAttributeCondition(
+                            SHAPE_STATUS, TraceAttributeOperator.NONE_EQ, "UNSET")));
+
+            assertEquals(1, page.total());
+            assertTrue(page.hits().isEmpty(),
+                    "the condition holds because nothing matches -- there is nothing to highlight");
+        }
+
+        /**
+         * Under SPAN scope the zero-count is taken per span, so a positive and a universal condition
+         * together ask for one span that carries the first and is free of the second.
+         */
+        @Test
+        @DisplayName("NONE_EQ composes with a positive condition on one span")
+        void noneEqUnderSpanScope(DataSource dataSource) throws SQLException {
+            JdbcTraceAttributeRepository repository = derived(dataSource);
+
+            TraceAttributeCondition rows = holds(JDBC_ROWS, "42");
+
+            assertEquals(1, repository.search(search(TraceAttributeScope.SPAN, rows,
+                    new TraceAttributeCondition(SHAPE_STATUS, TraceAttributeOperator.NONE_EQ, "ERROR")))
+                    .total(), "the statement span carries rows=42 and is not an ERROR span");
+            assertEquals(0, repository.search(search(TraceAttributeScope.SPAN, rows,
+                    new TraceAttributeCondition(SHAPE_STATUS, TraceAttributeOperator.NONE_EQ, "UNSET")))
+                    .total(), "that same span's status is UNSET, so requiring none fails");
         }
 
         @Test

--- a/jeffrey-pages/src/views/docs/tracing/TracingAnalysisPage.vue
+++ b/jeffrey-pages/src/views/docs/tracing/TracingAnalysisPage.vue
@@ -28,6 +28,7 @@ const { setHeadings } = useDocHeadings();
 
 const headings = [
   { id: 'overview', text: 'Overview', level: 2 },
+  { id: 'all-traces', text: 'All Traces', level: 2 },
   { id: 'operations', text: 'Traces by Operation', level: 2 },
   { id: 'waterfall', text: 'The Trace Detail: Waterfall', level: 2 },
   { id: 'overlays', text: 'Overlays and Rails', level: 2 },
@@ -60,13 +61,19 @@ const virtualThreadExample = `POST /api/internal/recordings/…   tomcat-handler
     />
 
     <div class="docs-content">
-      <p>Once a recording with trace identity is opened as a profile, the <strong>Traces</strong> section appears in the profile's sidebar: Traces by Operation, attribute search, and — from any trace row — the full-screen Trace Detail with the waterfall. This page is the tour of the analysis side; the instrumentation that produces the data is the rest of this guide.</p>
+      <p>Once a recording with trace identity is opened as a profile, the <strong>Traces</strong> section appears in the profile's sidebar: All Traces, Traces by Operation, attribute search, and — from any trace row — the full-screen Trace Detail with the waterfall. This page is the tour of the analysis side; the instrumentation that produces the data is the rest of this guide.</p>
 
       <h2 id="overview">Overview</h2>
 
       <p>A tracing tool normally tells you that a span took 400&nbsp;ms and stops there — the next question, "doing what?", needs a profiler and a second correlated data source. Jeffrey has both in one file. Every span carries its thread and its time window, and the profile database already scopes flamegraphs, timeseries and event summaries to <code>(thread, from, to)</code> windows — so a span selected in the waterfall becomes a flamegraph query with no extra instrumentation and no second agent.</p>
 
       <p>After parsing, Jeffrey derives typed trace tables once per profile: every event type declaring a <code>spanId</code> field feeds one span table, which is why an HTTP request shows its JDBC statements as native children without either side knowing about the other. Trace and span ids are 64-bit values rendered as 16-character hex in the UI (they exceed the JavaScript safe-integer range, so the API carries them as strings).</p>
+
+      <h2 id="all-traces">All Traces</h2>
+
+      <p>All Traces is the one page that does not begin by choosing something. &quot;Which runs were the slowest&quot; and &quot;what failed&quot; are questions about the recording rather than about one operation or one attribute, and answering them through the operations page meant first knowing which operation to open &mdash; which is the thing being asked.</p>
+
+      <p>The chart above the list buckets every trace over the recording, pairing the slowest trace in each bucket with how many there were, so a burst reads as a burst where it happened. Below it, filter by operation name, restrict to traces that carry an error, set a duration floor, and order by duration, start time, span count or error count. The narrowing and the ordering happen in SQL over the whole profile, not over the page in the browser &mdash; a page ranked client-side would rank the page rather than the recording &mdash; and the list pages in fifty at a time. Every filter is mirrored into the URL, so a narrowed list is a link. Clicking a row opens the same full-screen Trace Detail the other pages open, and its header links onward to that trace's operation.</p>
 
       <h2 id="operations">Traces by Operation</h2>
 


### PR DESCRIPTION
## Summary

Follow-up to **#229**, which merged the analysis document (`TRACES_ANALYSIS_2026-09-01.md`) together with its tier-1 and tier-2 fixes. This PR is rebased onto that and carries the remaining tiers.

**Tier 3 — stranded backend surface**
- The implemented-but-unreachable operation-level AI export is now a button in the operation drill-down, as the docs already claimed.
- **New "All Traces" page** (`traces/all`, first in the TRACES sidebar group). `GET /traces` and `GET /traces/timeline` were fully implemented and tested but served to nobody — the page that consumed them was removed in a refactor — so "which traces in this recording were slowest" had no answer that did not begin by picking an operation. The page adds a bucketed timeline over the recording, server-side name search / errors-only / duration-floor filters, ordering by `DURATION | START | SPAN_COUNT | ERROR_COUNT`, fifty-at-a-time paging, URL-mirrored filters, and rows that open the existing trace waterfall. `TracesPage`, `TraceListQuery` and `TraceSortField` join `TraceModels.ts`, with `getTraces` / `getTracesTimeline` on `ProfileTracesClient`.
  Its timeline reuses the shared `TimeSeriesChart` in the same pairing as its two sibling charts rather than a bespoke density strip — which is what the "must not disagree" comment in `TraceAttributeResults.vue` asks for.

**Tier 4 — correctness**
- `DERIVE_TRACE_EXCEPTIONS` uses the same window arithmetic as every other span-window reading (integer division, inclusive bound) — the float/exclusive form gave throws a window up to 1 µs wider than every other reading of the same span.
- New universal `NONE_EQ` attribute operator ("no span has this value") alongside the existential `NOT_EQ`, end-to-end: enum + grouped `HAVING … = 0` + hit-lookup exclusion (a negated match has no row to highlight) + frontend picker ("is never") + repository tests. `status != ERROR` matched nearly every trace before; `status is never ERROR` is now expressible.
- `TraceSpanRow.threadHash` serializes as 16-char hex like the notification and exception rows (was decimal — a latent cross-compare bug).

**Tier 5 — UX**
- Slowest Traces tab: Show More paging over the already-fetched rows (it fetched up to 1000 and silently drew 50).
- Attribute Values: clicking the active column flips sort direction, passed through a new `desc` client parameter — the endpoint already accepted it.
- Design tokens: both trace timeline charts share one palette; the stacktrace message color and the waterfall's literal radii are tokenized.

Docs and the report are updated to match: the tracing analysis page documents All Traces and its place in the sidebar, and the findings are marked fixed in `TRACES_ANALYSIS_2026-09-01.md`.

Still report-only: attribute-search expressiveness (AND-only, no in-place editing), the remaining smaller findings, and the §5 enhancement proposals — W3C `traceparent` interop, cross-profile trace stitching, trace/operation diffing, waterfall virtualization.

## Test plan

- Frontend: `vue-tsc` clean; 573 Vitest tests pass, re-run after the rebase. The nav spec resolves the new `/traces/all` route against the real router and pins the item count at 111. ESLint 0 errors, with warning counts on touched files unchanged from baseline.
- Backend (JDK 25): `JdbcTraceRepositoryTest`, `JdbcTraceAttributeRepositoryTest` (including 3 new `NONE_EQ` tests) and `TraceManagerImplTest` all pass — `NotificationAndExceptionDerivation` (19 tests) covers the unified window arithmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wig3unGUJFLGhYsCMj3MUV