### PR TITLE
Rename flamegraph_panels to flamegraph_list and support imported profiles

### DIFF
--- a/jeffrey-claude-plugin/skills/advise/SKILL.md
+++ b/jeffrey-claude-plugin/skills/advise/SKILL.md
@@ -41,7 +41,7 @@ do only that one.
 | Allocation | `jdk.ObjectAllocationSample`, else `jdk.ObjectAllocationInNewTLAB`, else `jdk.ObjectAllocationOutsideTLAB` | `useWeight: true` (bytes, not call count) |
 | Blocking | `jdk.JavaMonitorEnter`, else `jdk.JavaMonitorWait`, else `jdk.ThreadPark` | `useWeight: true` (nanoseconds blocked) |
 
-`flamegraph_panels` says which of these the profile recorded. A group with no samples is
+`flamegraph_list` says which of these the profile recorded. A group with no samples is
 reported, not analysed, with the async-profiler flag that would capture it next time:
 `event=ctimer` (CPU), `wall=10ms`, `alloc=512k`, `lock=10ms`.
 
@@ -105,7 +105,7 @@ continue from step 4 above with that export instead of the whole-recording one.
 
 ## When something is missing
 
-- `flamegraph_panels` is empty → a heap dump or a recording without samples; there is nothing to
+- `flamegraph_list` is empty → a heap dump or a recording without samples; there is nothing to
   advise on from a flamegraph. For a heap dump, the `heap_` family and the `heap-sql` skill apply.
 - The profile's commit differs from `HEAD` and the user does not want to switch → analyse anyway,
   but say in the summary that every file reference was checked against a different commit than

--- a/jeffrey-claude-plugin/skills/advise/SKILL.md
+++ b/jeffrey-claude-plugin/skills/advise/SKILL.md
@@ -41,9 +41,11 @@ do only that one.
 | Allocation | `jdk.ObjectAllocationSample`, else `jdk.ObjectAllocationInNewTLAB`, else `jdk.ObjectAllocationOutsideTLAB` | `useWeight: true` (bytes, not call count) |
 | Blocking | `jdk.JavaMonitorEnter`, else `jdk.JavaMonitorWait`, else `jdk.ThreadPark` | `useWeight: true` (nanoseconds blocked) |
 
-`flamegraph_list` says which of these the profile recorded. A group with no samples is
-reported, not analysed, with the async-profiler flag that would capture it next time:
-`event=ctimer` (CPU), `wall=10ms`, `alloc=512k`, `lock=10ms`.
+`flamegraph_list` splits these for you: `available` holds the event types this recording actually
+carries — each with the export defaults for that type — and `notRecorded` names the groups the
+profiler was not configured to capture. A group in `notRecorded` is reported, not analysed, with
+the async-profiler flag that would capture it next time: `event=ctimer` (CPU), `wall=10ms`,
+`alloc=512k`, `lock=10ms`.
 
 ## 3. Export and read
 
@@ -105,8 +107,9 @@ continue from step 4 above with that export instead of the whole-recording one.
 
 ## When something is missing
 
-- `flamegraph_list` is empty → a heap dump or a recording without samples; there is nothing to
-  advise on from a flamegraph. For a heap dump, the `heap_` family and the `heap-sql` skill apply.
+- `flamegraph_list` reports no flamegraph-capable event types → a heap dump or a recording without
+  samples; there is nothing to advise on from a flamegraph. For a heap dump, the `heap_` family and
+  the `heap-sql` skill apply.
 - The profile's commit differs from `HEAD` and the user does not want to switch → analyse anyway,
   but say in the summary that every file reference was checked against a different commit than
   the one profiled.

--- a/jeffrey-claude-plugin/skills/analyze-profile/SKILL.md
+++ b/jeffrey-claude-plugin/skills/analyze-profile/SKILL.md
@@ -61,7 +61,7 @@ elsewhere; Jeffrey's accounting is stated precisely in the document and differs 
 
 ## Choosing a graph
 
-`flamegraph_panels` lists the event types this profile really recorded. Asking for one it did not
+`flamegraph_list` lists the event types this profile really recorded. Asking for one it did not
 record returns an empty tree rather than an error, so check first. Common starting points:
 
 - on-CPU time → `jdk.ExecutionSample`

--- a/jeffrey-claude-plugin/skills/analyze-profile/SKILL.md
+++ b/jeffrey-claude-plugin/skills/analyze-profile/SKILL.md
@@ -61,8 +61,10 @@ elsewhere; Jeffrey's accounting is stated precisely in the document and differs 
 
 ## Choosing a graph
 
-`flamegraph_list` lists the event types this profile really recorded. Asking for one it did not
-record returns an empty tree rather than an error, so check first. Common starting points:
+`flamegraph_list` lists under `available` the event types this profile really recorded, each with
+the export defaults for that type; `notRecorded` names the groups the profiler did not capture.
+Asking for one it did not record returns an empty tree rather than an error, so check first. Common
+starting points:
 
 - on-CPU time → `jdk.ExecutionSample`
 - allocation → `jdk.ObjectAllocationSample` (add `useWeight: true` to rank by bytes, not by call count)

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/configuration/McpConfiguration.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/configuration/McpConfiguration.java
@@ -28,6 +28,7 @@ import cafe.jeffrey.microscope.core.mcp.tools.RecordingsMcpTools;
 import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
 import cafe.jeffrey.microscope.persistence.api.MicroscopeCorePersistenceProvider;
 import cafe.jeffrey.profile.panel.JfrFlamegraphPanelProvider;
+import cafe.jeffrey.profile.panel.StackSampleFlamegraphPanelProvider;
 import cafe.jeffrey.provider.profile.api.DatabaseManagerResolver;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -104,11 +105,12 @@ public class McpConfiguration {
             ProfilesMcpTools profilesMcpTools,
             RecordingsMcpTools recordingsMcpTools,
             McpProfileContextCache contextCache,
-            JfrFlamegraphPanelProvider panelProvider,
+            JfrFlamegraphPanelProvider jfrPanelProvider,
+            StackSampleFlamegraphPanelProvider stackSamplePanelProvider,
             RecordingCommitResolver recordingCommitResolver,
             ExternalMcpProperties properties) {
         return new McpToolsetAssembler(
-                profilesMcpTools, recordingsMcpTools, contextCache, panelProvider,
-                recordingCommitResolver, properties);
+                profilesMcpTools, recordingsMcpTools, contextCache, jfrPanelProvider,
+                stackSamplePanelProvider, recordingCommitResolver, properties);
     }
 }

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/McpToolsetAssembler.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/McpToolsetAssembler.java
@@ -34,6 +34,7 @@ import cafe.jeffrey.profile.mcp.McpToolProvider;
 import cafe.jeffrey.profile.mcp.ProfileScopedToolset;
 import cafe.jeffrey.profile.mcp.ReflectiveToolset;
 import cafe.jeffrey.profile.panel.JfrFlamegraphPanelProvider;
+import cafe.jeffrey.profile.panel.StackSampleFlamegraphPanelProvider;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -78,7 +79,8 @@ public class McpToolsetAssembler {
             ProfilesMcpTools profilesMcpTools,
             RecordingsMcpTools recordingsMcpTools,
             McpProfileContextCache contextCache,
-            JfrFlamegraphPanelProvider panelProvider,
+            JfrFlamegraphPanelProvider jfrPanelProvider,
+            StackSampleFlamegraphPanelProvider stackSamplePanelProvider,
             RecordingCommitResolver recordingCommitResolver,
             ExternalMcpProperties properties) {
 
@@ -91,7 +93,10 @@ public class McpToolsetAssembler {
                         profileId -> new DuckDbMcpTools(contextCache.context(profileId).dataSource()),
                         WRITE_TOOLS),
                 new ProfileScopedToolset<>(FlamegraphMcpTools.class, PREFIX_FLAMEGRAPH,
-                        profileId -> new FlamegraphMcpTools(profileManager(contextCache, profileId), panelProvider)),
+                        profileId -> new FlamegraphMcpTools(
+                                profileManager(contextCache, profileId),
+                                jfrPanelProvider,
+                                stackSamplePanelProvider)),
                 new ProfileScopedToolset<>(TracesMcpTools.class, PREFIX_TRACES,
                         profileId -> new TracesMcpTools(profileManager(contextCache, profileId))),
                 new ProfileScopedToolset<>(HeapDumpMcpTools.class, PREFIX_HEAP,

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/FlamegraphMcpTools.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/FlamegraphMcpTools.java
@@ -25,8 +25,12 @@ import cafe.jeffrey.shared.common.GraphType;
 import cafe.jeffrey.profile.manager.ProfileManager;
 import cafe.jeffrey.profile.mcp.McpToolOutput;
 import cafe.jeffrey.profile.model.FlamegraphPanel;
+import cafe.jeffrey.profile.model.WeightKind;
+import cafe.jeffrey.profile.model.WeightOption;
+import cafe.jeffrey.profile.panel.FlamegraphPanelProvider;
 import cafe.jeffrey.profile.panel.JfrFlamegraphPanelProvider;
 import cafe.jeffrey.profile.panel.PanelContext;
+import cafe.jeffrey.profile.panel.StackSampleFlamegraphPanelProvider;
 import cafe.jeffrey.shared.common.model.ProfileInfo;
 import cafe.jeffrey.shared.common.model.ProfilingStartEnd;
 import cafe.jeffrey.shared.common.model.Type;
@@ -36,6 +40,7 @@ import cafe.jeffrey.shared.common.model.time.UndefinedTimeRange;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -52,25 +57,62 @@ public class FlamegraphMcpTools {
             "This profile has no flamegraph-capable event types. It may be a heap dump "
                     + "(use the heap_* tools) or a recording without execution samples.";
 
-    private final ProfileManager profileManager;
-    private final JfrFlamegraphPanelProvider panelProvider;
+    private static final String UNIT_BYTES = "bytes";
+    private static final String UNIT_NANOSECONDS = "nanoseconds";
 
-    public FlamegraphMcpTools(ProfileManager profileManager, JfrFlamegraphPanelProvider panelProvider) {
+    private final ProfileManager profileManager;
+    private final JfrFlamegraphPanelProvider jfrPanelProvider;
+    private final StackSampleFlamegraphPanelProvider stackSamplePanelProvider;
+
+    public FlamegraphMcpTools(
+            ProfileManager profileManager,
+            JfrFlamegraphPanelProvider jfrPanelProvider,
+            StackSampleFlamegraphPanelProvider stackSamplePanelProvider) {
+
         this.profileManager = profileManager;
-        this.panelProvider = panelProvider;
+        this.jfrPanelProvider = jfrPanelProvider;
+        this.stackSamplePanelProvider = stackSamplePanelProvider;
     }
 
-    @Tool(description = "List the flamegraphs available for this profile: which event types were "
-            + "actually recorded, with their sample and weight totals, and the options each graph is "
-            + "normally drawn with. Call this before flamegraph_export to learn the valid eventType "
-            + "values for this profile.")
+    @Tool(description = "List the flamegraphs this profile can actually produce: one entry per event "
+            + "type it recorded, with its sample and weight totals and the argument defaults that "
+            + "event type is normally graphed with. Call this before flamegraph_export to learn the "
+            + "valid eventType values for this profile. 'notRecorded' names the standard groups this "
+            + "recording is missing — a profiler-configuration finding to report, not an error.")
     public String list() {
-        List<FlamegraphPanel> panels = panelProvider.panels(
+        List<FlamegraphPanel> panels = panelProvider().panels(
                 profileManager.flamegraphManager().eventSummaries(), PanelContext.PRIMARY);
-        if (panels.isEmpty()) {
+
+        List<GraphableType> available = new ArrayList<>();
+        List<MissingGroup> notRecorded = new ArrayList<>();
+        for (FlamegraphPanel panel : panels) {
+            // The JFR provider emits the full catalog of standard sections, filling the ones this
+            // recording has no samples for with a zero-sample placeholder so the frontend grid stays
+            // complete. Graphing a placeholder yields an empty tree, so it is reported as a gap in what
+            // the profiler captured rather than offered as a valid eventType.
+            if (panel.event().primary().samples() > 0) {
+                available.add(GraphableType.from(panel));
+            } else {
+                notRecorded.add(new MissingGroup(panel.section(), panel.title()));
+            }
+        }
+
+        if (available.isEmpty()) {
             return NOTHING_TO_GRAPH;
         }
-        return McpToolOutput.json(panels);
+        return McpToolOutput.json(new GraphableTypes(available, notRecorded));
+    }
+
+    /**
+     * The grid this profile's format is drawn as — the same split the UI routes make. pprof and OTLP
+     * carry their own sample dimensions rather than JFR event types, so running them through the JFR
+     * catalog would report every dimension they do have as missing.
+     */
+    private FlamegraphPanelProvider panelProvider() {
+        if (profileManager.info().eventSource().isFlamegraphOnlyImport()) {
+            return stackSamplePanelProvider;
+        }
+        return jfrPanelProvider;
     }
 
     @Tool(description = "Export a flamegraph as Markdown for reading: a nested call tree where every "
@@ -163,5 +205,67 @@ public class FlamegraphMcpTools {
                     "endMs must be greater than startMs: startMs=" + from + " endMs=" + to);
         }
         return TimeRange.create(from, to, false).toRelativeTimeRange(startEnd);
+    }
+
+    /**
+     * What this profile can be graphed by, and which of the standard groups it is missing. The panel
+     * grid is a presentation model — it carries an accent color, a bootstrap icon class and a display
+     * order — so it is projected down to the arguments a caller can act on rather than handed over
+     * whole.
+     */
+    private record GraphableTypes(List<GraphableType> available, List<MissingGroup> notRecorded) {
+    }
+
+    /**
+     * One graphable event type: the {@code eventType} argument to pass to {@code flamegraph_export},
+     * what it weighs, and the argument values the UI draws it with by default.
+     * <p>
+     * {@code weight} and its unit are null together when weighing is meaningless for this event type
+     * (execution samples, wall-clock), so a caller can never read a weight without knowing what it
+     * counts.
+     */
+    private record GraphableType(
+            String eventType,
+            String label,
+            String section,
+            long samples,
+            Long weight,
+            String weightLabel,
+            String weightUnit,
+            boolean defaultUseWeight,
+            boolean defaultThreadMode,
+            boolean defaultExcludeIdle,
+            boolean defaultExcludeNonJava) {
+
+        static GraphableType from(FlamegraphPanel panel) {
+            WeightOption weight = panel.weight();
+            boolean weighable = weight.applicable();
+            return new GraphableType(
+                    panel.event().code(),
+                    panel.title(),
+                    panel.section(),
+                    panel.event().primary().samples(),
+                    weighable ? panel.event().primary().weight() : null,
+                    weighable ? weight.label() : null,
+                    weighable ? unitOf(weight.kind()) : null,
+                    weight.defaultOn(),
+                    panel.threadMode().defaultOn(),
+                    panel.excludeIdle().defaultOn(),
+                    panel.excludeNonJava().defaultOn());
+        }
+
+        private static String unitOf(WeightKind kind) {
+            return switch (kind) {
+                case BYTES -> UNIT_BYTES;
+                case DURATION -> UNIT_NANOSECONDS;
+            };
+        }
+    }
+
+    /**
+     * A standard group this recording captured nothing for — the profiler was not configured to
+     * collect it. Worth reporting to the reader; not a valid {@code eventType}.
+     */
+    private record MissingGroup(String section, String label) {
     }
 }

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/FlamegraphMcpTools.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/FlamegraphMcpTools.java
@@ -42,13 +42,13 @@ import java.util.List;
  * Flamegraphs of one profile, rendered as the Markdown export rather than as the protobuf the browser
  * draws — the same call tree, written to be read.
  * <p>
- * {@code panels} comes first on purpose: which event types a recording actually captured varies by
+ * {@link #list()} comes first on purpose: which event types a recording actually captured varies by
  * profiler configuration, and asking for a graph of an event type that was never recorded returns an
- * empty tree rather than an error. The panel list is the profile's own answer to "what can I graph".
+ * empty tree rather than an error. The list is the profile's own answer to "what can I graph".
  */
 public class FlamegraphMcpTools {
 
-    private static final String NO_PANELS =
+    private static final String NOTHING_TO_GRAPH =
             "This profile has no flamegraph-capable event types. It may be a heap dump "
                     + "(use the heap_* tools) or a recording without execution samples.";
 
@@ -64,11 +64,11 @@ public class FlamegraphMcpTools {
             + "actually recorded, with their sample and weight totals, and the options each graph is "
             + "normally drawn with. Call this before flamegraph_export to learn the valid eventType "
             + "values for this profile.")
-    public String panels() {
+    public String list() {
         List<FlamegraphPanel> panels = panelProvider.panels(
                 profileManager.flamegraphManager().eventSummaries(), PanelContext.PRIMARY);
         if (panels.isEmpty()) {
-            return NO_PANELS;
+            return NOTHING_TO_GRAPH;
         }
         return McpToolOutput.json(panels);
     }
@@ -81,7 +81,7 @@ public class FlamegraphMcpTools {
     public String export(
             @ToolParam(description = "JFR event type to graph, e.g. 'jdk.ExecutionSample' for CPU, "
                     + "'jdk.ObjectAllocationSample' for allocation, 'jdk.JavaMonitorEnter' for lock "
-                    + "contention. Use flamegraph_panels to see what this profile recorded.")
+                    + "contention. Use flamegraph_list to see what this profile recorded.")
             String eventType,
             @ToolParam(description = "Only show frames at or above this percentage of total samples "
                     + "(exclusive range 0-100). Lower means more detail and a longer document; the "

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/McpToolsetAssemblerTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/McpToolsetAssemblerTest.java
@@ -25,6 +25,7 @@ import cafe.jeffrey.microscope.core.mcp.tools.RecordingsMcpTools;
 import cafe.jeffrey.microscope.persistence.api.MicroscopeCoreRepositories;
 import cafe.jeffrey.profile.mcp.McpToolSpec;
 import cafe.jeffrey.profile.panel.JfrFlamegraphPanelProvider;
+import cafe.jeffrey.profile.panel.StackSampleFlamegraphPanelProvider;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -52,7 +53,10 @@ class McpToolsetAssemblerTest {
     McpProfileContextCache contextCache;
 
     @Mock
-    JfrFlamegraphPanelProvider panelProvider;
+    JfrFlamegraphPanelProvider jfrPanelProvider;
+
+    @Mock
+    StackSampleFlamegraphPanelProvider stackSamplePanelProvider;
 
     @Mock
     RecordingCommitResolver recordingCommitResolver;
@@ -62,7 +66,8 @@ class McpToolsetAssemblerTest {
                 new ProfilesMcpTools(coreRepositories),
                 new RecordingsMcpTools(recordingsManager),
                 contextCache,
-                panelProvider,
+                jfrPanelProvider,
+                stackSamplePanelProvider,
                 recordingCommitResolver,
                 new ExternalMcpProperties(true, ingestEnabled));
 
@@ -86,6 +91,7 @@ class McpToolsetAssemblerTest {
             List<String> names = toolNamesWithIngest(true);
 
             assertTrue(names.contains("profiles_list"));
+            assertTrue(names.contains("flamegraph_list"));
             assertTrue(names.contains("flamegraph_export"));
             assertTrue(names.contains("traces_notifications"));
             assertTrue(names.contains("heap_getHeapSummary"));
@@ -119,7 +125,8 @@ class McpToolsetAssemblerTest {
                     new ProfilesMcpTools(coreRepositories),
                     new RecordingsMcpTools(recordingsManager),
                     contextCache,
-                    panelProvider,
+                    jfrPanelProvider,
+                    stackSamplePanelProvider,
                     recordingCommitResolver,
                     new ExternalMcpProperties(true, false));
 

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/FlamegraphMcpToolsTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/FlamegraphMcpToolsTest.java
@@ -1,0 +1,189 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.microscope.core.mcp.tools;
+
+import cafe.jeffrey.profile.manager.FlamegraphManager;
+import cafe.jeffrey.profile.manager.ProfileManager;
+import cafe.jeffrey.profile.model.EventSummaryResult;
+import cafe.jeffrey.profile.panel.JfrFlamegraphPanelProvider;
+import cafe.jeffrey.profile.panel.StackSampleFlamegraphPanelProvider;
+import cafe.jeffrey.shared.common.Json;
+import cafe.jeffrey.shared.common.model.EventTypeName;
+import cafe.jeffrey.shared.common.model.ProfileInfo;
+import cafe.jeffrey.shared.common.model.RecordingEventSource;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.JsonNode;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FlamegraphMcpToolsTest {
+
+    private static final String SAMPLE_TYPE_EXTRA = "sampleType";
+
+    @Mock
+    ProfileManager profileManager;
+
+    @Mock
+    FlamegraphManager flamegraphManager;
+
+    private FlamegraphMcpTools tools() {
+        return new FlamegraphMcpTools(
+                profileManager, new JfrFlamegraphPanelProvider(), new StackSampleFlamegraphPanelProvider());
+    }
+
+    private static EventSummaryResult summary(String code, long samples, long weight) {
+        return summary(code, samples, weight, Map.of());
+    }
+
+    private static EventSummaryResult summary(
+            String code, long samples, long weight, Map<String, String> extras) {
+
+        EventSummaryResult.SingleResult primary =
+                new EventSummaryResult.SingleResult(code, code, null, null, samples, weight, false, extras);
+        return new EventSummaryResult(code, code, primary, null);
+    }
+
+    private void profileOf(RecordingEventSource source, List<EventSummaryResult> summaries) {
+        when(profileManager.info()).thenReturn(new ProfileInfo(
+                "profile-1", "project-1", "workspace-1", "Profile", source,
+                Instant.EPOCH, Instant.EPOCH.plusSeconds(60), Instant.EPOCH, true, false, "recording-1"));
+        when(profileManager.flamegraphManager()).thenReturn(flamegraphManager);
+        when(flamegraphManager.eventSummaries()).thenReturn(summaries);
+    }
+
+    private static JsonNode entry(String result, String eventType) {
+        JsonNode available = Json.mapper().readTree(result).get("available");
+        for (JsonNode node : available) {
+            if (node.get("eventType").asString().equals(eventType)) {
+                return node;
+            }
+        }
+        throw new AssertionError("no entry for " + eventType + " in " + result);
+    }
+
+    @Nested
+    class JfrProfile {
+
+        /**
+         * The JFR grid always emits all eight sections, filling the empty ones with a zero-sample
+         * placeholder. Offering those as valid eventTypes would send the caller after an empty tree,
+         * so they are reported as gaps in what the profiler captured instead.
+         */
+        @Test
+        void separatesRecordedTypesFromTheSectionsWithNoSamples() {
+            profileOf(RecordingEventSource.JDK, List.of(
+                    summary(EventTypeName.EXECUTION_SAMPLE, 4200, 0L),
+                    summary(EventTypeName.OBJECT_ALLOCATION_SAMPLE, 130, 9_000_000L)));
+
+            String result = tools().list();
+            JsonNode root = Json.mapper().readTree(result);
+
+            List<String> available = root.get("available").valueStream()
+                    .map(node -> node.get("eventType").asString())
+                    .toList();
+            assertEquals(
+                    List.of(EventTypeName.EXECUTION_SAMPLE, EventTypeName.OBJECT_ALLOCATION_SAMPLE),
+                    available);
+
+            List<String> notRecorded = root.get("notRecorded").valueStream()
+                    .map(node -> node.get("section").asString())
+                    .toList();
+            assertEquals(
+                    List.of("cpu-time", "method", "wall", "native-alloc", "native-leak", "blocking"),
+                    notRecorded);
+        }
+
+        @Test
+        void carriesTheExportArgumentDefaultsOfEachEventType() {
+            profileOf(RecordingEventSource.JDK, List.of(
+                    summary(EventTypeName.EXECUTION_SAMPLE, 4200, 0L),
+                    summary(EventTypeName.OBJECT_ALLOCATION_SAMPLE, 130, 9_000_000L),
+                    summary(EventTypeName.JAVA_MONITOR_ENTER, 12, 5_000_000_000L)));
+
+            String result = tools().list();
+
+            JsonNode allocation = entry(result, EventTypeName.OBJECT_ALLOCATION_SAMPLE);
+            assertEquals(130, allocation.get("samples").asLong());
+            assertEquals(9_000_000L, allocation.get("weight").asLong());
+            assertEquals("bytes", allocation.get("weightUnit").asString());
+            assertTrue(allocation.get("defaultUseWeight").asBoolean());
+
+            JsonNode blocking = entry(result, EventTypeName.JAVA_MONITOR_ENTER);
+            assertEquals("nanoseconds", blocking.get("weightUnit").asString());
+            assertTrue(blocking.get("defaultUseWeight").asBoolean());
+
+            // execution samples are counted, never weighed — the number and its unit are absent together
+            JsonNode execution = entry(result, EventTypeName.EXECUTION_SAMPLE);
+            assertTrue(execution.get("weight").isNull());
+            assertNull(execution.get("weightUnit").asString(null));
+            assertFalse(execution.get("defaultUseWeight").asBoolean());
+        }
+
+        /**
+         * Reachable only because the placeholders are filtered out: the grid itself is never empty.
+         */
+        @Test
+        void saysSoWhenNothingWasRecorded() {
+            profileOf(RecordingEventSource.HEAP_DUMP, List.of());
+
+            assertTrue(tools().list().startsWith("This profile has no flamegraph-capable event types."));
+        }
+    }
+
+    @Nested
+    class StackSampleImport {
+
+        /**
+         * pprof and OTLP carry their own sample dimensions rather than JFR event types. Running them
+         * through the JFR catalog would report every dimension they do have as missing.
+         */
+        @Test
+        void listsTheDimensionsOfAnImportedProfile() {
+            profileOf(RecordingEventSource.PPROF, List.of(
+                    summary("cpu", 900, 0L, Map.of(SAMPLE_TYPE_EXTRA, "cpu/nanoseconds")),
+                    summary("alloc_space", 40, 2048L, Map.of(SAMPLE_TYPE_EXTRA, "alloc_space/bytes"))));
+
+            String result = tools().list();
+            JsonNode root = Json.mapper().readTree(result);
+
+            List<String> available = root.get("available").valueStream()
+                    .map(node -> node.get("eventType").asString())
+                    .toList();
+            assertEquals(List.of("cpu", "alloc_space"), available);
+            assertTrue(root.get("notRecorded").isEmpty());
+
+            JsonNode alloc = entry(result, "alloc_space");
+            assertEquals("bytes", alloc.get("weightUnit").asString());
+            assertEquals(2048L, alloc.get("weight").asLong());
+        }
+    }
+}

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpRecipesPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpRecipesPage.vue
@@ -92,7 +92,7 @@ LIMIT 20`;
       <h2 id="analyse-a-recording-you-just-made">Analyse a Recording You Just Made</h2>
       <DocsCodeBlock :code="promptFreshRecording" language="bash" />
 
-      <p>Drives <code>recordings_analyzeFile</code> &rarr; <code>profiles_features</code> &rarr; <code>flamegraph_panels</code> &rarr; <code>flamegraph_export</code>.</p>
+      <p>Drives <code>recordings_analyzeFile</code> &rarr; <code>profiles_features</code> &rarr; <code>flamegraph_list</code> &rarr; <code>flamegraph_export</code>.</p>
 
       <p>This is the loop closing. You run a benchmark, a JFR file lands in <code>target/</code>, and the next thing you type is a question about it &mdash; no upload, no browser, no clicking Analyze. The first tool call imports the file and builds the profile, and hands back the <code>profileId</code> every later call uses; the profile is a normal one afterwards, visible in the Jeffrey UI and in <code>profiles_list</code>.</p>
 
@@ -105,7 +105,7 @@ LIMIT 20`;
       <h2 id="where-does-the-time-go">Where Does the Time Go</h2>
       <DocsCodeBlock :code="promptHotPaths" language="bash" />
 
-      <p>Drives <code>profiles_list</code> &rarr; <code>profiles_features</code> &rarr; <code>flamegraph_panels</code> &rarr; <code>flamegraph_export</code> with <code>jdk.ExecutionSample</code>.</p>
+      <p>Drives <code>profiles_list</code> &rarr; <code>profiles_features</code> &rarr; <code>flamegraph_list</code> &rarr; <code>flamegraph_export</code> with <code>jdk.ExecutionSample</code>.</p>
 
       <p>The export is a pruned call tree with total and self samples on every frame, and it opens by explaining exactly how those are computed. Expect an answer that names call paths and percentages. Follow up by narrowing: <em>&ldquo;drop the threshold to 0.5% and expand the path through the JDBC driver&rdquo;</em>, or <em>&ldquo;same graph but only the first 30 seconds&rdquo;</em> &mdash; both are arguments to the same tool.</p>
 
@@ -139,7 +139,7 @@ LIMIT 20`;
       <h2 id="from-profile-to-patch">From Profile to Patch</h2>
       <DocsCodeBlock :code="promptAdvise" language="bash" />
 
-      <p>Drives the <router-link to="/docs/microscope-mcp/skills#advise"><code>advise</code></router-link> skill: <code>profiles_get</code> for the recording&rsquo;s commit, <code>flamegraph_panels</code>, then <code>flamegraph_export</code> once per group the profile carries &mdash; CPU, wall-clock, allocation, blocking &mdash; followed by reads of the real source behind the heaviest frames.</p>
+      <p>Drives the <router-link to="/docs/microscope-mcp/skills#advise"><code>advise</code></router-link> skill: <code>profiles_get</code> for the recording&rsquo;s commit, <code>flamegraph_list</code>, then <code>flamegraph_export</code> once per group the profile carries &mdash; CPU, wall-clock, allocation, blocking &mdash; followed by reads of the real source behind the heaviest frames.</p>
 
       <p>The previous recipe reconciles one frame with one method. This one is the whole loop: every group at once, a recommendation per hotspot with the measured share that justifies it, and a stop before anything is edited. Say which findings to apply and Claude makes the smallest edit for each, runs the tests, and &mdash; if you name the command that produced the recording &mdash; re-runs it, analyses the new file with <code>recordings_analyzeFile</code> and reports the delta on the frames it changed.</p>
 

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpToolsPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpToolsPage.vue
@@ -120,7 +120,7 @@ const analyzeExample = `Analyze target/checkout-run.jfr and tell me where the ti
           <tr>
             <td><code>flamegraph_list</code></td>
             <td><code>profileId</code></td>
-            <td>Which event types this profile can be graphed by. Call it first &mdash; asking for a type the profile did not record returns an empty tree, not an error</td>
+            <td><code>available</code> &mdash; the event types this profile can be graphed by, each with its sample and weight totals and the argument defaults that type is normally graphed with &mdash; plus <code>notRecorded</code>, the standard groups the profiler did not capture. Call it first &mdash; asking for a type the profile did not record returns an empty tree, not an error</td>
           </tr>
           <tr>
             <td><code>flamegraph_export</code></td>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpToolsPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpToolsPage.vue
@@ -118,7 +118,7 @@ const analyzeExample = `Analyze target/checkout-run.jfr and tell me where the ti
         </thead>
         <tbody>
           <tr>
-            <td><code>flamegraph_panels</code></td>
+            <td><code>flamegraph_list</code></td>
             <td><code>profileId</code></td>
             <td>Which event types this profile can be graphed by. Call it first &mdash; asking for a type the profile did not record returns an empty tree, not an error</td>
           </tr>


### PR DESCRIPTION
## Summary
Refactors the flamegraph MCP tool to better serve both JFR recordings and imported profiles (pprof, OTLP). Renames `flamegraph_panels()` to `list()` and restructures its output to distinguish between recorded event types and missing standard groups, while adding support for stack-sample-based profiles that carry their own sample dimensions rather than JFR event types.

## Key Changes

- **Renamed tool**: `flamegraph_panels` → `flamegraph_list` across all documentation and code
  - Updated tool description to clarify the distinction between `available` (recorded types) and `notRecorded` (missing groups)
  - Updated all references in skills, recipes, and tool documentation

- **Restructured output model**: 
  - Filters out zero-sample placeholders from JFR grid (which the UI uses for layout) and reports them as `notRecorded` gaps instead of offering them as valid event types
  - New `GraphableTypes` record with `available` (list of graphable event types) and `notRecorded` (list of missing standard groups)
  - New `GraphableType` record projects panel metadata down to actionable arguments: `eventType`, `label`, `section`, `samples`, `weight`, `weightUnit`, and export defaults (`defaultUseWeight`, `defaultThreadMode`, `defaultExcludeIdle`, `defaultExcludeNonJava`)
  - New `MissingGroup` record for reporting profiler-configuration gaps

- **Added support for imported profiles**:
  - Constructor now accepts both `JfrFlamegraphPanelProvider` and `StackSampleFlamegraphPanelProvider`
  - New `panelProvider()` method routes to the correct provider based on `profileManager.info().eventSource().isFlamegraphOnlyImport()`
  - Imported profiles (pprof, OTLP) bypass the JFR event catalog and use their own sample dimensions

- **Comprehensive test coverage**:
  - New `FlamegraphMcpToolsTest` with nested test classes for JFR and stack-sample imports
  - Tests verify placeholder filtering, export argument defaults, weight units, and dimension handling for imported profiles

- **Updated infrastructure**:
  - `McpToolsetAssembler` and `McpConfiguration` now inject both panel providers
  - Updated `McpToolsetAssemblerTest` to verify `flamegraph_list` is present in tool names

## Implementation Details

The JFR provider emits the full catalog of standard sections (cpu-time, method, wall, allocation, native-leak, blocking) with zero-sample placeholders for uncaptured groups to keep the frontend grid complete. These placeholders are now filtered out and reported as `notRecorded` gaps rather than offered as valid `eventType` arguments, preventing callers from requesting empty trees.

Imported profiles (pprof, OTLP) carry their own sample dimensions (e.g., "cpu", "alloc_space") rather than JFR event types, so they route through `StackSampleFlamegraphPanelProvider` which does not apply the JFR catalog filtering.

Weight units are derived from `WeightKind` (BYTES → "bytes", DURATION → "nanoseconds") and null together with weight when weighing is not applicable (e.g., execution samples).

https://claude.ai/code/session_01BjWnyVwu6WjsAhMwmMq2Kg