### PR TITLE
Sandbox the DuckDB engine behind the MCP SQL tools

### DIFF
--- a/jeffrey-claude-plugin/skills/jfr-sql/SKILL.md
+++ b/jeffrey-claude-plugin/skills/jfr-sql/SKILL.md
@@ -103,7 +103,15 @@ assuming.
 `jfr_executeQuery` caps rows and total characters and says so when it truncates. Aggregate in SQL
 rather than pulling rows back to count them.
 
-## No writes
+## One statement, and no way out of the database
 
-`jfr_executeModification` is not exposed to external clients. Data cleanup and frame renaming happen
-in the Jeffrey UI.
+`jfr_executeModification` is not exposed to external clients: data cleanup and frame renaming happen
+in the Jeffrey UI. Two rules follow from how the read tools are sandboxed, and both fail loudly
+rather than silently:
+
+- **One statement per call.** Anything after a semicolon is refused before the query runs. Send the
+  `SELECT` on its own.
+- **The engine has no filesystem.** The profile database is opened with DuckDB's external file
+  access off, so `read_text`, `read_csv`, `read_parquet`, `glob` and `ATTACH` all fail. Nothing is
+  lost for analysis — every table you need is in this database — but a query that reaches for one
+  comes back with a permission error rather than a confusing empty result.

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/McpStreamableHttpController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/McpStreamableHttpController.java
@@ -93,8 +93,14 @@ public class McpStreamableHttpController extends AbstractMcpStreamableHttpContro
         return switch (toolset) {
             case TOOLSET_JFR -> {
                 ProfileInfo profileInfo = profileManagerResolver.resolve(profileId).info();
+                // Excluded for the same reason the external assembler excludes it: this toolset is
+                // built with canModify=false, so the tool could only ever refuse, and an advertised
+                // tool that always refuses spends a slot in the model's context on a call that
+                // cannot succeed. One set, so the two endpoints cannot drift apart.
                 yield new ReflectiveToolset(
-                        new DuckDbMcpTools(databaseManagerResolver.open(profileInfo)), TOOLSET_JFR);
+                        new DuckDbMcpTools(databaseManagerResolver.open(profileInfo)),
+                        TOOLSET_JFR,
+                        McpToolsetAssembler.WRITE_TOOLS);
             }
             case TOOLSET_HEAP -> {
                 HeapDumpManagerToolsDelegate delegate =

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/McpToolsetAssembler.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/McpToolsetAssembler.java
@@ -71,7 +71,7 @@ public class McpToolsetAssembler {
      * advertised tool that always answers "not enabled" spends a slot in the model's context and
      * invites a call that cannot succeed.
      */
-    private static final Set<String> WRITE_TOOLS = Set.of("executeModification");
+    static final Set<String> WRITE_TOOLS = Set.of("executeModification");
 
     private final McpToolProvider toolset;
 

--- a/jeffrey-microscope/core-microscope/src/main/resources/application.properties
+++ b/jeffrey-microscope/core-microscope/src/main/resources/application.properties
@@ -22,6 +22,12 @@
 # 8080. Overridable as any other Spring property.
 server.port=8585
 
+# Which interfaces to serve on. Left unset, Spring Boot binds all of them, so a Microscope on a
+# laptop is reachable from that laptop's network. Nothing under /api/internal authenticates --
+# reachable means trusted -- and that includes the MCP endpoint below, which reads every profile
+# in the installation. On any network you do not control, bind to loopback:
+# server.address=127.0.0.1
+
 # Serve HTTP requests on virtual threads (Tomcat + Spring task executors). Requires JDK 21+.
 # Note: under async-profiler, a long request can unmount/remount across carrier threads, which
 # reduces the accuracy of the "events during span" thread+time correlation (carrier fragmentation).

--- a/jeffrey-microscope/profiles/duckdb-jfr-mcp/src/main/java/cafe/jeffrey/profile/ai/duckdb/jfr/tools/DuckDbMcpTools.java
+++ b/jeffrey-microscope/profiles/duckdb-jfr-mcp/src/main/java/cafe/jeffrey/profile/ai/duckdb/jfr/tools/DuckDbMcpTools.java
@@ -39,6 +39,17 @@ public class DuckDbMcpTools {
     private static final int MAX_ROWS = 1000;
     private static final int MAX_QUERY_RESULT_LENGTH = 50000;
 
+    /**
+     * How long a caller's query may run. Matches the heap side's SqlExecutor, which is the existing
+     * precedent. Without it a cartesian join holds one of the profile pool's connections until the
+     * process dies, and that pool is the one the UI reads the same profile through.
+     */
+    private static final int QUERY_TIMEOUT_SECONDS = 30;
+
+    private static final String MULTIPLE_STATEMENTS_MESSAGE =
+            "Only one statement per call. Send the SELECT on its own, without a second statement "
+                    + "after a semicolon.";
+
     private final DataSource dataSource;
     private final boolean canModify;
 
@@ -129,22 +140,46 @@ public class DuckDbMcpTools {
             return "Error: Query is required";
         }
 
+        // Defence in depth, and deliberately not the boundary. What confines this query is the
+        // connection: the profile DataSource disables DuckDB's external file access and extension
+        // autoloading, so no spelling of a SELECT reaches read_text, glob or ATTACH. A prefix test
+        // could never do that on its own -- it is a string check, not a parser, and the reach is a
+        // function call rather than a leading keyword. It stays only to turn an obvious write into
+        // a clear message instead of an engine error.
         String normalizedQuery = query.trim().toLowerCase();
         if (!normalizedQuery.startsWith("select") && !normalizedQuery.startsWith("with")) {
-            return "Error: Only SELECT queries are allowed for security reasons";
+            return "Error: Only SELECT and WITH queries are allowed";
         }
 
-        // Add LIMIT if not present
-        String safeQuery = query;
-        if (!normalizedQuery.contains("limit")) {
-            safeQuery = query + " LIMIT " + MAX_ROWS;
+        // prepareStatement, not createStatement, for three reasons. DuckDB refuses a prepared
+        // statement carrying more than one statement, so ';' cannot smuggle a second one in. The row
+        // cap and the timeout are enforced by the driver rather than by appending text, which the
+        // old "does the query contain the word limit" test got wrong in both directions -- a query
+        // mentioning it in a comment or an alias went uncapped, and a trailing line comment
+        // swallowed the appended clause. And Statement.executeQuery reports every binder failure as
+        // "unsuccessful or closed pending query result", where a prepared statement surfaces the
+        // engine's real message: the missing column, or the permission error from the sandbox above.
+        // That message is the only thing the caller can act on.
+        if (carriesMultipleStatements(query)) {
+            return "Error: " + MULTIPLE_STATEMENTS_MESSAGE;
         }
 
+        // prepareStatement, not createStatement, for the error messages: Statement.executeQuery
+        // reports a missing column, a missing table and a refusal from the sandbox identically, as
+        // "unsuccessful or closed pending query result", where a prepared statement carries the
+        // engine's real message. That message is the only thing a caller can correct itself from.
+        //
+        // The row cap is applied while reading, not with setMaxRows: DuckDB's driver accepts that
+        // call and ignores it (getMaxRows stays 0). Reading is cheap because results stream, so
+        // stopping at the cap does not make the engine materialise the rest.
         try (Connection conn = dataSource.getConnection();
-             Statement stmt = conn.createStatement();
-             ResultSet rs = stmt.executeQuery(safeQuery)) {
+             PreparedStatement stmt = conn.prepareStatement(query)) {
 
-            return formatResultSet(rs);
+            stmt.setQueryTimeout(QUERY_TIMEOUT_SECONDS);
+
+            try (ResultSet rs = stmt.executeQuery()) {
+                return formatResultSet(rs);
+            }
         } catch (SQLException e) {
             LOG.error("Failed to execute query: query={} message={}", query, e.getMessage(), e);
             return "Error: Query execution failed: " + e.getMessage();
@@ -239,14 +274,18 @@ public class DuckDbMcpTools {
                 WHERE event_type = ?
                 """);
 
+        if (whereClause != null && !whereClause.isBlank() && carriesMultipleStatements(whereClause)) {
+            return "Error: " + MULTIPLE_STATEMENTS_MESSAGE;
+        }
+
         if (whereClause != null && !whereClause.isBlank()) {
-            // Basic SQL injection prevention
-            String sanitized = whereClause.toLowerCase();
-            if (sanitized.contains("drop") || sanitized.contains("delete") ||
-                    sanitized.contains("insert") || sanitized.contains("update") ||
-                    sanitized.contains("alter") || sanitized.contains("create")) {
-                return "Error: Invalid WHERE clause: contains forbidden keywords";
-            }
+            // The fragment is caller-supplied SQL spliced into the statement, and it is confined by
+            // the same thing executeQuery is: the connection has no filesystem and no extension
+            // loading, so the worst a fragment can do is read this profile's own tables -- which is
+            // what the tool is for. The keyword denylist that used to stand here was worse than
+            // nothing: it missed ATTACH, COPY and every file function, so a scalar subquery walked
+            // straight through the AND (...) it lands in, while it rejected honest filters over any
+            // value containing "created" or "updated".
             queryBuilder.append(" AND (").append(whereClause).append(")");
         }
 
@@ -257,6 +296,7 @@ public class DuckDbMcpTools {
 
             stmt.setString(1, eventType);
             stmt.setInt(2, safeLimit);
+            stmt.setQueryTimeout(QUERY_TIMEOUT_SECONDS);
 
             try (ResultSet rs = stmt.executeQuery()) {
                 return formatResultSet(rs);
@@ -373,9 +413,9 @@ public class DuckDbMcpTools {
         result.append("\n");
         result.append("-".repeat(widths.stream().mapToInt(Integer::intValue).sum() + widths.size())).append("\n");
 
-        // Build data rows
+        // Build data rows. Two caps: the row count, and the size of the rendered output.
         int rowCount = 0;
-        while (rs.next() && result.length() < MAX_QUERY_RESULT_LENGTH) {
+        while (rowCount < MAX_ROWS && result.length() < MAX_QUERY_RESULT_LENGTH && rs.next()) {
             for (int i = 1; i <= columnCount; i++) {
                 Object value = rs.getObject(i);
                 String strValue = value != null ? value.toString() : "NULL";
@@ -390,10 +430,91 @@ public class DuckDbMcpTools {
 
         if (result.length() >= MAX_QUERY_RESULT_LENGTH) {
             result.append("\n... (output truncated, ").append(rowCount).append(" rows shown)");
+        } else if (rowCount == MAX_ROWS && rs.next()) {
+            // Asked once more, so this says what is true rather than what is likely. A capped answer
+            // is otherwise indistinguishable from a complete one, and a reader that cannot see the
+            // cap reports the first page as the whole story.
+            result.append("\n").append(rowCount)
+                    .append(" row(s) returned - the ").append(MAX_ROWS)
+                    .append(" row cap was reached and there are more. ")
+                    .append("Aggregate in SQL rather than pulling rows back to count them.");
         } else {
             result.append("\n").append(rowCount).append(" row(s) returned");
         }
 
         return result.toString();
+    }
+
+    /**
+     * Whether the text carries more than one statement.
+     * <p>
+     * DuckDB's driver runs every statement in the string and only afterwards complains that
+     * {@code executeQuery} produced no result set — by which time the second one has already run.
+     * {@code SELECT 1; DROP TABLE events} therefore satisfies a leading-keyword check and still drops
+     * the table, which is how a tool documented as read-only turns out to write. Nothing else here
+     * stops it: the engine sandbox blocks the filesystem, not DDL against this database.
+     * <p>
+     * A semicolon inside a string literal, a quoted identifier or a comment is not a separator, so
+     * those are masked out before looking. A single trailing semicolon is a statement terminator, not
+     * a second statement.
+     */
+    static boolean carriesMultipleStatements(String sql) {
+        String masked = maskLiteralsAndComments(sql);
+        int separator = masked.indexOf(';');
+        return separator >= 0 && !masked.substring(separator + 1).isBlank();
+    }
+
+    /**
+     * The same text with every string literal, quoted identifier and comment blanked out, keeping the
+     * original length so positions still line up. Anything unterminated blanks to the end, which
+     * hides a semicolon rather than inventing one — the safe direction here is to under-report a
+     * separator inside a malformed query, since DuckDB rejects the query anyway.
+     */
+    private static String maskLiteralsAndComments(String sql) {
+        char[] out = sql.toCharArray();
+        int i = 0;
+        while (i < out.length) {
+            char current = out[i];
+            if (current == '\'' || current == '"') {
+                i = maskUntil(out, i, current);
+            } else if (current == '-' && i + 1 < out.length && out[i + 1] == '-') {
+                while (i < out.length && out[i] != '\n') {
+                    out[i++] = ' ';
+                }
+            } else if (current == '/' && i + 1 < out.length && out[i + 1] == '*') {
+                i = maskBlockComment(out, i);
+            } else {
+                i++;
+            }
+        }
+        return new String(out);
+    }
+
+    /** Blanks a quoted run, including both quotes, and returns the index just past it. */
+    private static int maskUntil(char[] out, int start, char quote) {
+        out[start] = ' ';
+        int i = start + 1;
+        while (i < out.length) {
+            boolean closing = out[i] == quote;
+            out[i++] = ' ';
+            if (closing) {
+                return i;
+            }
+        }
+        return i;
+    }
+
+    private static int maskBlockComment(char[] out, int start) {
+        int i = start;
+        out[i++] = ' ';
+        while (i < out.length) {
+            boolean closing = out[i] == '*' && i + 1 < out.length && out[i + 1] == '/';
+            out[i++] = ' ';
+            if (closing) {
+                out[i++] = ' ';
+                return i;
+            }
+        }
+        return i;
     }
 }

--- a/jeffrey-microscope/profiles/duckdb-jfr-mcp/src/test/java/cafe/jeffrey/profile/ai/duckdb/jfr/tools/DuckDbMcpToolsTest.java
+++ b/jeffrey-microscope/profiles/duckdb-jfr-mcp/src/test/java/cafe/jeffrey/profile/ai/duckdb/jfr/tools/DuckDbMcpToolsTest.java
@@ -1,0 +1,280 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.ai.duckdb.jfr.tools;
+
+import cafe.jeffrey.test.DuckDBTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The guards on the JFR SQL tool.
+ * <p>
+ * The engine sandbox that actually confines these queries lives on the profile DataSource and is
+ * asserted by {@code DuckDBProfileDatabaseManagerTest}. What is left here is everything the tool
+ * itself owes its caller: a row cap that cannot be talked out of, and an error message worth acting
+ * on.
+ */
+@DuckDBTest
+class DuckDbMcpToolsTest {
+
+    private static final int MAX_ROWS = 1000;
+
+    /** More rows than the cap, so a capped answer and a complete one are distinguishable. */
+    private static void seedRows(DataSource dataSource, int rows) throws SQLException {
+        try (Connection conn = dataSource.getConnection();
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE big AS SELECT i FROM generate_series(1, " + rows + ") AS t(i)");
+        }
+    }
+
+    private static int rowsReported(String output) {
+        for (String line : output.split("\n")) {
+            if (line.contains("row(s) returned")) {
+                return Integer.parseInt(line.trim().split(" ")[0]);
+            }
+        }
+        throw new AssertionError("no row count in output: " + output);
+    }
+
+    @Nested
+    @DisplayName("Row cap")
+    class RowCap {
+
+        @Test
+        @DisplayName("caps a query that asks for everything")
+        void capsAnUnboundedQuery(DataSource dataSource) throws SQLException {
+            seedRows(dataSource, 1500);
+
+            String out = new DuckDbMcpTools(dataSource).executeQuery("SELECT i FROM big");
+
+            assertEquals(MAX_ROWS, rowsReported(out), out);
+        }
+
+        /*
+         * The regression this file exists for. The cap used to be a string append, skipped whenever
+         * the query contained the substring "limit" anywhere -- so a comment, a column alias or a
+         * string literal mentioning it handed back the whole table. The cap is the driver's now, and
+         * none of these three can reach it.
+         */
+        @Test
+        @DisplayName("caps a query whose only mention of limit is a comment")
+        void capsWhenLimitAppearsInAComment(DataSource dataSource) throws SQLException {
+            seedRows(dataSource, 1500);
+
+            String out = new DuckDbMcpTools(dataSource).executeQuery("SELECT i FROM big -- no limit here");
+
+            assertEquals(MAX_ROWS, rowsReported(out), out);
+        }
+
+        @Test
+        @DisplayName("caps a query whose only mention of limit is a column alias")
+        void capsWhenLimitAppearsAsAnAlias(DataSource dataSource) throws SQLException {
+            seedRows(dataSource, 1500);
+
+            String out = new DuckDbMcpTools(dataSource).executeQuery("SELECT i AS limit_reached FROM big");
+
+            assertEquals(MAX_ROWS, rowsReported(out), out);
+        }
+
+        @Test
+        @DisplayName("says the cap was reached, so a partial answer does not read as a complete one")
+        void announcesTheCap(DataSource dataSource) throws SQLException {
+            seedRows(dataSource, 1500);
+
+            String out = new DuckDbMcpTools(dataSource).executeQuery("SELECT i FROM big");
+
+            assertTrue(out.contains("row cap was reached"), out);
+        }
+
+        @Test
+        @DisplayName("stays quiet when the answer is complete")
+        void saysNothingWhenUncapped(DataSource dataSource) throws SQLException {
+            seedRows(dataSource, 10);
+
+            String out = new DuckDbMcpTools(dataSource).executeQuery("SELECT i FROM big");
+
+            assertEquals(10, rowsReported(out), out);
+            assertFalse(out.contains("row cap was reached"), out);
+        }
+
+        @Test
+        @DisplayName("a caller's own smaller LIMIT still wins")
+        void respectsACallersOwnLimit(DataSource dataSource) throws SQLException {
+            seedRows(dataSource, 1500);
+
+            String out = new DuckDbMcpTools(dataSource).executeQuery("SELECT i FROM big LIMIT 5");
+
+            assertEquals(5, rowsReported(out), out);
+        }
+    }
+
+    @Nested
+    @DisplayName("Errors a caller can act on")
+    class Errors {
+
+        /*
+         * Statement.executeQuery reports a missing column, a missing table and a sandbox refusal
+         * identically, as "unsuccessful or closed pending query result". A model given that cannot
+         * correct itself, so it retries the same query. A prepared statement carries the real one.
+         */
+        @Test
+        @DisplayName("an unknown column comes back named, not as a generic driver failure")
+        void surfacesTheRealBinderError(DataSource dataSource) throws SQLException {
+            seedRows(dataSource, 1);
+
+            String out = new DuckDbMcpTools(dataSource).executeQuery("SELECT nope FROM big");
+
+            assertTrue(out.contains("nope"), "the caller has to be told which column: " + out);
+            assertFalse(out.contains("pending query result"), out);
+        }
+
+        @Test
+        @DisplayName("an unknown table comes back named")
+        void surfacesTheRealCatalogError(DataSource dataSource) {
+            String out = new DuckDbMcpTools(dataSource).executeQuery("SELECT * FROM no_such_table");
+
+            assertTrue(out.contains("no_such_table"), out);
+            assertFalse(out.contains("pending query result"), out);
+        }
+    }
+
+    @Nested
+    @DisplayName("Multiple statements")
+    class MultipleStatements {
+
+        /*
+         * DuckDB runs every statement in the string and only then complains that executeQuery
+         * returned no result set, so the second one has already happened. Nothing else in the tool
+         * stops it: the leading keyword is still SELECT, and the engine sandbox blocks the
+         * filesystem rather than DDL against this database.
+         */
+        @Test
+        @DisplayName("a statement after a semicolon is refused before anything runs")
+        void refusesStackedStatements(DataSource dataSource) throws SQLException {
+            seedRows(dataSource, 1);
+
+            String out = new DuckDbMcpTools(dataSource).executeQuery("SELECT i FROM big; DROP TABLE big");
+
+            assertTrue(out.startsWith("Error:"), out);
+            assertTrue(tableExists(dataSource), "the DROP must not have run");
+        }
+
+        @Test
+        @DisplayName("a trailing semicolon is a terminator, not a second statement")
+        void allowsATrailingSemicolon(DataSource dataSource) throws SQLException {
+            seedRows(dataSource, 3);
+
+            String out = new DuckDbMcpTools(dataSource).executeQuery("SELECT i FROM big;  ");
+
+            assertFalse(out.startsWith("Error:"), out);
+        }
+
+        @Test
+        @DisplayName("a semicolon inside a string literal is not a separator")
+        void allowsASemicolonInsideALiteral() {
+            assertFalse(DuckDbMcpTools.carriesMultipleStatements(
+                    "SELECT i FROM big WHERE name LIKE '%;%'"));
+            assertFalse(DuckDbMcpTools.carriesMultipleStatements(
+                    "SELECT 'it''s; fine' AS quoted FROM big"));
+        }
+
+        @Test
+        @DisplayName("a semicolon inside a comment is not a separator")
+        void allowsASemicolonInsideAComment() {
+            assertFalse(DuckDbMcpTools.carriesMultipleStatements("SELECT i FROM big -- ; not a statement"));
+            assertFalse(DuckDbMcpTools.carriesMultipleStatements("SELECT i /* ; still not */ FROM big"));
+        }
+
+        @Test
+        @DisplayName("a separator hidden behind a literal or a comment is still found")
+        void findsASeparatorAfterALiteral() {
+            assertTrue(DuckDbMcpTools.carriesMultipleStatements(
+                    "SELECT 'a;b' FROM big; DROP TABLE big"));
+            assertTrue(DuckDbMcpTools.carriesMultipleStatements(
+                    "SELECT i FROM big /* c */; DROP TABLE big"));
+            assertTrue(DuckDbMcpTools.carriesMultipleStatements(
+                    "SELECT i FROM big;\n-- a comment\nDROP TABLE big"));
+        }
+
+        @Test
+        @DisplayName("a comment after the terminator is still only one statement")
+        void allowsACommentAfterTheTerminator() {
+            assertFalse(DuckDbMcpTools.carriesMultipleStatements("SELECT i FROM big; -- done"));
+        }
+
+        @Test
+        @DisplayName("the WHERE fragment cannot smuggle one in either")
+        void guardsTheWhereClause(DataSource dataSource) throws SQLException {
+            seedRows(dataSource, 1);
+
+            String out = new DuckDbMcpTools(dataSource)
+                    .queryEvents("jdk.ExecutionSample", 10, "1=1); DROP TABLE big; --");
+
+            assertTrue(out.startsWith("Error:"), out);
+            assertTrue(tableExists(dataSource), "the DROP must not have run");
+        }
+
+        private boolean tableExists(DataSource dataSource) throws SQLException {
+            try (Connection conn = dataSource.getConnection();
+                 Statement stmt = conn.createStatement()) {
+                stmt.executeQuery("SELECT 1 FROM big LIMIT 1");
+                return true;
+            } catch (SQLException e) {
+                return false;
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Statement shape")
+    class StatementShape {
+
+        @Test
+        @DisplayName("refuses anything that is not a SELECT or a WITH")
+        void refusesNonSelect(DataSource dataSource) {
+            DuckDbMcpTools tools = new DuckDbMcpTools(dataSource);
+
+            assertTrue(tools.executeQuery("DELETE FROM big").startsWith("Error:"));
+            assertTrue(tools.executeQuery("ATTACH 'other.db' AS other").startsWith("Error:"));
+            assertTrue(tools.executeQuery("COPY big TO '/tmp/out.csv'").startsWith("Error:"));
+        }
+
+        @Test
+        @DisplayName("accepts a WITH, which is a read")
+        void acceptsWith(DataSource dataSource) throws SQLException {
+            seedRows(dataSource, 3);
+
+            String out = new DuckDbMcpTools(dataSource)
+                    .executeQuery("WITH x AS (SELECT i FROM big) SELECT COUNT(*) FROM x");
+
+            assertFalse(out.startsWith("Error:"), out);
+        }
+
+    }
+}

--- a/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/persistence/DuckDbHeapView.java
+++ b/jeffrey-microscope/profiles/heap-dump/src/main/java/cafe/jeffrey/profile/heapdump/persistence/DuckDbHeapView.java
@@ -191,6 +191,14 @@ public final class DuckDbHeapView implements HeapView {
         String url = "jdbc:duckdb:" + indexDbPath.toAbsolutePath();
         Properties props = new Properties();
         props.setProperty("duckdb.read_only", "true");
+        // Read-only stops a write to the index; it does nothing about the host filesystem, which a
+        // SELECT reaches through read_text/read_csv/glob unless external access is turned off. This
+        // connection serves heap queries that originate outside Jeffrey (the MCP heap_ family), so
+        // it is confined to the index it opened. Only the read path: building the index legitimately
+        // uses COPY and read_parquet, and that runs on HeapDumpIndexDb's own connection.
+        props.setProperty("enable_external_access", "false");
+        props.setProperty("autoinstall_known_extensions", "false");
+        props.setProperty("autoload_known_extensions", "false");
         Connection conn = DriverManager.getConnection(url, props);
         LOG.debug("Opened heap dump index for reading: path={} hprof_attached={}",
                 indexDbPath, hprof != null);

--- a/jeffrey-microscope/profiles/mcp-server/src/main/java/cafe/jeffrey/profile/mcp/ReflectiveToolset.java
+++ b/jeffrey-microscope/profiles/mcp-server/src/main/java/cafe/jeffrey/profile/mcp/ReflectiveToolset.java
@@ -24,6 +24,7 @@ import tools.jackson.databind.JsonNode;
 
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Adapts an object whose methods are annotated with Spring AI's {@link Tool}/{@link ToolParam} into a
@@ -44,8 +45,18 @@ public final class ReflectiveToolset implements McpToolProvider {
     private final ToolMethodIndex index;
 
     public ReflectiveToolset(Object target, String prefix) {
+        this(target, prefix, Set.of());
+    }
+
+    /**
+     * @param excludedMethods tool method names to leave out of this toolset entirely, for a target
+     *                        carrying a tool this endpoint will always refuse. Advertising one costs
+     *                        a slot in the model's context and invites a call that cannot succeed,
+     *                        which is why the exclusion happens here rather than in the tool.
+     */
+    public ReflectiveToolset(Object target, String prefix, Set<String> excludedMethods) {
         this.target = target;
-        this.index = new ToolMethodIndex(target.getClass(), prefix, List.of());
+        this.index = new ToolMethodIndex(target.getClass(), prefix, List.of(), excludedMethods);
     }
 
     @Override

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/DuckDBProfileDatabaseManager.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/main/java/cafe/jeffrey/provider/profile/jdbc/DuckDBProfileDatabaseManager.java
@@ -50,6 +50,35 @@ public class DuckDBProfileDatabaseManager implements DatabaseManager {
     // cache) alive between requests; further connections are created on demand
     private static final int MIN_IDLE_CONNECTIONS = 1;
 
+    /**
+     * DuckDB settings that confine a query to this database file.
+     * <p>
+     * DuckDB treats SQL as code: its own guidance is not to run SQL from an untrusted source without
+     * sandboxing the engine first. A {@code SELECT} can reach the host filesystem through
+     * {@code read_text}, {@code read_csv}, {@code read_parquet} and {@code glob}, and can pull an
+     * extension over the network by naming one, all of which are enabled by default. That matters
+     * here because the external MCP server hands a caller's SQL string to this pool
+     * ({@code jfr_executeQuery}), and no string check in front of it is a substitute — a prefix test
+     * is not a parser, and the reach is a function call rather than a statement keyword.
+     * <p>
+     * Turning external access off costs this database nothing: nothing in Jeffrey reads or writes a
+     * file through SQL on a profile database. Ingestion goes through {@code DuckDBAppender}, and the
+     * heap-dump index, which genuinely does use {@code COPY} and {@code read_parquet}, is a separate
+     * database with its own connection. <b>A feature that needs a file function on a profile database
+     * has to weigh that against reopening this hole.</b>
+     */
+    private static final String EXTERNAL_ACCESS_SETTING = "enable_external_access";
+    private static final String EXTERNAL_ACCESS_VALUE = "false";
+
+    /**
+     * Stops a query causing an extension to be fetched and loaded. Autoloading turns naming an
+     * unknown function into a network request, which is both a way out of the sandbox above and a
+     * surprising cost inside an ordinary query.
+     */
+    private static final String AUTOINSTALL_EXTENSIONS_SETTING = "autoinstall_known_extensions";
+    private static final String AUTOLOAD_EXTENSIONS_SETTING = "autoload_known_extensions";
+    private static final String EXTENSION_AUTOLOADING_VALUE = "false";
+
     private static final String WAL_AUTOCHECKPOINT_PROPERTY = "wal_autocheckpoint";
 
     /**
@@ -109,6 +138,9 @@ public class DuckDBProfileDatabaseManager implements DatabaseManager {
                 .keepAliveTime(Duration.ZERO)
                 .additionalProperty(WAL_AUTOCHECKPOINT_PROPERTY, WAL_AUTOCHECKPOINT_THRESHOLD)
                 .additionalProperty(PRESERVE_INSERTION_ORDER_SETTING, PRESERVE_INSERTION_ORDER_VALUE)
+                .additionalProperty(EXTERNAL_ACCESS_SETTING, EXTERNAL_ACCESS_VALUE)
+                .additionalProperty(AUTOINSTALL_EXTENSIONS_SETTING, EXTENSION_AUTOLOADING_VALUE)
+                .additionalProperty(AUTOLOAD_EXTENSIONS_SETTING, EXTENSION_AUTOLOADING_VALUE)
                 .build();
 
         return DataSourceProvider.open(params);

--- a/jeffrey-microscope/profiles/profile-sql-persistence/src/test/java/cafe/jeffrey/provider/profile/jdbc/DuckDBProfileDatabaseManagerTest.java
+++ b/jeffrey-microscope/profiles/profile-sql-persistence/src/test/java/cafe/jeffrey/provider/profile/jdbc/DuckDBProfileDatabaseManagerTest.java
@@ -1,0 +1,168 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.provider.profile.jdbc;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.sql.DataSource;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The sandbox around a profile database.
+ * <p>
+ * These are not tests of a feature; they are the guard on one. The external MCP server hands a
+ * caller's SQL string to this pool, and DuckDB's file-reading functions are legal inside a
+ * {@code SELECT} — so if the settings this asserts are ever dropped, an unauthenticated endpoint
+ * starts serving the contents of the host's filesystem, and nothing else in the build would notice.
+ */
+class DuckDBProfileDatabaseManagerTest {
+
+    @TempDir
+    Path baseDir;
+
+    private DataSource dataSource;
+
+    private DataSource profileDatabase() {
+        dataSource = new DuckDBProfileDatabaseManager(baseDir).open("p-1");
+        return dataSource;
+    }
+
+    @AfterEach
+    void closePool() throws Exception {
+        if (dataSource instanceof AutoCloseable closeable) {
+            closeable.close();
+        }
+    }
+
+    /**
+     * Through a prepared statement, because that is what the MCP tool uses and it is the only shape
+     * that surfaces DuckDB's real message; {@code Statement.executeQuery} reports every one of these
+     * as "unsuccessful or closed pending query result", which would make this assertion meaningless.
+     */
+    private SQLException refusedBy(DataSource dataSource, String sql) {
+        return assertThrows(SQLException.class, () -> {
+            try (Connection conn = dataSource.getConnection();
+                 PreparedStatement stmt = conn.prepareStatement(sql);
+                 ResultSet rs = stmt.executeQuery()) {
+                rs.next();
+            }
+        });
+    }
+
+    @Nested
+    @DisplayName("Ordinary use is unaffected")
+    class OrdinaryUse {
+
+        @Test
+        @DisplayName("the database opens, migrates and answers a query")
+        void opensAndMigrates() throws SQLException {
+            DataSource dataSource = profileDatabase();
+
+            try (Connection conn = dataSource.getConnection();
+                 PreparedStatement stmt = conn.prepareStatement("SELECT COUNT(*) FROM events");
+                 ResultSet rs = stmt.executeQuery()) {
+
+                assertTrue(rs.next());
+                assertEquals(0, rs.getLong(1), "the migrated schema is present and queryable");
+            }
+        }
+
+        @Test
+        @DisplayName("the settings the sandbox does not own are still applied")
+        void keepsTheIngestionSettings() throws SQLException {
+            DataSource dataSource = profileDatabase();
+
+            assertEquals("false", setting(dataSource, "preserve_insertion_order"));
+            assertEquals("false", setting(dataSource, "enable_external_access"));
+        }
+
+        private String setting(DataSource dataSource, String name) throws SQLException {
+            try (Connection conn = dataSource.getConnection();
+                 PreparedStatement stmt = conn.prepareStatement("SELECT current_setting('" + name + "')");
+                 ResultSet rs = stmt.executeQuery()) {
+
+                assertTrue(rs.next());
+                return rs.getString(1);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("A query cannot leave the database")
+    class Sandbox {
+
+        @Test
+        @DisplayName("reading a file from the host is refused, and says why")
+        void refusesToReadAHostFile() throws Exception {
+            Path secret = Files.writeString(baseDir.resolve("secret.txt"), "a private key");
+
+            SQLException e = refusedBy(profileDatabase(),
+                    "SELECT content FROM read_text('" + secret.toAbsolutePath() + "')");
+
+            assertTrue(e.getMessage().contains("disabled by configuration"),
+                    "the refusal must name the configuration, not read as a missing function: "
+                            + e.getMessage());
+        }
+
+        @Test
+        @DisplayName("a file function reached from inside a WHERE fragment is refused too")
+        void refusesAFileFunctionInASubquery() throws Exception {
+            // The shape queryEvents' whereClause lands in: AND (<caller's fragment>). A scalar
+            // subquery is valid there, so the boundary has to be the engine rather than the syntax.
+            Path secret = Files.writeString(baseDir.resolve("secret.txt"), "a private key");
+
+            SQLException e = refusedBy(profileDatabase(),
+                    "SELECT 1 WHERE 1=1 AND ((SELECT content FROM read_text('"
+                            + secret.toAbsolutePath() + "')) IS NOT NULL)");
+
+            assertTrue(e.getMessage().contains("disabled by configuration"), e.getMessage());
+        }
+
+        @Test
+        @DisplayName("enumerating the filesystem is refused")
+        void refusesToEnumerateTheFilesystem() {
+            SQLException e = refusedBy(profileDatabase(),
+                    "SELECT file FROM glob('" + baseDir.toAbsolutePath() + "/*')");
+
+            assertTrue(e.getMessage().contains("disabled by configuration"), e.getMessage());
+        }
+
+        @Test
+        @DisplayName("attaching another database is refused")
+        void refusesToAttachAnotherDatabase() {
+            SQLException e = refusedBy(profileDatabase(),
+                    "ATTACH '" + baseDir.resolve("elsewhere.db").toAbsolutePath() + "' AS other");
+
+            assertTrue(e.getMessage().contains("disabled by configuration"), e.getMessage());
+        }
+    }
+}

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpEnablingPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpEnablingPage.vue
@@ -46,6 +46,9 @@ const ingestToggle = `jeffrey.microscope.mcp.ingest.enabled=false`;
 
 const defaultEndpoint = `http://localhost:8585/api/internal/mcp`;
 
+const loopback = `# application.properties -- reachable from this machine and nowhere else
+server.address=127.0.0.1`;
+
 const tunnel = `ssh -N -L 8585:localhost:8585 you@the-host-running-jeffrey`;
 
 const disabledProbe = `curl -s -o /dev/null -w '%{http_code}\\n' \\
@@ -110,7 +113,9 @@ const disabledProbe = `curl -s -o /dev/null -w '%{http_code}\\n' \\
 
       <p>So decide what can reach the address:</p>
       <ul>
-        <li><strong>Bound to loopback.</strong> The default, and enough for a Jeffrey and a Claude Code session on the same machine. This is what makes an on-by-default endpoint safe: it is reachable from that machine and nowhere else.</li>
+        <li><strong>Bound to loopback.</strong> Enough for a Jeffrey and a Claude Code session on the same machine, and the setting worth making first. It is <em>not</em> the default: Jeffrey binds every interface, as Spring Boot does unless told otherwise, so a laptop on a shared network is reachable by that network until you say
+          <DocsCodeBlock :code="loopback" language="properties" />
+          After that the endpoint is reachable from that machine and nowhere else, which is what makes an on-by-default endpoint safe.</li>
         <li><strong>Through an SSH tunnel.</strong> For a Jeffrey on a remote host or in a container, forward the port rather than publishing it:
           <DocsCodeBlock :code="tunnel" language="bash" />
           The client then points at <code>localhost</code> and the endpoint is never exposed.
@@ -118,7 +123,7 @@ const disabledProbe = `curl -s -o /dev/null -w '%{http_code}\\n' \\
         <li><strong>Behind an authenticating reverse proxy.</strong> For a shared installation. Note that MCP clients send an ordinary <code>Authorization</code> header, so a proxy that expects one works today &mdash; but Jeffrey itself does not check it.</li>
       </ul>
 
-      <p>Two things limit the blast radius even so. Every analysis tool is read-only &mdash; the one JFR tool that writes is deliberately not exposed, so an external client can read a profile's data but not rewrite it. And the server has no shell: it answers questions about profiles, and does not run anything.</p>
+      <p>Three things limit the blast radius even so. Every analysis tool is read-only &mdash; the one JFR tool that writes is deliberately not exposed, so an external client can read a profile's data but not rewrite it, and the SQL tools refuse a second statement after a semicolon rather than running it. The SQL engine itself is sandboxed: a profile database is opened with DuckDB's external file access and extension autoloading turned off, so a query is confined to that profile's tables and cannot read a file from the host or fetch anything over the network, however it is spelled. And the server has no shell: it answers questions about profiles, and does not run anything.</p>
 
       <p>The <code>recordings_</code> family is the exception worth understanding, because it is the one place the server touches the filesystem. A client sends a <em>path</em>, not a file &mdash; a JFR recording routinely runs to hundreds of megabytes, and base64 through a JSON-RPC message would spend the client's whole context on bytes neither side ever reads. The path is therefore opened by the Jeffrey process, on the machine Jeffrey runs on, and Jeffrey copies whatever it finds there into the Quick Analysis store.</p>
 

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpOverviewPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpOverviewPage.vue
@@ -151,7 +151,7 @@ onMounted(() => {
       <p>The <router-link to="/docs/microscope-mcp/tools">Tool Reference</router-link> lists every one of them with its arguments.</p>
 
       <DocsCallout type="warning" title="Know what it exposes">
-        The endpoint is on by default and has no authentication yet &mdash; anyone who can reach the address can read every profile in that installation, and ask it to open a recording file from that machine. On a Jeffrey bound to loopback, that is only the machine it runs on. <router-link to="/docs/microscope-mcp/enabling">Enabling the Server</router-link> covers how to expose it safely, how to turn ingestion off on its own, and how to switch the whole thing off.
+        The endpoint is on by default and has no authentication yet &mdash; anyone who can reach the address can read every profile in that installation, and ask it to open a recording file from that machine. Jeffrey binds every interface by default, so on a shared network &ldquo;anyone who can reach the address&rdquo; is wider than it sounds until you bind it to loopback. <router-link to="/docs/microscope-mcp/enabling">Enabling the Server</router-link> covers how to expose it safely, how to turn ingestion off on its own, and how to switch the whole thing off.
       </DocsCallout>
 
       <h2 id="where-to-go-next">Where to Go Next</h2>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpToolsPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpToolsPage.vue
@@ -226,7 +226,7 @@ const analyzeExample = `Analyze target/checkout-run.jfr and tell me where the ti
           <tr>
             <td><code>jfr_executeQuery</code></td>
             <td><code>profileId</code>, <code>query</code></td>
-            <td>An arbitrary read-only query (<code>SELECT</code> / <code>WITH</code> only)</td>
+            <td>An arbitrary read-only query (<code>SELECT</code> / <code>WITH</code> only), one statement per call, capped at 1,000 rows and 30 seconds</td>
           </tr>
           <tr>
             <td><code>jfr_getProfileInfo</code></td>
@@ -236,7 +236,11 @@ const analyzeExample = `Analyze target/checkout-run.jfr and tell me where the ti
         </tbody>
       </table>
 
-      <DocsCallout type="warning" title="Query events, never events_raw">
+      <DocsCallout type="info" title="The engine is sandboxed, not just the syntax">
+        The engine behind these two is sandboxed rather than merely checked: the profile database is opened with DuckDB&rsquo;s external file access and extension autoloading disabled, so a query cannot reach the host&rsquo;s filesystem through <code>read_text</code>, <code>read_csv</code> or <code>glob</code>, and cannot <code>ATTACH</code> another database. A second statement after a semicolon is refused rather than run. What a query can reach is this profile&rsquo;s own tables, which is what the family is for.
+      </DocsCallout>
+
+      <DocsCallout type="warning" title="Query the events view, not events_raw">
         <code>jfr_listTables</code> shows both. <code>events</code> is a view over <code>events_raw</code> that splices back the one large string field the parser pools out of each row; querying <code>events_raw</code> silently returns truncated JSON in <code>fields</code>, with no error to warn you. The bundled <code>jfr-sql</code> skill carries this and the rest of the schema.
       </DocsCallout>
 


### PR DESCRIPTION
## Why

`jfr_executeQuery` handed a caller's SQL string to a profile's DuckDB connection, guarded only by a prefix test for `select`/`with`. A prefix test is not a parser, and DuckDB's file-reading functions are legal inside a `SELECT` with external access at its default. So this passed every check and returned the file over an endpoint that has no authentication:

```sql
SELECT content FROM read_text('/home/user/.ssh/id_rsa')
```

`jfr_queryEvents` had the same reach by a second route. Its `whereClause` is spliced into the statement inside `AND (…)`, where a scalar subquery is valid, behind a six-word keyword denylist that named none of the dangerous constructs.

DuckDB's own guidance is that SQL is code and must be sandboxed before untrusted input reaches it.

## Two more holes, found while testing the fix

Both contradict what the docs currently claim, and neither was in the original diagnosis.

- **Statement stacking executed.** DuckDB runs every statement in the string and only afterwards reports that `executeQuery` returned no result set. `SELECT 1; DROP TABLE events` therefore satisfied the prefix test and dropped the table: the tool documented as read-only could write.
- **`setMaxRows` is accepted and silently ignored** by the driver (`getMaxRows` stays 0). The first version of this change used it and removed the row cap entirely. A test caught it.

## What changed

- The profile `DataSource` and the heap index **read** connection disable external file access and extension autoloading. This costs nothing: no Jeffrey code reads a file through SQL on a profile database, and the heap index build, which genuinely uses `COPY` and `read_parquet`, runs on its own connection and is untouched.
- Both SQL entry points refuse a second statement. The scanner masks string literals, quoted identifiers and comments first, so a semicolon inside `'%;%'` or a trailing `-- ;` is not a separator, while one hidden behind a literal still is.
- The row cap moved into the read loop, and now says when it was reached **and** more rows exist rather than looking like a complete answer. Results stream, so stopping early does not make the engine materialise the rest.
- Queries carry a 30 second timeout, matching `SqlExecutor` on the heap side. Without it one cartesian join holds a connection the UI shares for that profile.
- Statements are prepared rather than executed directly. That is what surfaces DuckDB's real message: every missing column, missing table and refused read previously came back as `unsuccessful or closed pending query result`, which a caller cannot correct itself from.
- The keyword denylist is gone. It missed `ATTACH`, `COPY` and every file function while rejecting honest filters over any value containing `created` or `updated`.

## Two claims corrected

- `/api/internal/mcp/claude-code` advertised `jfr_executeModification` in `tools/list` although it always refused. It now shares the assembler's exclusion set, so the two endpoints cannot drift.
- The docs said loopback binding was the default, and the case for an on-by-default unauthenticated endpoint rested on it. There is no `server.address` anywhere, so Spring binds every interface. The binding is unchanged by request; the property is documented in `application.properties` and the claim rewritten.

## Verification

Each hole was reproduced against a real DuckDB before being fixed, then confirmed closed. 1306 tests pass across the six modules touched, including the heap-dump suite that exercises index build and read.

17 new tests. The sandbox test asserts the refusal names the configuration, so it fails loudly rather than passing vacuously if the settings are ever dropped.

## Not addressed

`recordings_analyzeFile` has no directory containment, no symlink resolution, and accepts a wider extension set than documented including `*-app.log`. A file that fails to parse is still copied into the Quick Analysis store and remains downloadable. That is a file-exfiltration path independent of SQL, and it needs its own decision rather than being folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JNWrxWnAhmevSpYejaUN9o

---
_Generated by [Claude Code](https://claude.ai/code/session_01JNWrxWnAhmevSpYejaUN9o)_