### PR TITLE
Add analyze-heap skill for heap dump analysis guidance

### DIFF
--- a/jeffrey-claude-plugin/README.md
+++ b/jeffrey-claude-plugin/README.md
@@ -65,6 +65,8 @@ both) and not the case for a Jeffrey in a container or on another host.
 **Skills**, which you can also invoke directly:
 
 - `/microscope:analyze-profile` — where to start and which family answers which question
+- `/microscope:analyze-heap` — a heap dump end to end: what is holding the memory, what is leaking,
+  which class loader never went away, and the order the heap tools have to be run in
 - `/microscope:advise` — from a profile to a code change: the hottest CPU, wall-clock, allocation
   and blocking frames mapped to real source in your checkout, a recommendation, then the edit and a
   re-profile on request
@@ -96,6 +98,10 @@ Or, starting from a recording that is not in Jeffrey yet:
 
 > the `GET /api/orders` operation is slow — find a slow example and tell me what the JVM was doing
 > inside its slowest span
+
+Or, from a heap dump:
+
+> analyze /tmp/heap.hprof in Jeffrey — what is holding the memory, and is anything leaking?
 
 Or, once the hotspot is known, in the repository that produced it:
 

--- a/jeffrey-claude-plugin/skills/advise/SKILL.md
+++ b/jeffrey-claude-plugin/skills/advise/SKILL.md
@@ -108,8 +108,8 @@ continue from step 4 above with that export instead of the whole-recording one.
 ## When something is missing
 
 - `flamegraph_list` reports no flamegraph-capable event types → a heap dump or a recording without
-  samples; there is nothing to advise on from a flamegraph. For a heap dump, the `heap_` family and
-  the `heap-sql` skill apply.
+  samples; there is nothing to advise on from a flamegraph. For a heap dump, the `analyze-heap`
+  skill applies instead.
 - The profile's commit differs from `HEAD` and the user does not want to switch → analyse anyway,
   but say in the summary that every file reference was checked against a different commit than
   the one profiled.

--- a/jeffrey-claude-plugin/skills/analyze-heap/SKILL.md
+++ b/jeffrey-claude-plugin/skills/analyze-heap/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: analyze-heap
+description: Work a heap dump with a running Jeffrey Microscope — what is holding the memory, what is leaking, which class loader never went away, where the waste is — including a .hprof file that is not in Jeffrey yet. Use whenever the question is "what is holding memory", "why is the heap growing", "why did this OOM", "what is leaking", or when retained size, a dominator tree, GC roots or a heap dump file are mentioned.
+allowed-tools: mcp__plugin_microscope_jeffrey__heap_* mcp__plugin_microscope_jeffrey__profiles_* mcp__plugin_microscope_jeffrey__recordings_* mcp__jeffrey__heap_* mcp__jeffrey__profiles_* mcp__jeffrey__recordings_*
+---
+
+# Analysing a heap dump
+
+A parsed heap dump is a profile like any other, but it answers a different question from a JFR
+recording. A recording says where the time went; a dump says what was alive at one instant and
+what was keeping it alive. Every tool here reads; none of them changes the dump.
+
+## 1. Resolve the profile
+
+**If the user named a file** — `heap.hprof`, `dump.hprof.gz`, anything with a heap-dump extension —
+call **`recordings_analyzeFile`** with its **absolute** path. It imports the file, parses it and
+returns the `profileId` everything below needs. Two constraints:
+
+- The path is opened by the **Jeffrey process**, so the file must be on the machine Jeffrey runs
+  on. A container or a remote Jeffrey cannot see your working directory.
+- Each call imports the file **again** and builds another profile. Check `recordings_list` or
+  `profiles_list` first if the dump may already be in Jeffrey.
+
+Parsing a large dump takes a while and the call returns only when it is done — that is the work,
+not a hang.
+
+**Otherwise start from the catalogue:** `profiles_list`, where the **`event source`** column reads
+`HEAP_DUMP` for the profiles this skill applies to. Then `profiles_features`, which lists
+`HEAP_DUMP` under `disabledFeatures` when the profile has no dump or its index is not ready.
+
+## 2. Orient before analysing
+
+- **`heap_getDumpMetadata`** — HPROF version, id size, compressed-oops flag, record count and
+  `warning_count`. One call, and it explains a lot later.
+- **`heap_getHeapSummary`** — total live bytes and instances, class count, GC-root count.
+
+A non-zero `warning_count` means the parser skipped, truncated or recovered records, so the totals
+are a lower bound. When the numbers look wrong, read the `parse_warning` table (the `heap-sql`
+skill) before concluding anything from them.
+
+## 3. Shallow is not retained
+
+The distinction decides every answer here, so settle it before reading a number:
+
+- **Shallow size** is the object itself — its header and fields, nothing it points at.
+- **Retained size** is everything that would be freed if the object were collected: the object plus
+  what only it keeps alive.
+
+"What is holding this memory" is always a retained question. A class histogram ranked by shallow
+size answers a different one — it tells you what there is a lot of, not who is responsible for it.
+
+## 4. Build the dominator tree before any retained question
+
+Retained sizes and the dominator tree are computed **lazily**. Until something builds them, the
+`dominator` and `retained_size` tables are empty and every retained figure is missing rather than
+zero.
+
+**`heap_getDominatorTreeRoots`** is what builds them. Call it once, early, before anything that
+ranks by retained size. This is exactly what the tools mean when they say *"this analysis may need
+to be run first"*, and skipping it is the usual reason a heap session stalls on empty results.
+
+## 5. Pick the route
+
+| Question | Sequence |
+|---|---|
+| What is using the heap at all | `heap_getClassHistogram`, then `heap_getTopConsumers` for the same picture grouped by package and class loader |
+| What is leaking | `heap_getLeakSuspects` → `heap_getPathToGCRoot` on the object it names → `heap_getReferrers` to walk outwards |
+| Which single objects are the biggest | `heap_getBiggestObjects` for the flat ranking, `heap_getDominatorTreeRoots` → `heap_getDominatorTreeChildren` to walk down into one |
+| Redeploys leak, or classes look duplicated | `heap_getClassLoaderLeakChains` — the canonical Tomcat-redeploy diagnostic; it names the loader, the GC-root path keeping it alive, and the pattern that matched (ThreadLocal, JDBC driver, JNI global, ServiceLoader, static logger, context class loader) |
+| Where the waste is | `heap_getStringAnalysis` (duplicates, oversized strings), `heap_getCollectionAnalysis` (empty, singleton and oversized collections with their fill ratios) |
+| What is in one particular class | `heap_browseClassInstances` → `heap_getInstanceDetail` → `heap_getPathToGCRoot` |
+| Who is rooting all this | `heap_getGCRootSummary`, and `heap_getThreads` when a thread is the suspect |
+
+Tool names are camelCase after the prefix: `heap_getLeakSuspects`, not `heap_get_leak_suspects`.
+
+`heap_getPathToGCRoot` is the tool that turns an observation into a cause: the histogram says a
+class is large, the GC-root path says *why those instances are still reachable*. Do not report a
+leak without one.
+
+## 6. Grounding claims
+
+- Cite the **class name, the retained bytes and the GC-root path** — the three together are what
+  makes a claim checkable.
+- Object ids are stable within one dump and **meaningless across dumps**. Never carry an id from
+  one dump into a question about another; carry the class name and the path instead.
+- A dump shows a state, not a trend. Two dumps taken apart are what shows growth; one dump alone
+  cannot distinguish a leak from a large working set, so say which one you are claiming.
+- If the repository is open alongside, read the real source of the retaining field before naming a
+  cause. Do not infer a code path from a class name.
+
+## 7. When something is missing
+
+- `Profile … has no heap dump` → it is a JFR recording. Use the `jfr_`, `flamegraph_` and `traces_`
+  families; the `analyze-profile` skill covers them.
+- `The heap dump of profile … is still being indexed` → open it once in the Jeffrey UI to build the
+  index, then try again.
+- Retained sizes come back empty → the dominator tree has not been built. Go back to step 4.
+- A report says its analysis has not been run → run it once and re-read; the results are cached
+  afterwards.
+- No `recordings_` tool is advertised → this Jeffrey was started with
+  `jeffrey.microscope.mcp.ingest.enabled=false`. Upload the dump in the UI and work from
+  `profiles_list`.
+- Every call fails to connect → Jeffrey is not running at that address. Point the plugin at the
+  real `…/api/internal/mcp` endpoint with `/plugin`; **Settings → Claude Code (MCP)** shows the URL
+  for your installation.
+
+Jeffrey's OQL engine is not exposed over MCP; OQL has to be run in the Jeffrey UI. For a question
+none of the reports above cover, drop to DuckDB SQL over the heap index — see the `heap-sql` skill.

--- a/jeffrey-claude-plugin/skills/analyze-profile/SKILL.md
+++ b/jeffrey-claude-plugin/skills/analyze-profile/SKILL.md
@@ -45,7 +45,7 @@ Every tool except `profiles_list` and the `recordings_` family takes a `profileI
 | `flamegraph_` | `panels` (which event types this profile can graph — call it first), `export` (the call tree as Markdown) |
 | `traces_` | `overview`, `operations`, `notifications`, `operationExport`, `slowestTraces`, `traceExport`, `spanFlamegraphExport`, `operationFlamegraphExport` |
 | `jfr_` | `listTables`, `describeTable`, `listEventTypes`, `queryEvents`, `executeQuery`, `getProfileInfo` — raw DuckDB when no purpose-built tool fits |
-| `heap_` | 20 tools: `getHeapSummary`, `getClassHistogram`, `getBiggestObjects`, `getLeakSuspects`, `getPathToGCRoot`, `getDominatorTree*`, `executeQuery`, … |
+| `heap_` | Everything a heap dump answers — summary, histogram, dominator tree, leak suspects, GC-root paths. The largest family, with an order to work it in: see the `analyze-heap` skill |
 | `recordings_` | `analyzeFile` (a file not in Jeffrey yet), `analyzeRecording` (one already uploaded but never analysed), `list` (the Quick Analysis store) |
 
 Tool names are camelCase after the prefix: `jfr_listTables`, not `jfr_list_tables`.
@@ -101,6 +101,8 @@ document shows. If the repository is open alongside, read the real source before
 ## When something is missing
 
 - A tool answers `Profile … has no heap dump` → it is a JFR recording; use `jfr_`, `flamegraph_`, `traces_`.
+- The profile *is* a heap dump (`profiles_list` shows `event source` = `HEAP_DUMP`) → switch to the
+  `analyze-heap` skill; flamegraphs and traces do not apply to it.
 - `recordings_analyzeFile` says the path must be absolute → pass the full path, not a repo-relative one.
 - It says there is no such file, but the file is right there → Jeffrey is looking on *its own*
   filesystem. Copy or mount the recording somewhere Jeffrey can reach, or upload it in the UI.
@@ -114,6 +116,7 @@ document shows. If the repository is open alongside, read the real source before
   `…/api/internal/mcp` endpoint: run `/plugin`, open the `microscope` plugin's configuration
   and set **Jeffrey MCP endpoint**.
 
-For raw SQL against a profile or a heap dump, see the `jfr-sql` and `heap-sql` skills. To go from
-a profile to a code change — hot frames mapped to this repository, a recommendation, an edit and a
-re-profile — see the `advise` skill.
+For a heap dump — what is holding the memory, what is leaking, which class loader never went away
+— see the `analyze-heap` skill. For raw SQL against a profile or a heap dump, see the `jfr-sql` and
+`heap-sql` skills. To go from a profile to a code change — hot frames mapped to this repository, a
+recommendation, an edit and a re-profile — see the `advise` skill.

--- a/jeffrey-claude-plugin/skills/heap-sql/SKILL.md
+++ b/jeffrey-claude-plugin/skills/heap-sql/SKILL.md
@@ -10,13 +10,12 @@ A parsed heap dump becomes its own DuckDB index, separate from the profile's JFR
 
 ## Try the purpose-built tools first
 
-`heap_getHeapSummary`, `heap_getClassHistogram`, `heap_getBiggestObjects`, `heap_getLeakSuspects`,
-`heap_getClassLoaderLeakChains`, `heap_getTopConsumers`, `heap_getStringAnalysis`,
-`heap_getCollectionAnalysis`, `heap_getDominatorTreeRoots` / `Children`, `heap_getPathToGCRoot`,
-`heap_getReferrers`, `heap_browseClassInstances`, `heap_getInstanceDetail`.
+The `heap_` family already answers the usual questions with pre-computed reports — the summary, the
+histogram, the dominator tree, leak suspects, class-loader leak chains, GC-root paths. The
+`analyze-heap` skill covers which one answers what, and the order to run them in. Reproducing those
+reports in SQL is slower and easier to get wrong.
 
-Several of these are pre-computed reports; reproducing them in SQL is slower and easier to get
-wrong. Reach for `heap_executeQuery` only for a question they do not cover. `heap_listTables` and
+Reach for `heap_executeQuery` only for a question they do not cover. `heap_listTables` and
 `heap_describeTable` give the live schema.
 
 ## The tables

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpPluginPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpPluginPage.vue
@@ -97,9 +97,10 @@ const removal = `/plugin uninstall microscope@jeffrey`;
 
       <p><strong>The endpoint, already configured</strong> &mdash; including the per-machine setting above, so the same install works on a laptop and against a tunnelled staging Jeffrey.</p>
 
-      <p><strong>Four skills</strong>, which Claude picks up on its own when a question calls for them, and which you can also invoke directly:</p>
+      <p><strong>Five skills</strong>, which Claude picks up on its own when a question calls for them, and which you can also invoke directly:</p>
       <ul>
         <li><code>/microscope:analyze-profile</code> &mdash; where to start and which family answers which question</li>
+        <li><code>/microscope:analyze-heap</code> &mdash; a heap dump end to end: what is holding the memory, what is leaking, and the order the twenty heap tools have to be run in</li>
         <li><code>/microscope:advise</code> &mdash; from a profile to a code change: hot frames mapped to your checkout, a recommendation, then the edit and a re-profile on request</li>
         <li><code>/microscope:jfr-sql</code> &mdash; the JFR schema and the DuckDB idioms that go with it</li>
         <li><code>/microscope:heap-sql</code> &mdash; the heap-dump index schema</li>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpRecipesPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpRecipesPage.vue
@@ -125,9 +125,11 @@ LIMIT 20`;
       <h2 id="chase-a-memory-problem">Chase a Memory Problem</h2>
       <DocsCodeBlock :code="promptMemory" language="bash" />
 
-      <p>Drives <code>heap_getHeapSummary</code> &rarr; <code>heap_getDominatorTreeRoots</code> &rarr; <code>heap_getPathToGCRoot</code>, usually with <code>heap_getLeakSuspects</code> and <code>heap_getInstanceDetail</code> along the way.</p>
+      <p>Loads <router-link to="/docs/microscope-mcp/skills"><code>/microscope:analyze-heap</code></router-link>, which drives <code>heap_getHeapSummary</code> &rarr; <code>heap_getDominatorTreeRoots</code> &rarr; <code>heap_getPathToGCRoot</code>, usually with <code>heap_getLeakSuspects</code> and <code>heap_getInstanceDetail</code> along the way.</p>
 
       <p>The two-step matters. A class histogram answers &ldquo;what is there&rdquo;; the dominator tree answers &ldquo;what would be freed&rdquo;, which is the one that finds a leak. And <code>heap_getPathToGCRoot</code> is the actual answer to &ldquo;why is this still alive&rdquo; &mdash; a reference chain from a root, usually ending somewhere recognisable like a static cache or a thread-local.</p>
+
+      <p>The order is not optional: <code>dominator</code> and <code>retained_size</code> are built lazily, so every retained figure comes back missing until <code>heap_getDominatorTreeRoots</code> has run once. That is what the skill exists to get right.</p>
 
       <h2 id="does-the-code-agree-with-the-profile">Does the Code Agree With the Profile</h2>
       <DocsCodeBlock :code="promptCrossCheck" language="bash" />

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpSkillsPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpSkillsPage.vue
@@ -29,6 +29,7 @@ const { setHeadings } = useDocHeadings();
 const headings = [
   { id: 'why-skills-at-all', text: 'Why Skills at All', level: 2 },
   { id: 'analyze-profile', text: 'analyze-profile', level: 2 },
+  { id: 'analyze-heap', text: 'analyze-heap', level: 2 },
   { id: 'advise', text: 'advise', level: 2 },
   { id: 'jfr-sql', text: 'jfr-sql', level: 2 },
   { id: 'heap-sql', text: 'heap-sql', level: 2 },
@@ -41,6 +42,7 @@ onMounted(() => {
 });
 
 const invoke = `/microscope:analyze-profile
+/microscope:analyze-heap
 /microscope:advise
 /microscope:jfr-sql
 /microscope:heap-sql`;
@@ -62,7 +64,7 @@ SELECT event_type, COUNT(*) FROM events_raw GROUP BY event_type`;
     />
 
     <div class="docs-content">
-      <p>The <router-link to="/docs/microscope-mcp/plugin">plugin</router-link> ships four skills. Claude loads one on its own when a question calls for it; you can also invoke any of them directly. Registering the MCP server by hand gives you the tools but not these.</p>
+      <p>The <router-link to="/docs/microscope-mcp/plugin">plugin</router-link> ships five skills. Claude loads one on its own when a question calls for it; you can also invoke any of them directly. Registering the MCP server by hand gives you the tools but not these.</p>
 
       <h2 id="why-skills-at-all">Why Skills at All</h2>
       <p>Most of what a model needs in order to <em>read</em> Jeffrey&rsquo;s output already travels with the output. Every flamegraph and trace export opens with a preamble that defines what <code>self</code> means against <code>total</code>, what the frame tags mean, what was pruned, and how to analyse that particular event type. Nothing needs to repeat that, and a skill that did would go stale the moment the preamble changed.</p>
@@ -80,6 +82,19 @@ SELECT event_type, COUNT(*) FROM events_raw GROUP BY event_type`;
       <p>It carries the entry sequence &mdash; <code>profiles_list</code>, then <code>profiles_features</code>, then the family that matches the question &mdash; a map of the six families to the questions each answers, when to start instead from <code>recordings_analyzeFile</code> because the user named a file Jeffrey has never seen, the rule that every scoped tool takes a <code>profileId</code>, which flamegraph to pick for CPU versus allocation versus lock contention versus wall-clock, the order to work a latency question in traces, and what a failure means (a <code>404</code> means the server was switched off, not a bug).</p>
 
       <p>It also tells the model to <strong>ground its claims</strong>: the exports contain call paths and numbers, not source locations, so file and line numbers must be read from the repository rather than inferred from a profile.</p>
+
+      <h2 id="analyze-heap">analyze-heap</h2>
+      <p><em>A heap dump end to end.</em> Loaded when the question is &ldquo;what is holding memory&rdquo;, &ldquo;why is the heap growing&rdquo;, &ldquo;why did this OOM&rdquo;, &ldquo;what is leaking&rdquo;, or when retained size, a dominator tree, GC roots or a <code>.hprof</code> file are mentioned.</p>
+
+      <p><code>heap_</code> is the largest family, and the only one whose tools have to be run in an order. Half of its reports say &ldquo;this analysis may need to be run first&rdquo; without saying which one, and nothing in a tool list explains what that means. The skill carries the order and the two rules that decide every heap answer:</p>
+      <ul>
+        <li><strong>Shallow is not retained.</strong> Shallow size is the object itself; retained size is what dies with it. Only the second answers &ldquo;who is holding this memory&rdquo; &mdash; a histogram ranked by shallow size tells you what there is a lot of, not who is responsible for it.</li>
+        <li><strong>The dominator tree is built lazily.</strong> <code>dominator</code> and <code>retained_size</code> stay empty until <code>heap_getDominatorTreeRoots</code> runs, so every retained figure is missing rather than zero. Calling it once, early, is what the reports mean by their warning, and skipping it is the usual reason a heap session stalls on empty results.</li>
+      </ul>
+
+      <p>On top of that it carries the routes &mdash; the histogram and top consumers for what is using the heap, leak suspects into a GC-root path for what is leaking, <code>heap_getClassLoaderLeakChains</code> for the redeploy case that leaves a class loader behind, string and collection analysis for waste, and instance browsing for one particular class &mdash; plus how to enter from a <code>.hprof</code> file Jeffrey has never seen, and what the two guard messages mean when a profile turns out to have no heap dump or an index that is still being built.</p>
+
+      <p>It grounds claims the way <code>analyze-profile</code> does: cite the class name, the retained bytes and the GC-root path together, never carry an object id between dumps, and say whether one dump is being read as a leak or as a large working set &mdash; a single dump cannot tell those apart.</p>
 
       <h2 id="advise">advise</h2>
       <p><em>From a profile to a code change.</em> Loaded when the question is &ldquo;what should I change&rdquo;, &ldquo;optimise this&rdquo;, or when a hotspot has been found and the next question is what to do about it. It is the successor of the in-app Profile Advisor: the same job, done by the agent that is already in your checkout and can build, test and re-profile, instead of by a model given a read-only view of one folder.</p>
@@ -113,7 +128,7 @@ SELECT event_type, COUNT(*) FROM events_raw GROUP BY event_type`;
 
       <p>It carries the index schema &mdash; <code>class</code>, <code>instance</code>, <code>outbound_ref</code>, <code>gc_root</code>, <code>dominator</code>, <code>retained_size</code>, <code>string</code>, <code>dump_metadata</code> &mdash; with the details that are not guessable: <code>dominator</code> and <code>retained_size</code> are built lazily and are empty until something asks for them; <code>class.name</code> is already dot-notation; <code>record_kind</code> is a small integer enum; and the <code>string</code> table is the HPROF UTF-8 <em>name</em> pool, not the contents of Java <code>String</code> instances.</p>
 
-      <p>It opens by listing the purpose-built <code>heap_</code> tools and saying to try them first &mdash; several are pre-computed reports, and reproducing one in SQL is slower and easier to get wrong.</p>
+      <p>It opens by pointing back at <code>analyze-heap</code> and saying to try the purpose-built tools first &mdash; several are pre-computed reports, and reproducing one in SQL is slower and easier to get wrong. This skill is the escape hatch for what they do not cover, not the way in.</p>
 
       <h2 id="invoking-one-directly">Invoking One Directly</h2>
       <p>Each skill is also a slash command, namespaced by the plugin:</p>


### PR DESCRIPTION
## Summary
Introduces a new `analyze-heap` skill that guides Claude through heap dump analysis workflows. This complements the existing `analyze-profile` skill by providing structured guidance on memory analysis, leak detection, and dominator tree interpretation.

## Key Changes

- **New skill document** (`jeffrey-claude-plugin/skills/analyze-heap/SKILL.md`): Comprehensive guide covering:
  - How to resolve heap dump profiles (from file or catalogue)
  - Orientation with metadata and summary tools
  - Critical distinction between shallow and retained size
  - Lazy dominator tree building and its implications
  - Decision tree for different memory analysis questions (leaks, class loaders, waste, etc.)
  - Grounding claims with class names, retained bytes, and GC-root paths
  - Troubleshooting missing data and error messages

- **Updated skill references** across documentation:
  - `McpSkillsPage.vue`: Added `analyze-heap` to headings and invoke list; updated skill count from four to five
  - `McpPluginPage.vue`: Updated skill count and added `analyze-heap` to the skills list
  - `McpRecipesPage.vue`: Updated memory problem recipe to reference the new skill
  - `README.md`: Added `analyze-heap` to the skills section with example usage

- **Updated related skills** to cross-reference the new skill:
  - `analyze-profile/SKILL.md`: Simplified `heap_` family description and added guidance to switch to `analyze-heap` for heap dumps
  - `heap-sql/SKILL.md`: Redirected users to `analyze-heap` for purpose-built tools before attempting raw SQL
  - `advise/SKILL.md`: Updated to reference `analyze-heap` instead of generic `heap_` family for heap dump analysis

## Implementation Details

The skill teaches two foundational concepts that determine all heap analysis answers:
1. **Shallow vs. retained size**: Shallow is the object itself; retained is what dies with it. Only retained answers "who is holding this memory."
2. **Lazy dominator tree building**: The dominator tree and retained sizes are computed on-demand via `heap_getDominatorTreeRoots`, which must be called early before any retained-size queries.

The skill provides a decision table mapping common questions to tool sequences (e.g., leak suspects → GC-root path → referrers for leak analysis; class loader leak chains for redeploy diagnostics; string/collection analysis for waste).

It also establishes grounding rules: cite class name + retained bytes + GC-root path together, never carry object IDs between dumps, and distinguish between leak and large working set claims (a single dump cannot tell them apart).

https://claude.ai/code/session_017cjUCRSvNNM2Kkw5fRQZ7E