### PR TITLE
Change default Microscope port from 8080 to 8585

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,12 @@
     {
       "name": "microscope",
       "source": "./jeffrey-claude-plugin",
-      "description": "Read JVM profiles from a running Jeffrey Microscope: list analysed recordings, query their DuckDB tables, and pull flamegraph, trace and heap-dump exports."
+      "version": "1.0.0",
+      "description": "Read JVM profiles from a running Jeffrey Microscope: list analysed recordings, query their DuckDB tables, and pull flamegraph, trace and heap-dump exports.",
+      "author": {
+        "name": "Petr Bouda",
+        "url": "https://www.jeffrey-analyst.cafe/"
+      }
     }
   ]
 }

--- a/.github/workflows/validate-claude-plugin.yml
+++ b/.github/workflows/validate-claude-plugin.yml
@@ -1,0 +1,57 @@
+# The repository root doubles as a Claude Code plugin marketplace: users run
+# `/plugin marketplace add petrbouda/jeffrey` and Claude Code reads
+# .claude-plugin/marketplace.json straight off the default branch. There is no release
+# step in between, so a malformed manifest on master breaks every install and update
+# the moment it lands. This job is that missing gate - it runs the same validator the
+# docs tell plugin authors to run before publishing.
+name: Validate Claude Code Plugin
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.claude-plugin/**'
+      - 'jeffrey-claude-plugin/**'
+      - '.github/workflows/validate-claude-plugin.yml'
+  pull_request:
+    paths:
+      - '.claude-plugin/**'
+      - 'jeffrey-claude-plugin/**'
+      - '.github/workflows/validate-claude-plugin.yml'
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+
+    - name: Install Claude Code CLI
+      run: npm install -g @anthropic-ai/claude-code
+
+    # Checks JSON syntax, duplicate plugin names, source path traversal, and that the
+    # version on the marketplace entry matches the one in the plugin's own manifest.
+    - name: Validate the marketplace manifest
+      run: claude plugin validate .
+
+    # --strict turns warnings (unrecognised fields, typos in field names) into failures.
+    - name: Validate the microscope plugin
+      run: claude plugin validate ./jeffrey-claude-plugin --strict
+
+    # The validator does not look inside skills; a skill missing its front matter loads
+    # as an unnamed no-op, so check that each one is at least present and non-empty.
+    - name: Check every skill carries front matter
+      run: |
+        for skill in jeffrey-claude-plugin/skills/*/SKILL.md; do
+          if ! head -n 1 "$skill" | grep -q '^---$'; then
+            echo "::error file=$skill::SKILL.md does not start with YAML front matter"
+            exit 1
+          fi
+          echo "ok: $skill"
+        done

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ curl -L -o microscope.jar \
 java -jar microscope.jar
 ```
 
-Then open **http://localhost:8080**, go to **Recordings → upload a JFR or Heap dump → Analyze**,
+Then open **http://localhost:8585**, go to **Recordings → upload a JFR or Heap dump → Analyze**,
 and Jeffrey builds a profile you can explore. That's it. 🎉
 
 ## 🧩 The Jeffrey ecosystem

--- a/build/build-microscope-examples-jib/pom.xml
+++ b/build/build-microscope-examples-jib/pom.xml
@@ -70,7 +70,7 @@
                     <container>
                         <mainClass>${mainClass}</mainClass>
                         <ports>
-                            <port>8080</port>
+                            <port>8585</port>
                         </ports>
                         <!--
                           Same default ENTRYPOINT arg as the previous Dockerfile-microscope-examples:

--- a/build/build-microscope-jib/pom.xml
+++ b/build/build-microscope-jib/pom.xml
@@ -71,7 +71,7 @@
                     <container>
                         <mainClass>${mainClass}</mainClass>
                         <ports>
-                            <port>8080</port>
+                            <port>8585</port>
                         </ports>
                     </container>
                 </configuration>

--- a/jeffrey-claude-plugin/.claude-plugin/plugin.json
+++ b/jeffrey-claude-plugin/.claude-plugin/plugin.json
@@ -10,10 +10,18 @@
   "repository": "https://github.com/petrbouda/jeffrey",
   "license": "AGPL-3.0",
   "keywords": ["jfr", "jvm", "profiling", "flamegraph", "heap-dump", "performance"],
+  "userConfig": {
+    "endpoint_url": {
+      "type": "string",
+      "title": "Jeffrey MCP endpoint",
+      "description": "URL of the Microscope MCP endpoint. Keep the default for a Jeffrey on its usual port; change it for another port, a container or an SSH tunnel. Settings → Claude Code (MCP) shows the exact URL for your installation.",
+      "default": "http://localhost:8080/api/internal/mcp"
+    }
+  },
   "mcpServers": {
     "jeffrey": {
       "type": "http",
-      "url": "${JEFFREY_MCP_URL:-http://localhost:8080/api/internal/mcp}"
+      "url": "${user_config.endpoint_url}"
     }
   }
 }

--- a/jeffrey-claude-plugin/.claude-plugin/plugin.json
+++ b/jeffrey-claude-plugin/.claude-plugin/plugin.json
@@ -15,7 +15,7 @@
       "type": "string",
       "title": "Jeffrey MCP endpoint",
       "description": "URL of the Microscope MCP endpoint. Keep the default for a Jeffrey on its usual port; change it for another port, a container or an SSH tunnel. Settings → Claude Code (MCP) shows the exact URL for your installation.",
-      "default": "http://localhost:8080/api/internal/mcp"
+      "default": "http://localhost:8585/api/internal/mcp"
     }
   },
   "mcpServers": {

--- a/jeffrey-claude-plugin/README.md
+++ b/jeffrey-claude-plugin/README.md
@@ -30,7 +30,7 @@ claude --plugin-dir ./jeffrey-claude-plugin
 
 ## Pointing it at your Jeffrey
 
-The plugin ships with the endpoint set to `http://localhost:8080/api/internal/mcp`. Anywhere else — a
+The plugin ships with the endpoint set to `http://localhost:8585/api/internal/mcp`. Anywhere else — a
 different port, a container, an SSH tunnel — change it in the plugin's own configuration; Claude Code
 offers the field when you enable the plugin, and `/plugin` reopens it afterwards:
 

--- a/jeffrey-claude-plugin/README.md
+++ b/jeffrey-claude-plugin/README.md
@@ -30,14 +30,17 @@ claude --plugin-dir ./jeffrey-claude-plugin
 
 ## Pointing it at your Jeffrey
 
-The plugin defaults to `http://localhost:8080/api/internal/mcp`. Anywhere else — a different port, a
-container, an SSH tunnel — set the endpoint before starting Claude Code:
+The plugin ships with the endpoint set to `http://localhost:8080/api/internal/mcp`. Anywhere else — a
+different port, a container, an SSH tunnel — change it in the plugin's own configuration; Claude Code
+offers the field when you enable the plugin, and `/plugin` reopens it afterwards:
 
-```bash
-export JEFFREY_MCP_URL="http://localhost:9000/api/internal/mcp"
+```
+Jeffrey MCP endpoint: http://localhost:9000/api/internal/mcp
 ```
 
-The Settings tab shows the exact URL for your installation.
+The setting lives in `~/.claude/settings.json`, so one machine can point at a tunnelled staging
+Jeffrey while another stays on localhost. The Settings tab in Jeffrey shows the exact URL for your
+installation.
 
 ## What you get
 
@@ -87,4 +90,4 @@ network.
 
 ## Licence
 
-AGPL-3.0, as the rest of Jeffrey. See [LICENSE](../LICENSE).
+AGPL-3.0, as the rest of Jeffrey. See [LICENSE](https://github.com/petrbouda/jeffrey/blob/master/LICENSE).

--- a/jeffrey-claude-plugin/skills/analyze-profile/SKILL.md
+++ b/jeffrey-claude-plugin/skills/analyze-profile/SKILL.md
@@ -73,7 +73,8 @@ document shows. If the repository is open alongside, read the real source before
 - Every call fails to connect → Jeffrey is not running at that address.
 - The server 404s → this Jeffrey was started with `jeffrey.microscope.mcp.enabled=false`. The server
   is on by default; **Settings → Claude Code (MCP)** reports whether it is serving.
-- Jeffrey is not on `http://localhost:8080` → set `JEFFREY_MCP_URL` to the real
-  `…/api/internal/mcp` endpoint before starting Claude Code.
+- Jeffrey is not on `http://localhost:8080` → point the plugin at the real
+  `…/api/internal/mcp` endpoint: run `/plugin`, open the `microscope` plugin's configuration
+  and set **Jeffrey MCP endpoint**.
 
 For raw SQL against a profile or a heap dump, see the `jfr-sql` and `heap-sql` skills.

--- a/jeffrey-claude-plugin/skills/analyze-profile/SKILL.md
+++ b/jeffrey-claude-plugin/skills/analyze-profile/SKILL.md
@@ -73,7 +73,7 @@ document shows. If the repository is open alongside, read the real source before
 - Every call fails to connect → Jeffrey is not running at that address.
 - The server 404s → this Jeffrey was started with `jeffrey.microscope.mcp.enabled=false`. The server
   is on by default; **Settings → Claude Code (MCP)** reports whether it is serving.
-- Jeffrey is not on `http://localhost:8080` → point the plugin at the real
+- Jeffrey is not on `http://localhost:8585` → point the plugin at the real
   `…/api/internal/mcp` endpoint: run `/plugin`, open the `microscope` plugin's configuration
   and set **Jeffrey MCP endpoint**.
 

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/McpAccessController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/McpAccessController.java
@@ -29,7 +29,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
  * command to connect to it.
  * <p>
  * The URL is derived from the request rather than configured, because the address that reaches this
- * Jeffrey is the one the reader's browser just used — a hardcoded {@code localhost:8080} is wrong for
+ * Jeffrey is the one the reader's browser just used — a hardcoded {@code localhost:8585} is wrong for
  * every container, reverse proxy and non-default port, and it is wrong in a way the reader only finds
  * out about after pasting the command.
  * <p>

--- a/jeffrey-microscope/core-microscope/src/main/resources/application.properties
+++ b/jeffrey-microscope/core-microscope/src/main/resources/application.properties
@@ -17,7 +17,10 @@
 #
 
 # Server
-# server.port=8080
+# 8585 rather than Spring Boot's 8080: Microscope is a tool you leave running beside the
+# application you are profiling, and that application is very often the one already holding
+# 8080. Overridable as any other Spring property.
+server.port=8585
 
 # Serve HTTP requests on virtual threads (Tomcat + Spring task executors). Requires JDK 21+.
 # Note: under async-profiler, a long request can unmount/remount across carrier threads, which

--- a/jeffrey-microscope/core-microscope/src/main/resources/settings-mappings.conf
+++ b/jeffrey-microscope/core-microscope/src/main/resources/settings-mappings.conf
@@ -8,7 +8,7 @@ settings {
         base-url = "http://localhost:11434"
         cli-path = "claude"
         timeout-seconds = "600"
-        mcp-url = "http://127.0.0.1:8080/api/internal/mcp/claude-code"
+        mcp-url = "http://127.0.0.1:8585/api/internal/mcp/claude-code"
       }
     }
     logging {

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/configuration/AiWiringContextTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/configuration/AiWiringContextTest.java
@@ -70,7 +70,7 @@ class AiWiringContextTest {
             MicroscopeSettingKeys.AI_BASE_URL, "http://localhost:11434",
             MicroscopeSettingKeys.AI_CLI_PATH, "claude",
             MicroscopeSettingKeys.AI_TIMEOUT_SECONDS, "120",
-            MicroscopeSettingKeys.AI_MCP_URL, "http://127.0.0.1:8080/api/internal/mcp/claude-code");
+            MicroscopeSettingKeys.AI_MCP_URL, "http://127.0.0.1:8585/api/internal/mcp/claude-code");
 
     /**
      * The OpenAI SDK infers which service to talk to from the model name, so each provider gets a name

--- a/jeffrey-microscope/pages-microscope/vite.config.ts
+++ b/jeffrey-microscope/pages-microscope/vite.config.ts
@@ -57,7 +57,7 @@ export default defineConfig({
       allow: ['../..']
     },
     proxy: {
-      '/api': 'http://localhost:8080'
+      '/api': 'http://localhost:8585'
     }
   },
   build: {

--- a/jeffrey-microscope/profiles/ai-config/src/main/java/cafe/jeffrey/profile/ai/chat/McpToolsetFactory.java
+++ b/jeffrey-microscope/profiles/ai-config/src/main/java/cafe/jeffrey/profile/ai/chat/McpToolsetFactory.java
@@ -36,7 +36,7 @@ public final class McpToolsetFactory {
     private static final String TOOLSET_HEAP = "heap";
     private static final String TOOLSET_ADVISOR_SOURCE = "advisor-source";
 
-    private static final String DEFAULT_BASE_URL = "http://127.0.0.1:8080/api/internal/mcp/claude-code";
+    private static final String DEFAULT_BASE_URL = "http://127.0.0.1:8585/api/internal/mcp/claude-code";
 
     private final SettingsStore settingsStore;
     private final List<String> allowedTools;

--- a/jeffrey-pages/articles/01-getting-started-with-jeffrey.md
+++ b/jeffrey-pages/articles/01-getting-started-with-jeffrey.md
@@ -52,7 +52,7 @@ Jeffrey is a self-hosted analysis tool — no cloud services, no account signup,
 docker run -it --network host petrbouda/microscope
 ```
 
-Open [http://localhost:8080](http://localhost:8080) in your browser. That's it — Jeffrey is ready to analyze your recordings.
+Open [http://localhost:8585](http://localhost:8585) in your browser. That's it — Jeffrey is ready to analyze your recordings.
 
 If you want to explore Jeffrey with pre-loaded example data first (recommended for your first time), use the examples image instead:
 
@@ -156,4 +156,4 @@ You can find the source code at [github.com/petrbouda/jeffrey](https://github.co
 docker run -it --network host petrbouda/microscope-examples
 ```
 
-Open [http://localhost:8080](http://localhost:8080), explore the pre-loaded examples, and see what your own recordings reveal.
+Open [http://localhost:8585](http://localhost:8585), explore the pre-loaded examples, and see what your own recordings reveal.

--- a/jeffrey-pages/articles/02-reading-flamegraphs-like-a-pro.md
+++ b/jeffrey-pages/articles/02-reading-flamegraphs-like-a-pro.md
@@ -158,4 +158,4 @@ You can find the source code at [github.com/petrbouda/jeffrey](https://github.co
 docker run -it --network host petrbouda/microscope-examples
 ```
 
-Open [http://localhost:8080](http://localhost:8080) and explore the pre-loaded flamegraph examples hands-on.
+Open [http://localhost:8585](http://localhost:8585) and explore the pre-loaded flamegraph examples hands-on.

--- a/jeffrey-pages/articles/03-finding-and-fixing-memory-leaks.md
+++ b/jeffrey-pages/articles/03-finding-and-fixing-memory-leaks.md
@@ -185,4 +185,4 @@ You can find the source code at [github.com/petrbouda/jeffrey](https://github.co
 docker run -it --network host petrbouda/microscope-examples
 ```
 
-Open [http://localhost:8080](http://localhost:8080) and explore the pre-loaded heap dump examples.
+Open [http://localhost:8585](http://localhost:8585) and explore the pre-loaded heap dump examples.

--- a/jeffrey-pages/articles/04-monitoring-http-database-grpc-with-custom-jfr-events.md
+++ b/jeffrey-pages/articles/04-monitoring-http-database-grpc-with-custom-jfr-events.md
@@ -173,4 +173,4 @@ You can find the source code at [github.com/petrbouda/jeffrey](https://github.co
 docker run -it --network host petrbouda/microscope-examples
 ```
 
-Open [http://localhost:8080](http://localhost:8080) and explore the pre-loaded examples with custom event data.
+Open [http://localhost:8585](http://localhost:8585) and explore the pre-loaded examples with custom event data.

--- a/jeffrey-pages/articles/05-ai-powered-java-profiling.md
+++ b/jeffrey-pages/articles/05-ai-powered-java-profiling.md
@@ -172,4 +172,4 @@ You can find the source code at [github.com/petrbouda/jeffrey](https://github.co
 docker run -it --network host petrbouda/microscope-examples
 ```
 
-Open [http://localhost:8080](http://localhost:8080), configure your AI provider in Settings, and start asking questions about the pre-loaded profiles.
+Open [http://localhost:8585](http://localhost:8585), configure your AI provider in Settings, and start asking questions about the pre-loaded profiles.

--- a/jeffrey-pages/src/views/LaunchItView.vue
+++ b/jeffrey-pages/src/views/LaunchItView.vue
@@ -63,7 +63,7 @@
                   </div>
                   <div class="step">
                     <div class="step-content">
-                      <p>Open <a href="http://localhost:8080" target="_blank">http://localhost:8080</a> in your browser
+                      <p>Open <a href="http://localhost:8585" target="_blank">http://localhost:8585</a> in your browser
                       </p>
                     </div>
                   </div>
@@ -93,7 +93,7 @@
                   </div>
                   <div class="step">
                     <div class="step-content">
-                      <p>Open <a href="http://localhost:8080" target="_blank">http://localhost:8080</a> in your browser
+                      <p>Open <a href="http://localhost:8585" target="_blank">http://localhost:8585</a> in your browser
                       </p>
                     </div>
                   </div>
@@ -118,7 +118,7 @@
                   </div>
                   <div class="step">
                     <div class="step-content">
-                      <p>Open <a href="http://localhost:8080" target="_blank">http://localhost:8080</a> in your browser
+                      <p>Open <a href="http://localhost:8585" target="_blank">http://localhost:8585</a> in your browser
                       </p>
                     </div>
                   </div>

--- a/jeffrey-pages/src/views/TourWithExamplesView.vue
+++ b/jeffrey-pages/src/views/TourWithExamplesView.vue
@@ -48,7 +48,7 @@
                 <h3>Quick Start</h3>
                 <p>Launch the Docker container with the following command:</p>
                 <pre><code>docker run -it --network host petrbouda/microscope-examples</code></pre>
-                <p>After starting the container, open <a href="http://localhost:8080" target="_blank">http://localhost:8080</a> in your browser to access the Jeffrey UI.</p>
+                <p>After starting the container, open <a href="http://localhost:8585" target="_blank">http://localhost:8585</a> in your browser to access the Jeffrey UI.</p>
               </div>
             </div>
 

--- a/jeffrey-pages/src/views/blog/GettingStartedWithJeffreyView.vue
+++ b/jeffrey-pages/src/views/blog/GettingStartedWithJeffreyView.vue
@@ -176,7 +176,7 @@ const closeImageModal = (): void => {
             </div>
 
             <p>
-              Open <a href="http://localhost:8080" target="_blank">http://localhost:8080</a> in your browser.
+              Open <a href="http://localhost:8585" target="_blank">http://localhost:8585</a> in your browser.
               That's it — Jeffrey is ready to analyze your recordings.
             </p>
 
@@ -420,7 +420,7 @@ const closeImageModal = (): void => {
                 <pre><code>docker run -it --network host petrbouda/microscope-examples</code></pre>
               </div>
               <p>
-                Open <a href="http://localhost:8080" target="_blank">http://localhost:8080</a>, explore the
+                Open <a href="http://localhost:8585" target="_blank">http://localhost:8585</a>, explore the
                 pre-loaded examples, and see what your own recordings reveal.
               </p>
               <div class="download-buttons">

--- a/jeffrey-pages/src/views/docs/getting-started/GettingStartedInstallationPage.vue
+++ b/jeffrey-pages/src/views/docs/getting-started/GettingStartedInstallationPage.vue
@@ -80,7 +80,7 @@ onMounted(() => {
 
         <DocsCodeBlock
           language="text"
-          code="http://localhost:8080"
+          code="http://localhost:8585"
         />
 
         <DocsCallout type="tip">

--- a/jeffrey-pages/src/views/docs/getting-started/GettingStartedQuickStartPage.vue
+++ b/jeffrey-pages/src/views/docs/getting-started/GettingStartedQuickStartPage.vue
@@ -58,7 +58,7 @@ onMounted(() => {
           code="docker run -it --network host petrbouda/microscope"
         />
 
-        <p>Then open <a href="http://localhost:8080" target="_blank">http://localhost:8080</a> in your browser.</p>
+        <p>Then open <a href="http://localhost:8585" target="_blank">http://localhost:8585</a> in your browser.</p>
 
         <h2 id="upload-recording">Upload a Recording</h2>
         <p>Use <strong>Recordings</strong> to analyze your first JFR recording:</p>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpEnablingPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpEnablingPage.vue
@@ -41,12 +41,12 @@ onMounted(() => {
 
 const propertyToggle = `jeffrey.microscope.mcp.enabled=false`;
 
-const defaultEndpoint = `http://localhost:8080/api/internal/mcp`;
+const defaultEndpoint = `http://localhost:8585/api/internal/mcp`;
 
-const tunnel = `ssh -N -L 8080:localhost:8080 you@the-host-running-jeffrey`;
+const tunnel = `ssh -N -L 8585:localhost:8585 you@the-host-running-jeffrey`;
 
 const disabledProbe = `curl -s -o /dev/null -w '%{http_code}\\n' \\
-  -X POST http://localhost:8080/api/internal/mcp \\
+  -X POST http://localhost:8585/api/internal/mcp \\
   -H 'Content-Type: application/json' \\
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
 # 404 while disabled, 200 once enabled`;
@@ -72,7 +72,7 @@ const disabledProbe = `curl -s -o /dev/null -w '%{http_code}\\n' \\
       <p>The profile is a tool argument rather than part of the URL, so a client registers this address once and can then move between profiles &mdash; and between the JFR, flamegraph, trace and heap-dump families &mdash; inside a single session.</p>
 
       <DocsCallout type="tip" title="Do not type the URL from memory">
-        The Settings tab shows the endpoint <em>as your browser just reached it</em>, derived from the request rather than hardcoded. Behind a container, a reverse proxy or a non-default port, <code>localhost:8080</code> is wrong &mdash; and wrong in a way you would only discover after pasting the command. Copy the one the tab shows.
+        The Settings tab shows the endpoint <em>as your browser just reached it</em>, derived from the request rather than hardcoded. Behind a container, a reverse proxy or a non-default port, <code>localhost:8585</code> is wrong &mdash; and wrong in a way you would only discover after pasting the command. Copy the one the tab shows.
       </DocsCallout>
 
       <h2 id="turning-it-off">Turning It Off</h2>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpOtherClientsPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpOtherClientsPage.vue
@@ -38,18 +38,18 @@ onMounted(() => {
   setHeadings(headings);
 });
 
-const manualAdd = `claude mcp add --transport http jeffrey http://localhost:8080/api/internal/mcp`;
+const manualAdd = `claude mcp add --transport http jeffrey http://localhost:8585/api/internal/mcp`;
 
 const mcpJson = `{
   "mcpServers": {
     "jeffrey": {
       "type": "http",
-      "url": "http://localhost:8080/api/internal/mcp"
+      "url": "http://localhost:8585/api/internal/mcp"
     }
   }
 }`;
 
-const initialize = `curl -s -X POST http://localhost:8080/api/internal/mcp \\
+const initialize = `curl -s -X POST http://localhost:8585/api/internal/mcp \\
   -H 'Content-Type: application/json' \\
   -d '{
     "jsonrpc": "2.0",
@@ -68,7 +68,7 @@ const initializeResult = `{
   }
 }`;
 
-const toolsCall = `curl -s -X POST http://localhost:8080/api/internal/mcp \\
+const toolsCall = `curl -s -X POST http://localhost:8585/api/internal/mcp \\
   -H 'Content-Type: application/json' \\
   -d '{
     "jsonrpc": "2.0",
@@ -120,7 +120,7 @@ const protocolError = `{
       <DocsCodeBlock :code="mcpJson" language="json" />
 
       <DocsCallout type="tip" title="Both are offered ready-made">
-        <strong>Settings &rarr; Claude Code (MCP)</strong> shows the command and the <code>.mcp.json</code> entry with the URL your browser actually reached Jeffrey on &mdash; correct behind a container, a proxy or a non-default port, where <code>localhost:8080</code> is not.
+        <strong>Settings &rarr; Claude Code (MCP)</strong> shows the command and the <code>.mcp.json</code> entry with the URL your browser actually reached Jeffrey on &mdash; correct behind a container, a proxy or a non-default port, where <code>localhost:8585</code> is not.
       </DocsCallout>
 
       <h2 id="what-you-give-up">What You Give Up</h2>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpPluginPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpPluginPage.vue
@@ -45,7 +45,9 @@ const installMarketplace = `/plugin marketplace add petrbouda/jeffrey
 const installLocal = `git clone https://github.com/petrbouda/jeffrey
 claude --plugin-dir ./jeffrey/jeffrey-claude-plugin`;
 
-const customUrl = `export JEFFREY_MCP_URL="http://localhost:9000/api/internal/mcp"`;
+const customUrl = `Jeffrey MCP endpoint: http://localhost:9000/api/internal/mcp`;
+
+const pinnedInstall = `/plugin marketplace add petrbouda/jeffrey@v1.2.0`;
 
 const permissionRule = `mcp__plugin_microscope_jeffrey__*`;
 
@@ -81,16 +83,19 @@ const removal = `/plugin uninstall microscope@jeffrey`;
       <p>Or, if you would rather work from a clone &mdash; useful when developing against a modified Jeffrey:</p>
       <DocsCodeBlock :code="installLocal" language="bash" />
 
-      <h2 id="pointing-it-elsewhere">Pointing It Elsewhere</h2>
-      <p>The plugin defaults to <code>http://localhost:8080/api/internal/mcp</code>. For any other address &mdash; a different port, a container, an SSH tunnel &mdash; set the endpoint before starting Claude Code:</p>
-      <DocsCodeBlock :code="customUrl" language="bash" />
+      <p>The marketplace is the repository itself, read straight off its default branch, so <code>/plugin marketplace update</code> is all it takes to pick up a newer plugin. To hold a machine on one release instead, add the marketplace at a tag:</p>
+      <DocsCodeBlock :code="pinnedInstall" language="bash" />
 
-      <p>One plugin therefore serves every installation: a non-default port is an environment variable, not an edit to the manifest.</p>
+      <h2 id="pointing-it-elsewhere">Pointing It Elsewhere</h2>
+      <p>The plugin ships pointed at <code>http://localhost:8080/api/internal/mcp</code>. For any other address &mdash; a different port, a container, an SSH tunnel &mdash; change the endpoint in the plugin's own configuration. Claude Code offers the field when you enable the plugin, and <code>/plugin</code> reopens it afterwards:</p>
+      <DocsCodeBlock :code="customUrl" language="text" />
+
+      <p>The value is stored per machine, in <code>~/.claude/settings.json</code>. One plugin therefore serves every installation: a non-default port is a setting, not an edit to the manifest, and a laptop can point at a tunnelled staging Jeffrey while the machine beside it stays on localhost.</p>
 
       <h2 id="what-the-plugin-adds">What the Plugin Adds</h2>
       <p>Registering the server by hand gives you the thirty-nine tools. The plugin adds two things on top.</p>
 
-      <p><strong>The endpoint, already configured</strong> &mdash; including the <code>JEFFREY_MCP_URL</code> indirection above, so the same install works on a laptop and against a tunnelled staging Jeffrey.</p>
+      <p><strong>The endpoint, already configured</strong> &mdash; including the per-machine setting above, so the same install works on a laptop and against a tunnelled staging Jeffrey.</p>
 
       <p><strong>Three skills</strong>, which Claude picks up on its own when a question calls for them, and which you can also invoke directly:</p>
       <ul>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpPluginPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpPluginPage.vue
@@ -87,7 +87,7 @@ const removal = `/plugin uninstall microscope@jeffrey`;
       <DocsCodeBlock :code="pinnedInstall" language="bash" />
 
       <h2 id="pointing-it-elsewhere">Pointing It Elsewhere</h2>
-      <p>The plugin ships pointed at <code>http://localhost:8080/api/internal/mcp</code>. For any other address &mdash; a different port, a container, an SSH tunnel &mdash; change the endpoint in the plugin's own configuration. Claude Code offers the field when you enable the plugin, and <code>/plugin</code> reopens it afterwards:</p>
+      <p>The plugin ships pointed at <code>http://localhost:8585/api/internal/mcp</code>. For any other address &mdash; a different port, a container, an SSH tunnel &mdash; change the endpoint in the plugin's own configuration. Claude Code offers the field when you enable the plugin, and <code>/plugin</code> reopens it afterwards:</p>
       <DocsCodeBlock :code="customUrl" language="text" />
 
       <p>The value is stored per machine, in <code>~/.claude/settings.json</code>. One plugin therefore serves every installation: a non-default port is a setting, not an edit to the manifest, and a laptop can point at a tunnelled staging Jeffrey while the machine beside it stays on localhost.</p>

--- a/jeffrey-pages/src/views/docs/microscope/MicroscopeQuickStartPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/MicroscopeQuickStartPage.vue
@@ -51,7 +51,7 @@ onMounted(() => {
         <p class="hero-eyebrow"><i class="bi bi-stopwatch"></i> Up and running in minutes</p>
         <h2 class="hero-title">Install, open, analyze.</h2>
         <p class="hero-lede">
-          Pick Docker or a plain Java run, point a browser at <code>localhost:8080</code>, drop a JFR
+          Pick Docker or a plain Java run, point a browser at <code>localhost:8585</code>, drop a JFR
           recording or heap dump, and you're inside the Microscope. The whole loop is four steps.
         </p>
 
@@ -108,11 +108,11 @@ onMounted(() => {
       </section>
 
       <h2 id="open-ui">Open the UI</h2>
-      <p>Microscope listens on port <strong>8080</strong> by default. Open the URL in any modern browser:</p>
+      <p>Microscope listens on port <strong>8585</strong> by default. Open the URL in any modern browser:</p>
 
       <DocsCodeBlock
         language="text"
-        code="http://localhost:8080"
+        code="http://localhost:8585"
       />
 
       <DocsCallout type="info">

--- a/jeffrey-pages/src/views/docs/microscope/configuration/MicroscopeConfigApplicationPropertiesPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/configuration/MicroscopeConfigApplicationPropertiesPage.vue
@@ -75,8 +75,8 @@ onMounted(() => {
         <tbody>
           <tr>
             <td><code>server.port</code></td>
-            <td><code>8080</code></td>
-            <td>HTTP port for the Microscope web UI. Standard Spring Boot property.</td>
+            <td><code>8585</code></td>
+            <td>HTTP port for the Microscope web UI. Standard Spring Boot property. Microscope sets 8585 rather than Spring Boot's own 8080, which is usually taken by the application being profiled.</td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
## Summary
Changes the default HTTP port for Jeffrey Microscope from 8080 to 8585 throughout the codebase. This avoids port conflicts with applications being profiled, which commonly use port 8080.

## Key Changes

- **Server configuration**: Updated `application.properties` to set `server.port=8585` with explanatory comments about why this port was chosen over Spring Boot's default 8080
- **Claude Code plugin**: 
  - Added `userConfig` section to `plugin.json` to allow users to configure the MCP endpoint per machine via Claude Code's settings UI
  - Changed from environment variable (`JEFFREY_MCP_URL`) to user configuration (`${user_config.endpoint_url}`)
  - Updated default endpoint to `http://localhost:8585/api/internal/mcp`
- **Documentation**: Updated all references across docs, guides, and configuration files from `localhost:8080` to `localhost:8585`
- **Plugin marketplace**: Enhanced `.claude-plugin/marketplace.json` with version, author information, and proper metadata
- **CI/CD**: Added GitHub Actions workflow (`.github/workflows/validate-claude-plugin.yml`) to validate Claude Code plugin manifests on every push to master and pull request
- **Plugin configuration guidance**: Updated plugin README and documentation to explain the new per-machine configuration approach instead of environment variables
- **Docker/Jib configuration**: Updated container port mappings in Maven Jib build configurations

## Notable Implementation Details

- The plugin now uses Claude Code's native user configuration system rather than environment variables, allowing different machines to point at different Jeffrey instances (e.g., localhost vs. tunnelled staging) without modifying the plugin manifest
- The MCP endpoint configuration is stored per machine in `~/.claude/settings.json`, making it portable across different deployment scenarios
- Added comprehensive validation workflow for the Claude Code plugin to prevent malformed manifests from breaking installations
- All documentation now consistently references the new port, including troubleshooting guides and skill documentation

https://claude.ai/code/session_0126zPTU3Rf9Z6C17RU3XtrU