### PR TITLE
Reorganize MCP skills: split analyze-profile into analyze-jfr and advise-jfr

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,9 +195,10 @@ jeffrey/
 │   └── filesystem-recording-storage/  # Filesystem storage implementation
 ├── jeffrey-provisioner/               # Provisioner tool (GraalVM Native Image)
 ├── jeffrey-agent/                     # Agent module
-├── jeffrey-claude-plugin/             # Claude Code plugin "microscope" (MCP server + skills)
+├── jeffrey-claude-plugin/             # Claude Code plugin "microscope" (MCP server + skills + agent)
 │   ├── .claude-plugin/plugin.json     # Manifest, with the MCP server declared inline
-│   └── skills/                        # analyze-jfr, analyze-heap, advise-jfr, jfr-sql, heap-sql
+│   ├── skills/                        # analyze-jfr, analyze-heap, advise-jfr, jfr-sql, heap-sql
+│   └── agents/                        # profile-analyst — reads an export, returns only the findings
 ├── .claude-plugin/marketplace.json    # Makes the repo itself a Claude Code plugin marketplace
 ├── jeffrey-pages/                     # Documentation site
 ├── build/                             # Build configurations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,7 +197,7 @@ jeffrey/
 ├── jeffrey-agent/                     # Agent module
 ├── jeffrey-claude-plugin/             # Claude Code plugin "microscope" (MCP server + skills)
 │   ├── .claude-plugin/plugin.json     # Manifest, with the MCP server declared inline
-│   └── skills/                        # analyze-profile, jfr-sql, heap-sql
+│   └── skills/                        # analyze-jfr, analyze-heap, advise-jfr, jfr-sql, heap-sql
 ├── .claude-plugin/marketplace.json    # Makes the repo itself a Claude Code plugin marketplace
 ├── jeffrey-pages/                     # Documentation site
 ├── build/                             # Build configurations

--- a/jeffrey-claude-plugin/README.md
+++ b/jeffrey-claude-plugin/README.md
@@ -64,10 +64,10 @@ both) and not the case for a Jeffrey in a container or on another host.
 
 **Skills**, which you can also invoke directly:
 
-- `/microscope:analyze-profile` — where to start and which family answers which question
+- `/microscope:analyze-jfr` — where to start and which family answers which question
 - `/microscope:analyze-heap` — a heap dump end to end: what is holding the memory, what is leaking,
   which class loader never went away, and the order the heap tools have to be run in
-- `/microscope:advise [profile-id | recording-file] [cpu|wall|alloc|lock]` — from a profile to a
+- `/microscope:advise-jfr [profile-id | recording-file] [cpu|wall|alloc|lock]` — from a profile to a
   code change: the hottest CPU, wall-clock, allocation and blocking frames mapped to real source in
   your checkout, a recommendation, then the edit and a re-profile on request
 - `/microscope:jfr-sql` — the JFR schema and the DuckDB idioms that go with it

--- a/jeffrey-claude-plugin/README.md
+++ b/jeffrey-claude-plugin/README.md
@@ -76,6 +76,13 @@ both) and not the case for a Jeffrey in a container or on another host.
 The exports carry their own reading instructions, so the skills stay short: they cover the
 workflows and the two schemas, not things the tool output already explains.
 
+**One subagent**, `microscope:profile-analyst`. A single flamegraph export can run to 120,000
+characters, and a question usually takes several. The analyst runs a sequence and returns only the
+findings — the hot frames with their shares, or the retaining classes with their GC-root paths —
+leaving everything it read in its own context. The skills hand it the reading and keep what needs
+your conversation: mapping frames onto the checkout, the recommendation, and every question put to
+you. It reads over MCP only, so it cannot touch your files, import a recording or propose an edit.
+
 ## Permissions
 
 Claude Code asks before each tool the first time. Every Jeffrey tool except `recordings_` is

--- a/jeffrey-claude-plugin/README.md
+++ b/jeffrey-claude-plugin/README.md
@@ -67,9 +67,9 @@ both) and not the case for a Jeffrey in a container or on another host.
 - `/microscope:analyze-profile` — where to start and which family answers which question
 - `/microscope:analyze-heap` — a heap dump end to end: what is holding the memory, what is leaking,
   which class loader never went away, and the order the heap tools have to be run in
-- `/microscope:advise` — from a profile to a code change: the hottest CPU, wall-clock, allocation
-  and blocking frames mapped to real source in your checkout, a recommendation, then the edit and a
-  re-profile on request
+- `/microscope:advise [profile-id | recording-file] [cpu|wall|alloc|lock]` — from a profile to a
+  code change: the hottest CPU, wall-clock, allocation and blocking frames mapped to real source in
+  your checkout, a recommendation, then the edit and a re-profile on request
 - `/microscope:jfr-sql` — the JFR schema and the DuckDB idioms that go with it
 - `/microscope:heap-sql` — the heap-dump index schema
 

--- a/jeffrey-claude-plugin/agents/profile-analyst.md
+++ b/jeffrey-claude-plugin/agents/profile-analyst.md
@@ -1,0 +1,85 @@
+---
+name: profile-analyst
+description: Reads one Jeffrey Microscope export end to end and returns only the findings — the hottest frames with their shares, or the retaining objects with their GC-root paths. Delegate to it whenever a flamegraph, trace or heap report has to be read but the raw document is not wanted in the main conversation, and when several event types or heap questions can be worked at the same time. It reports figures; it never maps them to source, edits anything or creates a profile.
+tools:
+  - mcp__plugin_microscope_jeffrey__*
+  - mcp__jeffrey__*
+disallowedTools:
+  - mcp__plugin_microscope_jeffrey__recordings_analyzeFile
+  - mcp__plugin_microscope_jeffrey__recordings_analyzeRecording
+  - mcp__plugin_microscope_jeffrey__recordings_list
+  - mcp__jeffrey__recordings_analyzeFile
+  - mcp__jeffrey__recordings_analyzeRecording
+  - mcp__jeffrey__recordings_list
+model: inherit
+skills:
+  - analyze-jfr
+  - analyze-heap
+color: orange
+---
+
+You read one Jeffrey export or heap report and return what it says. A single
+`flamegraph_export` can run to 120,000 characters; the caller wants the dozen lines that matter,
+not the document. Everything you are given the profile for stays with you, and only the findings
+come back.
+
+## What you are given
+
+A `profileId`, and one question — an event type to graph, a trace operation to work, or a heap
+question. The `analyze-jfr` and `analyze-heap` skills are preloaded: they carry the tool families,
+the entry sequence, the flamegraph choice per question, the trace order, and the heap rules
+(shallow versus retained, the lazily built dominator tree, which reports only the UI can compute).
+Follow them. If the request names no `profileId`, say so and stop rather than picking one — the
+caller knows which profile the conversation is about and you do not.
+
+You are the analyst. The preloaded skills tell their reader to hand export reading to
+`microscope:profile-analyst` — that instruction is written for the main conversation, not for you.
+Do the reading yourself, and never spawn another agent.
+
+## What you do
+
+1. Run the sequence the preloaded skill prescribes for that question, and read every export the
+   way its own preamble instructs.
+2. Follow the profile where it leads: walk into a heavy subtree, lower `thresholdPct` on one path,
+   take the GC-root path of the object the histogram named. Extra reads cost the caller nothing —
+   they end in your context, not theirs.
+3. Stop when you can name the causes and their sizes. A second export that would not change the
+   findings is not worth the time.
+
+## What you return
+
+Findings only, in the units the export used, so a reader who never sees the document can check
+every claim against it. Keep it under roughly forty lines.
+
+For a flamegraph or trace:
+
+```
+## <eventType> — <what the totals were>
+
+1. `<full.package.Class.method>` — total <x%> (<n> samples/bytes/ns), self <y%>
+   The call path that reaches it, in one line, and what it is doing there.
+2. …
+
+Notes: filters, threshold, or anything pruned that a reader would want to know about.
+```
+
+For a heap dump, the same shape with class name, retained bytes and the GC-root path together —
+those three are what makes a heap claim checkable.
+
+Two rules that decide whether the report is usable:
+
+- **Every figure comes from a tool result.** Never estimate, round a number you did not see, or
+  carry a total between event types.
+- **Say what is missing.** A group the profiler never recorded, a report only the Jeffrey UI can
+  compute, an empty result — name it plainly. A gap reported is useful; a gap papered over sends
+  the caller down a path that has no data under it.
+
+## What you never do
+
+- **No source.** You have no file tools and cannot read the repository. Name the frame, never a
+  file or a line: mapping frames onto the checkout is the caller's job, and a guess made here
+  would arrive looking measured.
+- **No recommendations.** Report what the profile shows. Whether to change anything, and what,
+  belongs to the caller and its user.
+- **No writing.** You cannot import a recording or build a profile. If the profile you were given
+  does not exist or is not ready, report that and stop.

--- a/jeffrey-claude-plugin/skills/advise-jfr/SKILL.md
+++ b/jeffrey-claude-plugin/skills/advise-jfr/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: advise
+name: advise-jfr
 description: Turns a Jeffrey profile into concrete code changes in the current repository — maps the hottest CPU, wall-clock, allocation and blocking frames to real source, recommends minimal behaviour-preserving edits, applies them on request and verifies with the tests and a re-profile. Use whenever the user asks what to change, optimise or fix based on a profile, JFR recording or flamegraph, or a hotspot is known and the question is what to do about it.
 argument-hint: "[profile-id | recording-file] [cpu|wall|alloc|lock]"
 allowed-tools: mcp__plugin_microscope_jeffrey__* mcp__jeffrey__*
@@ -34,7 +34,7 @@ before the recommendation has been read cannot be reviewed on its own terms. Tra
 ## 1. Resolve the profile and its commit
 
 Start from `profiles_list`, or `recordings_analyzeFile` when the user named a file (the
-`analyze-profile` skill covers that path). Then `profiles_get` and read `recordingCommit`:
+`analyze-jfr` skill covers that path). Then `profiles_get` and read `recordingCommit`:
 
 - equal to `git rev-parse HEAD` — say so in one line and continue;
 - different — say so **before anything else**, name both commits, and ask whether to check the
@@ -115,7 +115,7 @@ For each accepted finding:
 when the overview reports any (a `CRITICAL` or `HIGH` one is the application's own diagnosis and
 comes before any frame), `traces_slowestTraces`, `traces_traceExport`, then
 `traces_spanFlamegraphExport` for the frames inside the slow span — the sequence in the
-`analyze-profile` skill. Once a span's flamegraph names the hot frames, continue from step 4 with
+`analyze-jfr` skill. Once a span's flamegraph names the hot frames, continue from step 4 with
 that export instead of the whole-recording one.
 
 ## When something is missing

--- a/jeffrey-claude-plugin/skills/advise-jfr/SKILL.md
+++ b/jeffrey-claude-plugin/skills/advise-jfr/SKILL.md
@@ -63,10 +63,16 @@ that would capture it next time: `event=ctimer` (cpu), `wall=10ms`, `alloc=512k`
 
 ## 3. Export and read
 
-`flamegraph_export` once per group, whole recording, default threshold. Every export opens with
-its own reading instructions and an analysis section written for that event type — what counts as
-a hotspot, what the frame tags mean, what to skip. Follow that document rather than generic
-flamegraph lore. Lower `thresholdPct` only to chase one specific path deeper.
+One export per group, whole recording, default threshold. Every export opens with its own reading
+instructions and an analysis section written for that event type — what counts as a hotspot, what
+the frame tags mean, what to skip. That document governs, not generic flamegraph lore. Lower
+`thresholdPct` only to chase one specific path deeper.
+
+Send the groups to **`microscope:profile-analyst`**, one delegation per group and all of them in a
+single message so they run at once. Each returns the hot frames with their shares; four raw
+exports would otherwise crowd out the source reading that step 4 depends on. Call
+`flamegraph_export` here only when you are working a single group and want the document in front
+of you.
 
 ## 4. Ground every finding in source
 

--- a/jeffrey-claude-plugin/skills/advise/SKILL.md
+++ b/jeffrey-claude-plugin/skills/advise/SKILL.md
@@ -1,75 +1,88 @@
 ---
 name: advise
-description: Turn a Jeffrey profile into concrete code changes in this repository — map the hottest CPU, wall-clock, allocation and blocking frames to real source, recommend minimal behaviour-preserving edits, apply them on request, and verify with the tests and a re-profile. Use when asked what to change, optimise or fix based on a profile, a JFR recording or a flamegraph, or when a hotspot has been found and the next question is "so what do I do about it".
+description: Turns a Jeffrey profile into concrete code changes in the current repository — maps the hottest CPU, wall-clock, allocation and blocking frames to real source, recommends minimal behaviour-preserving edits, applies them on request and verifies with the tests and a re-profile. Use whenever the user asks what to change, optimise or fix based on a profile, JFR recording or flamegraph, or a hotspot is known and the question is what to do about it.
+argument-hint: "[profile-id | recording-file] [cpu|wall|alloc|lock]"
 allowed-tools: mcp__plugin_microscope_jeffrey__* mcp__jeffrey__*
 ---
 
 # From a profile to a code change
 
-The analysis tools read a profile; this skill is what happens after the reading. It takes the
-measured call trees, finds the code behind the heaviest frames in the checkout you are sitting in,
-and proposes the smallest change that would reduce the measured cost — then, only when asked,
-makes it and checks that it helped.
+The analysis tools read a profile; this skill is what happens after. It takes the measured call
+trees, finds the code behind the heaviest frames in the checkout you are sitting in, and proposes
+the smallest change that would reduce the measured cost — then, only when asked, makes it and
+checks that it helped.
 
-Two phases, with a stop between them: **recommend**, then **change**. Never edit before the
-recommendation has been read.
+Requested scope: `$ARGUMENTS` — a profile id or a recording file, then optionally one group
+(`cpu`, `wall`, `alloc`, `lock`). Empty means the profile the conversation is about (or the most
+recently modified one in `profiles_list`) and every group it carries.
+
+Tool names below omit the server prefix (`mcp__plugin_microscope_jeffrey__` for the plugin,
+`mcp__jeffrey__` for a hand-registered server).
+
+Two phases with a stop between them — **recommend**, then **change** — because an edit made
+before the recommendation has been read cannot be reviewed on its own terms. Track progress:
+
+```
+- [ ] 1. Profile resolved, commit compared with HEAD
+- [ ] 2. Groups chosen from flamegraph_list
+- [ ] 3. One export per group, read as the document says
+- [ ] 4. Every finding tied to a frame and to source that was actually read
+- [ ] 5. Recommendation written — STOP and wait for the user's choice
+- [ ] 6. Accepted edits made, built, tested, re-profiled where possible
+```
 
 ## 1. Resolve the profile and its commit
 
-- Start from `profiles_list` (or `recordings_analyzeFile` when the user named a file — the
-  `analyze-profile` skill covers that path). Nothing works without a `profileId`.
-- Call **`profiles_get`** and read `recordingCommit`. If it is set, compare it with
-  `git rev-parse HEAD`:
-  - equal — say so in one line and continue;
-  - different — say so **before anything else**, name both commits, and ask whether to check
-    the recording's commit out. Do not switch branches unasked. A profile of another commit
-    describes code that may have moved, been renamed or been deleted; mapping it onto the wrong
-    tree produces confident nonsense.
-  - `null` — say the commit is unknown, not that it matched. (Tag the recording with
-    `git.commit` at build time to fix that for next time.)
+Start from `profiles_list`, or `recordings_analyzeFile` when the user named a file (the
+`analyze-profile` skill covers that path). Then `profiles_get` and read `recordingCommit`:
+
+- equal to `git rev-parse HEAD` — say so in one line and continue;
+- different — say so **before anything else**, name both commits, and ask whether to check the
+  recording's commit out. Do not switch branches unasked. A profile of another commit describes
+  code that may have moved, been renamed or been deleted; mapping it onto the wrong tree produces
+  confident nonsense.
+- `null` — say the commit is unknown, not that it matched. (Tagging the recording with
+  `git.commit` at build time fixes that for next time.)
 
 ## 2. Pick the groups
 
 A recording answers up to four questions, each with its own event type. Analyse every group the
-profile actually carries, in this order; if the user named one (`cpu`, `wall`, `alloc`, `lock`),
-do only that one.
+profile carries, in this order; if the user named one, do only that one.
 
 | Group | Event type (first present wins) | Export options |
 |---|---|---|
-| CPU | `jdk.ExecutionSample` | defaults |
-| Wall-clock | `profiler.WallClockSample` | defaults |
-| Allocation | `jdk.ObjectAllocationSample`, else `jdk.ObjectAllocationInNewTLAB`, else `jdk.ObjectAllocationOutsideTLAB` | `useWeight: true` (bytes, not call count) |
-| Blocking | `jdk.JavaMonitorEnter`, else `jdk.JavaMonitorWait`, else `jdk.ThreadPark` | `useWeight: true` (nanoseconds blocked) |
+| `cpu` | `jdk.ExecutionSample` | defaults |
+| `wall` | `profiler.WallClockSample` | defaults |
+| `alloc` | `jdk.ObjectAllocationSample`, else `jdk.ObjectAllocationInNewTLAB`, else `jdk.ObjectAllocationOutsideTLAB` | `useWeight: true` (bytes, not call count) |
+| `lock` | `jdk.JavaMonitorEnter`, else `jdk.JavaMonitorWait`, else `jdk.ThreadPark` | `useWeight: true` (nanoseconds blocked) |
 
-`flamegraph_list` splits these for you: `available` holds the event types this recording actually
-carries — each with the export defaults for that type — and `notRecorded` names the groups the
-profiler was not configured to capture. A group in `notRecorded` is reported, not analysed, with
-the async-profiler flag that would capture it next time: `event=ctimer` (CPU), `wall=10ms`,
-`alloc=512k`, `lock=10ms`.
+`flamegraph_list` splits these for you: `available` holds the event types the recording carries,
+each with its export defaults; `notRecorded` names the groups the profiler was not configured to
+capture. Report a `notRecorded` group rather than analysing it, with the async-profiler option
+that would capture it next time: `event=ctimer` (cpu), `wall=10ms`, `alloc=512k`, `lock=10ms`.
 
 ## 3. Export and read
 
 `flamegraph_export` once per group, whole recording, default threshold. Every export opens with
-its own reading instructions and an analysis section written for that event type — what counts
-as a hotspot, what the frame tags mean, what to skip. **Follow the document, do not substitute
-generic flamegraph lore.** Lower `thresholdPct` only to chase one specific path deeper.
+its own reading instructions and an analysis section written for that event type — what counts as
+a hotspot, what the frame tags mean, what to skip. Follow that document rather than generic
+flamegraph lore. Lower `thresholdPct` only to chase one specific path deeper.
 
 ## 4. Ground every finding in source
 
-The export has call paths and numbers, never file or line numbers. Map the heaviest frames to
-the checkout with your own Read, Grep and Glob, and hold to these rules — they are what separates
-a recommendation from a guess:
+The export has call paths and numbers, never file or line numbers. Map the heaviest frames to the
+checkout with Read, Grep and Glob, holding to these rules — they are what separates a
+recommendation from a guess:
 
 - **Never name a file, method or line you have not read.** Open it first.
-- **Tie each finding to a frame and its share** (`total`, `self`, the percentage) taken from the
-  export, so the reader can check the claim against the profile.
+- **Tie each finding to a frame and its share** (`total`, `self`, the percentage) from the export,
+  so the reader can check the claim against the profile.
 - **Prefer a few high-impact findings** over many speculative ones. Frames under 1 % are noise
   unless the user is chasing something specific.
-- **Say when a hotspot cannot be located** — a frame in a library you cannot patch, generated
-  code, or a method that no longer exists at this commit. Note it once and move on to the next
-  frame that is in this repository.
-- Distinguish leaf work (`self ≈ total`) from orchestration (`self << total`); recommend
-  changes to the former, and walk into the latter.
+- **Say when a hotspot cannot be located** — a library you cannot patch, generated code, a method
+  that no longer exists at this commit. Note it once and move to the next frame in this repository.
+- Distinguish leaf work (`self ≈ total`) from orchestration (`self << total`): recommend changes
+  to the former, walk into the latter.
 
 ## 5. Recommend, then stop
 
@@ -77,41 +90,41 @@ Write the recommendation in this shape:
 
 - **Summary** — the dominant hotspots per group, two or three sentences.
 - One **`### <file>: <method>`** section per finding: the cause, why it is hot according to the
-  profile (frame, share), and the proposed change in prose — minimal, behaviour-preserving, and
+  profile (frame, share), and the proposed change in prose — minimal, behaviour-preserving,
   reviewable on its own. No diffs in this phase.
-- **Not located** — hotspots you could not map to this repository, if any.
+- **Not located** — hotspots that could not be mapped to this repository, if any.
 
-Then ask which findings to apply. This is the gate; wait for the answer.
+Then ask which findings to apply, and wait for the answer. This is the gate.
 
 ## 6. Change and verify
 
-On go, for each accepted finding:
+For each accepted finding:
 
-1. Make the smallest edit that implements it. One reviewable change beats a sweeping rewrite.
-2. Run the project's build and its tests the way a contributor would.
+1. Make the smallest edit that implements it; one reviewable change beats a sweeping rewrite.
+2. Run the project's build and tests the way a contributor would.
 3. If the recording can be reproduced (a benchmark, a load script, a command the user names),
-   run it, then `recordings_analyzeFile` the new recording and export the **same group with the
-   same parameters**. Report the delta on the frames you changed; keep the threshold and options
-   identical, or a difference in pruning will read as a change that is not there.
+   run it, `recordings_analyzeFile` the new recording, and export the **same group with the same
+   parameters** — keep threshold and options identical, or a difference in pruning will read as a
+   change that is not there. Report the delta on the frames you changed.
 4. Never claim a saving you did not measure. Without a re-profile, the estimate is capped at the
-   frame's own `total` share — a change cannot save more time than the frame used.
+   frame's own `total` share: a change cannot save more time than the frame used.
 
-## When the question is latency, not throughput
+## Latency rather than throughput
 
 "This endpoint is slow" is a traces question first: `traces_operations`, `traces_notifications`
 when the overview reports any (a `CRITICAL` or `HIGH` one is the application's own diagnosis and
 comes before any frame), `traces_slowestTraces`, `traces_traceExport`, then
 `traces_spanFlamegraphExport` for the frames inside the slow span — the sequence in the
-`analyze-profile` skill. Once a span's flamegraph names the hot frames,
-continue from step 4 above with that export instead of the whole-recording one.
+`analyze-profile` skill. Once a span's flamegraph names the hot frames, continue from step 4 with
+that export instead of the whole-recording one.
 
 ## When something is missing
 
-- `flamegraph_list` reports no flamegraph-capable event types → a heap dump or a recording without
+- `flamegraph_list` reports no graphable event types → a heap dump, or a recording without
   samples; there is nothing to advise on from a flamegraph. For a heap dump, the `analyze-heap`
-  skill applies instead.
+  skill applies.
 - The profile's commit differs from `HEAD` and the user does not want to switch → analyse anyway,
-  but say in the summary that every file reference was checked against a different commit than
+  and say in the summary that every file reference was checked against a different commit than
   the one profiled.
 - The code behind the top frame is in a dependency → say so, name the calling frame in this
   repository, and advise there (fewer calls, a cheaper API, caching) rather than inside the library.

--- a/jeffrey-claude-plugin/skills/analyze-heap/SKILL.md
+++ b/jeffrey-claude-plugin/skills/analyze-heap/SKILL.md
@@ -1,108 +1,114 @@
 ---
 name: analyze-heap
-description: Work a heap dump with a running Jeffrey Microscope — what is holding the memory, what is leaking, which class loader never went away, where the waste is — including a .hprof file that is not in Jeffrey yet. Use whenever the question is "what is holding memory", "why is the heap growing", "why did this OOM", "what is leaking", or when retained size, a dominator tree, GC roots or a heap dump file are mentioned.
+description: Analyses a heap dump held by a running Jeffrey Microscope — what is holding the memory, what is leaking, which class loader survived a redeploy, where the waste is — starting from the catalogue or from a .hprof file Jeffrey has not seen yet. Use whenever the user asks what is holding memory, why the heap keeps growing, why the JVM ran out of memory, what is leaking, or mentions retained size, a dominator tree, GC roots, a heap dump or an .hprof file.
 allowed-tools: mcp__plugin_microscope_jeffrey__heap_* mcp__plugin_microscope_jeffrey__profiles_* mcp__plugin_microscope_jeffrey__recordings_* mcp__jeffrey__heap_* mcp__jeffrey__profiles_* mcp__jeffrey__recordings_*
 ---
 
 # Analysing a heap dump
 
 A parsed heap dump is a profile like any other, but it answers a different question from a JFR
-recording. A recording says where the time went; a dump says what was alive at one instant and
-what was keeping it alive. Every tool here reads; none of them changes the dump.
+recording: a recording says where the time went, a dump says what was alive at one instant and
+what kept it alive. Every tool here reads; none changes the dump.
 
-## 1. Resolve the profile
+Tool names below omit the server prefix — `mcp__plugin_microscope_jeffrey__` for the plugin,
+`mcp__jeffrey__` for a hand-registered server. The part after it is exact and camelCase:
+`heap_getLeakSuspects`, not `heap_get_leak_suspects`.
 
-**If the user named a file** — `heap.hprof`, `dump.hprof.gz`, anything with a heap-dump extension —
-call **`recordings_analyzeFile`** with its **absolute** path. It imports the file, parses it and
-returns the `profileId` everything below needs. Two constraints:
+## 1. Get a `profileId`
 
-- The path is opened by the **Jeffrey process**, so the file must be on the machine Jeffrey runs
-  on. A container or a remote Jeffrey cannot see your working directory.
-- Each call imports the file **again** and builds another profile. Check `recordings_list` or
-  `profiles_list` first if the dump may already be in Jeffrey.
+**The user named a file** (`heap.hprof`, `dump.hprof.gz`) — check `recordings_list` or
+`profiles_list` for it first, because every `recordings_analyzeFile` call imports the file again
+and creates another profile. If absent, call `recordings_analyzeFile` with the **absolute** path.
+The Jeffrey process opens that path, so the file has to be on the machine Jeffrey runs on. The
+call returns once the dump is parsed, which takes a while for a large dump; that is the work, not
+a hang.
 
-Parsing a large dump takes a while and the call returns only when it is done — that is the work,
-not a hang.
-
-**Otherwise start from the catalogue:** `profiles_list`, where the **`event source`** column reads
-`HEAP_DUMP` for the profiles this skill applies to. Then `profiles_features`, which lists
-`HEAP_DUMP` under `disabledFeatures` when the profile has no dump or its index is not ready.
+**Otherwise** — `profiles_list`, where the `event source` column reads `HEAP_DUMP` for the profiles
+this skill applies to. `profiles_features` lists `HEAP_DUMP` under `disabledFeatures` when the
+profile has no dump or its index is not ready yet.
 
 ## 2. Orient before analysing
 
-- **`heap_getDumpMetadata`** — HPROF version, id size, compressed-oops flag, record count and
-  `warning_count`. One call, and it explains a lot later.
-- **`heap_getHeapSummary`** — total live bytes and instances, class count, GC-root count.
-
-A non-zero `warning_count` means the parser skipped, truncated or recovered records, so the totals
-are a lower bound. When the numbers look wrong, read the `parse_warning` table (the `heap-sql`
-skill) before concluding anything from them.
+- `heap_getDumpMetadata` — HPROF version, id size, compressed-oops flag, record count and
+  `warning_count`. A non-zero `warning_count` means the parser skipped or truncated records, so
+  every total below is a lower bound; read the `parse_warning` table (the `heap-sql` skill)
+  before concluding anything from odd numbers.
+- `heap_getHeapSummary` — live bytes and instances, class count, GC-root count.
 
 ## 3. Shallow is not retained
 
-The distinction decides every answer here, so settle it before reading a number:
+- **Shallow size** is the object itself: header and fields, nothing it points at.
+- **Retained size** is everything that would be freed if the object were collected.
 
-- **Shallow size** is the object itself — its header and fields, nothing it points at.
-- **Retained size** is everything that would be freed if the object were collected: the object plus
-  what only it keeps alive.
+"What is holding this memory" is always a retained question. A histogram ranked by shallow size
+answers a different one — what there is a lot of, not who is responsible for it.
 
-"What is holding this memory" is always a retained question. A class histogram ranked by shallow
-size answers a different one — it tells you what there is a lot of, not who is responsible for it.
+## 4. Two kinds of heap tools
 
-## 4. Build the dominator tree before any retained question
+**Computed on demand.** The first call does the work and later calls reuse it: `heap_getHeapSummary`,
+`heap_getClassHistogram`, `heap_getDominatorTreeRoots` / `heap_getDominatorTreeChildren`,
+`heap_getPathToGCRoot`, `heap_getReferrers`, `heap_browseClassInstances`, `heap_getInstanceDetail`,
+`heap_getThreads`, `heap_getGCRootSummary`, and the SQL tools.
 
-Retained sizes and the dominator tree are computed **lazily**. Until something builds them, the
-`dominator` and `retained_size` tables are empty and every retained figure is missing rather than
-zero.
+Retained sizes and the dominator tree are built lazily by **`heap_getDominatorTreeRoots`**. Until
+it has run once, the `dominator` and `retained_size` tables are empty and every retained figure is
+*missing*, not zero. Call it once, early, before anything that ranks by retained size — skipping it
+is the usual reason a heap session stalls on empty results.
 
-**`heap_getDominatorTreeRoots`** is what builds them. Call it once, early, before anything that
-ranks by retained size. This is exactly what the tools mean when they say *"this analysis may need
-to be run first"*, and skipping it is the usual reason a heap session stalls on empty results.
+**Pre-computed reports.** Jeffrey computes these when the user opens the report in the UI and
+stores the result; over MCP they can only be read. Each answers `… has not been run yet` until then:
+
+| Tool | Report to run in the Jeffrey UI |
+|---|---|
+| `heap_getLeakSuspects` | Leak Suspects |
+| `heap_getBiggestObjects` | Biggest Objects |
+| `heap_getClassLoaderLeakChains` | Class Loader Analysis |
+| `heap_getTopConsumers` | Top Consumers |
+| `heap_getStringAnalysis` | String Analysis |
+| `heap_getCollectionAnalysis` | Collection Analysis |
+
+When one answers that way, do not retry it. Give the user the `profiles_link` URL and the report's
+name, and carry on with the on-demand route for the same question meanwhile — the table in step 5
+names it — so the answer does not wait on the UI.
 
 ## 5. Pick the route
 
-| Question | Sequence |
-|---|---|
-| What is using the heap at all | `heap_getClassHistogram`, then `heap_getTopConsumers` for the same picture grouped by package and class loader |
-| What is leaking | `heap_getLeakSuspects` → `heap_getPathToGCRoot` on the object it names → `heap_getReferrers` to walk outwards |
-| Which single objects are the biggest | `heap_getBiggestObjects` for the flat ranking, `heap_getDominatorTreeRoots` → `heap_getDominatorTreeChildren` to walk down into one |
-| Redeploys leak, or classes look duplicated | `heap_getClassLoaderLeakChains` — the canonical Tomcat-redeploy diagnostic; it names the loader, the GC-root path keeping it alive, and the pattern that matched (ThreadLocal, JDBC driver, JNI global, ServiceLoader, static logger, context class loader) |
-| Where the waste is | `heap_getStringAnalysis` (duplicates, oversized strings), `heap_getCollectionAnalysis` (empty, singleton and oversized collections with their fill ratios) |
-| What is in one particular class | `heap_browseClassInstances` → `heap_getInstanceDetail` → `heap_getPathToGCRoot` |
-| Who is rooting all this | `heap_getGCRootSummary`, and `heap_getThreads` when a thread is the suspect |
+| Question | Sequence | Without the report |
+|---|---|---|
+| What is using the heap at all | `heap_getClassHistogram`, then `heap_getTopConsumers` for the same picture by package and class loader | The histogram alone |
+| What is leaking | `heap_getLeakSuspects` → `heap_getPathToGCRoot` on the object it names → `heap_getReferrers` to walk outwards | `heap_getDominatorTreeRoots` → `heap_getPathToGCRoot` on the largest roots |
+| Which single objects are the biggest | `heap_getBiggestObjects` for the flat ranking; `heap_getDominatorTreeRoots` → `heap_getDominatorTreeChildren` to walk into one | The dominator tree already is the ranking |
+| Redeploys leak, or classes look duplicated | `heap_getClassLoaderLeakChains` — names the loader, the GC-root path keeping it alive and the pattern that matched (ThreadLocal, JDBC driver, JNI global, ServiceLoader, static logger, context class loader) | `heap_browseClassInstances` on the loader class → `heap_getPathToGCRoot` |
+| Where the waste is | `heap_getStringAnalysis` (duplicate and oversized strings), `heap_getCollectionAnalysis` (empty, singleton and oversized collections with fill ratios) | Histogram by `COUNT`, then `heap_browseClassInstances` |
+| What is in one particular class | `heap_browseClassInstances` → `heap_getInstanceDetail` → `heap_getPathToGCRoot` | — |
+| Who is rooting all this | `heap_getGCRootSummary`; `heap_getThreads` when a thread is the suspect | — |
 
-Tool names are camelCase after the prefix: `heap_getLeakSuspects`, not `heap_get_leak_suspects`.
-
-`heap_getPathToGCRoot` is the tool that turns an observation into a cause: the histogram says a
-class is large, the GC-root path says *why those instances are still reachable*. Do not report a
-leak without one.
+`heap_getPathToGCRoot` turns an observation into a cause: the histogram says a class is large, the
+path says *why those instances are still reachable*. Do not report a leak without one. The paths
+skip weak and soft references, so an object reachable only through a `WeakHashMap` or a soft cache
+shows no path — that is the answer, not an error.
 
 ## 6. Grounding claims
 
-- Cite the **class name, the retained bytes and the GC-root path** — the three together are what
+- Cite the **class name, the retained bytes and the GC-root path** together; the three are what
   makes a claim checkable.
-- Object ids are stable within one dump and **meaningless across dumps**. Never carry an id from
-  one dump into a question about another; carry the class name and the path instead.
-- A dump shows a state, not a trend. Two dumps taken apart are what shows growth; one dump alone
-  cannot distinguish a leak from a large working set, so say which one you are claiming.
-- If the repository is open alongside, read the real source of the retaining field before naming a
-  cause. Do not infer a code path from a class name.
+- Object ids are stable within one dump and meaningless across dumps. Carry the class name and
+  the path between dumps, never an id.
+- A dump shows a state, not a trend. One dump cannot distinguish a leak from a large working set;
+  say which of the two you are claiming, and ask for a second dump taken later when it matters.
+- If the repository is open alongside, read the real source of the retaining field before naming
+  a cause. Do not infer a code path from a class name.
 
-## 7. When something is missing
+## When something fails
 
-- `Profile … has no heap dump` → it is a JFR recording. Use the `jfr_`, `flamegraph_` and `traces_`
-  families; the `analyze-profile` skill covers them.
-- `The heap dump of profile … is still being indexed` → open it once in the Jeffrey UI to build the
-  index, then try again.
-- Retained sizes come back empty → the dominator tree has not been built. Go back to step 4.
-- A report says its analysis has not been run → run it once and re-read; the results are cached
-  afterwards.
-- No `recordings_` tool is advertised → this Jeffrey was started with
-  `jeffrey.microscope.mcp.ingest.enabled=false`. Upload the dump in the UI and work from
-  `profiles_list`.
-- Every call fails to connect → Jeffrey is not running at that address. Point the plugin at the
-  real `…/api/internal/mcp` endpoint with `/plugin`; **Settings → Claude Code (MCP)** shows the URL
-  for your installation.
+- `Profile … has no heap dump` → it is a JFR recording; the `analyze-profile` skill applies.
+- `… is still being indexed` → open the profile once in the Jeffrey UI to build the index, then retry.
+- Retained sizes come back empty → the dominator tree has not been built; go back to step 4.
+- `… has not been run yet` → a pre-computed report; step 4 says what to do.
+- No `recordings_` tool advertised → this Jeffrey runs with `jeffrey.microscope.mcp.ingest.enabled=false`;
+  upload the dump in the UI and work from `profiles_list`.
+- Every call fails to connect → Jeffrey is not running at the configured address. Point the plugin
+  at the real `…/api/internal/mcp` endpoint: `/plugin` → `microscope` → **Jeffrey MCP endpoint**.
 
-Jeffrey's OQL engine is not exposed over MCP; OQL has to be run in the Jeffrey UI. For a question
-none of the reports above cover, drop to DuckDB SQL over the heap index — see the `heap-sql` skill.
+Jeffrey's OQL engine is not exposed over MCP. For a question none of the tools above cover, drop
+to DuckDB SQL over the heap index — the `heap-sql` skill has the schema.

--- a/jeffrey-claude-plugin/skills/analyze-heap/SKILL.md
+++ b/jeffrey-claude-plugin/skills/analyze-heap/SKILL.md
@@ -88,6 +88,17 @@ path says *why those instances are still reachable*. Do not report a leak withou
 skip weak and soft references, so an object reachable only through a `WeakHashMap` or a soft cache
 shows no path — that is the answer, not an error.
 
+## Hand the reading to the analyst
+
+The plugin ships a subagent, **`microscope:profile-analyst`**, that runs a heap route and returns
+only the findings — class, retained bytes, GC-root path — with everything it read left in its own
+context. Delegate a whole route from step 5 (give it the `profileId` and the question), and send
+independent questions in one message so they run at once.
+
+Work here instead when a single tool answers the question, or when the user is walking the
+dominator tree with you object by object. Reading the real source behind a retaining field, and
+every question to the user, stays here either way.
+
 ## 6. Grounding claims
 
 - Cite the **class name, the retained bytes and the GC-root path** together; the three are what

--- a/jeffrey-claude-plugin/skills/analyze-heap/SKILL.md
+++ b/jeffrey-claude-plugin/skills/analyze-heap/SKILL.md
@@ -101,7 +101,7 @@ shows no path — that is the answer, not an error.
 
 ## When something fails
 
-- `Profile … has no heap dump` → it is a JFR recording; the `analyze-profile` skill applies.
+- `Profile … has no heap dump` → it is a JFR recording; the `analyze-jfr` skill applies.
 - `… is still being indexed` → open the profile once in the Jeffrey UI to build the index, then retry.
 - Retained sizes come back empty → the dominator tree has not been built; go back to step 4.
 - `… has not been run yet` → a pre-computed report; step 4 says what to do.

--- a/jeffrey-claude-plugin/skills/analyze-jfr/SKILL.md
+++ b/jeffrey-claude-plugin/skills/analyze-jfr/SKILL.md
@@ -83,6 +83,24 @@ the code that produced it.
 3. `traces_operationExport` for the population, then `traces_slowestTraces` → `traces_traceExport`
    for one exemplar, then `traces_spanFlamegraphExport` for the frames inside a single slow span.
 
+## Hand the reading to the analyst
+
+An export can run to 120,000 characters, and answering a question well often takes several. The
+plugin ships a subagent, **`microscope:profile-analyst`**, that runs a sequence and returns only
+the findings — the hottest frames with their shares, the causes named. Everything it read stays in
+its own context.
+
+Delegate when more than one export is in play — several event types, a whole trace operation, a
+deep chase down one path — and give it the `profileId` and the one question. Independent questions
+go out in a single message so they run at once.
+
+Read an export here, in this conversation, when there is exactly one and its result will be
+discussed turn by turn. The analyst returns a report; it cannot answer a follow-up about a document
+the conversation never saw.
+
+Whatever it reports, keep here: mapping frames onto the checkout, the recommendation, and every
+question to the user. The analyst has no file tools and never proposes changes.
+
 ## Grounding claims
 
 The exports carry call paths and figures, not source locations. Cite the path and the numbers the

--- a/jeffrey-claude-plugin/skills/analyze-jfr/SKILL.md
+++ b/jeffrey-claude-plugin/skills/analyze-jfr/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: analyze-profile
+name: analyze-jfr
 description: Analyses a JVM profile held by a running Jeffrey Microscope — CPU, wall-clock, allocation, lock contention and trace latency — starting from the catalogue or from a .jfr file Jeffrey has not seen yet. Use whenever the user asks why something is slow, where the time goes, what is allocating, what a JFR recording or flamegraph shows, or mentions a Jeffrey profile, a .jfr file or async-profiler output. For a heap dump or .hprof file, analyze-heap applies instead.
 allowed-tools: mcp__plugin_microscope_jeffrey__* mcp__jeffrey__*
 ---
@@ -87,7 +87,7 @@ the code that produced it.
 
 The exports carry call paths and figures, not source locations. Cite the path and the numbers the
 document shows. If the repository is open alongside, read the real source before naming a file,
-method or line — never infer them from a frame name. The `advise` skill carries the full
+method or line — never infer them from a frame name. The `advise-jfr` skill carries the full
 profile-to-code-change workflow.
 
 ## When something fails
@@ -105,4 +105,4 @@ profile-to-code-change workflow.
   by default.
 
 Related skills: `analyze-heap` for a heap dump, `jfr-sql` for raw SQL against the profile,
-`advise` to go from a hotspot to an edit in this repository.
+`advise-jfr` to go from a hotspot to an edit in this repository.

--- a/jeffrey-claude-plugin/skills/analyze-profile/SKILL.md
+++ b/jeffrey-claude-plugin/skills/analyze-profile/SKILL.md
@@ -1,122 +1,108 @@
 ---
 name: analyze-profile
-description: Analyse a JVM profile with a running Jeffrey Microscope — CPU, allocation, lock contention, GC, latency, traces or a heap dump — including analysing a .jfr or .hprof file that is not in Jeffrey yet. Use whenever the question is "why is this slow", "where does the time go", "what is allocating", "what is holding memory", or when a Jeffrey profile, a JFR recording or a heap dump file is mentioned.
+description: Analyses a JVM profile held by a running Jeffrey Microscope — CPU, wall-clock, allocation, lock contention and trace latency — starting from the catalogue or from a .jfr file Jeffrey has not seen yet. Use whenever the user asks why something is slow, where the time goes, what is allocating, what a JFR recording or flamegraph shows, or mentions a Jeffrey profile, a .jfr file or async-profiler output. For a heap dump or .hprof file, analyze-heap applies instead.
 allowed-tools: mcp__plugin_microscope_jeffrey__* mcp__jeffrey__*
 ---
 
 # Analysing a Jeffrey profile
 
-Jeffrey holds *profiles*: one analysed JFR recording or heap dump each. The analysis tools read
-them and never write. The one family that writes is `recordings_`, which turns a recording *file*
-into a profile.
+Jeffrey holds *profiles*: one analysed JFR recording or heap dump each. Every tool reads; the one
+family that writes is `recordings_`, which turns a recording *file* into a profile.
 
-## Start from a file, or from the catalogue
+Tool names below omit the server prefix — `mcp__plugin_microscope_jeffrey__` for the plugin,
+`mcp__jeffrey__` for a hand-registered server. The part after it is exact and camelCase:
+`jfr_listTables`, not `jfr_list_tables`.
 
-**If the user named a file** — `target/app.jfr`, `heap.hprof`, anything with a recording extension —
-it may not be in Jeffrey yet. Call **`recordings_analyzeFile`** with its **absolute** path; it
-imports the file, builds the profile, and returns the `profileId` the rest of this skill needs. Then
-carry on from step 2 below.
+## 1. Get a `profileId`
 
-Two constraints, both easy to trip on:
+Every tool except `profiles_list` and the `recordings_` family takes one.
 
-- The path is opened by the **Jeffrey process**, so the file must be on the machine Jeffrey runs on.
-  A container or a remote Jeffrey cannot see your working directory.
-- Each call imports the file **again** and builds another profile. If the same file may already be
-  analysed, check `recordings_list` or `profiles_list` first and reuse the id.
+**The user named a file** (`target/app.jfr`, anything with a recording extension) — it may not be
+in Jeffrey yet. Check `recordings_list` or `profiles_list` for it first, because every
+`recordings_analyzeFile` call imports the file again and creates another profile. If it is absent,
+call `recordings_analyzeFile` with the **absolute** path. The Jeffrey process opens that path, so
+the file has to be on the machine Jeffrey runs on — a container or a remote Jeffrey cannot see your
+working directory. The call returns once the profile is built, which takes a while for a large
+recording; that is the analysis running, not a hang.
 
-The call returns only once the profile is built, which for a large recording takes a while — that is
-the analysis running, not a hang.
+**Otherwise** — `profiles_list`, pick the profile, then `profiles_features` to learn what it can
+answer before asking for it: `disabledFeatures` names what the profile lacks (traces exist only if
+the app ran Jeffrey's instrumentation; `HEAP_DUMP` there means no dump), and `eventTypes` lists
+every recorded event type with its sample and weight totals.
 
-**Otherwise start from the catalogue:**
+A profile whose `event source` column reads `HEAP_DUMP` is a heap dump: switch to the
+`analyze-heap` skill, because flamegraphs and traces do not apply to it.
 
-1. **`profiles_list`** — every profile in the installation. Nothing else works without an id from it.
-2. **`profiles_features`** — what that profile can actually answer. A JFR recording usually has no
-   heap dump; a heap dump has no flamegraphs; traces exist only if the app ran Jeffrey's tracing
-   instrumentation. It also lists every event type recorded, with sample counts.
-3. Then the family that matches the question.
+## 2. Pick the family that matches the question
 
-Every tool except `profiles_list` and the `recordings_` family takes a `profileId`.
-
-## The families
-
-| Family | Use it for |
+| Family | Tools |
 |---|---|
-| `profiles_` | `list`, `get` (identity, recording window, size), `features`, `link` (deep link into the Jeffrey UI) |
-| `flamegraph_` | `panels` (which event types this profile can graph — call it first), `export` (the call tree as Markdown) |
+| `profiles_` | `list`, `get` (identity, recording window, size, source commit), `features`, `link` (deep link into the Jeffrey UI) |
+| `flamegraph_` | `list` (which event types this profile can graph — call it first), `export` (the call tree as Markdown) |
 | `traces_` | `overview`, `operations`, `notifications`, `operationExport`, `slowestTraces`, `traceExport`, `spanFlamegraphExport`, `operationFlamegraphExport` |
-| `jfr_` | `listTables`, `describeTable`, `listEventTypes`, `queryEvents`, `executeQuery`, `getProfileInfo` — raw DuckDB when no purpose-built tool fits |
-| `heap_` | Everything a heap dump answers — summary, histogram, dominator tree, leak suspects, GC-root paths. The largest family, with an order to work it in: see the `analyze-heap` skill |
-| `recordings_` | `analyzeFile` (a file not in Jeffrey yet), `analyzeRecording` (one already uploaded but never analysed), `list` (the Quick Analysis store) |
+| `jfr_` | `listTables`, `describeTable`, `listEventTypes`, `queryEvents`, `executeQuery`, `getProfileInfo` — raw DuckDB when no purpose-built tool fits; the `jfr-sql` skill has the schema |
+| `heap_` | Everything a heap dump answers — the `analyze-heap` skill has the order to run it in |
+| `recordings_` | `analyzeFile` (a file not in Jeffrey yet), `analyzeRecording` (uploaded but never analysed), `list` (the Quick Analysis store) |
 
-Tool names are camelCase after the prefix: `jfr_listTables`, not `jfr_list_tables`.
+## 3. Choosing a flamegraph
 
-## Reading the exports
-
-`flamegraph_export`, `traces_traceExport` and `traces_operationExport` return Markdown documents
-that **carry their own reading instructions** — what `self` versus `total` means, what the frame
-tags mean, what was pruned, and how to analyse that particular event type. Read the preamble the
-document gives you and follow it. Do not substitute assumptions about flamegraph conventions from
-elsewhere; Jeffrey's accounting is stated precisely in the document and differs in places (its
-`self` is a merged-interval computation, not a subtraction).
-
-## Choosing a graph
-
-`flamegraph_list` lists under `available` the event types this profile really recorded, each with
-the export defaults for that type; `notRecorded` names the groups the profiler did not capture.
-Asking for one it did not record returns an empty tree rather than an error, so check first. Common
-starting points:
+`flamegraph_list` returns `available` — the event types this profile really recorded, each with
+the export defaults for that type — and `notRecorded`, the standard groups the profiler did not
+capture. Asking for a type it did not record returns an empty tree rather than an error, so check
+first. Starting points:
 
 - on-CPU time → `jdk.ExecutionSample`
-- allocation → `jdk.ObjectAllocationSample` (add `useWeight: true` to rank by bytes, not by call count)
-- lock contention → `jdk.JavaMonitorEnter` (with `useWeight: true`, weight is nanoseconds blocked)
-- wall-clock latency, including off-CPU → `profiler.WallClockSample` — async-profiler's event, so
-  it does **not** carry the `jdk.` prefix its neighbours here do
+- allocation → `jdk.ObjectAllocationSample`, with `useWeight: true` to rank by bytes rather than call count
+- lock contention → `jdk.JavaMonitorEnter`, with `useWeight: true` (weight is nanoseconds blocked)
+- wall-clock latency including off-CPU → `profiler.WallClockSample` — async-profiler's event, so it
+  does **not** carry the `jdk.` prefix its neighbours do
 
-`thresholdPct` controls how much detail survives pruning. Raise it for an overview, lower it to
-chase a specific path.
+`thresholdPct` decides how much survives pruning: raise it for an overview, lower it to chase one
+specific path.
 
-## Working a latency question with traces
+## 4. Read the export the way it tells you to
 
-`traces_overview` → `traces_operations` (sorted by `TOTAL_TIME` by default, which is where the
-wall-clock actually went) → `traces_operationExport` for the population → `traces_slowestTraces`
-then `traces_traceExport` for one exemplar → `traces_spanFlamegraphExport` for the frames inside a
-single slow span. An operation is identified by the triple `(name, kind, eventType)`, not by name
-alone — an inbound `GET /orders` and an outbound call to the same path are different operations.
+`flamegraph_export`, `traces_traceExport` and `traces_operationExport` return Markdown documents
+that open with their own reading instructions — what `self` versus `total` means, what the frame
+tags mean, what was pruned, and how to analyse that event type. Follow that preamble rather than
+generic flamegraph conventions; Jeffrey's accounting is stated there in the version that matches
+the code that produced it.
 
-Read the application's own account before the timing. `traces_overview` reports how many
-**notifications** — `jeffrey.Notification` events an instrumented application emits about itself,
-a pool exhausted, a fallback taken — were raised inside traces, and how many were `CRITICAL` or
-`HIGH`. When there are any, call `traces_notifications` (filter by `severity`, `type`, `source`, or
-the operation triple) before exporting a trace: a CRITICAL notification usually names the cause
-the span tree only shows the cost of, and its exemplar trace ids are the traces worth exporting.
-The operation and trace exports carry their own Notifications section, and its instructions say
-how to weigh each severity.
+## Latency: work the traces first
+
+"This endpoint is slow" is a traces question before it is a flamegraph question:
+
+1. `traces_overview` — totals, and how many **notifications** were raised inside traces.
+   Notifications are `jeffrey.Notification` events an instrumented application emits about
+   itself (a pool exhausted, a fallback taken). When any are `CRITICAL` or `HIGH`, call
+   `traces_notifications` *before* exporting a trace: such a notification usually names the cause
+   the span tree only shows the cost of, and its exemplar trace ids are the ones worth exporting.
+2. `traces_operations` — sorted by `TOTAL_TIME` by default, which is where the wall-clock went.
+   An operation is the triple `(name, kind, eventType)`, not a name alone: an inbound
+   `GET /orders` and an outbound call to the same path are different operations.
+3. `traces_operationExport` for the population, then `traces_slowestTraces` → `traces_traceExport`
+   for one exemplar, then `traces_spanFlamegraphExport` for the frames inside a single slow span.
 
 ## Grounding claims
 
-The exports contain call paths and numbers, not source locations. Cite the path and the figures the
-document shows. If the repository is open alongside, read the real source before proposing a change
-— do not infer file or line numbers from a profile.
+The exports carry call paths and figures, not source locations. Cite the path and the numbers the
+document shows. If the repository is open alongside, read the real source before naming a file,
+method or line — never infer them from a frame name. The `advise` skill carries the full
+profile-to-code-change workflow.
 
-## When something is missing
+## When something fails
 
-- A tool answers `Profile … has no heap dump` → it is a JFR recording; use `jfr_`, `flamegraph_`, `traces_`.
-- The profile *is* a heap dump (`profiles_list` shows `event source` = `HEAP_DUMP`) → switch to the
-  `analyze-heap` skill; flamegraphs and traces do not apply to it.
-- `recordings_analyzeFile` says the path must be absolute → pass the full path, not a repo-relative one.
-- It says there is no such file, but the file is right there → Jeffrey is looking on *its own*
-  filesystem. Copy or mount the recording somewhere Jeffrey can reach, or upload it in the UI.
-- No `recordings_` tool is advertised at all → this Jeffrey was started with
-  `jeffrey.microscope.mcp.ingest.enabled=false`. Upload and analyse the recording in the Jeffrey UI,
-  then work from `profiles_list`.
-- Every call fails to connect → Jeffrey is not running at that address.
-- The server 404s → this Jeffrey was started with `jeffrey.microscope.mcp.enabled=false`. The server
-  is on by default; **Settings → Claude Code (MCP)** reports whether it is serving.
-- Jeffrey is not on `http://localhost:8585` → point the plugin at the real
-  `…/api/internal/mcp` endpoint: run `/plugin`, open the `microscope` plugin's configuration
-  and set **Jeffrey MCP endpoint**.
+- `Profile … has no heap dump` → it is a JFR recording; stay with `jfr_`, `flamegraph_`, `traces_`.
+- `The recording path must be absolute` → pass the full path, not a repository-relative one.
+- `No such recording file` but the file is right there → Jeffrey is looking on *its own*
+  filesystem. Copy or mount the recording where Jeffrey can reach it, or upload it in the UI.
+- No `recordings_` tool advertised → this Jeffrey runs with `jeffrey.microscope.mcp.ingest.enabled=false`.
+  Upload and analyse in the Jeffrey UI, then work from `profiles_list`.
+- Every call fails to connect → Jeffrey is not running at the configured address. Point the plugin
+  at the real `…/api/internal/mcp` endpoint: `/plugin` → `microscope` → **Jeffrey MCP endpoint**;
+  Jeffrey's **Settings → Claude Code (MCP)** shows the URL for the installation.
+- The server answers 404 → it was started with `jeffrey.microscope.mcp.enabled=false`; it is on
+  by default.
 
-For a heap dump — what is holding the memory, what is leaking, which class loader never went away
-— see the `analyze-heap` skill. For raw SQL against a profile or a heap dump, see the `jfr-sql` and
-`heap-sql` skills. To go from a profile to a code change — hot frames mapped to this repository, a
-recommendation, an edit and a re-profile — see the `advise` skill.
+Related skills: `analyze-heap` for a heap dump, `jfr-sql` for raw SQL against the profile,
+`advise` to go from a hotspot to an edit in this repository.

--- a/jeffrey-pages/src/views/ReleaseNotesView.vue
+++ b/jeffrey-pages/src/views/ReleaseNotesView.vue
@@ -399,7 +399,7 @@ onUnmounted(() => document.removeEventListener('keydown', onLightboxKey))
             <span class="hero-docs-label"><i class="bi bi-journal-text"></i> Documentation</span>
             <router-link to="/docs/microscope" class="hero-docs-btn"><i class="bi bi-search"></i> Microscope</router-link>
             <router-link to="/docs/hub" class="hero-docs-btn"><i class="bi bi-cloud"></i> Hub</router-link>
-            <router-link to="/docs/microscope-mcp/skills" class="hero-docs-btn"><i class="bi bi-lightbulb"></i> Advisor (now the advise skill)</router-link>
+            <router-link to="/docs/microscope-mcp/skills" class="hero-docs-btn"><i class="bi bi-lightbulb"></i> Advisor (now the advise-jfr skill)</router-link>
           </div>
         </div>
       </div>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpOverviewPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpOverviewPage.vue
@@ -97,7 +97,7 @@ onMounted(() => {
         </tbody>
       </table>
 
-      <p>They are not alternatives; running both is normal. The <router-link to="/docs/ai/overview">AI Analysis</router-link> pages cover the in-app side. What used to be the third thing &mdash; the Profile Advisor, which read one source folder from inside Jeffrey and proposed a patch &mdash; is now the <router-link to="/docs/microscope-mcp/skills#advise"><code>advise</code> skill</router-link> on this side: the same job, done by the agent that can also build, test and re-profile.</p>
+      <p>They are not alternatives; running both is normal. The <router-link to="/docs/ai/overview">AI Analysis</router-link> pages cover the in-app side. What used to be the third thing &mdash; the Profile Advisor, which read one source folder from inside Jeffrey and proposed a patch &mdash; is now the <router-link to="/docs/microscope-mcp/skills#advise-jfr"><code>advise-jfr</code> skill</router-link> on this side: the same job, done by the agent that can also build, test and re-profile.</p>
 
       <h2 id="how-a-request-travels">How a Request Travels</h2>
       <p>The server speaks <strong>MCP over Streamable HTTP</strong> &mdash; JSON-RPC 2.0 against a single endpoint, <code>POST /api/internal/mcp</code>, on the Jeffrey Microscope you already run. There is no separate process to start and no extra port to open.</p>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpPluginPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpPluginPage.vue
@@ -99,9 +99,9 @@ const removal = `/plugin uninstall microscope@jeffrey`;
 
       <p><strong>Five skills</strong>, which Claude picks up on its own when a question calls for them, and which you can also invoke directly:</p>
       <ul>
-        <li><code>/microscope:analyze-profile</code> &mdash; where to start and which family answers which question</li>
+        <li><code>/microscope:analyze-jfr</code> &mdash; where to start and which family answers which question</li>
         <li><code>/microscope:analyze-heap</code> &mdash; a heap dump end to end: what is holding the memory, what is leaking, and the order the twenty heap tools have to be run in</li>
-        <li><code>/microscope:advise</code> &mdash; from a profile to a code change: hot frames mapped to your checkout, a recommendation, then the edit and a re-profile on request</li>
+        <li><code>/microscope:advise-jfr</code> &mdash; from a profile to a code change: hot frames mapped to your checkout, a recommendation, then the edit and a re-profile on request</li>
         <li><code>/microscope:jfr-sql</code> &mdash; the JFR schema and the DuckDB idioms that go with it</li>
         <li><code>/microscope:heap-sql</code> &mdash; the heap-dump index schema</li>
       </ul>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpPluginPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpPluginPage.vue
@@ -93,7 +93,7 @@ const removal = `/plugin uninstall microscope@jeffrey`;
       <p>The value is stored per machine, in <code>~/.claude/settings.json</code>. One plugin therefore serves every installation: a non-default port is a setting, not an edit to the manifest, and a laptop can point at a tunnelled staging Jeffrey while the machine beside it stays on localhost.</p>
 
       <h2 id="what-the-plugin-adds">What the Plugin Adds</h2>
-      <p>Registering the server by hand gives you the forty-three tools. The plugin adds two things on top.</p>
+      <p>Registering the server by hand gives you the forty-three tools. The plugin adds three things on top.</p>
 
       <p><strong>The endpoint, already configured</strong> &mdash; including the per-machine setting above, so the same install works on a laptop and against a tunnelled staging Jeffrey.</p>
 
@@ -107,6 +107,10 @@ const removal = `/plugin uninstall microscope@jeffrey`;
       </ul>
 
       <p>The <router-link to="/docs/microscope-mcp/skills">Skills</router-link> page covers what each one carries and why it exists.</p>
+
+      <p><strong>One subagent</strong>, <code>microscope:profile-analyst</code>. A single <code>flamegraph_export</code> can run to 120,000 characters &mdash; the cap a tool result is truncated at &mdash; and answering a question properly often takes several of them. The analyst runs a sequence and returns only the findings: the hot frames with their <code>total</code> and <code>self</code> shares, or the retaining classes with their retained bytes and GC-root paths. Everything it read stays in its own context window rather than crowding out the conversation you are having.</p>
+
+      <p>The skills hand it the reading and keep what actually needs your session: mapping frames onto the checkout, the recommendation, and every question put to you. <code>advise-jfr</code> uses it hardest, sending CPU, wall-clock, allocation and blocking out as four parallel delegations instead of pulling four documents into one context. Its tools are the read-only MCP families and nothing else &mdash; no file access, no <code>recordings_</code> &mdash; so it can neither touch your repository nor create a profile.</p>
 
       <h2 id="permissions">Permissions</h2>
       <p>Claude Code asks before each tool the first time. Every tool here reads except the <code>recordings_</code> family, which imports a recording file and builds a profile from it, so approving the whole family once is usually what you want &mdash; from the prompt, or up front with <code>/permissions</code>:</p>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpRecipesPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpRecipesPage.vue
@@ -141,7 +141,7 @@ LIMIT 20`;
       <h2 id="from-profile-to-patch">From Profile to Patch</h2>
       <DocsCodeBlock :code="promptAdvise" language="bash" />
 
-      <p>Drives the <router-link to="/docs/microscope-mcp/skills#advise"><code>advise</code></router-link> skill: <code>profiles_get</code> for the recording&rsquo;s commit, <code>flamegraph_list</code>, then <code>flamegraph_export</code> once per group the profile carries &mdash; CPU, wall-clock, allocation, blocking &mdash; followed by reads of the real source behind the heaviest frames.</p>
+      <p>Drives the <router-link to="/docs/microscope-mcp/skills#advise-jfr"><code>advise-jfr</code></router-link> skill: <code>profiles_get</code> for the recording&rsquo;s commit, <code>flamegraph_list</code>, then <code>flamegraph_export</code> once per group the profile carries &mdash; CPU, wall-clock, allocation, blocking &mdash; followed by reads of the real source behind the heaviest frames.</p>
 
       <p>The previous recipe reconciles one frame with one method. This one is the whole loop: every group at once, a recommendation per hotspot with the measured share that justifies it, and a stop before anything is edited. Say which findings to apply and Claude makes the smallest edit for each, runs the tests, and &mdash; if you name the command that produced the recording &mdash; re-runs it, analyses the new file with <code>recordings_analyzeFile</code> and reports the delta on the frames it changed.</p>
 

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpSkillsPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpSkillsPage.vue
@@ -33,6 +33,7 @@ const headings = [
   { id: 'advise-jfr', text: 'advise-jfr', level: 2 },
   { id: 'jfr-sql', text: 'jfr-sql', level: 2 },
   { id: 'heap-sql', text: 'heap-sql', level: 2 },
+  { id: 'the-analyst', text: 'The Analyst They Delegate To', level: 2 },
   { id: 'invoking-one-directly', text: 'Invoking One Directly', level: 2 },
   { id: 'what-they-deliberately-omit', text: 'What They Deliberately Omit', level: 2 }
 ];
@@ -65,7 +66,7 @@ SELECT event_type, COUNT(*) FROM events_raw GROUP BY event_type`;
     />
 
     <div class="docs-content">
-      <p>The <router-link to="/docs/microscope-mcp/plugin">plugin</router-link> ships five skills. Claude loads one on its own when a question calls for it; you can also invoke any of them directly. Registering the MCP server by hand gives you the tools but not these.</p>
+      <p>The <router-link to="/docs/microscope-mcp/plugin">plugin</router-link> ships five skills and <a href="#the-analyst">one subagent</a>. Claude loads one on its own when a question calls for it; you can also invoke any of them directly. Registering the MCP server by hand gives you the tools but not these.</p>
 
       <h2 id="why-skills-at-all">Why Skills at All</h2>
       <p>Most of what a model needs in order to <em>read</em> Jeffrey&rsquo;s output already travels with the output. Every flamegraph and trace export opens with a preamble that defines what <code>self</code> means against <code>total</code>, what the frame tags mean, what was pruned, and how to analyse that particular event type. Nothing needs to repeat that, and a skill that did would go stale the moment the preamble changed.</p>
@@ -131,6 +132,13 @@ SELECT event_type, COUNT(*) FROM events_raw GROUP BY event_type`;
       <p>It carries the index schema &mdash; <code>class</code>, <code>instance</code>, <code>outbound_ref</code>, <code>gc_root</code>, <code>dominator</code>, <code>retained_size</code>, <code>string</code>, <code>dump_metadata</code> &mdash; with the details that are not guessable: <code>dominator</code> and <code>retained_size</code> are built lazily and are empty until something asks for them; <code>class.name</code> is already dot-notation; <code>record_kind</code> is a small integer enum; and the <code>string</code> table is the HPROF UTF-8 <em>name</em> pool, not the contents of Java <code>String</code> instances.</p>
 
       <p>It opens by pointing back at <code>analyze-heap</code> and saying to try the purpose-built tools first &mdash; several are pre-computed reports, and reproducing one in SQL is slower and easier to get wrong. This skill is the escape hatch for what they do not cover, not the way in.</p>
+
+      <h2 id="the-analyst">The Analyst They Delegate To</h2>
+      <p>Three of the skills do not read the big documents themselves. A single <code>flamegraph_export</code> can run to 120,000 characters, and a question worth asking usually takes several &mdash; four of them in <code>advise-jfr</code>, one per group. Pulled into the session, they leave little room for the thing that has to happen next: reading the actual source behind the frames.</p>
+
+      <p>So the plugin ships a subagent, <code>microscope:profile-analyst</code>, and the skills hand it the reading. It runs the sequence, follows the profile where it leads &mdash; deeper into a subtree, a lower threshold on one path, the GC-root path of the class the histogram named &mdash; and returns the findings alone: frames with their <code>total</code> and <code>self</code> shares, or classes with their retained bytes and root paths. What it read stays in its context.</p>
+
+      <p>What it is not allowed to do is as much of the design as what it does. Its tools are the read-only MCP families and nothing else &mdash; no file access, no <code>recordings_</code> &mdash; so it cannot map a frame to a line, invent a file name that would arrive looking measured, edit anything, or build a profile. Mapping onto the checkout, the recommendation, and every question put to you stay in the session, where you can answer them.</p>
 
       <h2 id="invoking-one-directly">Invoking One Directly</h2>
       <p>Each skill is also a slash command, namespaced by the plugin:</p>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpSkillsPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpSkillsPage.vue
@@ -47,7 +47,8 @@ const invoke = `/microscope:analyze-profile
 /microscope:jfr-sql
 /microscope:heap-sql`;
 
-const advisePrompt = `advise on the most recent Jeffrey profile - what should I change in this repo?`;
+const advisePrompt = `advise on the most recent Jeffrey profile - what should I change in this repo?
+/microscope:advise 019f885e-8e69-7d65-8ac7-32a70b92cb94 alloc`;
 
 const eventsView = `-- correct
 SELECT event_type, COUNT(*) FROM events GROUP BY event_type
@@ -86,10 +87,11 @@ SELECT event_type, COUNT(*) FROM events_raw GROUP BY event_type`;
       <h2 id="analyze-heap">analyze-heap</h2>
       <p><em>A heap dump end to end.</em> Loaded when the question is &ldquo;what is holding memory&rdquo;, &ldquo;why is the heap growing&rdquo;, &ldquo;why did this OOM&rdquo;, &ldquo;what is leaking&rdquo;, or when retained size, a dominator tree, GC roots or a <code>.hprof</code> file are mentioned.</p>
 
-      <p><code>heap_</code> is the largest family, and the only one whose tools have to be run in an order. Half of its reports say &ldquo;this analysis may need to be run first&rdquo; without saying which one, and nothing in a tool list explains what that means. The skill carries the order and the two rules that decide every heap answer:</p>
+      <p><code>heap_</code> is the largest family, and the only one whose tools have to be run in an order. Half of its reports say &ldquo;this analysis may need to be run first&rdquo; without saying which one, and nothing in a tool list explains what that means. The skill carries the order and the three rules that decide every heap answer:</p>
       <ul>
         <li><strong>Shallow is not retained.</strong> Shallow size is the object itself; retained size is what dies with it. Only the second answers &ldquo;who is holding this memory&rdquo; &mdash; a histogram ranked by shallow size tells you what there is a lot of, not who is responsible for it.</li>
-        <li><strong>The dominator tree is built lazily.</strong> <code>dominator</code> and <code>retained_size</code> stay empty until <code>heap_getDominatorTreeRoots</code> runs, so every retained figure is missing rather than zero. Calling it once, early, is what the reports mean by their warning, and skipping it is the usual reason a heap session stalls on empty results.</li>
+        <li><strong>The dominator tree is built lazily.</strong> <code>dominator</code> and <code>retained_size</code> stay empty until <code>heap_getDominatorTreeRoots</code> runs, so every retained figure is missing rather than zero. Calling it once, early, is what makes retained sizes appear, and skipping it is the usual reason a heap session stalls on empty results.</li>
+        <li><strong>Six reports are pre-computed in the UI.</strong> Leak Suspects, Biggest Objects, Class Loader Analysis, Top Consumers, String Analysis and Collection Analysis are computed when someone opens them in Jeffrey and only <em>read</em> over MCP; until then their tools answer &ldquo;has not been run yet&rdquo;. The skill names which tools those are, tells the model to hand the user the <code>profiles_link</code> URL and the report to run instead of retrying, and gives an on-demand route for the same question &mdash; the dominator tree into <code>heap_getPathToGCRoot</code> &mdash; so the answer does not wait on the UI.</li>
       </ul>
 
       <p>On top of that it carries the routes &mdash; the histogram and top consumers for what is using the heap, leak suspects into a GC-root path for what is leaking, <code>heap_getClassLoaderLeakChains</code> for the redeploy case that leaves a class loader behind, string and collection analysis for waste, and instance browsing for one particular class &mdash; plus how to enter from a <code>.hprof</code> file Jeffrey has never seen, and what the two guard messages mean when a profile turns out to have no heap dump or an index that is still being built.</p>
@@ -100,7 +102,7 @@ SELECT event_type, COUNT(*) FROM events_raw GROUP BY event_type`;
       <p><em>From a profile to a code change.</em> Loaded when the question is &ldquo;what should I change&rdquo;, &ldquo;optimise this&rdquo;, or when a hotspot has been found and the next question is what to do about it. It is the successor of the in-app Profile Advisor: the same job, done by the agent that is already in your checkout and can build, test and re-profile, instead of by a model given a read-only view of one folder.</p>
       <DocsCodeBlock :code="advisePrompt" language="bash" />
 
-      <p>It works in two phases with a stop between them &mdash; <strong>recommend</strong>, then <strong>change</strong> &mdash; and carries what neither the exports nor the tool list say:</p>
+      <p>It takes an optional argument &mdash; a profile id or a recording file, then one of <code>cpu</code>, <code>wall</code>, <code>alloc</code>, <code>lock</code> to narrow the analysis to one group &mdash; and works in two phases with a stop between them, <strong>recommend</strong>, then <strong>change</strong>, tracked as a checklist so the gate is visible. It carries what neither the exports nor the tool list say:</p>
       <ul>
         <li><strong>The commit check.</strong> <code>profiles_get</code> reports the commit the profiled build came from when the recording was tagged with one. The skill compares it with <code>HEAD</code> before mapping a single frame, and says so when they differ or when the commit is unknown &mdash; a profile of another commit describes code that may no longer exist.</li>
         <li><strong>The four groups.</strong> CPU, wall-clock, allocation and blocking, each with the event type that answers it and the fallback when a recording carries an older one (the TLAB pair for allocation; monitor-wait and park for blocking), weighted by bytes or nanoseconds where that is the meaningful ranking. A group with no samples is reported with the profiler flag that would capture it next time.</li>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpSkillsPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpSkillsPage.vue
@@ -28,9 +28,9 @@ const { setHeadings } = useDocHeadings();
 
 const headings = [
   { id: 'why-skills-at-all', text: 'Why Skills at All', level: 2 },
-  { id: 'analyze-profile', text: 'analyze-profile', level: 2 },
+  { id: 'analyze-jfr', text: 'analyze-jfr', level: 2 },
   { id: 'analyze-heap', text: 'analyze-heap', level: 2 },
-  { id: 'advise', text: 'advise', level: 2 },
+  { id: 'advise-jfr', text: 'advise-jfr', level: 2 },
   { id: 'jfr-sql', text: 'jfr-sql', level: 2 },
   { id: 'heap-sql', text: 'heap-sql', level: 2 },
   { id: 'invoking-one-directly', text: 'Invoking One Directly', level: 2 },
@@ -41,14 +41,14 @@ onMounted(() => {
   setHeadings(headings);
 });
 
-const invoke = `/microscope:analyze-profile
+const invoke = `/microscope:analyze-jfr
 /microscope:analyze-heap
-/microscope:advise
+/microscope:advise-jfr
 /microscope:jfr-sql
 /microscope:heap-sql`;
 
 const advisePrompt = `advise on the most recent Jeffrey profile - what should I change in this repo?
-/microscope:advise 019f885e-8e69-7d65-8ac7-32a70b92cb94 alloc`;
+/microscope:advise-jfr 019f885e-8e69-7d65-8ac7-32a70b92cb94 alloc`;
 
 const eventsView = `-- correct
 SELECT event_type, COUNT(*) FROM events GROUP BY event_type
@@ -77,7 +77,7 @@ SELECT event_type, COUNT(*) FROM events_raw GROUP BY event_type`;
         <li><strong>The two database schemas.</strong> Jeffrey&rsquo;s in-app assistant is given the JFR and heap-dump schemas in its system prompt. An external client never sees that prompt, so without a skill it would be guessing at column names.</li>
       </ul>
 
-      <h2 id="analyze-profile">analyze-profile</h2>
+      <h2 id="analyze-jfr">analyze-jfr</h2>
       <p><em>Orientation.</em> Loaded whenever the question is &ldquo;why is this slow&rdquo;, &ldquo;where does the time go&rdquo;, &ldquo;what is allocating&rdquo;, &ldquo;what is holding memory&rdquo;, or when a Jeffrey profile, a JFR recording or a heap dump is mentioned.</p>
 
       <p>It carries the entry sequence &mdash; <code>profiles_list</code>, then <code>profiles_features</code>, then the family that matches the question &mdash; a map of the six families to the questions each answers, when to start instead from <code>recordings_analyzeFile</code> because the user named a file Jeffrey has never seen, the rule that every scoped tool takes a <code>profileId</code>, which flamegraph to pick for CPU versus allocation versus lock contention versus wall-clock, the order to work a latency question in traces, and what a failure means (a <code>404</code> means the server was switched off, not a bug).</p>
@@ -96,9 +96,9 @@ SELECT event_type, COUNT(*) FROM events_raw GROUP BY event_type`;
 
       <p>On top of that it carries the routes &mdash; the histogram and top consumers for what is using the heap, leak suspects into a GC-root path for what is leaking, <code>heap_getClassLoaderLeakChains</code> for the redeploy case that leaves a class loader behind, string and collection analysis for waste, and instance browsing for one particular class &mdash; plus how to enter from a <code>.hprof</code> file Jeffrey has never seen, and what the two guard messages mean when a profile turns out to have no heap dump or an index that is still being built.</p>
 
-      <p>It grounds claims the way <code>analyze-profile</code> does: cite the class name, the retained bytes and the GC-root path together, never carry an object id between dumps, and say whether one dump is being read as a leak or as a large working set &mdash; a single dump cannot tell those apart.</p>
+      <p>It grounds claims the way <code>analyze-jfr</code> does: cite the class name, the retained bytes and the GC-root path together, never carry an object id between dumps, and say whether one dump is being read as a leak or as a large working set &mdash; a single dump cannot tell those apart.</p>
 
-      <h2 id="advise">advise</h2>
+      <h2 id="advise-jfr">advise-jfr</h2>
       <p><em>From a profile to a code change.</em> Loaded when the question is &ldquo;what should I change&rdquo;, &ldquo;optimise this&rdquo;, or when a hotspot has been found and the next question is what to do about it. It is the successor of the in-app Profile Advisor: the same job, done by the agent that is already in your checkout and can build, test and re-profile, instead of by a model given a read-only view of one folder.</p>
       <DocsCodeBlock :code="advisePrompt" language="bash" />
 


### PR DESCRIPTION
## Summary

Reorganizes the Claude Code MCP skills to better align with their distinct purposes and improve discoverability. Splits the monolithic `analyze-profile` skill into two focused skills: `analyze-jfr` for profile analysis and `advise-jfr` for turning profiles into code changes. Adds a new `advise-jfr` skill documentation and updates all references across the codebase.

## Key Changes

- **New skill: `advise-jfr`** — Extracted from the old `advise` skill with clarified scope and improved documentation. Focuses on mapping hotspots to source code and recommending minimal, behaviour-preserving edits. Includes explicit two-phase workflow (recommend, then change) and verification steps.

- **Renamed skill: `analyze-profile` → `analyze-jfr`** — Clarifies that this skill handles JFR recordings and profiles, not heap dumps. Updated description to be more precise about when to use it (CPU, wall-clock, allocation, lock contention, traces) and when to switch to `analyze-heap` instead.

- **Removed skill: `advise`** — Consolidated into `advise-jfr` with improved structure and clearer argument hints.

- **Documentation improvements across all skills:**
  - Consistent tool naming conventions (omit server prefix, use exact camelCase)
  - Clearer separation of concerns between on-demand tools and pre-computed reports
  - Better guidance on when to use each tool family
  - Improved tables and structured workflows
  - More explicit error handling and troubleshooting sections

- **Updated skill references:**
  - `McpSkillsPage.vue` — Updated headings and example invocations
  - `McpPluginPage.vue` — Updated skill list references
  - `McpRecipesPage.vue` — Updated recipe examples
  - `README.md` — Updated skill descriptions in the plugin documentation
  - `ReleaseNotesView.vue` — Updated documentation links
  - `McpOverviewPage.vue` — Updated skill references
  - `CLAUDE.md` — Updated project structure documentation

## Implementation Details

- The `analyze-jfr` skill now explicitly covers the full JFR analysis workflow: getting a profileId, choosing event families, reading exports, and working with traces for latency questions.

- The `advise-jfr` skill includes a detailed progress checklist and clearer phase separation to prevent premature edits before recommendations are reviewed.

- Both skills now include explicit "When something is missing" sections with troubleshooting guidance for common failure modes.

- Tool naming conventions are now documented consistently: server prefix omitted in examples, camelCase enforced (e.g., `heap_getLeakSuspects`, not `heap_get_leak_suspects`).

- The distinction between computed-on-demand tools and pre-computed reports is now explicit in `analyze-heap` and `analyze-jfr`, with guidance on when to use each.

https://claude.ai/code/session_017DvJUfGoWHxQjW5HmXmrJp