### PR TITLE
Add differential flamegraph analysis and compare-jfr MCP tools

### DIFF
--- a/jeffrey-claude-plugin/README.md
+++ b/jeffrey-claude-plugin/README.md
@@ -47,12 +47,13 @@ installation.
 
 ## What you get
 
-**Tools**, in six families:
+**Tools**, in seven families:
 
 | Family | What it does |
 |---|---|
 | `profiles_` | The catalogue: which recordings are analysed, what each one can answer, a deep link into the UI |
 | `flamegraph_` | Which graphs a profile supports, and the call tree as Markdown |
+| `compare_` | Two profiles against each other: whether they are comparable, what moved, and the differential call tree |
 | `traces_` | Trace operations, the application's own notifications, exemplars, span trees and span-scoped flamegraphs |
 | `jfr_` | The profile's DuckDB tables — schema and read-only SQL |
 | `heap_` | Heap summary, class histogram, dominator tree, leak suspects, GC-root paths, and read-only SQL |
@@ -67,6 +68,8 @@ both) and not the case for a Jeffrey in a container or on another host.
 - `/microscope:analyze-jfr` — where to start and which family answers which question
 - `/microscope:analyze-heap` — a heap dump end to end: what is holding the memory, what is leaking,
   which class loader never went away, and the order the heap tools have to be run in
+- `/microscope:compare-jfr` — before against after: whether a change made it slower, which methods
+  moved, and whether the two recordings were comparable in the first place
 - `/microscope:advise-jfr [profile-id | recording-file] [cpu|wall|alloc|lock]` — from a profile to a
   code change: the hottest CPU, wall-clock, allocation and blocking frames mapped to real source in
   your checkout, a recommendation, then the edit and a re-profile on request

--- a/jeffrey-claude-plugin/agents/profile-analyst.md
+++ b/jeffrey-claude-plugin/agents/profile-analyst.md
@@ -15,6 +15,7 @@ model: inherit
 skills:
   - analyze-jfr
   - analyze-heap
+  - compare-jfr
 color: orange
 ---
 
@@ -26,9 +27,13 @@ come back.
 ## What you are given
 
 A `profileId`, and one question — an event type to graph, a trace operation to work, or a heap
-question. The `analyze-jfr` and `analyze-heap` skills are preloaded: they carry the tool families,
-the entry sequence, the flamegraph choice per question, the trace order, and the heap rules
-(shallow versus retained, the lazily built dominator tree, which reports only the UI can compute).
+question. A comparison question comes with a second id, the **baseline**: the `profileId` is the run
+under examination and the baseline is what it is measured against, and you never swap them to make a
+result read better. The `analyze-jfr`, `analyze-heap` and `compare-jfr` skills are preloaded: they
+carry the tool families, the entry sequence, the flamegraph choice per question, the trace order,
+the heap rules (shallow versus retained, the lazily built dominator tree, which reports only the UI
+can compute), and — for a comparison — that `compare_list` runs first and that "these two runs are
+not comparable" is a finding to report rather than an obstacle to work around.
 Follow them. If the request names no `profileId`, say so and stop rather than picking one — the
 caller knows which profile the conversation is about and you do not.
 

--- a/jeffrey-claude-plugin/skills/analyze-jfr/SKILL.md
+++ b/jeffrey-claude-plugin/skills/analyze-jfr/SKILL.md
@@ -39,6 +39,7 @@ A profile whose `event source` column reads `HEAP_DUMP` is a heap dump: switch t
 |---|---|
 | `profiles_` | `list`, `get` (identity, recording window, size, source commit), `features`, `link` (deep link into the Jeffrey UI) |
 | `flamegraph_` | `list` (which event types this profile can graph — call it first), `export` (the call tree as Markdown) |
+| `compare_` | `list` (whether two profiles are comparable at all — call it first), `movements` (what moved, ranked), `flamegraph` (the differential call tree) — the `compare-jfr` skill has the workflow |
 | `traces_` | `overview`, `operations`, `notifications`, `operationExport`, `slowestTraces`, `traceExport`, `spanFlamegraphExport`, `operationFlamegraphExport` |
 | `jfr_` | `listTables`, `describeTable`, `listEventTypes`, `queryEvents`, `executeQuery`, `getProfileInfo` — raw DuckDB when no purpose-built tool fits; the `jfr-sql` skill has the schema |
 | `heap_` | Everything a heap dump answers — the `analyze-heap` skill has the order to run it in |
@@ -122,5 +123,6 @@ profile-to-code-change workflow.
 - The server answers 404 → it was started with `jeffrey.microscope.mcp.enabled=false`; it is on
   by default.
 
-Related skills: `analyze-heap` for a heap dump, `jfr-sql` for raw SQL against the profile,
-`advise-jfr` to go from a hotspot to an edit in this repository.
+Related skills: `analyze-heap` for a heap dump, `compare-jfr` when there is a before and an after
+to weigh against each other, `jfr-sql` for raw SQL against the profile, `advise-jfr` to go from a
+hotspot to an edit in this repository.

--- a/jeffrey-claude-plugin/skills/compare-jfr/SKILL.md
+++ b/jeffrey-claude-plugin/skills/compare-jfr/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: compare-jfr
+description: Compares two JVM profiles held by a running Jeffrey Microscope — a before and an after — using differential flamegraphs, to answer whether a change made the application slower, faster, or allocate more. Use whenever the user asks if a change regressed performance, what got slower or faster between two runs, to compare two recordings, benchmarks or branches, or mentions a baseline, a before/after or a performance regression. For a single profile, analyze-jfr applies instead; for a heap dump, analyze-heap.
+allowed-tools: mcp__plugin_microscope_jeffrey__* mcp__jeffrey__*
+---
+
+# Comparing two Jeffrey profiles
+
+Two recordings of the same application — one from before a change, one from after — subtracted
+frame by frame. The **primary** is the run under examination and the **baseline** is what it is
+measured against; a positive delta always means the primary spends *more*.
+
+Tool names below omit the server prefix — `mcp__plugin_microscope_jeffrey__` for the plugin,
+`mcp__jeffrey__` for a hand-registered server. The part after it is exact and camelCase:
+`compare_movements`, not `compare_movements_list`.
+
+## The one thing that makes this analysis worthless
+
+Any two recordings can be subtracted, and the result always looks like a finding. Whether it *is*
+one depends on facts the deltas do not show: that both runs did the same kind of work, for a
+comparable length of time, with the same profiler settings. Nothing inside a JFR file proves any of
+that.
+
+So `compare_list` is not a warm-up call. It is the step that decides whether the rest means
+anything, and its answer is a finding in its own right — "these two runs are not comparable" is a
+real, reportable result, and a far better one than a confident regression that was really a
+recording twice as long.
+
+## 1. Get two `profileId`s
+
+`profiles_list` shows every analysed profile with its name, recording time and duration. Pick the
+**baseline** (before) and the **primary** (after) from it.
+
+**The user named two files** (`before.jfr` and `after.jfr`) — check `profiles_list` for them first,
+then `recordings_analyzeFile` with the **absolute** path for each one that is missing. Every call
+imports the file again and creates another profile, so never re-analyse one that is already there.
+Jeffrey opens those paths itself, so both files must be on the machine Jeffrey runs on. If no
+`recordings_` tool is advertised, this Jeffrey has ingestion switched off — upload both in the UI
+first.
+
+Getting the direction right matters: pass the **after** run as `profileId` and the **before** run
+as `baselineProfileId`. Backwards, every regression reads as an improvement.
+
+## 2. Establish comparability — always first
+
+`compare_list` reports both recordings' length, the event types they have in common with each
+side's totals, and the types only one of them recorded.
+
+Read its `notes`, and stop to think when:
+
+- **The durations differ.** Sample counts scale with recording time. The comparison scales the
+  baseline onto the primary's length automatically, which is right for a steady workload and wrong
+  for a fixed-size benchmark (N requests replayed in both runs). On a benchmark, read the **share**
+  column rather than the delta.
+- **An event type appears on one side only.** That is a difference between the two *profiler
+  configurations*, not a change in the application. Report it as such; do not report the work as
+  having appeared or vanished.
+- **`comparable` is empty.** There is nothing to compare — different formats, one is a heap dump,
+  or wholly different profiler settings. Say so and stop.
+
+If the two runs came from different machines, different load levels or different JVM flags, say so
+before anything else. No amount of arithmetic recovers that, and the numbers will look just as
+precise either way.
+
+## 3. Rank what moved
+
+`compare_movements` with the `eventType` from `compare_list`. This is the main tool. It returns the
+methods that grew and the ones that shrank, ranked by how much work moved with them.
+
+- on-CPU time → `jdk.ExecutionSample`
+- allocation → `jdk.ObjectAllocationSample` with `useWeight: true`, so the ranking is by bytes
+  rather than by allocation count
+- lock contention → `jdk.JavaMonitorEnter` with `useWeight: true` (weight is nanoseconds blocked)
+
+Movements are attributed by **self** weight, so a change is charged to the method that actually
+moved rather than to every caller above it. That is why the ranked list is the first read and the
+tree is the second.
+
+The document opens with its own comparability section and an explanation of every column. Follow
+that preamble; it is written against the code that produced the numbers.
+
+## 4. Drill into one method
+
+`compare_flamegraph` exports the merged call tree, so a movement can be followed to the call paths
+it travelled through — which caller started spending more, whether the work is new or grew in
+place.
+
+Pruning is by **movement**, not by size: a subtree in which nothing changed is dropped however
+large it is. **Absence in this tree means "did not move", not "not present"** — the opposite of the
+single-profile `flamegraph_export`. Lower `thresholdPct` to chase one path; raise it for the shape
+of the change.
+
+## 5. Read the result honestly
+
+- **A rename is not a regression.** The tree matches method names level by level, so a renamed,
+  moved or extracted method appears once as `[NEW]` and once as `[GONE]`, often of near-identical
+  size. Both documents list such pairs as **candidate renames**. They are suspicions; you have the
+  source diff and the profile does not, so check it before reporting either half as a real change.
+- **Share and delta answer different questions.** The delta says how much more work there is; the
+  share says where the profile goes. A method can grow in share while the process as a whole got
+  faster. Quote whichever the question asked for, and say which one it is.
+- **Small movements on thin profiles are noise.** One pair of recordings cannot separate a real 5%
+  move from run-to-run variance. If the comparability section flags a thin profile, report
+  movements as suggestive, not measured.
+- **This is one event type's distribution, not a benchmark.** A CPU profile that shifted work into
+  a shorter path may still have regressed end-to-end latency. Nothing here measures wall-clock
+  improvement of the application; do not claim it did.
+
+## 6. Tie it back to the change
+
+The profile says where, never why. With the repository open alongside, read the real source for
+each moved method before naming a file or a line — never infer them from a frame name — and map
+the movements onto the actual diff. A regression that lines up with a hunk in the change is a
+finding; one that does not is a lead, and often a rename or an unrelated shift in load.
+
+`advise-jfr` carries the full profile-to-code-change workflow once the regression is located.
+
+## Hand the reading to the analyst
+
+Comparison documents are large, and answering well often takes several. The plugin ships
+**`microscope:profile-analyst`**, which runs a sequence and returns only the findings. Give it both
+profile ids, which is the baseline, and the one question. Delegate when more than one event type is
+in play or the chase runs deep; read here when there is exactly one document and it will be
+discussed turn by turn.
+
+## When something fails
+
+- `profileId and baselineProfileId are the same profile` → pick two different runs.
+- `no event type in common` → the two profiles cannot be compared; `profiles_features` on each
+  shows what they actually hold.
+- Everything reads as new or as gone → almost always different profiler settings between the runs,
+  or the two profiles are of different applications. Check `compare_list` before reporting it.
+- A movement that looks enormous → check the recording lengths in `compare_list` first, then the
+  candidate renames, before believing it.
+
+Related skills: `analyze-jfr` for a single profile, `advise-jfr` to turn a located regression into
+an edit, `jfr-sql` for raw SQL against either profile.

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/McpToolsetAssembler.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/McpToolsetAssembler.java
@@ -18,6 +18,7 @@
 
 package cafe.jeffrey.microscope.core.mcp;
 
+import cafe.jeffrey.microscope.core.mcp.tools.CompareMcpTools;
 import cafe.jeffrey.microscope.core.mcp.tools.FlamegraphMcpTools;
 import cafe.jeffrey.microscope.core.mcp.tools.ProfileMcpTools;
 import cafe.jeffrey.microscope.core.mcp.tools.ProfilesMcpTools;
@@ -48,6 +49,11 @@ import java.util.Set;
  * {@link ProfileScopedToolset}, which resolves its target through the {@link McpProfileContextCache}
  * when a call actually arrives.
  * <p>
+ * Every family here is scoped to one profile except {@link CompareMcpTools}, which is scoped to a
+ * pair: the toolset resolves the {@code profileId} as usual and the tool resolves its
+ * {@code baselineProfileId} through the same cache, so both profiles stay pinned for the session
+ * rather than the baseline being reopened on every call.
+ * <p>
  * Every analysis family here is read-only. {@code DuckDbMcpTools} is constructed with its
  * single-argument constructor, which leaves {@code executeModification} refusing — an external client
  * gets to read a profile's data, not to rewrite it.
@@ -62,6 +68,7 @@ public class McpToolsetAssembler {
     private static final String PREFIX_PROFILES = "profiles";
     private static final String PREFIX_JFR = "jfr";
     private static final String PREFIX_FLAMEGRAPH = "flamegraph";
+    private static final String PREFIX_COMPARE = "compare";
     private static final String PREFIX_TRACES = "traces";
     private static final String PREFIX_HEAP = "heap";
     private static final String PREFIX_RECORDINGS = "recordings";
@@ -97,6 +104,10 @@ public class McpToolsetAssembler {
                                 profileManager(contextCache, profileId),
                                 jfrPanelProvider,
                                 stackSamplePanelProvider)),
+                new ProfileScopedToolset<>(CompareMcpTools.class, PREFIX_COMPARE,
+                        profileId -> new CompareMcpTools(
+                                profileManager(contextCache, profileId),
+                                baselineId -> profileManager(contextCache, baselineId))),
                 new ProfileScopedToolset<>(TracesMcpTools.class, PREFIX_TRACES,
                         profileId -> new TracesMcpTools(profileManager(contextCache, profileId))),
                 new ProfileScopedToolset<>(HeapDumpMcpTools.class, PREFIX_HEAP,

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/CompareMcpTools.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/CompareMcpTools.java
@@ -1,0 +1,358 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.microscope.core.mcp.tools;
+
+import cafe.jeffrey.flamegraph.ai.AiExportConfig;
+import cafe.jeffrey.flamegraph.ai.WeightContext;
+import cafe.jeffrey.profile.common.config.GraphComponents;
+import cafe.jeffrey.profile.common.config.GraphParameters;
+import cafe.jeffrey.profile.manager.DifferentialFlamegraphManager;
+import cafe.jeffrey.profile.manager.ProfileManager;
+import cafe.jeffrey.profile.mcp.McpToolOutput;
+import cafe.jeffrey.profile.model.EventSummaryResult;
+import cafe.jeffrey.shared.common.GraphType;
+import cafe.jeffrey.shared.common.model.ProfileInfo;
+import cafe.jeffrey.shared.common.model.Type;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Two profiles of the same application, compared — the question a reader in their own repository
+ * actually has, which no single-profile tool can answer.
+ * <p>
+ * The one family that is scoped to a <em>pair</em>. The toolset resolves the {@code profileId} as
+ * usual — it is the run under examination — and {@code baselineProfileId} names the run it is measured
+ * against, resolved here. Sign convention throughout: positive means the primary spends more, so a
+ * positive delta is a regression.
+ * <p>
+ * {@link #list()} comes first for a reason that is sharper here than elsewhere. Two recordings can
+ * always be subtracted, and the result always looks like a finding; whether it <em>is</em> one depends
+ * on facts about the recordings — comparable length, comparable volume, the same profiler settings —
+ * that the deltas themselves do not show. Establishing that first is not a formality, it is the
+ * difference between an analysis and a plausible fiction.
+ */
+public class CompareMcpTools {
+
+    private static final int DEFAULT_MOVEMENT_LIMIT = 15;
+    private static final int MAX_MOVEMENT_LIMIT = 100;
+
+    /** Beyond this ratio the recordings are different enough that the reader should be told. */
+    private static final double DURATION_NOTICE_RATIO = 1.25;
+
+    private static final String NOTHING_COMPARABLE =
+            "These two profiles have no event type in common that can be compared. They may be "
+                    + "different recording formats, one may be a heap dump, or they were captured with "
+                    + "different profiler settings. Use profiles_features on each to see what it holds.";
+
+    private static final String SAME_PROFILE =
+            "profileId and baselineProfileId are the same profile. Pick two different runs to compare.";
+
+    private static final String NOTE_DURATION_MISMATCH =
+            "The recordings are of noticeably different length. Sample counts scale with recording "
+                    + "time, so compare_movements will scale the baseline onto the primary's time base "
+                    + "— valid only if both runs did the same kind of work at the same rate.";
+    private static final String NOTE_ONLY_IN_PRIMARY =
+            "Some event types were recorded only in the primary. That is a profiler-configuration "
+                    + "difference between the two runs, not a change in the application.";
+    private static final String NOTE_ONLY_IN_BASELINE =
+            "Some event types were recorded only in the baseline. That is a profiler-configuration "
+                    + "difference between the two runs, not a change in the application.";
+
+    private final ProfileManager primaryManager;
+    private final Function<String, ProfileManager> baselineResolver;
+
+    public CompareMcpTools(
+            ProfileManager primaryManager, Function<String, ProfileManager> baselineResolver) {
+
+        this.primaryManager = primaryManager;
+        this.baselineResolver = baselineResolver;
+    }
+
+    @Tool(description = "Establish whether two profiles can be compared at all, and on which event "
+            + "types. Call this before any other compare_ tool: it reports both recordings' length, "
+            + "the event types they have in common with each side's sample and weight totals, and the "
+            + "event types only one of them recorded — which is a profiler-configuration difference "
+            + "between the runs rather than a change in the application. A comparison of recordings of "
+            + "very different length or volume produces numbers that look precise and mean nothing.")
+    public String list(
+            @ToolParam(description = "Id of the profile to compare against — the baseline, normally "
+                    + "the run from before the change. As listed by profiles_list.")
+            String baselineProfileId) {
+
+        ProfileManager baseline = baseline(baselineProfileId);
+        List<EventSummaryResult> shared = diffManager(baseline).eventSummaries();
+
+        List<ComparableType> comparable = shared.stream()
+                .map(ComparableType::from)
+                .toList();
+
+        Set<String> comparableCodes = comparable.stream()
+                .map(ComparableType::eventType)
+                .collect(LinkedHashSet::new, Set::add, Set::addAll);
+
+        List<String> onlyInPrimary = exclusiveTypes(primaryManager, comparableCodes);
+        List<String> onlyInBaseline = exclusiveTypes(baseline, comparableCodes);
+
+        Comparability comparability = new Comparability(
+                side(primaryManager),
+                side(baseline),
+                comparable,
+                onlyInPrimary,
+                onlyInBaseline,
+                notes(primaryManager.info(), baseline.info(), onlyInPrimary, onlyInBaseline));
+
+        if (comparable.isEmpty()) {
+            return NOTHING_COMPARABLE + "\n\n" + McpToolOutput.json(comparability);
+        }
+        return McpToolOutput.json(comparability);
+    }
+
+    @Tool(description = "Rank the methods that moved between two profiles: which the primary spends "
+            + "more in (a regression) and which it spends less in. This is the main tool for 'did my "
+            + "change make it slower'. Movements are attributed by SELF weight, so a change is charged "
+            + "to the method that actually moved rather than to every caller above it, and the "
+            + "baseline is scaled onto the primary's recording length first. The output opens with a "
+            + "comparability section — read it before reporting any finding.")
+    public String movements(
+            @ToolParam(description = "Id of the profile to compare against — the baseline, normally "
+                    + "the run from before the change.")
+            String baselineProfileId,
+            @ToolParam(description = "JFR event type to compare, e.g. 'jdk.ExecutionSample' for CPU or "
+                    + "'jdk.ObjectAllocationSample' for allocation. Use compare_list to see which "
+                    + "types these two profiles have in common.")
+            String eventType,
+            @ToolParam(description = "How many movements to report in each direction (default 15)")
+            Integer limit,
+            @ToolParam(description = "Start of the window, in milliseconds from the beginning of each "
+                    + "recording. Applied at the same offset into both. Omit for the whole recording.")
+            Long startMs,
+            @ToolParam(description = "End of the window, in milliseconds from the beginning of each "
+                    + "recording. Omit for the whole recording.")
+            Long endMs,
+            @ToolParam(description = "Compare by the event's weight (bytes allocated, nanoseconds "
+                    + "blocked) instead of by sample count")
+            Boolean useWeight,
+            @ToolParam(description = "Drop samples of threads that were idle")
+            Boolean excludeIdle,
+            @ToolParam(description = "Drop samples that were not executing Java code")
+            Boolean excludeNonJava) {
+
+        ProfileManager baseline = baseline(baselineProfileId);
+        GraphParameters params = params(eventType, startMs, endMs, useWeight, excludeIdle, excludeNonJava);
+        return McpToolOutput.capped(
+                diffManager(baseline).rankedMovements(params, boundedLimit(limit)));
+    }
+
+    @Tool(description = "Export the differential flamegraph of two profiles as Markdown: the merged "
+            + "call tree, with every frame carrying what the primary spends there, what the baseline "
+            + "spent, and the movement between them. Use this to drill into a method compare_movements "
+            + "has already flagged — it shows the call paths the movement travelled through. Subtrees "
+            + "in which nothing moved are pruned, so absence here means 'did not change', not 'not "
+            + "present'.")
+    public String flamegraph(
+            @ToolParam(description = "Id of the profile to compare against — the baseline, normally "
+                    + "the run from before the change.")
+            String baselineProfileId,
+            @ToolParam(description = "JFR event type to compare. Use compare_list to see which types "
+                    + "these two profiles have in common.")
+            String eventType,
+            @ToolParam(description = "Keep only subtrees containing a movement of at least this "
+                    + "percentage of the primary's total (exclusive range 0-100). Lower means more "
+                    + "detail and a longer document; the configured default is used when omitted.")
+            Double thresholdPct,
+            @ToolParam(description = "Start of the window, in milliseconds from the beginning of each "
+                    + "recording. Applied at the same offset into both. Omit for the whole recording.")
+            Long startMs,
+            @ToolParam(description = "End of the window, in milliseconds from the beginning of each "
+                    + "recording. Omit for the whole recording.")
+            Long endMs,
+            @ToolParam(description = "Compare by the event's weight (bytes allocated, nanoseconds "
+                    + "blocked) instead of by sample count")
+            Boolean useWeight,
+            @ToolParam(description = "Drop samples of threads that were idle")
+            Boolean excludeIdle,
+            @ToolParam(description = "Drop samples that were not executing Java code")
+            Boolean excludeNonJava) {
+
+        ProfileManager baseline = baseline(baselineProfileId);
+        GraphParameters params = params(eventType, startMs, endMs, useWeight, excludeIdle, excludeNonJava);
+        return McpToolOutput.capped(
+                diffManager(baseline).generateAiExport(params, aiExportConfig(thresholdPct)));
+    }
+
+    private ProfileManager baseline(String baselineProfileId) {
+        if (baselineProfileId == null || baselineProfileId.isBlank()) {
+            throw new IllegalArgumentException("baselineProfileId is required");
+        }
+        String trimmed = baselineProfileId.trim();
+        if (trimmed.equals(primaryManager.info().id())) {
+            throw new IllegalArgumentException(SAME_PROFILE);
+        }
+        return baselineResolver.apply(trimmed);
+    }
+
+    private DifferentialFlamegraphManager diffManager(ProfileManager baseline) {
+        return primaryManager.diffFlamegraphManager(baseline);
+    }
+
+    private GraphParameters params(
+            String eventType,
+            Long startMs,
+            Long endMs,
+            Boolean useWeight,
+            Boolean excludeIdle,
+            Boolean excludeNonJava) {
+
+        Type type = FlamegraphMcpTools.requireEventType(eventType);
+        return GraphParameters.builder()
+                .withEventType(type)
+                .withTimeRange(FlamegraphMcpTools.timeRange(primaryManager.info(), startMs, endMs))
+                .withThreads(List.of())
+                // Per-thread mode splits the tree by thread name, and thread names differ between two
+                // runs (pool-1-thread-7 is not the same worker twice), so every branch would read as
+                // appeared/vanished. A comparison is always thread-aggregated.
+                .withThreadMode(false)
+                .withUseWeight(useWeight)
+                .withExcludeNonJavaSamples(Boolean.TRUE.equals(excludeNonJava))
+                .withExcludeIdleSamples(Boolean.TRUE.equals(excludeIdle))
+                .withOnlyUnsafeAllocationSamples(false)
+                .withParseLocation(true)
+                .withGraphType(GraphType.DIFFERENTIAL)
+                .withGraphComponents(GraphComponents.FLAMEGRAPH_ONLY)
+                .build();
+    }
+
+    private static AiExportConfig aiExportConfig(Double thresholdPct) {
+        if (thresholdPct == null) {
+            return null;
+        }
+        if (!(thresholdPct > 0.0 && thresholdPct < 100.0)) {
+            throw new IllegalArgumentException(
+                    "thresholdPct must be between 0 and 100 (exclusive): " + thresholdPct);
+        }
+        return new AiExportConfig(thresholdPct);
+    }
+
+    private static int boundedLimit(Integer limit) {
+        if (limit == null || limit < 1) {
+            return DEFAULT_MOVEMENT_LIMIT;
+        }
+        return Math.min(limit, MAX_MOVEMENT_LIMIT);
+    }
+
+    /**
+     * Event types one profile recorded and the pair cannot be compared on. Reported rather than
+     * dropped: a type missing from one side is a difference between the two profiler configurations,
+     * and a reader who does not know that will read its absence as the application no longer doing it.
+     */
+    private static List<String> exclusiveTypes(ProfileManager manager, Set<String> comparableCodes) {
+        List<String> exclusive = new ArrayList<>();
+        for (EventSummaryResult summary : manager.flamegraphManager().eventSummaries()) {
+            if (summary.primary().samples() > 0 && !comparableCodes.contains(summary.code())) {
+                exclusive.add(summary.code());
+            }
+        }
+        return exclusive;
+    }
+
+    private static ProfileSide side(ProfileManager manager) {
+        ProfileInfo info = manager.info();
+        Duration duration = info.duration() == null ? Duration.ZERO : info.duration();
+        return new ProfileSide(info.id(), info.name(), duration.toString(), duration.toMillis());
+    }
+
+    private static List<String> notes(
+            ProfileInfo primary,
+            ProfileInfo baseline,
+            List<String> onlyInPrimary,
+            List<String> onlyInBaseline) {
+
+        List<String> notes = new ArrayList<>();
+        if (durationsDiverge(primary, baseline)) {
+            notes.add(NOTE_DURATION_MISMATCH);
+        }
+        if (!onlyInPrimary.isEmpty()) {
+            notes.add(NOTE_ONLY_IN_PRIMARY);
+        }
+        if (!onlyInBaseline.isEmpty()) {
+            notes.add(NOTE_ONLY_IN_BASELINE);
+        }
+        return notes;
+    }
+
+    private static boolean durationsDiverge(ProfileInfo primary, ProfileInfo baseline) {
+        long primaryMillis = primary.duration() == null ? 0L : primary.duration().toMillis();
+        long baselineMillis = baseline.duration() == null ? 0L : baseline.duration().toMillis();
+        if (primaryMillis <= 0 || baselineMillis <= 0) {
+            return true;
+        }
+        double ratio = (double) Math.max(primaryMillis, baselineMillis)
+                / Math.min(primaryMillis, baselineMillis);
+        return ratio > DURATION_NOTICE_RATIO;
+    }
+
+    /**
+     * What the pair can be compared on, and everything that decides whether it should be.
+     */
+    private record Comparability(
+            ProfileSide primary,
+            ProfileSide baseline,
+            List<ComparableType> comparable,
+            List<String> onlyInPrimary,
+            List<String> onlyInBaseline,
+            List<String> notes) {
+    }
+
+    private record ProfileSide(String profileId, String name, String duration, long durationMs) {
+    }
+
+    /**
+     * One event type both profiles recorded, with each side's totals so a reader can see the volumes
+     * they are about to compare before asking for a delta.
+     */
+    private record ComparableType(
+            String eventType,
+            String label,
+            long primarySamples,
+            long baselineSamples,
+            Long primaryWeight,
+            Long baselineWeight,
+            String weightUnit) {
+
+        static ComparableType from(EventSummaryResult summary) {
+            WeightContext weight = WeightContext.of(Type.fromCode(summary.code()));
+            boolean weighted = weight.weighted();
+            return new ComparableType(
+                    summary.code(),
+                    summary.label(),
+                    summary.primary().samples(),
+                    summary.secondary().samples(),
+                    weighted ? summary.primary().weight() : null,
+                    weighted ? summary.secondary().weight() : null,
+                    weight.weightUnit());
+        }
+    }
+}

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/DifferentialFlamegraphControllerTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/DifferentialFlamegraphControllerTest.java
@@ -24,7 +24,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
 import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
-import cafe.jeffrey.profile.manager.FlamegraphManager;
+import cafe.jeffrey.profile.manager.DifferentialFlamegraphManager;
 import cafe.jeffrey.profile.manager.ProfileManager;
 import cafe.jeffrey.profile.panel.JfrFlamegraphPanelProvider;
 import cafe.jeffrey.shared.common.exception.Exceptions;
@@ -48,7 +48,7 @@ class DifferentialFlamegraphControllerTest {
     ProfileManager secondary;
 
     @Mock
-    FlamegraphManager diffManager;
+    DifferentialFlamegraphManager diffManager;
 
     @Test
     void listsEvents() {

--- a/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/ai/FlamegraphAiMarkdownBuilder.java
+++ b/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/ai/FlamegraphAiMarkdownBuilder.java
@@ -20,8 +20,6 @@ package cafe.jeffrey.flamegraph.ai;
 
 import cafe.jeffrey.frameir.Frame;
 import cafe.jeffrey.profile.common.model.FrameType;
-import cafe.jeffrey.shared.common.BytesUtils;
-import cafe.jeffrey.shared.common.DurationUtils;
 import cafe.jeffrey.shared.common.model.Type;
 
 import java.util.ArrayList;
@@ -205,29 +203,18 @@ public final class FlamegraphAiMarkdownBuilder {
     private static final String THREADS_MODE_PER_THREAD = "per-thread";
     private static final String THREADS_MODE_AGGREGATED = "aggregated";
 
-    private static final LongFunction<String> ALLOCATION_FORMATTER =
-            weight -> BytesUtils.format(weight) + " Allocated";
-    private static final LongFunction<String> BLOCKING_FORMATTER =
-            weight -> DurationUtils.formatNanos2Units(weight) + " Blocked";
-    private static final LongFunction<String> LATENCY_FORMATTER =
-            weight -> DurationUtils.formatNanos2Units(weight) + " Latency";
-
-    /** Per-frame weights carry the value alone; the header's suffix would repeat on every line. */
-    private static final LongFunction<String> BYTES_VALUE_FORMATTER = BytesUtils::format;
-    private static final LongFunction<String> NANOS_VALUE_FORMATTER = DurationUtils::formatNanos2Units;
-
     private static final String WEIGHT_SEPARATOR = " · ";
 
     private final Type eventType;
     private final AiExportConfig config;
-    private final ExportContext ctx;
+    private final WeightContext ctx;
     private final AnalysisCategory category;
     private final List<HeaderField> extraHeaderFields = new ArrayList<>();
 
     public FlamegraphAiMarkdownBuilder(Type eventType, AiExportConfig config) {
         this.eventType = eventType;
         this.config = config;
-        this.ctx = resolveContext(eventType);
+        this.ctx = WeightContext.of(eventType);
         this.category = AnalysisCategory.resolve(eventType);
     }
 
@@ -281,13 +268,13 @@ public final class FlamegraphAiMarkdownBuilder {
 
     private void renderHeader(StringBuilder out, long totalSamples, long totalWeight) {
         out.append("event_type: ").append(eventType.code()).append('\n');
-        out.append("unit: ").append(ctx.unit).append('\n');
+        out.append("unit: ").append(ctx.unit()).append('\n');
         out.append("samples_total: ").append(totalSamples).append('\n');
-        if (ctx.weightUnit != null) {
-            out.append("weight_unit: ").append(ctx.weightUnit).append('\n');
+        if (ctx.weightUnit() != null) {
+            out.append("weight_unit: ").append(ctx.weightUnit()).append('\n');
             out.append("weight_total: ").append(totalWeight);
-            if (ctx.weightFormatter != null) {
-                out.append(" (").append(ctx.weightFormatter.apply(totalWeight)).append(')');
+            if (ctx.totalFormatter() != null) {
+                out.append(" (").append(ctx.totalFormatter().apply(totalWeight)).append(')');
             }
             out.append('\n');
         }
@@ -323,11 +310,11 @@ public final class FlamegraphAiMarkdownBuilder {
             out.append(')');
         }
         if (ctx.weighted() && root.totalWeight() > 0) {
-            out.append(WEIGHT_SEPARATOR).append(ctx.weightValueFormatter.apply(root.totalWeight()));
+            out.append(WEIGHT_SEPARATOR).append(ctx.valueFormatter().apply(root.totalWeight()));
             out.append(" (100%");
             long prunedWeight = prunedTailWeight(root, minMeasure);
             if (prunedWeight > 0) {
-                out.append(", +pruned ").append(ctx.weightValueFormatter.apply(prunedWeight));
+                out.append(", +pruned ").append(ctx.valueFormatter().apply(prunedWeight));
             }
             out.append(')');
         }
@@ -368,7 +355,7 @@ public final class FlamegraphAiMarkdownBuilder {
      * root's, the frame's own, and what its pruned children came to in the same unit.
      */
     private void renderWeightClause(StringBuilder out, Frame frame, Frame root, long minMeasure) {
-        LongFunction<String> format = ctx.weightValueFormatter;
+        LongFunction<String> format = ctx.valueFormatter();
         out.append(WEIGHT_SEPARATOR).append(format.apply(frame.totalWeight()));
         out.append(" (").append(formatPercent(frame.totalWeight(), root.totalWeight()));
         out.append(", self ").append(format.apply(frame.selfWeight()));
@@ -498,39 +485,6 @@ public final class FlamegraphAiMarkdownBuilder {
             return "?";
         }
         return title.replace(';', '_').replace('\n', '_').replace('\r', '_');
-    }
-
-    private static ExportContext resolveContext(Type eventType) {
-        if (eventType.isAllocationEvent()) {
-            return new ExportContext("samples", "bytes", ALLOCATION_FORMATTER, BYTES_VALUE_FORMATTER);
-        }
-        if (eventType.isBlockingEvent()) {
-            return new ExportContext("samples", "nanoseconds", BLOCKING_FORMATTER, NANOS_VALUE_FORMATTER);
-        }
-        if (eventType.isMethodTraceEvent()) {
-            return new ExportContext("samples", "nanoseconds", LATENCY_FORMATTER, NANOS_VALUE_FORMATTER);
-        }
-        return new ExportContext("samples", null, null, null);
-    }
-
-    /**
-     * How the event type is measured.
-     *
-     * @param unit                 what the tree counts, always samples
-     * @param weightUnit           what a sample's weight is in, or {@code null} for an unweighted
-     *                             event such as a CPU sample
-     * @param weightFormatter      the header's total, with its noun ("... Allocated")
-     * @param weightValueFormatter a bare per-frame value in the same unit
-     */
-    private record ExportContext(
-            String unit,
-            String weightUnit,
-            LongFunction<String> weightFormatter,
-            LongFunction<String> weightValueFormatter) {
-
-        boolean weighted() {
-            return weightUnit != null;
-        }
     }
 
     private record HeaderField(String key, String value) {

--- a/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/ai/WeightContext.java
+++ b/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/ai/WeightContext.java
@@ -1,0 +1,94 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.flamegraph.ai;
+
+import cafe.jeffrey.shared.common.BytesUtils;
+import cafe.jeffrey.shared.common.DurationUtils;
+import cafe.jeffrey.shared.common.model.Type;
+
+import java.util.function.LongFunction;
+
+/**
+ * What one event type is measured in, and how to write those measurements down.
+ * <p>
+ * Shared by every AI-facing export so a single profile and a comparison of two of them agree on what a
+ * number means: the tree always counts samples, and a weighted event type carries a second dimension —
+ * bytes for allocation, nanoseconds for blocking and method latency — that is the one the question is
+ * usually about. An export that resolved this for itself would eventually disagree with its neighbour
+ * about whether {@code jdk.ObjectAllocationSample} is weighed in bytes.
+ *
+ * @param unit           what the tree counts, always samples
+ * @param weightUnit     what a sample's weight is in, or {@code null} for an unweighted event such as
+ *                       a CPU sample
+ * @param totalFormatter a header total, with the noun that says what it is ("... Allocated"), or
+ *                       {@code null} when unweighted
+ * @param valueFormatter a bare per-frame value in the weight unit, or {@code null} when unweighted
+ */
+public record WeightContext(
+        String unit,
+        String weightUnit,
+        LongFunction<String> totalFormatter,
+        LongFunction<String> valueFormatter) {
+
+    private static final String UNIT_SAMPLES = "samples";
+    private static final String UNIT_BYTES = "bytes";
+    private static final String UNIT_NANOSECONDS = "nanoseconds";
+
+    private static final LongFunction<String> ALLOCATION_TOTAL_FORMATTER =
+            weight -> BytesUtils.format(weight) + " Allocated";
+    private static final LongFunction<String> BLOCKING_TOTAL_FORMATTER =
+            weight -> DurationUtils.formatNanos2Units(weight) + " Blocked";
+    private static final LongFunction<String> LATENCY_TOTAL_FORMATTER =
+            weight -> DurationUtils.formatNanos2Units(weight) + " Latency";
+
+    /** Per-frame weights carry the value alone; the header's noun would repeat on every line. */
+    private static final LongFunction<String> BYTES_VALUE_FORMATTER = BytesUtils::format;
+    private static final LongFunction<String> NANOS_VALUE_FORMATTER = DurationUtils::formatNanos2Units;
+
+    private static final WeightContext UNWEIGHTED =
+            new WeightContext(UNIT_SAMPLES, null, null, null);
+
+    public static WeightContext of(Type eventType) {
+        if (eventType.isAllocationEvent()) {
+            return new WeightContext(
+                    UNIT_SAMPLES, UNIT_BYTES, ALLOCATION_TOTAL_FORMATTER, BYTES_VALUE_FORMATTER);
+        }
+        if (eventType.isBlockingEvent()) {
+            return new WeightContext(
+                    UNIT_SAMPLES, UNIT_NANOSECONDS, BLOCKING_TOTAL_FORMATTER, NANOS_VALUE_FORMATTER);
+        }
+        if (eventType.isMethodTraceEvent()) {
+            return new WeightContext(
+                    UNIT_SAMPLES, UNIT_NANOSECONDS, LATENCY_TOTAL_FORMATTER, NANOS_VALUE_FORMATTER);
+        }
+        return UNWEIGHTED;
+    }
+
+    public boolean weighted() {
+        return weightUnit != null;
+    }
+
+    /**
+     * A measurement written for a reader: the weight in its own unit on a weighted event type, the
+     * bare sample count otherwise. Lets a caller render a number without first asking which it holds.
+     */
+    public String format(long value) {
+        return weighted() ? valueFormatter.apply(value) : Long.toString(value);
+    }
+}

--- a/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/diff/ComparisonMarkdownBuilder.java
+++ b/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/diff/ComparisonMarkdownBuilder.java
@@ -1,0 +1,291 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.flamegraph.diff;
+
+import cafe.jeffrey.flamegraph.ai.WeightContext;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.OptionalDouble;
+
+/**
+ * Renders a {@link ComparisonReport} as Markdown for a model to read.
+ * <p>
+ * The preamble is the substance here, not decoration. Handed a bare table of deltas a reader will
+ * report the largest one as a regression, and will be wrong whenever the two recordings differed in
+ * length, in workload or in profiler configuration — none of which is visible in the numbers
+ * themselves. So the document states what was measured, what correction was applied, and which
+ * conclusions the data cannot support, before it shows a single number.
+ */
+public final class ComparisonMarkdownBuilder {
+
+    private static final String PREAMBLE = """
+            # How to read this comparison
+
+            Two profiles of the same application, compared by Jeffrey. One is the **primary** — the
+            run under examination — and the other is the **baseline** it is measured against. A
+            positive delta means the primary spends *more* than the baseline did: a regression.
+
+            ## Read the comparability section first
+
+            Everything below is arithmetic on two independent recordings. The arithmetic is always
+            valid; the *comparison* is only valid if both recordings watched the same kind of work.
+            Nothing in a JFR file proves that they did. If the comparability section lists warnings,
+            weigh them before reporting any finding — a warned comparison can be worse than no
+            comparison, because the numbers look equally precise either way.
+
+            ## Scaling
+
+            A sampling profiler emits samples at a roughly fixed rate, so a recording that ran twice
+            as long holds about twice as many samples of the same steady workload. Baseline values
+            are therefore multiplied by `baseline_scale_factor` (= primary duration / baseline
+            duration) before any delta is taken, and both the raw and the scaled figure are shown.
+            When the header says `baseline_scale_factor: 1.000` and `scaled: no`, no correction could
+            be made and the deltas compare raw counts.
+
+            This correction assumes a steady workload measured over time. It is wrong for a
+            fixed-size benchmark — N requests replayed in both runs — where the honest normaliser is
+            per-request and Jeffrey cannot know it. On such a run, read the **share** column instead.
+
+            ## The columns
+
+            - **primary self** / **baseline self** — work that stopped *at* this method, not in
+              anything it called. Self, not total, because a total-based delta charges a change to
+              every caller above it: one slow leaf would report `main`, the thread-pool runnable and
+              every framework frame in between as having regressed by the same amount. Self weight
+              moves only where the work moved.
+            - **baseline self** shows `raw -> scaled` when a scale factor was applied.
+            - **delta** — primary self minus scaled baseline self, in the unit named by `unit` (or
+              `weight_unit` on a weighted event type).
+            - **change** — that delta as a percentage of the scaled baseline. `new` means the method
+              carried no work in the baseline at all: that is a different kind of finding from a
+              large percentage, not an infinite one.
+            - **share delta** — percentage *points* of the whole profile this method gained or lost.
+              This is the column to trust when the comparability section is unhappy: it asks where
+              the profile went, not how big it was. A method can regress in share while the process
+              as a whole got faster, and vice versa.
+            - **paths** — how many distinct call paths reached this method. Numbers are aggregated
+              per method across all of them, because a method that got slower usually got slower
+              everywhere it is called from.
+            - **example path** — the single call path that contributed most to the movement, so the
+              method can be found in the source. Truncated to its last few frames.
+
+            ## Candidate renames
+
+            The diff is built by matching method names level by level, so a renamed, moved or
+            extracted method breaks the match and its work appears twice: once as entirely new, once
+            as entirely gone. Pairs of similar size are listed as **candidate renames**. They are
+            suspicions, not conclusions — weight alone cannot tell a rename from a coincidence. You
+            have the source diff, which this document does not; check it before reporting either half
+            of such a pair as a real change.
+
+            ## What this document cannot tell you
+
+            - Whether the application got faster overall. This is one event type's distribution, not
+              a wall-clock benchmark. A CPU profile that shifted work into a shorter path may still
+              have regressed end-to-end latency, and vice versa.
+            - Whether a difference is significant. There is no repetition here and no confidence
+              interval; a single pair of recordings cannot separate a real 5% move from run-to-run
+              variance. Small movements on thin profiles are noise.
+            - Why something changed. Correlate the movements with the source diff; the profile says
+              where, never why.
+
+            ---
+            """;
+
+    private static final String COMPARABILITY_HEADING = "## Comparability";
+    private static final String COMPARABILITY_CLEAN =
+            "No comparability problems detected: the two recordings are of similar length and carry "
+                    + "comparable volumes of this event type. The deltas below can be read as stated — "
+                    + "bearing in mind that a single pair of runs still cannot separate a small "
+                    + "movement from run-to-run variance.";
+
+    private static final String REGRESSED_HEADING = "## Regressed — the primary spends more here";
+    private static final String IMPROVED_HEADING = "## Improved — the primary spends less here";
+    private static final String RENAMES_HEADING = "## Candidate renames (unconfirmed)";
+
+    private static final String MOVERS_TABLE_HEADER = """
+            | method | primary self | baseline self | delta | change | share delta | paths | example path |
+            |---|---|---|---|---|---|---|---|
+            """;
+
+    private static final String RENAMES_TABLE_HEADER = """
+            | appeared | at | measure | vanished | at | measure (scaled) |
+            |---|---|---|---|---|---|
+            """;
+
+    private static final String NO_REGRESSIONS =
+            "Nothing regressed: no method carries more work in the primary than in the baseline.";
+    private static final String NO_IMPROVEMENTS =
+            "Nothing improved: no method carries less work in the primary than in the baseline.";
+    private static final String NOTHING_COMPARED =
+            "Neither profile recorded any work for this event type, so there is nothing to compare. "
+                    + "Check that both recordings were made with the same profiler configuration.";
+
+    private static final String CHANGE_NEW = "new";
+    private static final String CHANGE_GONE = "gone";
+    private static final String SCALE_ARROW = " -> ";
+
+    private final ComparisonReport report;
+
+    public ComparisonMarkdownBuilder(ComparisonReport report) {
+        this.report = report;
+    }
+
+    public String build() {
+        StringBuilder out = new StringBuilder(8192);
+        out.append(PREAMBLE).append('\n');
+        renderHeader(out);
+        out.append('\n');
+        renderComparability(out);
+
+        if (report.empty()) {
+            out.append('\n').append(NOTHING_COMPARED).append('\n');
+            return out.toString();
+        }
+
+        renderMovers(out, REGRESSED_HEADING, report.regressed(), NO_REGRESSIONS);
+        renderMovers(out, IMPROVED_HEADING, report.improved(), NO_IMPROVEMENTS);
+        renderRenames(out);
+        return out.toString();
+    }
+
+    private void renderHeader(StringBuilder out) {
+        ComparisonScale scale = report.scale();
+        WeightContext weight = report.weightContext();
+
+        out.append("event_type: ").append(report.eventType().code()).append('\n');
+        out.append("unit: ").append(weight.unit()).append('\n');
+        if (weight.weighted()) {
+            out.append("weight_unit: ").append(weight.weightUnit()).append('\n');
+            out.append("measured_by: weight\n");
+        } else {
+            out.append("measured_by: samples\n");
+        }
+        out.append("primary_duration: ").append(scale.primaryDuration()).append('\n');
+        out.append("baseline_duration: ").append(scale.baselineDuration()).append('\n');
+        out.append("scaled: ").append(scale.scaled() ? "yes" : "no").append('\n');
+        out.append("baseline_scale_factor: ")
+                .append(String.format(Locale.ROOT, "%.3f", scale.factor())).append('\n');
+        out.append("primary_total: ").append(weight.format(scale.primaryTotal())).append('\n');
+        out.append("baseline_total: ").append(weight.format(scale.baselineTotal()));
+        if (scale.scaled()) {
+            out.append(" (scaled: ").append(weight.format(scale.scaledBaselineTotal())).append(')');
+        }
+        out.append('\n');
+        out.append("methods_compared: ").append(report.methodsCompared()).append('\n');
+    }
+
+    private void renderComparability(StringBuilder out) {
+        out.append(COMPARABILITY_HEADING).append('\n').append('\n');
+        List<String> warnings = report.scale().warnings();
+        if (warnings.isEmpty()) {
+            out.append(COMPARABILITY_CLEAN).append('\n');
+            return;
+        }
+        for (String warning : warnings) {
+            out.append("- **").append(warning).append("**\n");
+        }
+    }
+
+    private void renderMovers(StringBuilder out, String heading, List<MethodDelta> movers, String emptyNote) {
+        out.append('\n').append(heading).append('\n').append('\n');
+        if (movers.isEmpty()) {
+            out.append(emptyNote).append('\n');
+            return;
+        }
+        out.append(MOVERS_TABLE_HEADER);
+        for (MethodDelta mover : movers) {
+            renderMover(out, mover);
+        }
+    }
+
+    private void renderMover(StringBuilder out, MethodDelta mover) {
+        ComparisonScale scale = report.scale();
+        WeightContext weight = report.weightContext();
+
+        out.append("| ").append(sanitize(mover.methodName()))
+                .append(" | ").append(weight.format(mover.primarySelf()))
+                .append(" | ").append(baselineCell(mover))
+                .append(" | ").append(signed(mover.delta(scale)))
+                .append(" | ").append(changeCell(mover))
+                .append(" | ").append(signedPoints(mover.shareDeltaPoints(scale)))
+                .append(" | ").append(mover.callPaths())
+                .append(" | ").append(sanitize(mover.examplePath()))
+                .append(" |\n");
+    }
+
+    private String baselineCell(MethodDelta mover) {
+        ComparisonScale scale = report.scale();
+        WeightContext weight = report.weightContext();
+        String raw = weight.format(mover.baselineSelf());
+        if (!scale.scaled()) {
+            return raw;
+        }
+        return raw + SCALE_ARROW + weight.format(scale.scaleBaseline(mover.baselineSelf()));
+    }
+
+    private String changeCell(MethodDelta mover) {
+        OptionalDouble change = mover.changePct(report.scale());
+        if (change.isPresent()) {
+            return String.format(Locale.ROOT, "%+.1f%%", change.getAsDouble());
+        }
+        if (mover.appeared()) {
+            return CHANGE_NEW;
+        }
+        return CHANGE_GONE;
+    }
+
+    /** A delta reads as a movement, so it always carries its direction, formatted in its own unit. */
+    private String signed(long delta) {
+        String magnitude = report.weightContext().format(Math.abs(delta));
+        return (delta < 0 ? "-" : "+") + magnitude;
+    }
+
+    private static String signedPoints(double points) {
+        return String.format(Locale.ROOT, "%+.2f pp", points);
+    }
+
+    private void renderRenames(StringBuilder out) {
+        List<RenameCandidate> candidates = report.renameCandidates();
+        if (candidates.isEmpty()) {
+            return;
+        }
+        WeightContext weight = report.weightContext();
+        out.append('\n').append(RENAMES_HEADING).append('\n').append('\n');
+        out.append(RENAMES_TABLE_HEADER);
+        for (RenameCandidate candidate : candidates) {
+            out.append("| ").append(sanitize(candidate.appearedMethod()))
+                    .append(" | ").append(sanitize(candidate.appearedPath()))
+                    .append(" | ").append(weight.format(candidate.appearedMeasure()))
+                    .append(" | ").append(sanitize(candidate.vanishedMethod()))
+                    .append(" | ").append(sanitize(candidate.vanishedPath()))
+                    .append(" | ").append(weight.format(candidate.vanishedMeasure()))
+                    .append(" |\n");
+        }
+    }
+
+    /** Keeps a cell on one table row: a pipe in a method name would otherwise split the row. */
+    private static String sanitize(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replace('|', '/').replace('\n', ' ').replace('\r', ' ');
+    }
+}

--- a/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/diff/ComparisonReport.java
+++ b/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/diff/ComparisonReport.java
@@ -1,0 +1,63 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.flamegraph.diff;
+
+import cafe.jeffrey.flamegraph.ai.WeightContext;
+import cafe.jeffrey.shared.common.model.Type;
+
+import java.util.List;
+
+/**
+ * What moved between two profiles: the methods that grew, the ones that shrank, and the pairs that may
+ * simply have been renamed.
+ * <p>
+ * The ranked answer to "did my change make it worse", as opposed to the diff tree, which is where a
+ * reader goes once they know which method to look at.
+ *
+ * @param eventType        what was compared
+ * @param weightContext    what the numbers are measured in
+ * @param scale            the time-base correction applied, and every reason to distrust it
+ * @param regressed        methods the primary spends more in, heaviest movement first
+ * @param improved         methods the primary spends less in, largest saving first
+ * @param renameCandidates appeared/vanished pairs of similar size — possibly the same work renamed
+ * @param methodsCompared  how many distinct methods carried work in either profile
+ */
+public record ComparisonReport(
+        Type eventType,
+        WeightContext weightContext,
+        ComparisonScale scale,
+        List<MethodDelta> regressed,
+        List<MethodDelta> improved,
+        List<RenameCandidate> renameCandidates,
+        int methodsCompared) {
+
+    public ComparisonReport {
+        regressed = List.copyOf(regressed);
+        improved = List.copyOf(improved);
+        renameCandidates = List.copyOf(renameCandidates);
+    }
+
+    /**
+     * True when nothing carried work in either profile — an event type neither recording captured,
+     * which is a different answer from "nothing changed".
+     */
+    public boolean empty() {
+        return methodsCompared == 0;
+    }
+}

--- a/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/diff/ComparisonScale.java
+++ b/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/diff/ComparisonScale.java
@@ -1,0 +1,226 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.flamegraph.diff;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Puts two recordings on one measuring stick — and says out loud when they do not belong on one.
+ * <p>
+ * This is the part of a comparison that decides whether any of the rest can be believed. A sampling
+ * profiler emits samples at a roughly fixed rate, so a recording that ran twice as long carries about
+ * twice as many samples of the same steady workload. Compare the raw counts and every frame looks like
+ * it doubled. The baseline is therefore scaled onto the primary's time base before any delta is taken,
+ * and both the raw and the scaled number are reported so a reader can see the correction that was
+ * applied rather than trust it blindly.
+ * <p>
+ * The scaling assumes both recordings observed the <em>same kind</em> of work, differing only in how
+ * long they watched it. That assumption is not checkable from the recordings alone, which is what
+ * {@link #warnings()} is for: it names every reason the pair looks mismatched so the finding travels
+ * with the numbers instead of being discovered later, if at all. A comparison of a two-minute
+ * production capture against a ten-second local run is arithmetically fine and analytically
+ * worthless, and only the warning says so.
+ *
+ * @param primaryDuration  wall-clock length of the profile under examination
+ * @param baselineDuration wall-clock length of the profile it is measured against
+ * @param primaryTotal     the primary's root measurement, in whatever unit the event type is weighed by
+ * @param baselineTotal    the baseline's root measurement, in the same unit
+ */
+public record ComparisonScale(
+        Duration primaryDuration,
+        Duration baselineDuration,
+        long primaryTotal,
+        long baselineTotal) {
+
+    /**
+     * How far the two recording lengths may drift before the scaling is worth mentioning. Sampling
+     * jitter and a recording that was stopped a beat late land well inside this; a deliberately
+     * different run does not.
+     */
+    private static final double DURATION_NOTICE_RATIO = 1.25;
+
+    /**
+     * Beyond this, the two runs were almost certainly not doing the same work, and no time-base
+     * correction rescues the comparison.
+     */
+    private static final double WORKLOAD_DIVERGENCE_RATIO = 3.0;
+
+    /**
+     * Under this many measurements a difference is mostly sampling noise, and a percentage computed
+     * from it reads far more confidently than it deserves.
+     */
+    private static final long THIN_SAMPLE_FLOOR = 200L;
+
+    private static final double NO_SCALING = 1.0;
+
+    private static final String WARNING_NO_DURATIONS =
+            "One of the profiles reports no duration, so the baseline could NOT be scaled onto the "
+                    + "primary's time base. The deltas below compare raw counts: if the two recordings "
+                    + "ran for different lengths, every delta is wrong by that ratio.";
+    private static final String WARNING_DURATION_MISMATCH =
+            "The recordings are of noticeably different length (primary %s, baseline %s). Baseline "
+                    + "values were scaled by %.3f to compensate. This is only valid if both recordings "
+                    + "observed the same kind of work at the same rate — if the baseline covered a "
+                    + "different phase, load level or machine, treat the deltas as unusable.";
+    private static final String WARNING_WORKLOAD_DIVERGENCE =
+            "After scaling, the two profiles still differ by %.1fx in total (%d vs %d). That is far "
+                    + "more than a code change normally moves: suspect different workloads, different "
+                    + "profiler settings or a different machine before reporting any regression.";
+    private static final String WARNING_THIN_PRIMARY =
+            "The primary profile has only %d measurements of this event type. Percentages computed "
+                    + "from so few are dominated by sampling noise — report movements as suggestive, "
+                    + "not measured.";
+    private static final String WARNING_THIN_BASELINE =
+            "The baseline profile has only %d measurements of this event type, so every 'change vs "
+                    + "baseline' percentage below rests on a very small denominator.";
+    private static final String WARNING_EMPTY_BASELINE =
+            "The baseline profile recorded nothing for this event type. Everything therefore looks "
+                    + "new; this is a profiler-configuration difference, not a regression.";
+    private static final String WARNING_EMPTY_PRIMARY =
+            "The primary profile recorded nothing for this event type, so everything looks removed. "
+                    + "Check that both recordings were taken with the same profiler settings.";
+
+    public ComparisonScale {
+        if (primaryDuration == null || baselineDuration == null) {
+            throw new IllegalArgumentException("both durations are required");
+        }
+        if (primaryTotal < 0 || baselineTotal < 0) {
+            throw new IllegalArgumentException(
+                    "totals cannot be negative: primaryTotal=" + primaryTotal
+                            + " baselineTotal=" + baselineTotal);
+        }
+    }
+
+    /**
+     * Whether the baseline could be put on the primary's time base at all. False when either recording
+     * reports no duration, in which case {@link #factor()} is 1 and the deltas are raw-count deltas.
+     */
+    public boolean scaled() {
+        return !primaryDuration.isZero() && !primaryDuration.isNegative()
+                && !baselineDuration.isZero() && !baselineDuration.isNegative();
+    }
+
+    /**
+     * What a baseline measurement is multiplied by to answer "what would this have been, had the
+     * baseline run for as long as the primary did".
+     */
+    public double factor() {
+        if (!scaled()) {
+            return NO_SCALING;
+        }
+        return (double) primaryDuration.toNanos() / baselineDuration.toNanos();
+    }
+
+    public long scaleBaseline(long value) {
+        if (!scaled()) {
+            return value;
+        }
+        return Math.round(value * factor());
+    }
+
+    public long scaledBaselineTotal() {
+        return scaleBaseline(baselineTotal);
+    }
+
+    /**
+     * The total a threshold is taken against: the larger of the two sides, once the baseline is on the
+     * primary's time base.
+     * <p>
+     * Not simply the primary's, because a comparison where the primary recorded nothing — an event
+     * type switched off in the newer run — would otherwise give every threshold a denominator of zero,
+     * and a "keep what moved by at least 2%" rule would keep the entire baseline tree.
+     */
+    public long referenceTotal() {
+        return Math.max(primaryTotal, scaledBaselineTotal());
+    }
+
+    /**
+     * A value's share of the primary's total, as a percentage. Share is the one comparison that
+     * survives a bad time base: it asks where the profile spent itself, not how much there was of it.
+     */
+    public double primarySharePct(long value) {
+        return sharePct(value, primaryTotal);
+    }
+
+    public double baselineSharePct(long value) {
+        return sharePct(value, baselineTotal);
+    }
+
+    private static double sharePct(long value, long total) {
+        if (total <= 0) {
+            return 0.0;
+        }
+        return 100.0 * value / total;
+    }
+
+    /**
+     * Every reason this pair may not be comparable, in the order a reader should weigh them. Empty
+     * when the two recordings look like the same workload observed twice — which is the only case
+     * where a delta means what it appears to mean.
+     */
+    public List<String> warnings() {
+        List<String> warnings = new ArrayList<>();
+        if (!scaled()) {
+            warnings.add(WARNING_NO_DURATIONS);
+        } else if (durationRatio() > DURATION_NOTICE_RATIO) {
+            warnings.add(String.format(Locale.ROOT, WARNING_DURATION_MISMATCH,
+                    primaryDuration, baselineDuration, factor()));
+        }
+
+        if (primaryTotal == 0) {
+            warnings.add(WARNING_EMPTY_PRIMARY);
+        } else if (primaryTotal < THIN_SAMPLE_FLOOR) {
+            warnings.add(String.format(Locale.ROOT, WARNING_THIN_PRIMARY, primaryTotal));
+        }
+
+        if (baselineTotal == 0) {
+            warnings.add(WARNING_EMPTY_BASELINE);
+        } else if (baselineTotal < THIN_SAMPLE_FLOOR) {
+            warnings.add(String.format(Locale.ROOT, WARNING_THIN_BASELINE, baselineTotal));
+        }
+
+        double divergence = workloadDivergence();
+        if (divergence > WORKLOAD_DIVERGENCE_RATIO) {
+            warnings.add(String.format(Locale.ROOT, WARNING_WORKLOAD_DIVERGENCE,
+                    divergence, primaryTotal, scaledBaselineTotal()));
+        }
+        return List.copyOf(warnings);
+    }
+
+    private double durationRatio() {
+        long primaryNanos = primaryDuration.toNanos();
+        long baselineNanos = baselineDuration.toNanos();
+        return (double) Math.max(primaryNanos, baselineNanos) / Math.min(primaryNanos, baselineNanos);
+    }
+
+    /**
+     * How far apart the two totals remain once the time base is corrected. One is 0 — a profiler
+     * configuration difference — is reported by its own warning rather than as an infinite ratio.
+     */
+    private double workloadDivergence() {
+        long scaledBaseline = scaledBaselineTotal();
+        if (primaryTotal == 0 || scaledBaseline == 0) {
+            return 0.0;
+        }
+        return (double) Math.max(primaryTotal, scaledBaseline) / Math.min(primaryTotal, scaledBaseline);
+    }
+}

--- a/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/diff/DbBasedDiffgraphGenerator.java
+++ b/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/diff/DbBasedDiffgraphGenerator.java
@@ -60,18 +60,9 @@ public class DbBasedDiffgraphGenerator implements GraphGenerator {
          */
         CompletableFuture<cafe.jeffrey.flamegraph.proto.FlamegraphData> flameFuture;
         if (GraphComponents.isFlamegraphCompatible(params.graphComponents())) {
-            FlamegraphDataProvider primaryFlame = FlamegraphDataProvider.differential(primaryRepository, params);
-            FlamegraphDataProvider secondaryFlame = FlamegraphDataProvider.differential(secondaryRepository, params);
-
-            CompletableFuture<Frame> primaryFlameFuture = CompletableFuture.supplyAsync(
-                    primaryFlame::provideFrame, Schedulers.sharedParallel());
-            CompletableFuture<Frame> secondaryFlameFuture = CompletableFuture.supplyAsync(
-                    secondaryFlame::provideFrame, Schedulers.sharedParallel());
-
-            flameFuture = primaryFlameFuture.thenCombine(secondaryFlameFuture, (primary, secondary) -> {
-                DiffFrame differentialFrames = new DiffTreeGenerator(primary, secondary).generate();
-                return new DiffgraphProtoFormatter(differentialFrames, minFrameThresholdPct, params.useWeight()).format();
-            });
+            flameFuture = diffFrameAsync(params).thenApply(differentialFrames ->
+                    new DiffgraphProtoFormatter(
+                            differentialFrames, minFrameThresholdPct, params.useWeight()).format());
         } else {
             flameFuture = CompletableFuture.completedFuture(null);
         }
@@ -109,6 +100,31 @@ public class DbBasedDiffgraphGenerator implements GraphGenerator {
         }
 
         return graphBuilder.build().toByteArray();
+    }
+
+    /**
+     * The merged call tree of the two profiles, as the intermediate representation rather than as the
+     * protobuf the browser draws.
+     * <p>
+     * The AI-facing exports read this: they rank and prune by <em>movement</em>, which the protobuf
+     * has already thrown away in favour of what a renderer needs. Same tree either way, so the two
+     * views of one comparison cannot disagree.
+     */
+    public DiffFrame diffFrame(GraphParameters params) {
+        return diffFrameAsync(params).join();
+    }
+
+    private CompletableFuture<DiffFrame> diffFrameAsync(GraphParameters params) {
+        FlamegraphDataProvider primaryFlame = FlamegraphDataProvider.differential(primaryRepository, params);
+        FlamegraphDataProvider secondaryFlame = FlamegraphDataProvider.differential(secondaryRepository, params);
+
+        CompletableFuture<Frame> primaryFlameFuture = CompletableFuture.supplyAsync(
+                primaryFlame::provideFrame, Schedulers.sharedParallel());
+        CompletableFuture<Frame> secondaryFlameFuture = CompletableFuture.supplyAsync(
+                secondaryFlame::provideFrame, Schedulers.sharedParallel());
+
+        return primaryFlameFuture.thenCombine(secondaryFlameFuture,
+                (primary, secondary) -> new DiffTreeGenerator(primary, secondary).generate());
     }
 
     private static cafe.jeffrey.flamegraph.proto.TimeseriesData convertTimeseries(TimeseriesData data) {

--- a/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/diff/DiffMeasure.java
+++ b/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/diff/DiffMeasure.java
@@ -1,0 +1,65 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.flamegraph.diff;
+
+import cafe.jeffrey.flamegraph.ai.WeightContext;
+import cafe.jeffrey.frameir.DiffFrame;
+import cafe.jeffrey.frameir.Frame;
+
+/**
+ * Reads one side's measurement out of a diff node, in whichever unit the event type is weighed by.
+ * <p>
+ * Shared by the ranking walk and the tree renderer so the two cannot drift apart. A node that exists
+ * on only one side is the subtle part: it holds a plain {@link Frame} rather than a primary/baseline
+ * pair, and it contributes nothing at all to the side it is missing from — which is exactly what makes
+ * an appeared or vanished call path fall in full into the delta. Getting that backwards in one of the
+ * two walks would have the ranked list and the tree disagree about the same recording.
+ */
+final class DiffMeasure {
+
+    private final boolean weighted;
+
+    DiffMeasure(WeightContext weightContext) {
+        this.weighted = weightContext.weighted();
+    }
+
+    long primary(DiffFrame node) {
+        return switch (node.type) {
+            case SHARED -> weighted ? node.primaryWeight : node.primarySamples;
+            case ADDED -> total(node.frame);
+            case REMOVED -> 0L;
+        };
+    }
+
+    long baseline(DiffFrame node) {
+        return switch (node.type) {
+            case SHARED -> weighted ? node.secondaryWeight : node.secondarySamples;
+            case ADDED -> 0L;
+            case REMOVED -> total(node.frame);
+        };
+    }
+
+    long total(Frame frame) {
+        return weighted ? frame.totalWeight() : frame.totalSamples();
+    }
+
+    long self(Frame frame) {
+        return weighted ? frame.selfWeight() : frame.selfSamples();
+    }
+}

--- a/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/diff/DiffgraphAiMarkdownBuilder.java
+++ b/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/diff/DiffgraphAiMarkdownBuilder.java
@@ -1,0 +1,315 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.flamegraph.diff;
+
+import cafe.jeffrey.flamegraph.ai.AiExportConfig;
+import cafe.jeffrey.flamegraph.ai.WeightContext;
+import cafe.jeffrey.frameir.DiffFrame;
+import cafe.jeffrey.shared.common.model.Type;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Renders a differential call tree as Markdown — the drill-down a reader reaches for once
+ * {@link ComparisonMarkdownBuilder} has told them which method moved.
+ * <p>
+ * Pruning is by movement, not by size, and that is the whole difference from the single-profile
+ * export. A diff tree pruned by weight keeps the application's biggest call paths, which are mostly
+ * the ones that did not change; the handful of frames that did move are small in absolute terms and
+ * get cut. So a subtree survives when <em>anything inside it</em> moved by more than the threshold,
+ * which also keeps the unmoved ancestors needed to place it in the call tree.
+ */
+public final class DiffgraphAiMarkdownBuilder {
+
+    private static final String PREAMBLE = """
+            # How to read this differential call tree
+
+            A **differential flamegraph** of two profiles of the same application, exported by
+            Jeffrey. One is the **primary** — the run under examination — and the other is the
+            **baseline** it is measured against. A positive delta means the primary spends *more*
+            than the baseline did: a regression.
+
+            ## Read the comparability section first
+
+            The arithmetic below is always valid; the comparison is only valid if both recordings
+            watched the same kind of work, which nothing in a recording can prove. If the
+            comparability section lists warnings, weigh them before reporting any finding.
+
+            ## Line format
+
+            A markdown nested bullet list. Every kept frame appears exactly once, two spaces of
+            indentation per level of call depth: a bullet nested under another was called by it.
+
+                - <method> [<state>] — Δ<delta> (<change>) · primary <p> (<p%>) · baseline <b> -> <b'> (<b%>)
+
+            - `[S]` — **shared**: the frame is present in both profiles.
+            - `[NEW]` — present only in the primary. Its whole subtree is new work; it has no
+              children in this document because there is nothing to pair it against.
+            - `[GONE]` — present only in the baseline. Its whole subtree disappeared.
+            - `Δ<delta>` — the movement: primary total minus scaled baseline total, in the unit
+              named by `unit` (or `weight_unit` on a weighted event type).
+            - `(<change>)` — that movement as a percentage of the scaled baseline. Absent on a
+              `[NEW]` or `[GONE]` frame, where there is no baseline to be a percentage of.
+            - `primary <p> (<p%>)` — the frame's **whole subtree** in the primary, and its share of
+              the primary's total. This is the bar width in the visual flamegraph.
+            - `baseline <b> -> <b'> (<b%>)` — the same subtree in the baseline: raw, then scaled onto
+              the primary's time base, then its share of the baseline's total.
+            - Children are sorted by the size of the movement inside them, largest first, so the
+              path to what changed is always the first nested bullet.
+
+            ## Totals here, self elsewhere
+
+            The numbers on each line are **subtree totals**, like any flamegraph. A change deep in a
+            call path therefore shows up on every ancestor above it with the same delta — that is
+            how a tree works, not five separate regressions. Walk down until the delta stops being
+            explained by a child: that frame is where the work actually moved. The companion ranked
+            list orders methods by *self* movement and does this attribution for you.
+
+            ## Pruning
+
+            Subtrees in which nothing moved by more than `prune_threshold_pct` of the larger of the
+            two profiles' totals are dropped entirely. **Absence therefore means "did not move", not "not present"** —
+            the opposite of the single-profile export, where absence means "small". A frame that is
+            large in both profiles and changed in neither will not appear here at all.
+
+            ## Renames read as a pair of dramatic findings
+
+            The tree is built by matching method names level by level, so a renamed, moved or
+            extracted method breaks the match: its work appears once as `[NEW]` and once as
+            `[GONE]`, often of near-identical size. Before reporting either half as a real change,
+            check the source diff — which you have and this document does not.
+
+            ---
+            """;
+
+    private static final String TREE_HEADING = "## Differential call tree";
+    private static final String COMPARABILITY_HEADING = "## Comparability";
+    private static final String COMPARABILITY_CLEAN =
+            "No comparability problems detected: the two recordings are of similar length and carry "
+                    + "comparable volumes of this event type.";
+
+    private static final String EMPTY_TREE_NOTE =
+            "(nothing moved by more than the prune threshold — the two profiles agree on this event "
+                    + "type to within that margin)";
+
+    private static final String ROOT_LABEL = "[root]";
+    private static final String INDENT_UNIT = "  ";
+    private static final String BULLET_PREFIX = "- ";
+    private static final String DASH_SEPARATOR = " — ";
+    private static final String CLAUSE_SEPARATOR = " · ";
+    private static final String SCALE_ARROW = " -> ";
+    private static final String DELTA_PREFIX = "Δ";
+
+    private static final String STATE_SHARED = "S";
+    private static final String STATE_NEW = "NEW";
+    private static final String STATE_GONE = "GONE";
+
+    private final Type eventType;
+    private final WeightContext weightContext;
+    private final DiffMeasure measure;
+    private final ComparisonScale scale;
+    private final AiExportConfig config;
+
+    /**
+     * Identity-keyed on purpose: {@link DiffFrame} extends {@code TreeMap}, so its {@code hashCode} is
+     * its whole content and walking it would cost more than the memo saves — and two structurally
+     * equal subtrees at different places in the tree would collide.
+     */
+    private final Map<DiffFrame, Long> movementCache = new IdentityHashMap<>();
+
+    public DiffgraphAiMarkdownBuilder(Type eventType, ComparisonScale scale, AiExportConfig config) {
+        this.eventType = eventType;
+        this.weightContext = WeightContext.of(eventType);
+        this.measure = new DiffMeasure(weightContext);
+        this.scale = scale;
+        this.config = config;
+    }
+
+    public String build(DiffFrame root) {
+        StringBuilder out = new StringBuilder(8192);
+        out.append(PREAMBLE).append('\n');
+        renderHeader(out);
+        out.append('\n');
+        renderComparability(out);
+        out.append('\n');
+        renderTree(out, root);
+        return out.toString();
+    }
+
+    private void renderHeader(StringBuilder out) {
+        out.append("event_type: ").append(eventType.code()).append('\n');
+        out.append("unit: ").append(weightContext.unit()).append('\n');
+        if (weightContext.weighted()) {
+            out.append("weight_unit: ").append(weightContext.weightUnit()).append('\n');
+            out.append("measured_by: weight\n");
+        } else {
+            out.append("measured_by: samples\n");
+        }
+        out.append("primary_duration: ").append(scale.primaryDuration()).append('\n');
+        out.append("baseline_duration: ").append(scale.baselineDuration()).append('\n');
+        out.append("scaled: ").append(scale.scaled() ? "yes" : "no").append('\n');
+        out.append("baseline_scale_factor: ")
+                .append(String.format(Locale.ROOT, "%.3f", scale.factor())).append('\n');
+        out.append("primary_total: ").append(weightContext.format(scale.primaryTotal())).append('\n');
+        out.append("baseline_total: ").append(weightContext.format(scale.baselineTotal()));
+        if (scale.scaled()) {
+            out.append(" (scaled: ").append(weightContext.format(scale.scaledBaselineTotal())).append(')');
+        }
+        out.append('\n');
+        out.append("prune_threshold_pct: ").append(config.minFrameThresholdPct()).append('\n');
+    }
+
+    private void renderComparability(StringBuilder out) {
+        out.append(COMPARABILITY_HEADING).append('\n').append('\n');
+        List<String> warnings = scale.warnings();
+        if (warnings.isEmpty()) {
+            out.append(COMPARABILITY_CLEAN).append('\n');
+            return;
+        }
+        for (String warning : warnings) {
+            out.append("- **").append(warning).append("**\n");
+        }
+    }
+
+    private void renderTree(StringBuilder out, DiffFrame root) {
+        out.append(TREE_HEADING).append('\n').append('\n');
+        if (root == null) {
+            out.append(BULLET_PREFIX).append(EMPTY_TREE_NOTE).append('\n');
+            return;
+        }
+
+        long minMovement = minMovement();
+        renderRootLine(out, root);
+
+        List<DiffFrame> survivors = survivingChildren(root, minMovement);
+        if (survivors.isEmpty()) {
+            out.append(INDENT_UNIT).append(BULLET_PREFIX).append(EMPTY_TREE_NOTE).append('\n');
+            return;
+        }
+        for (DiffFrame child : survivors) {
+            renderFrame(out, child, 1, minMovement);
+        }
+    }
+
+    /**
+     * The movement a subtree must contain to be worth printing: a share of the larger of the two
+     * profiles, so the threshold means the same thing here as it does in the single-profile export and
+     * still has a denominator when one of the two sides recorded nothing.
+     */
+    private long minMovement() {
+        return Math.round(scale.referenceTotal() * config.minFrameThresholdPct() / 100.0);
+    }
+
+    private void renderRootLine(StringBuilder out, DiffFrame root) {
+        out.append(BULLET_PREFIX).append(ROOT_LABEL);
+        renderMetrics(out, root);
+        out.append('\n');
+    }
+
+    private void renderFrame(StringBuilder out, DiffFrame node, int depth, long minMovement) {
+        out.append(INDENT_UNIT.repeat(depth)).append(BULLET_PREFIX);
+        out.append(sanitize(node.methodName));
+        out.append(" [").append(stateOf(node)).append(']');
+        renderMetrics(out, node);
+        out.append('\n');
+
+        for (DiffFrame child : survivingChildren(node, minMovement)) {
+            renderFrame(out, child, depth + 1, minMovement);
+        }
+    }
+
+    private void renderMetrics(StringBuilder out, DiffFrame node) {
+        long primary = measure.primary(node);
+        long baseline = measure.baseline(node);
+        long scaledBaseline = scale.scaleBaseline(baseline);
+        long delta = primary - scaledBaseline;
+
+        out.append(DASH_SEPARATOR).append(DELTA_PREFIX).append(signed(delta));
+        if (scaledBaseline > 0) {
+            out.append(" (").append(String.format(
+                    Locale.ROOT, "%+.1f%%", 100.0 * delta / scaledBaseline)).append(')');
+        }
+
+        out.append(CLAUSE_SEPARATOR).append("primary ").append(weightContext.format(primary));
+        out.append(" (").append(formatPercent(scale.primarySharePct(primary))).append(')');
+
+        out.append(CLAUSE_SEPARATOR).append("baseline ").append(weightContext.format(baseline));
+        if (scale.scaled()) {
+            out.append(SCALE_ARROW).append(weightContext.format(scaledBaseline));
+        }
+        out.append(" (").append(formatPercent(scale.baselineSharePct(baseline))).append(')');
+    }
+
+    private static String stateOf(DiffFrame node) {
+        return switch (node.type) {
+            case SHARED -> STATE_SHARED;
+            case ADDED -> STATE_NEW;
+            case REMOVED -> STATE_GONE;
+        };
+    }
+
+    private List<DiffFrame> survivingChildren(DiffFrame node, long minMovement) {
+        List<DiffFrame> survivors = new ArrayList<>();
+        for (DiffFrame child : node.values()) {
+            if (movement(child) >= minMovement) {
+                survivors.add(child);
+            }
+        }
+        survivors.sort(Comparator.comparingLong(this::movement).reversed());
+        return survivors;
+    }
+
+    /**
+     * The largest movement anywhere inside a subtree — what decides whether it is printed at all. Taken
+     * over the subtree rather than at the node so an unchanged frame that merely sits above a changed
+     * one is kept: without its ancestors, a moved frame cannot be placed in the call tree.
+     */
+    private long movement(DiffFrame node) {
+        Long cached = movementCache.get(node);
+        if (cached != null) {
+            return cached;
+        }
+        long largest = Math.abs(measure.primary(node) - scale.scaleBaseline(measure.baseline(node)));
+        for (DiffFrame child : node.values()) {
+            largest = Math.max(largest, movement(child));
+        }
+        movementCache.put(node, largest);
+        return largest;
+    }
+
+    private String signed(long delta) {
+        return (delta < 0 ? "-" : "+") + weightContext.format(Math.abs(delta));
+    }
+
+    private static String formatPercent(double pct) {
+        return String.format(Locale.ROOT, "%.1f%%", pct);
+    }
+
+    private static String sanitize(String title) {
+        if (title == null) {
+            return "?";
+        }
+        return title.replace(';', '_').replace('\n', '_').replace('\r', '_');
+    }
+}

--- a/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/diff/DiffgraphAnalyzer.java
+++ b/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/diff/DiffgraphAnalyzer.java
@@ -1,0 +1,285 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.flamegraph.diff;
+
+import cafe.jeffrey.flamegraph.ai.WeightContext;
+import cafe.jeffrey.frameir.DiffFrame;
+import cafe.jeffrey.frameir.Frame;
+import cafe.jeffrey.shared.common.model.Type;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Turns a diff tree into a ranked answer: which methods the primary profile spends more in than the
+ * baseline, which it spends less in, and which appeared/vanished pairs look like a rename.
+ * <p>
+ * The tree itself is a poor first read. Pruned to a threshold it is still mostly frames whose delta is
+ * nearly zero, and the two or three that actually moved are scattered through it at whatever depth
+ * they happen to live. Ranking by self movement puts them on the first line.
+ * <p>
+ * The walk descends into {@code ADDED} and {@code REMOVED} subtrees rather than charging each to its
+ * root. {@link cafe.jeffrey.frameir.DiffTreeGenerator} stops matching the moment a method name is
+ * missing on one side, so an entire new call path arrives as one opaque node; attributing all of its
+ * weight to the frame at the top would report the framework entry point that happens to sit there
+ * instead of the method doing the work.
+ */
+public final class DiffgraphAnalyzer {
+
+    /** Reads as a call path in the direction calls actually go: caller first. */
+    private static final String PATH_SEPARATOR = " -> ";
+
+    /**
+     * A path is a landmark for finding the method in the source, not a stack trace to be replayed.
+     * Full paths run to a hundred frames on a framework stack and would crowd out the numbers.
+     */
+    private static final int PATH_FRAMES_KEPT = 6;
+    private static final String PATH_TRUNCATION_MARKER = "... ";
+
+    /** Two subtrees this close in size are worth mentioning as possibly the same work renamed. */
+    private static final double RENAME_SIZE_TOLERANCE = 0.15;
+
+    /**
+     * Below this share of the profile, an appeared/vanished coincidence is likelier than a rename, and
+     * the pairing would produce noise rather than a finding.
+     */
+    private static final double RENAME_MIN_SHARE_PCT = 1.0;
+
+    private final Type eventType;
+    private final WeightContext weightContext;
+    private final DiffMeasure measure;
+    private final ComparisonScale scale;
+
+    private final Map<String, MethodAccumulator> byMethod = new HashMap<>();
+    private final List<Subtree> appeared = new ArrayList<>();
+    private final List<Subtree> vanished = new ArrayList<>();
+    private final List<String> path = new ArrayList<>();
+
+    private DiffgraphAnalyzer(Type eventType, ComparisonScale scale) {
+        this.eventType = eventType;
+        this.weightContext = WeightContext.of(eventType);
+        this.measure = new DiffMeasure(weightContext);
+        this.scale = scale;
+    }
+
+    /**
+     * @param root  the diff tree root, as produced by {@link cafe.jeffrey.frameir.DiffTreeGenerator}
+     * @param limit how many movements to report in each direction
+     */
+    public static ComparisonReport analyze(
+            Type eventType, DiffFrame root, ComparisonScale scale, int limit) {
+
+        if (limit < 1) {
+            throw new IllegalArgumentException("limit must be positive: limit=" + limit);
+        }
+        DiffgraphAnalyzer analyzer = new DiffgraphAnalyzer(eventType, scale);
+        if (root != null) {
+            analyzer.walk(root);
+        }
+        return analyzer.report(limit);
+    }
+
+    private void walk(DiffFrame node) {
+        path.add(node.methodName);
+        switch (node.type) {
+            case SHARED -> {
+                record(node.methodName, selfOf(node, true), selfOf(node, false));
+                for (DiffFrame child : node.values()) {
+                    walk(child);
+                }
+            }
+            case ADDED -> {
+                appeared.add(new Subtree(node.methodName, renderPath(), measure.total(node.frame)));
+                walkOneSided(node.methodName, node.frame, true);
+            }
+            case REMOVED -> {
+                vanished.add(new Subtree(node.methodName, renderPath(), measure.total(node.frame)));
+                walkOneSided(node.methodName, node.frame, false);
+            }
+        }
+        path.removeLast();
+    }
+
+    /**
+     * A subtree that exists in only one of the profiles. Its frames are plain {@link Frame}s — the diff
+     * tree stopped pairing here — so their self weight counts entirely towards the side they came from.
+     */
+    private void walkOneSided(String methodName, Frame frame, boolean primarySide) {
+        long self = measure.self(frame);
+        if (self > 0) {
+            record(methodName, primarySide ? self : 0L, primarySide ? 0L : self);
+        }
+        for (Map.Entry<String, Frame> child : frame.entrySet()) {
+            path.add(child.getKey());
+            walkOneSided(child.getKey(), child.getValue(), primarySide);
+            path.removeLast();
+        }
+    }
+
+    /**
+     * What stayed at a shared frame rather than going deeper: its own measurement minus everything its
+     * children account for on the same side.
+     * <p>
+     * Clamped at zero. The arithmetic is exact by construction — a frame's total is its self plus its
+     * children's totals — but a tree assembled from a partially-written recording can violate that, and
+     * a negative "self" in the output would read as a nonsensical finding rather than as bad input.
+     */
+    private long selfOf(DiffFrame node, boolean primarySide) {
+        long total = sideMeasure(node, primarySide);
+        long children = 0L;
+        for (DiffFrame child : node.values()) {
+            children += sideMeasure(child, primarySide);
+        }
+        return Math.max(0L, total - children);
+    }
+
+    private long sideMeasure(DiffFrame node, boolean primarySide) {
+        return primarySide ? measure.primary(node) : measure.baseline(node);
+    }
+
+    private void record(String methodName, long primarySelf, long baselineSelf) {
+        if (primarySelf == 0 && baselineSelf == 0) {
+            return;
+        }
+        byMethod.computeIfAbsent(methodName, name -> new MethodAccumulator())
+                .add(renderPath(), primarySelf, baselineSelf, scale);
+    }
+
+    private String renderPath() {
+        int from = Math.max(0, path.size() - PATH_FRAMES_KEPT);
+        StringBuilder rendered = new StringBuilder(128);
+        if (from > 0) {
+            rendered.append(PATH_TRUNCATION_MARKER);
+        }
+        for (int i = from; i < path.size(); i++) {
+            if (i > from) {
+                rendered.append(PATH_SEPARATOR);
+            }
+            rendered.append(path.get(i));
+        }
+        return rendered.toString();
+    }
+
+    private ComparisonReport report(int limit) {
+        List<MethodDelta> deltas = byMethod.entrySet().stream()
+                .map(entry -> entry.getValue().toDelta(entry.getKey()))
+                .toList();
+
+        List<MethodDelta> regressed = deltas.stream()
+                .filter(delta -> delta.delta(scale) > 0)
+                .sorted(Comparator.comparingLong((MethodDelta delta) -> delta.delta(scale)).reversed())
+                .limit(limit)
+                .toList();
+
+        List<MethodDelta> improved = deltas.stream()
+                .filter(delta -> delta.delta(scale) < 0)
+                .sorted(Comparator.comparingLong(delta -> delta.delta(scale)))
+                .limit(limit)
+                .toList();
+
+        return new ComparisonReport(
+                eventType, weightContext, scale, regressed, improved, renameCandidates(), deltas.size());
+    }
+
+    /**
+     * Pairs each appeared subtree with a vanished one of about the same size, largest first, each used
+     * at most once. Greedy rather than optimal on purpose: these are suspicions for a reader holding
+     * the source diff to confirm, and an exact assignment would not make a wrong guess any less wrong.
+     */
+    private List<RenameCandidate> renameCandidates() {
+        long floor = Math.round(scale.referenceTotal() * RENAME_MIN_SHARE_PCT / 100.0);
+
+        List<Subtree> candidates = appeared.stream()
+                .filter(subtree -> subtree.measure() >= floor)
+                .sorted(Comparator.comparingLong(Subtree::measure).reversed())
+                .toList();
+
+        List<Subtree> unmatched = new ArrayList<>(vanished.stream()
+                .map(subtree -> subtree.scaled(scale))
+                .filter(subtree -> subtree.measure() >= floor)
+                .sorted(Comparator.comparingLong(Subtree::measure).reversed())
+                .toList());
+
+        List<RenameCandidate> pairs = new ArrayList<>();
+        for (Subtree candidate : candidates) {
+            for (int i = 0; i < unmatched.size(); i++) {
+                Subtree other = unmatched.get(i);
+                if (similarSize(candidate.measure(), other.measure())) {
+                    pairs.add(new RenameCandidate(
+                            candidate.methodName(), candidate.path(), candidate.measure(),
+                            other.methodName(), other.path(), other.measure()));
+                    unmatched.remove(i);
+                    break;
+                }
+            }
+        }
+        return pairs;
+    }
+
+    private static boolean similarSize(long left, long right) {
+        long larger = Math.max(left, right);
+        if (larger == 0) {
+            return false;
+        }
+        return (double) Math.abs(left - right) / larger <= RENAME_SIZE_TOLERANCE;
+    }
+
+    /**
+     * One method's movement, still being summed. A method is normally reached by several call paths;
+     * the one kept is whichever contributed most to the movement, which is the path a reader should
+     * look at first.
+     */
+    private static final class MethodAccumulator {
+
+        private long primarySelf;
+        private long baselineSelf;
+        private int callPaths;
+        private String heaviestPath;
+        private long heaviestContribution = -1L;
+
+        void add(String path, long primary, long baseline, ComparisonScale scale) {
+            primarySelf += primary;
+            baselineSelf += baseline;
+            callPaths++;
+
+            long contribution = Math.abs(primary - scale.scaleBaseline(baseline));
+            if (contribution > heaviestContribution) {
+                heaviestContribution = contribution;
+                heaviestPath = path;
+            }
+        }
+
+        MethodDelta toDelta(String methodName) {
+            return new MethodDelta(methodName, primarySelf, baselineSelf, callPaths, heaviestPath);
+        }
+    }
+
+    /**
+     * A subtree that exists in one profile only, as a rename-pairing candidate.
+     */
+    private record Subtree(String methodName, String path, long measure) {
+
+        Subtree scaled(ComparisonScale scale) {
+            return new Subtree(methodName, path, scale.scaleBaseline(measure));
+        }
+    }
+}

--- a/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/diff/MethodDelta.java
+++ b/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/diff/MethodDelta.java
@@ -1,0 +1,99 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.flamegraph.diff;
+
+import java.util.OptionalDouble;
+
+/**
+ * How much one method moved between two profiles, measured by the work that stopped <em>at</em> it.
+ * <p>
+ * Self, not total, on purpose. A total-based delta charges a regression to every frame on the path
+ * that reaches it, so a change deep inside a request handler reports {@code main}, the thread-pool
+ * runnable and eight framework frames as having regressed by the same amount, and the one method that
+ * actually changed is buried among its own ancestors. Self weight moves only where the work moved.
+ * <p>
+ * Aggregated per method rather than per call path, because a method that got slower usually got slower
+ * everywhere it is called from, and splitting that across a dozen paths hides the size of the finding.
+ * {@link #examplePath} keeps one concrete route to the method so the reader can still find it in the
+ * source; {@link #callPaths} says how many routes were folded into the number.
+ *
+ * @param methodName   the frame's method, as the profiler recorded it
+ * @param primarySelf  self measurement in the profile under examination
+ * @param baselineSelf self measurement in the profile it is compared against, unscaled
+ * @param callPaths    how many distinct call paths reached this method across both profiles
+ * @param examplePath  the call path that contributed the most to this method's movement
+ */
+public record MethodDelta(
+        String methodName,
+        long primarySelf,
+        long baselineSelf,
+        int callPaths,
+        String examplePath) {
+
+    public MethodDelta {
+        if (methodName == null) {
+            throw new IllegalArgumentException("methodName is required");
+        }
+        if (primarySelf < 0 || baselineSelf < 0) {
+            throw new IllegalArgumentException(
+                    "self measurements cannot be negative: primarySelf=" + primarySelf
+                            + " baselineSelf=" + baselineSelf);
+        }
+    }
+
+    /**
+     * The movement, in measurement units, against the baseline put on the primary's time base.
+     * Positive means the primary spends more here than the baseline did.
+     */
+    public long delta(ComparisonScale scale) {
+        return primarySelf - scale.scaleBaseline(baselineSelf);
+    }
+
+    /**
+     * The movement as a percentage of the scaled baseline, or empty when there is no baseline to be a
+     * percentage of. "Appeared from nothing" is not "+100%" and not "+∞%" — it is a different kind of
+     * finding, and collapsing it into a number invites the reader to rank it against real ratios.
+     */
+    public OptionalDouble changePct(ComparisonScale scale) {
+        long scaledBaseline = scale.scaleBaseline(baselineSelf);
+        if (scaledBaseline == 0) {
+            return OptionalDouble.empty();
+        }
+        return OptionalDouble.of(100.0 * (primarySelf - scaledBaseline) / scaledBaseline);
+    }
+
+    /**
+     * How much of the profile this method accounts for now, minus how much it accounted for before, in
+     * percentage points. The one comparison that stays meaningful when the time base is doubtful: it
+     * asks where the profile went, not how big it was.
+     */
+    public double shareDeltaPoints(ComparisonScale scale) {
+        return scale.primarySharePct(primarySelf) - scale.baselineSharePct(baselineSelf);
+    }
+
+    /** Work that exists only in the primary — a call path the change introduced. */
+    public boolean appeared() {
+        return baselineSelf == 0 && primarySelf > 0;
+    }
+
+    /** Work that exists only in the baseline — a call path the change removed, or renamed. */
+    public boolean vanished() {
+        return primarySelf == 0 && baselineSelf > 0;
+    }
+}

--- a/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/diff/ProfileComparison.java
+++ b/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/diff/ProfileComparison.java
@@ -1,0 +1,99 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.flamegraph.diff;
+
+import cafe.jeffrey.flamegraph.ai.AiExportConfig;
+import cafe.jeffrey.flamegraph.ai.WeightContext;
+import cafe.jeffrey.frameir.DiffFrame;
+import cafe.jeffrey.shared.common.model.Type;
+
+import java.time.Duration;
+
+/**
+ * The two readable views of a differential call tree, and the one thing they must agree on.
+ * <p>
+ * Both the ranked list and the tree need the totals of the pair to normalise against, and both derive
+ * them from the same place — the diff tree's root — through this entry point. A caller that assembled
+ * its own {@link ComparisonScale} from, say, the profiles' overall event counts would be scaling
+ * against a different denominator than the tree it is describing, and the percentages in the two
+ * documents would quietly disagree.
+ */
+public final class ProfileComparison {
+
+    private ProfileComparison() {
+    }
+
+    /**
+     * The ranked movements between the two profiles: which methods grew, which shrank.
+     *
+     * @param limit how many movements to report in each direction
+     */
+    public static ComparisonReport report(
+            Type eventType,
+            DiffFrame root,
+            Duration primaryDuration,
+            Duration baselineDuration,
+            int limit) {
+
+        ComparisonScale scale = scaleOf(eventType, root, primaryDuration, baselineDuration);
+        return DiffgraphAnalyzer.analyze(eventType, root, scale, limit);
+    }
+
+    /**
+     * The same comparison rendered as a ranked Markdown document.
+     */
+    public static String rankedMarkdown(
+            Type eventType,
+            DiffFrame root,
+            Duration primaryDuration,
+            Duration baselineDuration,
+            int limit) {
+
+        return new ComparisonMarkdownBuilder(
+                report(eventType, root, primaryDuration, baselineDuration, limit)).build();
+    }
+
+    /**
+     * The differential call tree rendered as Markdown, pruned to the movements worth reading.
+     */
+    public static String treeMarkdown(
+            Type eventType,
+            DiffFrame root,
+            Duration primaryDuration,
+            Duration baselineDuration,
+            AiExportConfig config) {
+
+        ComparisonScale scale = scaleOf(eventType, root, primaryDuration, baselineDuration);
+        return new DiffgraphAiMarkdownBuilder(eventType, scale, config).build(root);
+    }
+
+    /**
+     * The totals the whole comparison is normalised against, read off the diff tree's root so they are
+     * exactly the totals of the tree being described — including any filter the graph parameters
+     * applied, which a profile-wide event count would have ignored.
+     */
+    private static ComparisonScale scaleOf(
+            Type eventType, DiffFrame root, Duration primaryDuration, Duration baselineDuration) {
+
+        DiffMeasure measure = new DiffMeasure(WeightContext.of(eventType));
+        long primaryTotal = root == null ? 0L : measure.primary(root);
+        long baselineTotal = root == null ? 0L : measure.baseline(root);
+        return new ComparisonScale(primaryDuration, baselineDuration, primaryTotal, baselineTotal);
+    }
+}

--- a/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/diff/RenameCandidate.java
+++ b/jeffrey-microscope/profiles/flamegraph/src/main/java/cafe/jeffrey/flamegraph/diff/RenameCandidate.java
@@ -1,0 +1,49 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.flamegraph.diff;
+
+/**
+ * A subtree that appeared and one of about the same size that vanished — possibly the same work under
+ * a new name.
+ * <p>
+ * The diff tree is built by matching method names level by level, so a rename, a moved method or an
+ * extracted helper severs the match: the work shows up once as brand-new and once as entirely gone.
+ * Read literally that is a dramatic finding ("we added a 4-second call path and deleted another"), and
+ * a reader with only the profile in front of them has no way to tell it from a real change.
+ * <p>
+ * This pairing is deliberately a <em>suspicion</em>, not a resolution. Matching on weight alone cannot
+ * distinguish a rename from a coincidence, and quietly folding the two entries into one would erase a
+ * genuine change whenever it guessed wrong. It is reported so the reader — who has the source diff,
+ * which this does not — can confirm or dismiss it in a second.
+ *
+ * @param appearedMethod   root method of the subtree present only in the primary
+ * @param appearedPath     where that subtree hangs in the call tree
+ * @param appearedMeasure  its measurement in the primary
+ * @param vanishedMethod   root method of the subtree present only in the baseline
+ * @param vanishedPath     where that subtree hung in the baseline
+ * @param vanishedMeasure  its measurement in the baseline, scaled onto the primary's time base
+ */
+public record RenameCandidate(
+        String appearedMethod,
+        String appearedPath,
+        long appearedMeasure,
+        String vanishedMethod,
+        String vanishedPath,
+        long vanishedMeasure) {
+}

--- a/jeffrey-microscope/profiles/flamegraph/src/test/java/cafe/jeffrey/flamegraph/diff/ComparisonMarkdownBuilderTest.java
+++ b/jeffrey-microscope/profiles/flamegraph/src/test/java/cafe/jeffrey/flamegraph/diff/ComparisonMarkdownBuilderTest.java
@@ -1,0 +1,178 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.flamegraph.diff;
+
+import cafe.jeffrey.frameir.DiffTreeGenerator;
+import cafe.jeffrey.frameir.Frame;
+import cafe.jeffrey.profile.common.model.FrameType;
+import cafe.jeffrey.shared.common.model.Type;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ComparisonMarkdownBuilderTest {
+
+    private static final Duration ONE_MINUTE = Duration.ofMinutes(1);
+    private static final Duration TWO_MINUTES = Duration.ofMinutes(2);
+    private static final int LIMIT = 10;
+
+    @Nested
+    class Header {
+
+        @Test
+        void statesWhatWasComparedAndHowItWasCorrected() {
+            String markdown = render(ONE_MINUTE, TWO_MINUTES);
+
+            assertTrue(markdown.contains("event_type: jdk.ExecutionSample"));
+            assertTrue(markdown.contains("primary_duration: PT1M"));
+            assertTrue(markdown.contains("baseline_duration: PT2M"));
+            assertTrue(markdown.contains("scaled: yes"));
+            assertTrue(markdown.contains("baseline_scale_factor: 0.500"),
+                    "the correction is shown, not merely applied");
+        }
+
+        @Test
+        void saysSoWhenNoTimeBaseCorrectionWasPossible() {
+            String markdown = render(ONE_MINUTE, Duration.ZERO);
+
+            assertTrue(markdown.contains("scaled: no"));
+            assertTrue(markdown.contains("could NOT be scaled"),
+                    "an uncorrected comparison must announce itself");
+        }
+    }
+
+    @Nested
+    class Comparability {
+
+        @Test
+        void warningsLeadTheDocumentWhenTheRecordingsDoNotMatch() {
+            String markdown = render(ONE_MINUTE, TWO_MINUTES);
+
+            int comparability = markdown.indexOf("## Comparability");
+            int regressed = markdown.indexOf("## Regressed");
+            assertTrue(comparability > 0 && comparability < regressed,
+                    "the caveats have to be read before the numbers they qualify");
+            assertTrue(markdown.contains("different length"));
+        }
+
+        @Test
+        void aCleanPairIsSaidToBeClean() {
+            String markdown = render(ONE_MINUTE, ONE_MINUTE);
+
+            assertTrue(markdown.contains("No comparability problems detected"));
+        }
+    }
+
+    @Nested
+    class Movements {
+
+        @Test
+        void aRegressionIsReportedWithItsDirectionAndItsShareMovement() {
+            String markdown = render(ONE_MINUTE, ONE_MINUTE);
+
+            assertTrue(markdown.contains("| handler |"), "the moved method gets a row");
+            assertTrue(markdown.contains("| +4000 |"), "deltas carry their sign");
+            assertTrue(markdown.contains("pp |"), "share movement is in percentage points");
+        }
+
+        @Test
+        void workWithNoBaselineIsReportedAsNewRatherThanAsAPercentage() {
+            Frame primary = node("all", 100L);
+            primary.put("brandNew", leaf("brandNew", 40L));
+            Frame baseline = node("all", 100L);
+
+            String markdown = render(primary, baseline, ONE_MINUTE, ONE_MINUTE);
+
+            assertTrue(markdown.contains("| new |"),
+                    "appearing from nothing is a different finding from a large ratio");
+            assertFalse(markdown.contains("Infinity"));
+        }
+
+        @Test
+        void anEmptyPairSaysNothingWasComparedRatherThanNothingChanged() {
+            String markdown = render(node("all", 0L), node("all", 0L), ONE_MINUTE, ONE_MINUTE);
+
+            assertTrue(markdown.contains("nothing to compare"));
+        }
+    }
+
+    @Nested
+    class Renames {
+
+        @Test
+        void aRenameSuspicionIsPresentedAsUnconfirmed() {
+            Frame primary = node("all", 100L);
+            primary.put("newName", leaf("newName", 30L));
+            Frame baseline = node("all", 100L);
+            baseline.put("oldName", leaf("oldName", 30L));
+
+            String markdown = render(primary, baseline, ONE_MINUTE, ONE_MINUTE);
+
+            assertTrue(markdown.contains("## Candidate renames (unconfirmed)"));
+            assertTrue(markdown.contains("| newName |"));
+            assertTrue(markdown.contains("oldName"));
+        }
+
+        @Test
+        void nothingIsClaimedWhenNoPairLinesUp() {
+            String markdown = render(ONE_MINUTE, ONE_MINUTE);
+
+            // The preamble explains what a rename candidate is either way; what must be absent is the
+            // table, which would present a guess as a finding.
+            assertFalse(markdown.contains("| appeared | at |"));
+        }
+    }
+
+    private static String render(Duration primaryDuration, Duration baselineDuration) {
+        // Volumes deliberately above the thin-profile floor: a small profile earns a comparability
+        // warning of its own, which would drown out whatever a given test is actually asserting.
+        Frame primary = node("all", 10_000L);
+        primary.put("handler", node("handler", 6_000L));
+        Frame baseline = node("all", 10_000L);
+        baseline.put("handler", node("handler", 2_000L));
+        return render(primary, baseline, primaryDuration, baselineDuration);
+    }
+
+    private static String render(
+            Frame primary, Frame baseline, Duration primaryDuration, Duration baselineDuration) {
+
+        return ProfileComparison.rankedMarkdown(
+                Type.EXECUTION_SAMPLE,
+                new DiffTreeGenerator(primary, baseline).generate(),
+                primaryDuration,
+                baselineDuration,
+                LIMIT);
+    }
+
+    private static Frame node(String methodName, long samples) {
+        Frame frame = new Frame(null, methodName, 0, 0);
+        frame.increment(FrameType.JIT_COMPILED, samples, samples, false);
+        return frame;
+    }
+
+    private static Frame leaf(String methodName, long samples) {
+        Frame frame = new Frame(null, methodName, 0, 0);
+        frame.increment(FrameType.JIT_COMPILED, samples, samples, true);
+        return frame;
+    }
+}

--- a/jeffrey-microscope/profiles/flamegraph/src/test/java/cafe/jeffrey/flamegraph/diff/ComparisonScaleTest.java
+++ b/jeffrey-microscope/profiles/flamegraph/src/test/java/cafe/jeffrey/flamegraph/diff/ComparisonScaleTest.java
@@ -1,0 +1,154 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.flamegraph.diff;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ComparisonScaleTest {
+
+    private static final Duration ONE_MINUTE = Duration.ofMinutes(1);
+    private static final Duration TWO_MINUTES = Duration.ofMinutes(2);
+
+    @Nested
+    class Scaling {
+
+        @Test
+        void baselineIsProjectedOntoThePrimaryRecordingLength() {
+            ComparisonScale scale = new ComparisonScale(ONE_MINUTE, TWO_MINUTES, 5_000L, 10_000L);
+
+            assertEquals(0.5, scale.factor(), 0.0001,
+                    "a baseline that ran twice as long is halved onto the primary's time base");
+            assertEquals(50L, scale.scaleBaseline(100L));
+            assertEquals(5_000L, scale.scaledBaselineTotal(),
+                    "the same steady workload, watched twice as long, scales back to the primary total");
+        }
+
+        @Test
+        void equalDurationsLeaveMeasurementsUntouched() {
+            ComparisonScale scale = new ComparisonScale(ONE_MINUTE, ONE_MINUTE, 100L, 100L);
+
+            assertEquals(1.0, scale.factor(), 0.0001);
+            assertEquals(100L, scale.scaleBaseline(100L));
+        }
+
+        @Test
+        void missingDurationFallsBackToRawCounts() {
+            ComparisonScale scale = new ComparisonScale(ONE_MINUTE, Duration.ZERO, 100L, 80L);
+
+            assertFalse(scale.scaled(), "nothing to scale against");
+            assertEquals(1.0, scale.factor(), 0.0001);
+            assertEquals(80L, scale.scaleBaseline(80L), "raw counts pass through unchanged");
+        }
+
+        @Test
+        void sharesAreTakenAgainstEachProfilesOwnTotal() {
+            ComparisonScale scale = new ComparisonScale(ONE_MINUTE, TWO_MINUTES, 200L, 1_000L);
+
+            assertEquals(25.0, scale.primarySharePct(50L), 0.0001);
+            assertEquals(10.0, scale.baselineSharePct(100L), 0.0001,
+                    "the baseline's share uses the baseline's own total, unscaled");
+        }
+
+        @Test
+        void emptyTotalsDoNotDivideByZero() {
+            ComparisonScale scale = new ComparisonScale(ONE_MINUTE, ONE_MINUTE, 0L, 0L);
+
+            assertEquals(0.0, scale.primarySharePct(0L), 0.0001);
+            assertEquals(0.0, scale.baselineSharePct(0L), 0.0001);
+        }
+
+        @Test
+        void negativeTotalsAreRejected() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> new ComparisonScale(ONE_MINUTE, ONE_MINUTE, -1L, 10L));
+        }
+    }
+
+    @Nested
+    class Warnings {
+
+        @Test
+        void comparableRecordingsWarnAboutNothing() {
+            ComparisonScale scale = new ComparisonScale(ONE_MINUTE, ONE_MINUTE, 10_000L, 9_500L);
+
+            assertTrue(scale.warnings().isEmpty(),
+                    "same length, comparable volume — nothing to caveat");
+        }
+
+        @Test
+        void differentRecordingLengthsAreReportedWithTheFactorApplied() {
+            ComparisonScale scale = new ComparisonScale(ONE_MINUTE, TWO_MINUTES, 5_000L, 10_000L);
+
+            assertTrue(contains(scale.warnings(), "different length"),
+                    "the reader has to know a correction was applied: " + scale.warnings());
+        }
+
+        @Test
+        void missingDurationsAreReportedAsUncorrectedCounts() {
+            ComparisonScale scale = new ComparisonScale(ONE_MINUTE, Duration.ZERO, 5_000L, 10_000L);
+
+            assertTrue(contains(scale.warnings(), "could NOT be scaled"),
+                    "an uncorrected comparison must not look like a corrected one");
+        }
+
+        @Test
+        void volumesThatStayFarApartAfterScalingSuggestDifferentWorkloads() {
+            ComparisonScale scale = new ComparisonScale(ONE_MINUTE, ONE_MINUTE, 100_000L, 1_000L);
+
+            assertTrue(contains(scale.warnings(), "different workloads"),
+                    "100x apart at equal length is not a code change: " + scale.warnings());
+        }
+
+        @Test
+        void thinProfilesAreFlaggedAsNoise() {
+            ComparisonScale scale = new ComparisonScale(ONE_MINUTE, ONE_MINUTE, 12L, 10L);
+
+            assertTrue(contains(scale.warnings(), "sampling noise"));
+            assertTrue(contains(scale.warnings(), "very small denominator"));
+        }
+
+        @Test
+        void anEventTypeOnlyOneProfileRecordedIsAConfigurationFinding() {
+            ComparisonScale scale = new ComparisonScale(ONE_MINUTE, ONE_MINUTE, 10_000L, 0L);
+
+            assertTrue(contains(scale.warnings(), "profiler-configuration difference"),
+                    "everything looking new is a settings difference, not a regression");
+        }
+
+        @Test
+        void anEmptyPrimaryIsReportedRatherThanReadAsEverythingRemoved() {
+            ComparisonScale scale = new ComparisonScale(ONE_MINUTE, ONE_MINUTE, 0L, 10_000L);
+
+            assertTrue(contains(scale.warnings(), "primary profile recorded nothing"));
+        }
+    }
+
+    private static boolean contains(List<String> warnings, String fragment) {
+        return warnings.stream().anyMatch(warning -> warning.contains(fragment));
+    }
+}

--- a/jeffrey-microscope/profiles/flamegraph/src/test/java/cafe/jeffrey/flamegraph/diff/DiffgraphAiMarkdownBuilderTest.java
+++ b/jeffrey-microscope/profiles/flamegraph/src/test/java/cafe/jeffrey/flamegraph/diff/DiffgraphAiMarkdownBuilderTest.java
@@ -1,0 +1,163 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.flamegraph.diff;
+
+import cafe.jeffrey.flamegraph.ai.AiExportConfig;
+import cafe.jeffrey.frameir.DiffTreeGenerator;
+import cafe.jeffrey.frameir.Frame;
+import cafe.jeffrey.profile.common.model.FrameType;
+import cafe.jeffrey.shared.common.model.Type;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DiffgraphAiMarkdownBuilderTest {
+
+    private static final Duration ONE_MINUTE = Duration.ofMinutes(1);
+    private static final AiExportConfig FIVE_PERCENT = new AiExportConfig(5.0);
+
+    @Nested
+    class PruningByMovement {
+
+        @Test
+        void aLargeSubtreeThatDidNotMoveIsDropped() {
+            // 'steady' is by far the biggest thing in both profiles — and therefore the least
+            // interesting. Pruning by size would have kept it and cut the frame that changed.
+            Frame primary = node("all", 1_000L);
+            primary.put("steady", node("steady", 800L));
+            primary.put("moved", node("moved", 100L));
+            Frame baseline = node("all", 1_000L);
+            baseline.put("steady", node("steady", 800L));
+            baseline.put("moved", node("moved", 20L));
+
+            String markdown = render(primary, baseline);
+
+            assertTrue(markdown.contains("moved"), "the frame that changed survives at 8% movement");
+            assertFalse(markdown.contains("steady"),
+                    "an unchanged frame is noise in a diff, however large it is");
+        }
+
+        @Test
+        void anUnmovedAncestorIsKeptSoTheMovedFrameCanBePlaced() {
+            // 'wrapper' nets out to zero — one child grew by exactly what the other shed — but
+            // dropping it would leave the frame that moved with nowhere to hang.
+            Frame primary = node("all", 1_000L);
+            Frame wrapper = node("wrapper", 900L);
+            wrapper.put("moved", node("moved", 100L));
+            wrapper.put("other", node("other", 800L));
+            primary.put("wrapper", wrapper);
+
+            Frame baseline = node("all", 1_000L);
+            Frame baselineWrapper = node("wrapper", 900L);
+            baselineWrapper.put("moved", node("moved", 20L));
+            baselineWrapper.put("other", node("other", 880L));
+            baseline.put("wrapper", baselineWrapper);
+
+            String markdown = render(primary, baseline);
+
+            assertTrue(markdown.contains("wrapper"),
+                    "kept for its subtree's movement, not its own");
+            assertTrue(markdown.contains("moved"));
+        }
+
+        @Test
+        void twoIdenticalProfilesProduceAnEmptyTreeWithAnExplanation() {
+            Frame primary = node("all", 1_000L);
+            primary.put("work", node("work", 800L));
+            Frame baseline = node("all", 1_000L);
+            baseline.put("work", node("work", 800L));
+
+            String markdown = render(primary, baseline);
+
+            assertTrue(markdown.contains("nothing moved by more than the prune threshold"),
+                    "an empty diff tree must not read as an empty profile");
+        }
+    }
+
+    @Nested
+    class FrameStates {
+
+        @Test
+        void framesArePresentedAsSharedNewOrGone() {
+            Frame primary = node("all", 1_000L);
+            primary.put("kept", node("kept", 400L));
+            primary.put("added", node("added", 300L));
+            Frame baseline = node("all", 1_000L);
+            baseline.put("kept", node("kept", 100L));
+            baseline.put("removed", node("removed", 300L));
+
+            String markdown = render(primary, baseline);
+
+            assertTrue(markdown.contains("kept [S]"));
+            assertTrue(markdown.contains("added [NEW]"));
+            assertTrue(markdown.contains("removed [GONE]"));
+        }
+
+        @Test
+        void everyLineCarriesBothSidesAndTheMovementBetweenThem() {
+            Frame primary = node("all", 1_000L);
+            primary.put("handler", node("handler", 400L));
+            Frame baseline = node("all", 1_000L);
+            baseline.put("handler", node("handler", 100L));
+
+            String markdown = render(primary, baseline);
+
+            assertTrue(markdown.contains("Δ+300"), "the movement, signed");
+            assertTrue(markdown.contains("primary 400"));
+            assertTrue(markdown.contains("baseline 100"));
+        }
+    }
+
+    @Nested
+    class Header {
+
+        @Test
+        void declaresTheThresholdAndTheTimeBase() {
+            Frame primary = node("all", 1_000L);
+            primary.put("moved", node("moved", 100L));
+            Frame baseline = node("all", 1_000L);
+            baseline.put("moved", node("moved", 20L));
+
+            String markdown = render(primary, baseline);
+
+            assertTrue(markdown.contains("prune_threshold_pct: 5.0"));
+            assertTrue(markdown.contains("event_type: jdk.ExecutionSample"));
+            assertTrue(markdown.contains("## Comparability"));
+        }
+    }
+
+    private static String render(Frame primary, Frame baseline) {
+        return ProfileComparison.treeMarkdown(
+                Type.EXECUTION_SAMPLE,
+                new DiffTreeGenerator(primary, baseline).generate(),
+                ONE_MINUTE,
+                ONE_MINUTE,
+                FIVE_PERCENT);
+    }
+
+    private static Frame node(String methodName, long samples) {
+        Frame frame = new Frame(null, methodName, 0, 0);
+        frame.increment(FrameType.JIT_COMPILED, samples, samples, false);
+        return frame;
+    }
+}

--- a/jeffrey-microscope/profiles/flamegraph/src/test/java/cafe/jeffrey/flamegraph/diff/DiffgraphAnalyzerTest.java
+++ b/jeffrey-microscope/profiles/flamegraph/src/test/java/cafe/jeffrey/flamegraph/diff/DiffgraphAnalyzerTest.java
@@ -1,0 +1,303 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.flamegraph.diff;
+
+import cafe.jeffrey.frameir.DiffFrame;
+import cafe.jeffrey.frameir.DiffTreeGenerator;
+import cafe.jeffrey.frameir.Frame;
+import cafe.jeffrey.profile.common.model.FrameType;
+import cafe.jeffrey.shared.common.model.Type;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DiffgraphAnalyzerTest {
+
+    private static final Duration ONE_MINUTE = Duration.ofMinutes(1);
+    private static final Duration TWO_MINUTES = Duration.ofMinutes(2);
+    private static final int LIMIT = 10;
+
+    @Nested
+    class SelfAttribution {
+
+        @Test
+        void aRegressionIsChargedToTheFrameThatMovedNotToItsCallers() {
+            // Same shape either side; only the leaf grew. 'all' keeps its own self weight constant.
+            Frame primary = node("all", 100L);
+            primary.put("handler", node("handler", 60L));
+            Frame baseline = node("all", 100L);
+            baseline.put("handler", node("handler", 30L));
+
+            ComparisonReport report = analyze(primary, baseline, ONE_MINUTE, ONE_MINUTE);
+
+            MethodDelta handler = find(report.regressed(), "handler");
+            assertEquals(60L, handler.primarySelf());
+            assertEquals(30L, handler.baselineSelf());
+            assertEquals(30L, handler.delta(report.scale()), "the leaf gained 30");
+
+            assertTrue(report.regressed().stream().noneMatch(delta -> delta.methodName().equals("all")),
+                    "the caller did not regress — a total-based delta would have said it did");
+        }
+
+        @Test
+        void workMovingOutOfACallerShowsUpAsThatCallerImproving() {
+            Frame primary = node("all", 100L);
+            primary.put("handler", node("handler", 60L));
+            Frame baseline = node("all", 100L);
+            baseline.put("handler", node("handler", 30L));
+
+            ComparisonReport report = analyze(primary, baseline, ONE_MINUTE, ONE_MINUTE);
+
+            MethodDelta root = find(report.improved(), "all");
+            assertEquals(40L, root.primarySelf(), "100 total minus 60 in the child");
+            assertEquals(70L, root.baselineSelf(), "100 total minus 30 in the child");
+            assertEquals(-30L, root.delta(report.scale()));
+        }
+
+        @Test
+        void aMethodReachedFromSeveralPathsIsSummedOnce() {
+            Frame primary = node("all", 100L);
+            primary.put("left", withChild(node("left", 30L), leaf("shared", 20L)));
+            primary.put("right", withChild(node("right", 40L), leaf("shared", 25L)));
+            Frame baseline = node("all", 100L);
+            baseline.put("left", withChild(node("left", 30L), leaf("shared", 10L)));
+            baseline.put("right", withChild(node("right", 40L), leaf("shared", 10L)));
+
+            ComparisonReport report = analyze(primary, baseline, ONE_MINUTE, ONE_MINUTE);
+
+            MethodDelta shared = find(report.regressed(), "shared");
+            assertEquals(45L, shared.primarySelf(), "20 + 25 across both call paths");
+            assertEquals(20L, shared.baselineSelf(), "10 + 10");
+            assertEquals(2, shared.callPaths());
+            assertTrue(shared.examplePath().contains("shared"),
+                    "the heaviest contributing path is kept for the reader: " + shared.examplePath());
+        }
+    }
+
+    @Nested
+    class OneSidedSubtrees {
+
+        @Test
+        void newWorkIsAttributedToItsOwnFramesNotToTheFrameItHangsFrom() {
+            // 'entry' is present in both, so the diff pairs it; everything under 'fresh' is new, and
+            // the diff tree stops matching there and hands over one opaque node.
+            Frame primary = node("all", 100L);
+            Frame entry = node("entry", 50L);
+            entry.put("fresh", withChild(node("fresh", 40L), leaf("deepNewWork", 35L)));
+            primary.put("entry", entry);
+            Frame baseline = node("all", 100L);
+            baseline.put("entry", node("entry", 10L));
+
+            ComparisonReport report = analyze(primary, baseline, ONE_MINUTE, ONE_MINUTE);
+
+            MethodDelta deep = find(report.regressed(), "deepNewWork");
+            assertEquals(35L, deep.primarySelf(),
+                    "the walk descends into the new subtree instead of charging its root");
+            assertEquals(0L, deep.baselineSelf());
+            assertTrue(deep.appeared(), "no baseline at all — reported as new, not as a percentage");
+            assertTrue(deep.changePct(report.scale()).isEmpty(),
+                    "there is no baseline to be a percentage of");
+        }
+
+        @Test
+        void removedWorkIsAttributedToTheFramesThatDisappeared() {
+            Frame primary = node("all", 100L);
+            primary.put("entry", node("entry", 10L));
+            Frame baseline = node("all", 100L);
+            Frame entry = node("entry", 50L);
+            entry.put("legacy", withChild(node("legacy", 40L), leaf("deepOldWork", 35L)));
+            baseline.put("entry", entry);
+
+            ComparisonReport report = analyze(primary, baseline, ONE_MINUTE, ONE_MINUTE);
+
+            MethodDelta deep = find(report.improved(), "deepOldWork");
+            assertEquals(0L, deep.primarySelf());
+            assertEquals(35L, deep.baselineSelf());
+            assertTrue(deep.vanished());
+        }
+    }
+
+    @Nested
+    class Normalisation {
+
+        @Test
+        void aLongerBaselineIsHalvedBeforeTheDeltaIsTaken() {
+            Frame primary = node("all", 100L);
+            primary.put("work", node("work", 60L));
+            // Twice the recording length, twice the samples: the same workload, not a 50% improvement.
+            Frame baseline = node("all", 200L);
+            baseline.put("work", node("work", 120L));
+
+            ComparisonReport report = analyze(primary, baseline, ONE_MINUTE, TWO_MINUTES);
+
+            assertTrue(moved(report, "work").isEmpty(),
+                    "raw counts would have shown 'work' halving; scaling cancels that out");
+            assertTrue(report.regressed().isEmpty() && report.improved().isEmpty(),
+                    "the same workload watched for twice as long is not a change");
+        }
+
+        @Test
+        void shareDeltaIsReportedInPercentagePointsOfEachProfilesOwnTotal() {
+            Frame primary = node("all", 100L);
+            primary.put("work", node("work", 60L));
+            Frame baseline = node("all", 200L);
+            baseline.put("work", node("work", 40L));
+
+            ComparisonReport report = analyze(primary, baseline, ONE_MINUTE, ONE_MINUTE);
+
+            MethodDelta work = find(report.regressed(), "work");
+            assertEquals(20L, work.delta(report.scale()), "60 now against 40 before");
+            assertEquals(60.0 - 20.0, work.shareDeltaPoints(report.scale()), 0.0001,
+                    "60% of the primary against 20% of the baseline");
+        }
+    }
+
+    @Nested
+    class RenameCandidates {
+
+        @Test
+        void anAppearedAndAVanishedSubtreeOfTheSameSizeArePairedAsASuspicion() {
+            Frame primary = node("all", 100L);
+            primary.put("newName", leaf("newName", 30L));
+            Frame baseline = node("all", 100L);
+            baseline.put("oldName", leaf("oldName", 30L));
+
+            ComparisonReport report = analyze(primary, baseline, ONE_MINUTE, ONE_MINUTE);
+
+            List<RenameCandidate> candidates = report.renameCandidates();
+            assertEquals(1, candidates.size());
+            assertEquals("newName", candidates.getFirst().appearedMethod());
+            assertEquals("oldName", candidates.getFirst().vanishedMethod());
+        }
+
+        @Test
+        void subtreesOfClearlyDifferentSizeAreNotPaired() {
+            Frame primary = node("all", 100L);
+            primary.put("newName", leaf("newName", 40L));
+            Frame baseline = node("all", 100L);
+            baseline.put("oldName", leaf("oldName", 5L));
+
+            ComparisonReport report = analyze(primary, baseline, ONE_MINUTE, ONE_MINUTE);
+
+            assertTrue(report.renameCandidates().isEmpty(),
+                    "40 against 5 is a real change, not a rename");
+        }
+
+        @Test
+        void trivialSubtreesAreNotPairedAtAll() {
+            Frame primary = node("all", 10_000L);
+            primary.put("newName", leaf("newName", 3L));
+            Frame baseline = node("all", 10_000L);
+            baseline.put("oldName", leaf("oldName", 3L));
+
+            ComparisonReport report = analyze(primary, baseline, ONE_MINUTE, ONE_MINUTE);
+
+            assertTrue(report.renameCandidates().isEmpty(),
+                    "below 1% of the profile a coincidence is likelier than a rename");
+        }
+    }
+
+    @Nested
+    class Ranking {
+
+        @Test
+        void movementsAreOrderedBySizeAndCappedAtTheLimit() {
+            Frame primary = node("all", 1_000L);
+            primary.put("big", leaf("big", 300L));
+            primary.put("medium", leaf("medium", 200L));
+            primary.put("small", leaf("small", 100L));
+            Frame baseline = node("all", 1_000L);
+            baseline.put("big", leaf("big", 10L));
+            baseline.put("medium", leaf("medium", 100L));
+            baseline.put("small", leaf("small", 90L));
+
+            ComparisonReport report = DiffgraphAnalyzer.analyze(
+                    Type.EXECUTION_SAMPLE,
+                    new DiffTreeGenerator(primary, baseline).generate(),
+                    new ComparisonScale(ONE_MINUTE, ONE_MINUTE, 1_000L, 1_000L),
+                    2);
+
+            assertEquals(2, report.regressed().size(), "capped at the requested limit");
+            assertEquals("big", report.regressed().get(0).methodName());
+            assertEquals("medium", report.regressed().get(1).methodName());
+        }
+
+        @Test
+        void identicalProfilesProduceNoMovementAtAll() {
+            Frame primary = node("all", 100L);
+            primary.put("work", node("work", 60L));
+            Frame baseline = node("all", 100L);
+            baseline.put("work", node("work", 60L));
+
+            ComparisonReport report = analyze(primary, baseline, ONE_MINUTE, ONE_MINUTE);
+
+            assertTrue(report.regressed().isEmpty());
+            assertTrue(report.improved().isEmpty());
+            assertFalse(report.empty(), "methods were compared; none of them moved");
+        }
+    }
+
+    private static ComparisonReport analyze(
+            Frame primary, Frame baseline, Duration primaryDuration, Duration baselineDuration) {
+
+        DiffFrame root = new DiffTreeGenerator(primary, baseline).generate();
+        return ProfileComparison.report(
+                Type.EXECUTION_SAMPLE, root, primaryDuration, baselineDuration, LIMIT);
+    }
+
+    private static List<MethodDelta> moved(ComparisonReport report, String methodName) {
+        return Stream.concat(report.regressed().stream(), report.improved().stream())
+                .filter(delta -> delta.methodName().equals(methodName))
+                .toList();
+    }
+
+    private static MethodDelta find(List<MethodDelta> deltas, String methodName) {
+        return deltas.stream()
+                .filter(delta -> delta.methodName().equals(methodName))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "no movement reported for " + methodName + " in " + deltas));
+    }
+
+    /** An interior frame: its total covers its children, its self is whatever they leave over. */
+    private static Frame node(String methodName, long samples) {
+        Frame frame = new Frame(null, methodName, 0, 0);
+        frame.increment(FrameType.JIT_COMPILED, samples, samples, false);
+        return frame;
+    }
+
+    /** A frame where the work stops: total and self are the same. */
+    private static Frame leaf(String methodName, long samples) {
+        Frame frame = new Frame(null, methodName, 0, 0);
+        frame.increment(FrameType.JIT_COMPILED, samples, samples, true);
+        return frame;
+    }
+
+    private static Frame withChild(Frame parent, Frame child) {
+        parent.put(child.methodName(), child);
+        return parent;
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/configuration/ProfileVisualizationConfiguration.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/configuration/ProfileVisualizationConfiguration.java
@@ -109,12 +109,15 @@ public class ProfileVisualizationConfiguration {
             DataSource primaryDb = databaseManagerResolver.open(primary);
             DataSource secondaryDb = databaseManagerResolver.open(secondary);
             return new DiffFlamegraphManagerImpl(
+                    primary,
+                    secondary,
                     profileRepositories.newEventTypeRepository(primaryDb),
                     profileRepositories.newEventTypeRepository(secondaryDb),
                     new DbBasedDiffgraphGenerator(
                             profileRepositories.newEventStreamRepository(primaryDb),
                             profileRepositories.newEventStreamRepository(secondaryDb),
-                            minFrameThresholdPct(settingsStore))
+                            minFrameThresholdPct(settingsStore)),
+                    new AiExportConfig(aiExportMinFrameThresholdPct(settingsStore))
             );
         };
     }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/DiffFlamegraphManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/DiffFlamegraphManagerImpl.java
@@ -20,19 +20,22 @@ package cafe.jeffrey.profile.manager;
 
 import cafe.jeffrey.flamegraph.ai.AiExportConfig;
 
+import cafe.jeffrey.flamegraph.diff.DbBasedDiffgraphGenerator;
+import cafe.jeffrey.flamegraph.diff.ProfileComparison;
 import cafe.jeffrey.profile.common.config.GraphParameters;
 import cafe.jeffrey.shared.common.model.EventSummary;
+import cafe.jeffrey.shared.common.model.ProfileInfo;
 import cafe.jeffrey.shared.common.model.SpanScope;
 import cafe.jeffrey.shared.common.model.Type;
-import cafe.jeffrey.flamegraph.GraphGenerator;
 import cafe.jeffrey.profile.model.EventSummaryResult;
 import cafe.jeffrey.provider.profile.api.ProfileEventTypeRepository;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-public class DiffFlamegraphManagerImpl implements FlamegraphManager {
+public class DiffFlamegraphManagerImpl implements DifferentialFlamegraphManager {
 
     private static final List<Type> SUPPORTED_EVENTS = List.of(
             Type.EXECUTION_SAMPLE,
@@ -44,18 +47,27 @@ public class DiffFlamegraphManagerImpl implements FlamegraphManager {
             Type.OBJECT_ALLOCATION_OUTSIDE_TLAB,
             Type.VIRTUAL_THREAD_PINNED);
 
+    private final ProfileInfo primaryInfo;
+    private final ProfileInfo secondaryInfo;
     private final ProfileEventTypeRepository primaryEventTypeRepository;
     private final ProfileEventTypeRepository secondaryEventTypeRepository;
-    private final GraphGenerator generator;
+    private final DbBasedDiffgraphGenerator generator;
+    private final AiExportConfig aiExportConfig;
 
     public DiffFlamegraphManagerImpl(
+            ProfileInfo primaryInfo,
+            ProfileInfo secondaryInfo,
             ProfileEventTypeRepository primaryEventTypeRepository,
             ProfileEventTypeRepository secondaryEventTypeRepository,
-            GraphGenerator generator) {
+            DbBasedDiffgraphGenerator generator,
+            AiExportConfig aiExportConfig) {
 
+        this.primaryInfo = primaryInfo;
+        this.secondaryInfo = secondaryInfo;
         this.primaryEventTypeRepository = primaryEventTypeRepository;
         this.secondaryEventTypeRepository = secondaryEventTypeRepository;
         this.generator = generator;
+        this.aiExportConfig = aiExportConfig;
     }
 
     @Override
@@ -65,14 +77,37 @@ public class DiffFlamegraphManagerImpl implements FlamegraphManager {
 
     @Override
     public String generateAiExport(GraphParameters parameters) {
-        throw new UnsupportedOperationException(
-                "AI export is not supported for differential flamegraphs");
+        return generateAiExport(parameters, null);
     }
 
     @Override
-    public String generateAiExport(GraphParameters parameters, AiExportConfig aiExportConfig) {
-        throw new UnsupportedOperationException(
-                "AI export is not supported for differential flamegraphs");
+    public String generateAiExport(GraphParameters parameters, AiExportConfig exportConfig) {
+        return ProfileComparison.treeMarkdown(
+                parameters.eventType(),
+                generator.diffFrame(parameters),
+                duration(primaryInfo),
+                duration(secondaryInfo),
+                exportConfig == null ? aiExportConfig : exportConfig);
+    }
+
+    @Override
+    public String rankedMovements(GraphParameters parameters, int limit) {
+        return ProfileComparison.rankedMarkdown(
+                parameters.eventType(),
+                generator.diffFrame(parameters),
+                duration(primaryInfo),
+                duration(secondaryInfo),
+                limit);
+    }
+
+    /**
+     * A profile that reports no duration cannot be put on a time base, and
+     * {@link cafe.jeffrey.flamegraph.diff.ComparisonScale} says so in its own warning rather than
+     * being handed a fabricated one here.
+     */
+    private static Duration duration(ProfileInfo profileInfo) {
+        Duration duration = profileInfo.duration();
+        return duration == null ? Duration.ZERO : duration;
     }
 
     @Override

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/DifferentialFlamegraphManager.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/DifferentialFlamegraphManager.java
@@ -1,0 +1,46 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager;
+
+import cafe.jeffrey.profile.common.config.GraphParameters;
+
+/**
+ * A {@link FlamegraphManager} over a <em>pair</em> of profiles.
+ * <p>
+ * Everything the interface already promises still holds — {@code generate} draws the differential
+ * flamegraph the browser renders, {@code eventSummaries} lists what the two profiles have in common —
+ * and {@code generateAiExport} renders the diff as a readable call tree rather than refusing.
+ * <p>
+ * The one addition is {@link #rankedMovements}, which exists because a diff tree is a poor first read.
+ * Pruned to any threshold it is still mostly frames that did not move, with the two or three that did
+ * scattered through it at whatever depth they live; the ranked list puts them on the first line and
+ * attributes each to the method that actually changed rather than to all of its callers.
+ */
+public interface DifferentialFlamegraphManager extends FlamegraphManager {
+
+    /**
+     * The methods that moved between the two profiles, ranked by how much work moved with them, as a
+     * Markdown document.
+     *
+     * @param graphParameters what to compare: event type, time window and filters
+     * @param limit           how many movements to report in each direction
+     * @return Markdown suitable for handing to a model
+     */
+    String rankedMovements(GraphParameters graphParameters, int limit);
+}

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/FlamegraphManager.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/FlamegraphManager.java
@@ -36,7 +36,7 @@ public interface FlamegraphManager {
     }
 
     @FunctionalInterface
-    interface DifferentialFactory extends BiFunction<ProfileInfo, ProfileInfo, FlamegraphManager> {
+    interface DifferentialFactory extends BiFunction<ProfileInfo, ProfileInfo, DifferentialFlamegraphManager> {
     }
 
     List<EventSummaryResult> eventSummaries();
@@ -74,8 +74,7 @@ public interface FlamegraphManager {
      *
      * @param graphParameters graph parameters
      * @return Markdown string suitable for pasting into an LLM
-     * @throws UnsupportedOperationException for graph modes that do not
-     *                                       support AI export (e.g. differential)
+     * @throws UnsupportedOperationException for graph modes that do not support AI export
      */
     String generateAiExport(GraphParameters graphParameters);
 

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/ProfileManager.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/ProfileManager.java
@@ -51,7 +51,7 @@ public interface ProfileManager {
 
     FlamegraphManager flamegraphManager();
 
-    FlamegraphManager diffFlamegraphManager(ProfileManager secondaryManager);
+    DifferentialFlamegraphManager diffFlamegraphManager(ProfileManager secondaryManager);
 
     SubSecondManager subSecondManager();
 

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/ProfileManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/ProfileManagerImpl.java
@@ -84,7 +84,7 @@ public class ProfileManagerImpl implements ProfileManager {
     }
 
     @Override
-    public FlamegraphManager diffFlamegraphManager(ProfileManager secondaryManager) {
+    public DifferentialFlamegraphManager diffFlamegraphManager(ProfileManager secondaryManager) {
         return registry.visualization().flamegraphDiff().apply(profileInfo, secondaryManager.info());
     }
 

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpOverviewPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpOverviewPage.vue
@@ -105,7 +105,7 @@ onMounted(() => {
       <p>A call arrives naming a tool and a <code>profileId</code>. Jeffrey resolves that id to the profile's own DuckDB database, holds a lease on it for as long as the session stays active, runs the tool, and returns Markdown or a result table. The heavy machinery &mdash; the flamegraph builder, the trace analysis, the heap-dump index &mdash; is the same code the UI renders from, so what the model reads and what you see on screen cannot drift apart.</p>
 
       <h2 id="what-it-can-read">What It Can Read</h2>
-      <p>Forty-three tools in six families:</p>
+      <p>Forty-six tools in seven families:</p>
       <table>
         <thead>
           <tr>
@@ -126,8 +126,13 @@ onMounted(() => {
             <td>Which graphs a profile supports, and the call tree as Markdown</td>
           </tr>
           <tr>
+            <td><code>compare_</code></td>
+            <td>3</td>
+            <td>Two profiles against each other: whether they are comparable, what moved, and the differential call tree</td>
+          </tr>
+          <tr>
             <td><code>traces_</code></td>
-            <td>7</td>
+            <td>8</td>
             <td>Trace operations, exemplars, span trees and span-scoped flamegraphs</td>
           </tr>
           <tr>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpPluginPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpPluginPage.vue
@@ -97,10 +97,11 @@ const removal = `/plugin uninstall microscope@jeffrey`;
 
       <p><strong>The endpoint, already configured</strong> &mdash; including the per-machine setting above, so the same install works on a laptop and against a tunnelled staging Jeffrey.</p>
 
-      <p><strong>Five skills</strong>, which Claude picks up on its own when a question calls for them, and which you can also invoke directly:</p>
+      <p><strong>Six skills</strong>, which Claude picks up on its own when a question calls for them, and which you can also invoke directly:</p>
       <ul>
         <li><code>/microscope:analyze-jfr</code> &mdash; where to start and which family answers which question</li>
         <li><code>/microscope:analyze-heap</code> &mdash; a heap dump end to end: what is holding the memory, what is leaking, and the order the twenty heap tools have to be run in</li>
+        <li><code>/microscope:compare-jfr</code> &mdash; before against after: whether a change made it slower, which methods moved, and whether the two recordings were comparable in the first place</li>
         <li><code>/microscope:advise-jfr</code> &mdash; from a profile to a code change: hot frames mapped to your checkout, a recommendation, then the edit and a re-profile on request</li>
         <li><code>/microscope:jfr-sql</code> &mdash; the JFR schema and the DuckDB idioms that go with it</li>
         <li><code>/microscope:heap-sql</code> &mdash; the heap-dump index schema</li>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpRecipesPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpRecipesPage.vue
@@ -58,8 +58,8 @@ you would change`;
 
 const promptAdvise = `advise on the most recent Jeffrey profile - what should I change in this repo?`;
 
-const promptCompare = `compare the allocation flamegraphs of the before and after profiles and
-tell me what actually changed`;
+const promptCompare = `compare the allocation profiles of the before and after runs and tell me
+what actually changed - and whether the two runs are even comparable`;
 
 const promptSql = `across the whole recording, what is the distribution of jdk.FileRead
 durations per file, and which file is worst?`;
@@ -152,9 +152,17 @@ LIMIT 20`;
       <h2 id="compare-two-recordings">Compare Two Recordings</h2>
       <DocsCodeBlock :code="promptCompare" language="bash" />
 
-      <p>Nothing special is needed: <code>profiles_list</code> returns both, and every tool takes a <code>profileId</code>, so the same export runs twice in one session. Comparison is where a terminal beats two browser tabs &mdash; the model holds both trees at once and reports the delta rather than making you scan for it.</p>
+      <p>The <code>compare_</code> family does this as one operation rather than as two exports the model has to hold side by side. <code>compare_list</code> first &mdash; both recordings&rsquo; length, the event types they share, and the ones only one of them captured. Then <code>compare_movements</code>, which ranks the methods that moved. Then <code>compare_flamegraph</code> on whichever one the answer turned out to be.</p>
 
-      <p>Keep the graph parameters identical across the two calls; a threshold difference will read as a change that is not there.</p>
+      <p>Pass the <strong>after</strong> run as <code>profileId</code> and the <strong>before</strong> run as <code>baselineProfileId</code>. A positive delta then means the primary spends more, which is a regression; swap them and every regression reads as an improvement.</p>
+
+      <DocsCallout type="warning" title="The first question is whether they are comparable at all">
+        Two recordings can always be subtracted, and the difference always looks like a finding. Recording lengths that differ, a volume that stays far apart after scaling, an event type only one profiler captured &mdash; each produces a confident number that means nothing. <code>compare_list</code> reports all three, and every comparison document repeats them in a comparability section before it shows a single delta. &ldquo;These two runs are not comparable&rdquo; is a real answer, and a better one than the alternative.
+      </DocsCallout>
+
+      <p>Two things the output will not let you misread. Movements are attributed by <strong>self</strong> weight, so a change lands on the method that moved rather than on every caller above it &mdash; without that, one slow leaf reports its whole call stack as regressed. And a renamed or extracted method appears once as new and once as gone, of near-identical size, which reads as two dramatic findings; those pairs are listed as <strong>candidate renames</strong> for you to settle against the source diff, which the profile cannot see.</p>
+
+      <p>The <code>/microscope:compare-jfr</code> skill carries the whole sequence, so the prompt above does not have to name any of it.</p>
 
       <h2 id="a-question-with-no-tool">A Question With No Tool</h2>
       <DocsCodeBlock :code="promptSql" language="bash" />

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpSkillsPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpSkillsPage.vue
@@ -30,6 +30,7 @@ const headings = [
   { id: 'why-skills-at-all', text: 'Why Skills at All', level: 2 },
   { id: 'analyze-jfr', text: 'analyze-jfr', level: 2 },
   { id: 'analyze-heap', text: 'analyze-heap', level: 2 },
+  { id: 'compare-jfr', text: 'compare-jfr', level: 2 },
   { id: 'advise-jfr', text: 'advise-jfr', level: 2 },
   { id: 'jfr-sql', text: 'jfr-sql', level: 2 },
   { id: 'heap-sql', text: 'heap-sql', level: 2 },
@@ -44,6 +45,7 @@ onMounted(() => {
 
 const invoke = `/microscope:analyze-jfr
 /microscope:analyze-heap
+/microscope:compare-jfr
 /microscope:advise-jfr
 /microscope:jfr-sql
 /microscope:heap-sql`;
@@ -81,7 +83,7 @@ SELECT event_type, COUNT(*) FROM events_raw GROUP BY event_type`;
       <h2 id="analyze-jfr">analyze-jfr</h2>
       <p><em>Orientation.</em> Loaded whenever the question is &ldquo;why is this slow&rdquo;, &ldquo;where does the time go&rdquo;, &ldquo;what is allocating&rdquo;, &ldquo;what is holding memory&rdquo;, or when a Jeffrey profile, a JFR recording or a heap dump is mentioned.</p>
 
-      <p>It carries the entry sequence &mdash; <code>profiles_list</code>, then <code>profiles_features</code>, then the family that matches the question &mdash; a map of the six families to the questions each answers, when to start instead from <code>recordings_analyzeFile</code> because the user named a file Jeffrey has never seen, the rule that every scoped tool takes a <code>profileId</code>, which flamegraph to pick for CPU versus allocation versus lock contention versus wall-clock, the order to work a latency question in traces, and what a failure means (a <code>404</code> means the server was switched off, not a bug).</p>
+      <p>It carries the entry sequence &mdash; <code>profiles_list</code>, then <code>profiles_features</code>, then the family that matches the question &mdash; a map of the seven families to the questions each answers, when to start instead from <code>recordings_analyzeFile</code> because the user named a file Jeffrey has never seen, the rule that every scoped tool takes a <code>profileId</code>, which flamegraph to pick for CPU versus allocation versus lock contention versus wall-clock, the order to work a latency question in traces, and what a failure means (a <code>404</code> means the server was switched off, not a bug).</p>
 
       <p>It also tells the model to <strong>ground its claims</strong>: the exports contain call paths and numbers, not source locations, so file and line numbers must be read from the repository rather than inferred from a profile.</p>
 
@@ -98,6 +100,20 @@ SELECT event_type, COUNT(*) FROM events_raw GROUP BY event_type`;
       <p>On top of that it carries the routes &mdash; the histogram and top consumers for what is using the heap, leak suspects into a GC-root path for what is leaking, <code>heap_getClassLoaderLeakChains</code> for the redeploy case that leaves a class loader behind, string and collection analysis for waste, and instance browsing for one particular class &mdash; plus how to enter from a <code>.hprof</code> file Jeffrey has never seen, and what the two guard messages mean when a profile turns out to have no heap dump or an index that is still being built.</p>
 
       <p>It grounds claims the way <code>analyze-jfr</code> does: cite the class name, the retained bytes and the GC-root path together, never carry an object id between dumps, and say whether one dump is being read as a leak or as a large working set &mdash; a single dump cannot tell those apart.</p>
+
+      <h2 id="compare-jfr">compare-jfr</h2>
+      <p><em>Before against after.</em> Loaded when the question is &ldquo;did my change make it slower&rdquo;, &ldquo;what got faster&rdquo;, &ldquo;compare these two runs&rdquo;, or when a baseline, a before/after or a performance regression is mentioned. It is the question a session in your own checkout actually has &mdash; the agent holds the code diff, and Jeffrey holds the behaviour diff &mdash; and the one no single-profile tool can answer.</p>
+
+      <p>Most of the skill is spent on the failure mode that makes this analysis worse than useless. Any two recordings can be subtracted, and the result always looks like a finding; whether it <em>is</em> one depends on facts the deltas do not show, and nothing in a JFR file proves them. So it carries:</p>
+      <ul>
+        <li><strong>Comparability first, as a real result.</strong> <code>compare_list</code> before anything else, and &ldquo;these two runs are not comparable&rdquo; reported as a finding rather than worked around &mdash; a far better answer than a confident regression that was really a recording twice as long. It names the three cases to stop on: different recording lengths, an event type only one side recorded (a profiler-configuration difference, not a change in the application), and nothing in common at all.</li>
+        <li><strong>The direction.</strong> The after run is the <code>profileId</code> and the before run is the <code>baselineProfileId</code>. Backwards, every regression reads as an improvement.</li>
+        <li><strong>Ranked first, tree second.</strong> <code>compare_movements</code> attributes by self weight, so a change is charged to the method that moved rather than to every caller above it; <code>compare_flamegraph</code> follows one movement down its call paths. Pruning there is by movement, so absence means &ldquo;did not move&rdquo; &mdash; the opposite of what it means in a single-profile export.</li>
+        <li><strong>What a rename looks like.</strong> A renamed or extracted method appears once as new and once as gone, of near-identical size, and reads as two dramatic findings. The skill has the model check the source diff &mdash; which it has and the profile does not &mdash; before reporting either half.</li>
+        <li><strong>The limits, stated.</strong> Share and delta answer different questions and must be quoted as the one they are; one pair of recordings cannot separate a 5% move from run-to-run variance; and one event type&rsquo;s distribution is not a wall-clock benchmark, so a shifted CPU profile is never evidence that the application got faster end to end.</li>
+      </ul>
+
+      <p>It ends where <code>advise-jfr</code> begins: the profile says where, never why, so the located movements are mapped onto the actual diff with the real source read first.</p>
 
       <h2 id="advise-jfr">advise-jfr</h2>
       <p><em>From a profile to a code change.</em> Loaded when the question is &ldquo;what should I change&rdquo;, &ldquo;optimise this&rdquo;, or when a hotspot has been found and the next question is what to do about it. It is the successor of the in-app Profile Advisor: the same job, done by the agent that is already in your checkout and can build, test and re-profile, instead of by a model given a read-only view of one folder.</p>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpToolsPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpToolsPage.vue
@@ -30,6 +30,7 @@ const headings = [
   { id: 'rules-that-apply-to-all-of-them', text: 'Rules That Apply to All of Them', level: 2 },
   { id: 'profiles', text: 'profiles_ — the catalogue', level: 2 },
   { id: 'flamegraph', text: 'flamegraph_ — call trees', level: 2 },
+  { id: 'compare', text: 'compare_ — two profiles', level: 2 },
   { id: 'traces', text: 'traces_ — latency', level: 2 },
   { id: 'jfr', text: 'jfr_ — the profile database', level: 2 },
   { id: 'heap', text: 'heap_ — heap dumps', level: 2 },
@@ -56,7 +57,7 @@ const analyzeExample = `Analyze target/checkout-run.jfr and tell me where the ti
     />
 
     <div class="docs-content">
-      <p>Forty-three tools in six families. Five families read a profile; the sixth, <code>recordings_</code>, is the only one that creates one.</p>
+      <p>Forty-six tools in seven families. Six families read a profile; the seventh, <code>recordings_</code>, is the only one that creates one.</p>
 
       <h2 id="rules-that-apply-to-all-of-them">Rules That Apply to All of Them</h2>
 
@@ -131,6 +132,47 @@ const analyzeExample = `Analyze target/checkout-run.jfr and tell me where the ti
       </table>
 
       <p>Common starting points: <code>jdk.ExecutionSample</code> for on-CPU time, <code>jdk.ObjectAllocationSample</code> for allocation (with <code>useWeight</code> to rank by bytes rather than call count), <code>jdk.JavaMonitorEnter</code> for lock contention (weight is nanoseconds blocked), <code>profiler.WallClockSample</code> for latency including off-CPU &mdash; async-profiler&rsquo;s event, so unlike its neighbours it carries no <code>jdk.</code> prefix. <code>thresholdPct</code> controls how much survives pruning &mdash; raise it for an overview, lower it to chase one path.</p>
+
+      <h2 id="compare">compare_ &mdash; two profiles</h2>
+      <p>The only family scoped to a <strong>pair</strong>. <code>profileId</code> is the run under examination and <code>baselineProfileId</code> is what it is measured against, so a positive delta always means the primary spends more &mdash; a regression. Get the direction wrong and every regression reads as an improvement.</p>
+      <table>
+        <thead>
+          <tr>
+            <th>Tool</th>
+            <th>Arguments</th>
+            <th>Returns</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>compare_list</code></td>
+            <td><code>profileId</code>, <code>baselineProfileId</code></td>
+            <td>Both recordings&rsquo; length, the event types they have in common with each side&rsquo;s totals, the types only one of them recorded, and the notes that decide whether the pair is comparable at all</td>
+          </tr>
+          <tr>
+            <td><code>compare_movements</code></td>
+            <td><code>profileId</code>, <code>baselineProfileId</code>, <code>eventType</code>, <code>limit?</code>, <code>startMs?</code>, <code>endMs?</code>, <code>useWeight?</code>, <code>excludeIdle?</code>, <code>excludeNonJava?</code></td>
+            <td>The methods that grew and the ones that shrank, ranked by how much work moved with them, as Markdown</td>
+          </tr>
+          <tr>
+            <td><code>compare_flamegraph</code></td>
+            <td><code>profileId</code>, <code>baselineProfileId</code>, <code>eventType</code>, <code>thresholdPct?</code>, <code>startMs?</code>, <code>endMs?</code>, <code>useWeight?</code>, <code>excludeIdle?</code>, <code>excludeNonJava?</code></td>
+            <td>The differential call tree as Markdown, every frame carrying both sides and the movement between them</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <DocsCallout type="warning" title="compare_list is not a warm-up call">
+        Any two recordings can be subtracted, and the result always looks like a finding. Whether it <em>is</em> one depends on facts the deltas do not show &mdash; comparable recording length, comparable volume, the same profiler settings &mdash; and nothing inside a JFR file proves them. <code>compare_list</code> is the step that decides whether the rest means anything, and &ldquo;these two runs are not comparable&rdquo; is a real result.
+      </DocsCallout>
+
+      <p><strong>Movements are attributed by self weight.</strong> A delta taken on subtree totals charges a change to every caller above it, so one slow leaf reports <code>main</code>, the thread-pool runnable and every framework frame in between as having regressed by the same amount. <code>compare_movements</code> ranks by the work that stopped <em>at</em> each method, which moves only where the work moved; <code>compare_flamegraph</code> is the drill-down once a method has been named.</p>
+
+      <p><strong>The baseline is scaled onto the primary&rsquo;s recording length</strong> before any delta is taken, because a sampling profiler emits samples at a roughly fixed rate and a run that lasted twice as long carries twice as many of them. Both documents print the raw figure, the scaled figure and the factor, so the correction is visible rather than merely applied. It assumes a steady workload measured over time and is wrong for a fixed-size benchmark &mdash; there the share column is the honest one.</p>
+
+      <p><strong>A rename is not a regression.</strong> The diff matches method names level by level, so a renamed, moved or extracted method breaks the match and its work appears once as new and once as gone, often of near-identical size. Both documents list such pairs as candidate renames &mdash; suspicions for a reader holding the source diff to confirm, never a resolution, because weight alone cannot tell a rename from a coincidence.</p>
+
+      <p>Pruning in <code>compare_flamegraph</code> is by <strong>movement</strong>, not by size: a subtree in which nothing changed is dropped however large it is, and unmoved ancestors are kept so the frames that did move can still be placed. Absence there means &ldquo;did not move&rdquo;, the opposite of what it means in <code>flamegraph_export</code>.</p>
 
       <h2 id="traces">traces_ &mdash; latency</h2>
       <p>Available only for a profile recorded with <router-link to="/docs/tracing">Jeffrey Tracing</router-link>. An operation is identified by the <strong>triple</strong> <code>(name, kind, eventType)</code>, not by name alone: an inbound <code>GET /orders</code> and an outbound call to the same path are different operations.</p>


### PR DESCRIPTION
## Summary

Adds comprehensive support for comparing two JVM profiles side-by-side through differential flamegraph analysis. This enables users to identify performance regressions, improvements, and changes between two recordings of the same application.

## Key Changes

### New Differential Analysis Framework
- **`ComparisonScale`**: Normalizes two recordings onto a common time base, accounting for different recording lengths while detecting and warning about incompatible recordings
- **`DiffgraphAnalyzer`**: Analyzes differential call trees to rank methods by movement (self-weight delta), identifying regressions and improvements
- **`ComparisonReport`**: Aggregates analysis results with scaling factors and warnings
- **`MethodDelta`**: Represents per-method movement between profiles with call path tracking

### Markdown Export for AI
- **`ComparisonMarkdownBuilder`**: Renders ranked method deltas as Markdown with detailed preambles explaining comparability, scaling corrections, and interpretation
- **`DiffgraphAiMarkdownBuilder`**: Renders differential call trees as nested Markdown, pruned by movement rather than size to highlight changed frames
- **`WeightContext`**: Extracted utility for formatting measurements (samples, bytes, duration) by event type, shared with single-profile exports

### MCP Tool Family
- **`CompareMcpTools`**: New tool family with four operations:
  - `compare_list`: Establishes comparability, reports common/exclusive event types, detects configuration mismatches
  - `compare_movements`: Ranked list of methods that regressed/improved with scaling and delta details
  - `compare_tree`: Differential flamegraph as nested Markdown for drill-down analysis
  - `compare_rename_candidates`: Detects likely method renames (appeared/vanished pairs of similar size)

### Integration Points
- **`DifferentialFlamegraphManager`**: New interface for differential analysis operations
- **`DiffFlamegraphManagerImpl`**: Implementation using `DbBasedDiffgraphGenerator` for tree generation
- **`McpToolsetAssembler`**: Registers `CompareMcpTools` in the MCP endpoint
- **`FlamegraphAiMarkdownBuilder`**: Refactored to use shared `WeightContext` for consistent formatting

### Documentation & Skills
- **`compare-jfr` skill**: New Claude skill for comparing profiles, with detailed usage guide and examples
- **Updated agent configuration**: Profile analyst agent now includes compare-jfr skill
- **Updated MCP documentation**: Added compare_ tool family to tools reference

## Notable Implementation Details

- **Self-weight attribution**: Deltas are charged to the frame where work moved, not to callers, preventing false positives on ancestors
- **Pruning by movement**: Differential trees are pruned by delta magnitude, not absolute size, keeping changed frames even if small and dropping large unchanged subtrees
- **Rename detection**: Appeared/vanished method pairs within size tolerance and minimum share threshold are paired as likely renames
- **Scaling assumptions**: Clearly documented that time-base correction assumes steady workload; warnings alert users when recordings differ significantly in length or total work
- **Comprehensive test coverage**: Added test suites for scaling logic, analysis ranking, and Markdown rendering with edge cases (duration mismatch, configuration differences, renames)

## Files Added
- Core analysis: `ComparisonScale`, `DiffgraphAnalyzer`, `ComparisonReport`, `MethodDelta`, `DiffMeasure`, `RenameCandidate`, `ProfileComparison`
- Markdown export: `ComparisonMarkdownBuilder`, `DiffgraphAiMarkdownBuilder`
- MCP tools: `CompareMcpTools`
- Manager interface: `DifferentialFlamegraphManager`
- Shared utilities: `WeightContext`
- Tests: `ComparisonScaleTest`, `DiffgraphAnalyzerTest`, `ComparisonMarkdownBuilderTest`, `DiffgraphAiMarkdownBuilderTest`
- Documentation: `compare-jfr/SKILL.md`

## Files Modified
- `FlamegraphAiMarkdownBuilder`: Refactored to use `WeightContext`
- `DbBasedDiffgraphGenerator`: Updated to use new manager interface

https://claude.ai/code/session_01PXZLAS2gp6LW3BNNCrXe8h