### PR TITLE
Make MCP server on by default, configurable only via application property

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ The project supports two deployment modes: **jeffrey-microscope** (standalone) a
 - `pages-microscope` — Full-featured Vue 3 SPA frontend
 - `profiles/` — All profile analysis modules (see below)
 - REST resources: `/api/internal/workspaces/**`, `/api/internal/projects/**`, `/api/internal/profiles/{profileId}/**`
-- `core-microscope/.../mcp/` — both MCP endpoints. `ExternalMcpController` serves `POST /api/internal/mcp` to an **outside** client (installation-wide, `profileId` as a tool argument, read-only, off by default behind `jeffrey.microscope.mcp.enabled`); `McpStreamableHttpController` serves `/api/internal/mcp/claude-code` to the headless CLI backend Jeffrey spawns for itself (per-profile, provider-gated). They differ on scoping, gating and lifecycle — keep them separate rather than branching on which query parameters are present
+- `core-microscope/.../mcp/` — both MCP endpoints. `ExternalMcpController` serves `POST /api/internal/mcp` to an **outside** client (installation-wide, `profileId` as a tool argument, read-only, on by default and switched off only by the `jeffrey.microscope.mcp.enabled` application property, read at startup); `McpStreamableHttpController` serves `/api/internal/mcp/claude-code` to the headless CLI backend Jeffrey spawns for itself (per-profile, provider-gated). They differ on scoping, gating and lifecycle — keep them separate rather than branching on which query parameters are present
 
 **jeffrey-microscope/profiles/** (profile analysis, used only by jeffrey-microscope):
 - `profile-management` — Profile analysis features + REST resources (Flamegraph, Timeseries, GC, Threads, HeapDump, AI)

--- a/jeffrey-claude-plugin/README.md
+++ b/jeffrey-claude-plugin/README.md
@@ -11,11 +11,11 @@ Full documentation: [Microscope MCP](https://www.jeffrey-analyst.cafe/docs/micro
 
 ## Install
 
-Jeffrey's MCP server is **off by default**. Turn it on first:
+Jeffrey's MCP server is **on by default** — a running Jeffrey is already serving it.
+**Settings → Claude Code (MCP)** reports whether the endpoint is serving and shows the
+connection details for this installation.
 
-> **Settings → Claude Code (MCP) → enable**
-
-Then, from Claude Code:
+From Claude Code:
 
 ```
 /plugin marketplace add petrbouda/jeffrey

--- a/jeffrey-claude-plugin/skills/analyze-profile/SKILL.md
+++ b/jeffrey-claude-plugin/skills/analyze-profile/SKILL.md
@@ -70,8 +70,9 @@ document shows. If the repository is open alongside, read the real source before
 ## When something is missing
 
 - A tool answers `Profile … has no heap dump` → it is a JFR recording; use `jfr_`, `flamegraph_`, `traces_`.
-- Every call fails to connect, or the server 404s → the MCP server is off. In Jeffrey: **Settings →
-  Claude Code (MCP) → enable**. It is off by default.
+- Every call fails to connect → Jeffrey is not running at that address.
+- The server 404s → this Jeffrey was started with `jeffrey.microscope.mcp.enabled=false`. The server
+  is on by default; **Settings → Claude Code (MCP)** reports whether it is serving.
 - Jeffrey is not on `http://localhost:8080` → set `JEFFREY_MCP_URL` to the real
   `…/api/internal/mcp` endpoint before starting Claude Code.
 

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/configuration/McpConfiguration.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/configuration/McpConfiguration.java
@@ -18,6 +18,7 @@
 
 package cafe.jeffrey.microscope.core.configuration;
 
+import cafe.jeffrey.microscope.core.mcp.ExternalMcpProperties;
 import cafe.jeffrey.microscope.core.mcp.McpProfileContextCache;
 import cafe.jeffrey.microscope.core.mcp.McpToolsetAssembler;
 import cafe.jeffrey.microscope.core.mcp.tools.ProfilesMcpTools;
@@ -25,6 +26,7 @@ import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
 import cafe.jeffrey.microscope.persistence.api.MicroscopeCorePersistenceProvider;
 import cafe.jeffrey.profile.panel.JfrFlamegraphPanelProvider;
 import cafe.jeffrey.provider.profile.api.DatabaseManagerResolver;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -33,12 +35,22 @@ import java.time.Clock;
 /**
  * Wiring for the external MCP server — the endpoint an interactive Claude Code session connects to.
  * <p>
- * Registered unconditionally, like the rest of the AI wiring: whether the server answers is a question
- * the controller asks the settings on each request, so turning it on is a change of answer rather than
- * a change of wiring, and needs no restart.
+ * The server is on by default. Whether it answers at all is read once here, from an application
+ * property rather than from the live settings: exposing every profile to whatever can reach the address
+ * belongs with the bind address and the reverse proxy, decided when the installation is deployed, not
+ * with the preferences a reader edits in the UI.
  */
 @Configuration
 public class McpConfiguration {
+
+    /**
+     * @param enabled whether the endpoint serves, from {@code jeffrey.microscope.mcp.enabled}
+     */
+    @Bean
+    public ExternalMcpProperties externalMcpProperties(
+            @Value("${jeffrey.microscope.mcp.enabled:true}") boolean enabled) {
+        return new ExternalMcpProperties(enabled);
+    }
 
     /**
      * Holds each profile an MCP client is working on open between its questions, and lets go once the

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/ExternalMcpController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/ExternalMcpController.java
@@ -19,8 +19,6 @@
 package cafe.jeffrey.microscope.core.mcp;
 
 import cafe.jeffrey.profile.mcp.AbstractMcpStreamableHttpController;
-import cafe.jeffrey.shared.common.config.MicroscopeSettingKeys;
-import cafe.jeffrey.shared.common.config.SettingsStore;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -39,37 +37,32 @@ import tools.jackson.databind.JsonNode;
  * different needs, and folding the two together would mean branching on which query parameters happen
  * to be present.
  * <p>
- * Serving is opt-in through {@code jeffrey.microscope.mcp.enabled}, checked per request rather than at
- * wiring time so the toggle takes effect without a restart — the same reason the sibling controller
- * checks its provider per request. While it is off the endpoint answers 404: a disabled server should
+ * Serving is on by default and switched off only through the {@code jeffrey.microscope.mcp.enabled}
+ * application property, fixed at wiring time — unlike the sibling controller, whose provider gate is a
+ * live setting checked per request. While it is off the endpoint answers 404: a disabled server should
  * look like no server at all, not like one refusing to talk.
  * <p>
  * Every tool it exposes is read-only. There is no authentication yet, so the endpoint carries the same
- * trust assumption as the rest of {@code /api/internal/**}: reachable means trusted. That is why it is
- * off by default and why the documentation asks for a loopback bind, an SSH tunnel or a reverse proxy
- * in front of anything wider.
+ * trust assumption as the rest of {@code /api/internal/**}: reachable means trusted. That is why the
+ * documentation asks for a loopback bind, an SSH tunnel or a reverse proxy in front of anything wider.
  */
 @RestController
 @RequestMapping("/api/internal/mcp")
 public class ExternalMcpController extends AbstractMcpStreamableHttpController {
 
     private final McpToolsetAssembler assembler;
-    private final SettingsStore settingsStore;
+    private final ExternalMcpProperties properties;
 
-    public ExternalMcpController(McpToolsetAssembler assembler, SettingsStore settingsStore) {
+    public ExternalMcpController(McpToolsetAssembler assembler, ExternalMcpProperties properties) {
         this.assembler = assembler;
-        this.settingsStore = settingsStore;
+        this.properties = properties;
     }
 
     @PostMapping
     public ResponseEntity<JsonNode> handle(@RequestBody JsonNode request) {
-        if (!isEnabled()) {
+        if (!properties.enabled()) {
             return ResponseEntity.notFound().build();
         }
         return dispatch(request, assembler::toolset);
-    }
-
-    private boolean isEnabled() {
-        return settingsStore.getBoolean(MicroscopeSettingKeys.MCP_ENABLED, false);
     }
 }

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/ExternalMcpProperties.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/ExternalMcpProperties.java
@@ -1,0 +1,32 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.microscope.core.mcp;
+
+/**
+ * Static configuration of the external MCP server at {@code /api/internal/mcp}.
+ * <p>
+ * Read once from {@code jeffrey.microscope.mcp.enabled} at wiring time rather than from the live
+ * settings: the server is on by default, and whether an installation exposes it is a deployment
+ * decision made alongside the bind address and the reverse proxy, not a switch a reader flips from the
+ * Settings page. Turning it off is therefore an application property and takes a restart.
+ *
+ * @param enabled whether the endpoint answers at all; while off it responds {@code 404}
+ */
+public record ExternalMcpProperties(boolean enabled) {
+}

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/McpAccessController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/McpAccessController.java
@@ -18,8 +18,7 @@
 
 package cafe.jeffrey.microscope.core.web.controllers;
 
-import cafe.jeffrey.shared.common.config.MicroscopeSettingKeys;
-import cafe.jeffrey.shared.common.config.SettingsStore;
+import cafe.jeffrey.microscope.core.mcp.ExternalMcpProperties;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -56,10 +55,10 @@ public class McpAccessController {
               }
             }""";
 
-    private final SettingsStore settingsStore;
+    private final ExternalMcpProperties properties;
 
-    public McpAccessController(SettingsStore settingsStore) {
-        this.settingsStore = settingsStore;
+    public McpAccessController(ExternalMcpProperties properties) {
+        this.properties = properties;
     }
 
     @GetMapping("/status")
@@ -69,14 +68,14 @@ public class McpAccessController {
                 .toUriString();
 
         return new McpAccessStatus(
-                settingsStore.getBoolean(MicroscopeSettingKeys.MCP_ENABLED, false),
+                properties.enabled(),
                 url,
                 CLAUDE_MCP_ADD_TEMPLATE.formatted(url),
                 MCP_JSON_TEMPLATE.formatted(SERVER_NAME, url));
     }
 
     /**
-     * @param enabled              whether the endpoint currently answers
+     * @param enabled              whether the endpoint answers; off only via {@code jeffrey.microscope.mcp.enabled}
      * @param url                  the MCP endpoint, as reachable from where this request came
      * @param claudeMcpAddCommand  the one-liner that registers it with the Claude Code CLI
      * @param mcpJsonSnippet       the equivalent {@code .mcp.json} entry, for a project-scoped setup

--- a/jeffrey-microscope/core-microscope/src/main/resources/application.properties
+++ b/jeffrey-microscope/core-microscope/src/main/resources/application.properties
@@ -49,6 +49,11 @@ jeffrey.microscope.temp.dir=${jeffrey.microscope.home.dir}/temp
 # Version update check (set to false to disable GitHub release checking)
 # jeffrey.microscope.update-check.enabled=true
 
+# External MCP server at POST /api/internal/mcp, for a Claude Code session in your own repository.
+# On by default and read-only; it has no authentication of its own, so keep Jeffrey on localhost or
+# behind a tunnel/proxy. Set to false to make the endpoint answer 404 (takes a restart).
+# jeffrey.microscope.mcp.enabled=true
+
 # IDE integration is always available (shows onboarding until an IntelliJ window is linked).
 # Default mode is the first-party Jeffrey IntelliJ plugin. To use the JFR Profiler plugin instead:
 #s

--- a/jeffrey-microscope/core-microscope/src/main/resources/settings-mappings.conf
+++ b/jeffrey-microscope/core-microscope/src/main/resources/settings-mappings.conf
@@ -11,11 +11,6 @@ settings {
         mcp-url = "http://127.0.0.1:8080/api/internal/mcp/claude-code"
       }
     }
-    mcp {
-      jeffrey.microscope.mcp {
-        enabled = "false"
-      }
-    }
     logging {
       logging.level.cafe.jeffrey = "INFO"
     }

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/configuration/SettingsApplicationListenerTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/configuration/SettingsApplicationListenerTest.java
@@ -184,10 +184,10 @@ class SettingsApplicationListenerTest {
                     (SettingsPropertySource) environment.getPropertySources().get(SettingsPropertySource.NAME);
 
             assertTrue(source.containsProperty(MicroscopeSettingKeys.AI_PROVIDER));
-            assertTrue(source.containsProperty(MicroscopeSettingKeys.MCP_ENABLED));
+            assertTrue(source.containsProperty(MicroscopeSettingKeys.LOGGING_LEVEL));
             // Moves by one whenever a setting is declared — deliberately, since a key that never
             // reaches the property source reads to the rest of the app as "not configurable".
-            assertEquals(15, source.getPropertyNames().length);
+            assertEquals(14, source.getPropertyNames().length);
         }
     }
 

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/ExternalMcpControllerTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/ExternalMcpControllerTest.java
@@ -19,8 +19,6 @@
 package cafe.jeffrey.microscope.core.mcp;
 
 import cafe.jeffrey.profile.mcp.ReflectiveToolset;
-import cafe.jeffrey.shared.common.config.MicroscopeSettingKeys;
-import cafe.jeffrey.shared.common.config.SettingsStore;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,8 +27,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
-
-import java.util.Map;
 
 import static cafe.jeffrey.microscope.core.web.MockMvcSupport.mockMvcTesterFor;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -57,19 +53,15 @@ class ExternalMcpControllerTest {
     McpToolsetAssembler assembler;
 
     private MockMvcTester mvcWith(boolean enabled) {
-        SettingsStore settingsStore = new SettingsStore(
-                Map.of(MicroscopeSettingKeys.MCP_ENABLED, "false"),
-                Map.of(MicroscopeSettingKeys.MCP_ENABLED, String.valueOf(enabled)));
-        return mockMvcTesterFor(new ExternalMcpController(assembler, settingsStore));
+        return mockMvcTesterFor(new ExternalMcpController(assembler, new ExternalMcpProperties(enabled)));
     }
 
     @Nested
     class Disabled {
 
         /**
-         * A disabled server should look like no server at all, so a client that was pointed at a
-         * Jeffrey with the toggle off gets a clean "no such endpoint" rather than a refusal it might
-         * retry.
+         * A disabled server should look like no server at all, so a client pointed at a Jeffrey that
+         * turned the endpoint off gets a clean "no such endpoint" rather than a refusal it might retry.
          */
         @Test
         void answers404() {

--- a/jeffrey-microscope/pages-microscope/src/views/global/SettingsView.vue
+++ b/jeffrey-microscope/pages-microscope/src/views/global/SettingsView.vue
@@ -640,23 +640,23 @@
         <div class="settings-form-grid settings-form-grid-single">
           <div class="settings-form-group">
             <label class="settings-label">MCP Server</label>
-            <div class="form-check form-switch">
-              <input
-                id="mcpEnabledToggle"
-                class="form-check-input"
-                type="checkbox"
-                role="switch"
-                :checked="mcpEnabled"
-                @change="onMcpToggle(($event.target as HTMLInputElement).checked)"
+            <div class="mcp-state">
+              <Badge
+                :value="mcpEnabled ? 'Serving' : 'Disabled'"
+                :variant="mcpEnabled ? 'success' : 'secondary'"
+                :icon="mcpEnabled ? 'bi bi-check-circle-fill' : 'bi bi-slash-circle'"
+                size="s"
               />
-              <label class="form-check-label" for="mcpEnabledToggle">
-                {{ mcpEnabled ? 'Enabled' : 'Disabled' }}
-              </label>
             </div>
             <div class="settings-hint">
               Lets an interactive Claude Code session in your own repository read this Jeffrey —
               list the analysed profiles, query their DuckDB tables, and pull flamegraph, trace and
               heap dump exports. Every tool is read-only.
+            </div>
+            <div v-if="!mcpEnabled" class="settings-hint">
+              Serving is on unless the deployment turns it off. This one sets
+              <code>jeffrey.microscope.mcp.enabled=false</code>, so the endpoint answers
+              <code>404</code>. Remove that property and restart Jeffrey to serve again.
             </div>
           </div>
         </div>
@@ -871,8 +871,10 @@ const previewSingleLine = ref<HTMLCanvasElement | null>(null);
 const previewTwoLine = ref<HTMLCanvasElement | null>(null);
 
 const aiToggle = ref(false);
-const mcpEnabled = ref(false);
 const mcpStatus = ref<McpAccessStatus | null>(null);
+// Whether the endpoint serves is the server's answer, not a stored preference: it comes from an
+// application property fixed at startup, so the page reports it rather than offering to change it.
+const mcpEnabled = computed(() => mcpStatus.value?.enabled === true);
 const aiEnabled = computed(() => aiToggle.value);
 
 const isOllama = computed(() => settings.get('jeffrey.microscope.ai.provider') === 'ollama');
@@ -1077,10 +1079,7 @@ onMounted(async () => {
     }
 
     aiToggle.value = settings.get('jeffrey.microscope.ai.provider') !== 'none';
-    mcpEnabled.value = settings.get('jeffrey.microscope.mcp.enabled') === 'true';
-    if (mcpEnabled.value) {
-      await loadMcpStatus();
-    }
+    await loadMcpStatus();
     frameTextMode.value =
       settings.get('jeffrey.microscope.visualization.flamegraph.frame-text-mode') || 'single-line';
 
@@ -1305,29 +1304,6 @@ async function loadMcpStatus() {
   } catch (e) {
     console.error('Failed to load MCP status', e);
     mcpStatus.value = null;
-  }
-}
-
-/**
- * Saved immediately rather than behind a Save button: it is one switch, and the value it writes is
- * the whole of what the tab configures.
- */
-async function onMcpToggle(enabled: boolean) {
-  mcpEnabled.value = enabled;
-  setSetting('jeffrey.microscope.mcp.enabled', String(enabled));
-  await save(
-    [
-      {
-        category: 'mcp',
-        name: 'jeffrey.microscope.mcp.enabled',
-        value: String(enabled),
-        secret: false
-      }
-    ],
-    () => ToastService.success('Settings', enabled ? 'MCP server enabled' : 'MCP server disabled')
-  );
-  if (enabled) {
-    await loadMcpStatus();
   }
 }
 
@@ -1876,6 +1852,10 @@ function announceAiChange(message: string) {
 }
 
 /* Claude Code (MCP) tab */
+.mcp-state {
+  margin-bottom: 8px;
+}
+
 .mcp-snippet {
   display: flex;
   align-items: flex-start;

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpEnablingPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpEnablingPage.vue
@@ -27,8 +27,9 @@ import { useDocHeadings } from '@/composables/useDocHeadings';
 const { setHeadings } = useDocHeadings();
 
 const headings = [
-  { id: 'turn-it-on', text: 'Turn It On', level: 2 },
+  { id: 'it-is-already-on', text: 'It Is Already On', level: 2 },
   { id: 'the-endpoint-url', text: 'The Endpoint URL', level: 2 },
+  { id: 'turning-it-off', text: 'Turning It Off', level: 2 },
   { id: 'while-it-is-off', text: 'While It Is Off', level: 2 },
   { id: 'what-a-session-holds-open', text: 'What a Session Holds Open', level: 2 },
   { id: 'security', text: 'Security', level: 2 }
@@ -38,7 +39,7 @@ onMounted(() => {
   setHeadings(headings);
 });
 
-const propertyToggle = `jeffrey.microscope.mcp.enabled=true`;
+const propertyToggle = `jeffrey.microscope.mcp.enabled=false`;
 
 const defaultEndpoint = `http://localhost:8080/api/internal/mcp`;
 
@@ -59,15 +60,10 @@ const disabledProbe = `curl -s -o /dev/null -w '%{http_code}\\n' \\
     />
 
     <div class="docs-content">
-      <p>The MCP server is <strong>off by default</strong>. That is deliberate: turning it on hands any client that can reach the address every profile in the installation, and there is no authentication in front of it yet. It should be a decision, not a default.</p>
+      <p>The MCP server is <strong>on by default</strong>. A fresh Jeffrey already answers on the endpoint below, so connecting a client is the only step &mdash; see <router-link to="/docs/microscope-mcp/plugin">Claude Code Plugin</router-link>.</p>
 
-      <h2 id="turn-it-on">Turn It On</h2>
-      <p>In the Jeffrey UI, open <strong>Settings &rarr; Claude Code (MCP)</strong> and enable it. The setting is hot-reloaded and checked per request, so it takes effect immediately &mdash; no restart, and turning it back off closes the door on the next call rather than at the next boot.</p>
-
-      <p>The same switch is an ordinary Jeffrey setting, so it can be set up front:</p>
-      <DocsCodeBlock :code="propertyToggle" language="properties" />
-
-      <p>See <router-link to="/docs/microscope/configuration/application-properties">Application Properties</router-link> for where such properties belong.</p>
+      <h2 id="it-is-already-on">It Is Already On</h2>
+      <p>Open <strong>Settings &rarr; Claude Code (MCP)</strong> to confirm it and to copy the connection details. The tab reports whether the endpoint is serving; it does not offer a switch, because whether Jeffrey exposes the endpoint at all belongs with the bind address and the reverse proxy rather than with the preferences a reader edits in the UI.</p>
 
       <h2 id="the-endpoint-url">The Endpoint URL</h2>
       <p>One endpoint serves the whole installation:</p>
@@ -79,10 +75,16 @@ const disabledProbe = `curl -s -o /dev/null -w '%{http_code}\\n' \\
         The Settings tab shows the endpoint <em>as your browser just reached it</em>, derived from the request rather than hardcoded. Behind a container, a reverse proxy or a non-default port, <code>localhost:8080</code> is wrong &mdash; and wrong in a way you would only discover after pasting the command. Copy the one the tab shows.
       </DocsCallout>
 
+      <h2 id="turning-it-off">Turning It Off</h2>
+      <p>An installation that should not expose the endpoint switches it off with an application property:</p>
+      <DocsCodeBlock :code="propertyToggle" language="properties" />
+
+      <p>It is read once at startup, so the change takes a restart. See <router-link to="/docs/microscope/configuration/application-properties">Application Properties</router-link> for where such properties belong.</p>
+
       <h2 id="while-it-is-off">While It Is Off</h2>
       <p>A disabled server answers <code>404</code>. It does not answer a JSON-RPC error explaining that it is disabled, because a disabled server should look like no server at all rather than like one refusing to talk &mdash; an unauthenticated probe learns nothing about whether this Jeffrey has profiles worth asking for.</p>
 
-      <p>The practical consequence: if a client reports that the server is unreachable or every tool call fails, check the toggle first.</p>
+      <p>The practical consequence: if a client reports that the server is unreachable or every tool call fails, check whether this installation set the property above.</p>
       <DocsCodeBlock :code="disabledProbe" language="bash" />
 
       <h2 id="what-a-session-holds-open">What a Session Holds Open</h2>
@@ -95,9 +97,9 @@ const disabledProbe = `curl -s -o /dev/null -w '%{http_code}\\n' \\
         The MCP endpoint carries the same trust assumption as the rest of Jeffrey&rsquo;s API: anyone who can reach the address can read every profile in that installation &mdash; the recordings, their stack traces, their SQL statements, and the contents of any heap dump you have indexed.
       </DocsCallout>
 
-      <p>Before enabling it, decide what can reach the address:</p>
+      <p>So decide what can reach the address:</p>
       <ul>
-        <li><strong>Bound to loopback.</strong> The default, and enough for a Jeffrey and a Claude Code session on the same machine.</li>
+        <li><strong>Bound to loopback.</strong> The default, and enough for a Jeffrey and a Claude Code session on the same machine. This is what makes an on-by-default endpoint safe: it is reachable from that machine and nowhere else.</li>
         <li><strong>Through an SSH tunnel.</strong> For a Jeffrey on a remote host or in a container, forward the port rather than publishing it:
           <DocsCodeBlock :code="tunnel" language="bash" />
           The client then points at <code>localhost</code> and the endpoint is never exposed.

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpOtherClientsPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpOtherClientsPage.vue
@@ -193,7 +193,7 @@ const protocolError = `{
         <li><code>-32603</code> &mdash; an internal failure outside the tool call</li>
       </ul>
 
-      <p>An HTTP <code>404</code> on the endpoint itself is a third thing again: it means the server is disabled, not that the request was wrong. See <router-link to="/docs/microscope-mcp/enabling">Enabling the Server</router-link>.</p>
+      <p>An HTTP <code>404</code> on the endpoint itself is a third thing again: it means this installation switched the server off, not that the request was wrong. See <router-link to="/docs/microscope-mcp/enabling">Enabling the Server</router-link>.</p>
     </div>
 
     <DocsNavFooter />

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpOverviewPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpOverviewPage.vue
@@ -92,7 +92,7 @@ onMounted(() => {
           <tr>
             <td>Configuration</td>
             <td>A provider and an API key or a local subscription</td>
-            <td>One toggle; the client brings its own model</td>
+            <td>Nothing to configure; the client brings its own model</td>
           </tr>
         </tbody>
       </table>
@@ -145,13 +145,13 @@ onMounted(() => {
 
       <p>The <router-link to="/docs/microscope-mcp/tools">Tool Reference</router-link> lists every one of them with its arguments.</p>
 
-      <DocsCallout type="warning" title="Read this before you turn it on">
-        The endpoint has no authentication yet &mdash; anyone who can reach the address can read every profile in that installation. It is off by default for exactly that reason. <router-link to="/docs/microscope-mcp/enabling">Enabling the Server</router-link> covers the toggle and how to expose it safely.
+      <DocsCallout type="warning" title="Know what it exposes">
+        The endpoint is on by default and has no authentication yet &mdash; anyone who can reach the address can read every profile in that installation. On a Jeffrey bound to loopback, that is only the machine it runs on. <router-link to="/docs/microscope-mcp/enabling">Enabling the Server</router-link> covers how to expose it safely, and how to switch it off.
       </DocsCallout>
 
       <h2 id="where-to-go-next">Where to Go Next</h2>
       <ul>
-        <li><router-link to="/docs/microscope-mcp/enabling">Enabling the Server</router-link> &mdash; the toggle, the endpoint URL, and the security posture</li>
+        <li><router-link to="/docs/microscope-mcp/enabling">Enabling the Server</router-link> &mdash; the endpoint URL, the security posture, and how to switch it off</li>
         <li><router-link to="/docs/microscope-mcp/plugin">Claude Code Plugin</router-link> &mdash; one install instead of a hand-written command per machine</li>
         <li><router-link to="/docs/microscope-mcp/recipes">Recipes</router-link> &mdash; worked sessions, from &ldquo;where does the time go&rdquo; to a leak hunt</li>
         <li><router-link to="/docs/microscope-mcp/other-clients">Other Clients</router-link> &mdash; connecting without the plugin, and the wire protocol</li>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpPluginPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpPluginPage.vue
@@ -68,8 +68,8 @@ const removal = `/plugin uninstall microscope@jeffrey`;
     <div class="docs-content">
       <p>The <strong>Microscope plugin</strong> packages the MCP server together with a few skills, so connecting is one install rather than a hand-written command per machine and per repository. It is a convenience over the plain server &mdash; everything it does can be done by hand, as <router-link to="/docs/microscope-mcp/other-clients">Other Clients</router-link> describes.</p>
 
-      <DocsCallout type="warning" title="Enable the server first">
-        The plugin will install and load whether or not Jeffrey is serving, and then every tool call fails. Turn the server on in <strong>Settings &rarr; Claude Code (MCP)</strong> &mdash; see <router-link to="/docs/microscope-mcp/enabling">Enabling the Server</router-link>.
+      <DocsCallout type="info" title="Jeffrey has to be running">
+        The plugin installs and loads whether or not Jeffrey is serving, and then every tool call fails. The server is on by default, so a running Jeffrey is usually all it takes &mdash; <strong>Settings &rarr; Claude Code (MCP)</strong> reports whether the endpoint is serving. See <router-link to="/docs/microscope-mcp/enabling">Enabling the Server</router-link>.
       </DocsCallout>
 
       <h2 id="install-it">Install It</h2>
@@ -118,7 +118,7 @@ const removal = `/plugin uninstall microscope@jeffrey`;
       <p>To remove it:</p>
       <DocsCodeBlock :code="removal" language="bash" />
 
-      <p>Uninstalling takes the skills with it. It does not change anything inside Jeffrey &mdash; the MCP server stays enabled until you turn it off in Settings.</p>
+      <p>Uninstalling takes the skills with it. It does not change anything inside Jeffrey &mdash; the MCP server keeps serving.</p>
     </div>
 
     <DocsNavFooter />

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpSkillsPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpSkillsPage.vue
@@ -72,7 +72,7 @@ SELECT event_type, COUNT(*) FROM events_raw GROUP BY event_type`;
       <h2 id="analyze-profile">analyze-profile</h2>
       <p><em>Orientation.</em> Loaded whenever the question is &ldquo;why is this slow&rdquo;, &ldquo;where does the time go&rdquo;, &ldquo;what is allocating&rdquo;, &ldquo;what is holding memory&rdquo;, or when a Jeffrey profile, a JFR recording or a heap dump is mentioned.</p>
 
-      <p>It carries the entry sequence &mdash; <code>profiles_list</code>, then <code>profiles_features</code>, then the family that matches the question &mdash; a map of the five families to the questions each answers, the rule that every scoped tool takes a <code>profileId</code>, which flamegraph to pick for CPU versus allocation versus lock contention versus wall-clock, the order to work a latency question in traces, and what a failure means (a <code>404</code> is the server toggle, not a bug).</p>
+      <p>It carries the entry sequence &mdash; <code>profiles_list</code>, then <code>profiles_features</code>, then the family that matches the question &mdash; a map of the five families to the questions each answers, the rule that every scoped tool takes a <code>profileId</code>, which flamegraph to pick for CPU versus allocation versus lock contention versus wall-clock, the order to work a latency question in traces, and what a failure means (a <code>404</code> means the server was switched off, not a bug).</p>
 
       <p>It also tells the model to <strong>ground its claims</strong>: the exports contain call paths and numbers, not source locations, so file and line numbers must be read from the repository rather than inferred from a profile.</p>
 

--- a/jeffrey-pages/src/views/docs/microscope/configuration/MicroscopeConfigApplicationPropertiesPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/configuration/MicroscopeConfigApplicationPropertiesPage.vue
@@ -31,6 +31,7 @@ const headings = [
   { id: 'uploads', text: 'File Uploads', level: 2 },
   { id: 'core-directories', text: 'Core Directories', level: 2 },
   { id: 'update-check', text: 'Update Check', level: 2 },
+  { id: 'mcp-server', text: 'MCP Server', level: 2 },
   { id: 'ai-assistant', text: 'AI Assistant', level: 2 },
   { id: 'advisor', text: 'Advisor', level: 2 }
 ];
@@ -149,6 +150,29 @@ onMounted(() => {
             <td>
               Periodically checks GitHub releases for new Microscope versions.
               Set to <code>false</code> in air-gapped environments.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2 id="mcp-server">MCP Server</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Default</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>jeffrey.microscope.mcp.enabled</code></td>
+            <td><code>true</code></td>
+            <td>
+              Serves the read-only MCP endpoint at <code>/api/internal/mcp</code>, which an external
+              Claude Code session reads profiles through. Set to <code>false</code> to make it answer
+              <code>404</code>. Read at startup, so a change takes a restart. See
+              <router-link to="/docs/microscope-mcp/enabling">Enabling the Server</router-link>.
             </td>
           </tr>
         </tbody>

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/config/MicroscopeSettingKeys.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/config/MicroscopeSettingKeys.java
@@ -40,13 +40,6 @@ public final class MicroscopeSettingKeys {
     public static final String AI_MCP_URL = "jeffrey.microscope.ai.mcp-url";
     public static final String AI_API_KEY = "jeffrey.microscope.ai.api-key";
 
-    /**
-     * Whether the MCP server at {@code /api/internal/mcp} answers at all. Off by default: it hands an
-     * external client every profile in the installation, so it is opened deliberately rather than by
-     * upgrading.
-     */
-    public static final String MCP_ENABLED = "jeffrey.microscope.mcp.enabled";
-
     public static final String LOGGING_LEVEL = "logging.level.cafe.jeffrey";
 
     public static final String FLAMEGRAPH_MIN_FRAME_THRESHOLD_PCT =
@@ -73,7 +66,6 @@ public final class MicroscopeSettingKeys {
             Map.entry(AI_TIMEOUT_SECONDS, SettingType.POSITIVE_INT),
             Map.entry(AI_MCP_URL, SettingType.STRING),
             Map.entry(AI_API_KEY, SettingType.STRING),
-            Map.entry(MCP_ENABLED, SettingType.BOOLEAN),
             Map.entry(LOGGING_LEVEL, SettingType.LOG_LEVEL),
             Map.entry(FLAMEGRAPH_MIN_FRAME_THRESHOLD_PCT, SettingType.PERCENTAGE),
             Map.entry(FLAMEGRAPH_FRAME_TEXT_MODE, SettingType.FRAME_TEXT_MODE),


### PR DESCRIPTION
## Summary
Changes the MCP server from an opt-in feature (off by default, toggled via Settings UI) to an opt-out deployment decision (on by default, disabled only via application property at startup). This reflects the reality that exposing profiles to external clients is a deployment-level security decision, not a user preference.

## Key Changes

**Backend (Java)**
- Created `ExternalMcpProperties` record to hold the static `enabled` flag read once from `jeffrey.microscope.mcp.enabled` application property (defaults to `true`)
- Updated `ExternalMcpController` to check `ExternalMcpProperties.enabled()` instead of querying live settings per request
- Updated `McpAccessController` to report the static property value instead of live settings
- Removed `MCP_ENABLED` from `MicroscopeSettingKeys` — no longer a live setting
- Updated `McpConfiguration` to wire `ExternalMcpProperties` as a bean
- Updated tests to use `ExternalMcpProperties` directly instead of mocking `SettingsStore`

**Frontend (Vue)**
- Removed the toggle switch from Settings → Claude Code (MCP) tab
- Replaced it with a read-only `Badge` showing "Serving" (green) or "Disabled" (gray)
- Changed `mcpEnabled` from a `ref` to a `computed` property derived from `mcpStatus.value?.enabled`
- Removed `onMcpToggle()` function entirely
- Added explanatory hint text when the server is disabled, explaining the property to set
- Removed the toggle from the component's initialization logic

**Documentation**
- Updated `McpEnablingPage.vue`: changed heading from "Turn It On" to "It Is Already On", reordered sections to explain the default-on behavior first
- Updated property documentation to show `jeffrey.microscope.mcp.enabled=false` as the way to disable (instead of `=true` to enable)
- Updated `McpOverviewPage.vue` callout: changed from warning about opt-in to warning about what it exposes
- Updated `McpPluginPage.vue`: changed from requiring manual enable to noting the server is on by default
- Updated `MicroscopeConfigApplicationPropertiesPage.vue`: added MCP Server section documenting the property with default `true`
- Updated `application.properties` and `settings-mappings.conf` to reflect the new default
- Updated skill documentation and README to reflect the new default behavior

## Implementation Details

- The property is read **once at startup** via Spring's `@Value` injection, not per-request like the AI provider setting. This is intentional: whether to expose every profile in an installation belongs with infrastructure decisions (bind address, reverse proxy), not with runtime preferences.
- While disabled, the endpoint returns HTTP 404 (not a JSON-RPC error), so an unauthenticated probe cannot determine whether the server exists or is merely refusing to talk.
- The Settings UI now reports the actual state but offers no way to change it — users must restart with the property set to toggle it.
- All existing deployments that had the setting enabled will continue to work (property defaults to `true`); those that had it disabled must explicitly set `jeffrey.microscope.mcp.enabled=false`.

https://claude.ai/code/session_01VMVfN2jd2RNaYuuTwypwmN