### PR TITLE
Wire up the client exchanges, fix method tracing, and answer three more questions

### DIFF
--- a/jeffrey-claude-plugin/README.md
+++ b/jeffrey-claude-plugin/README.md
@@ -47,14 +47,14 @@ installation.
 
 ## What you get
 
-**Tools**, in fifteen families:
+**Tools**, in sixteen families:
 
 | Family | What it does |
 |---|---|
 | `profiles_` | The catalogue: which recordings are analysed, what each one can answer, and deep links into the UI |
 | `flamegraph_` | Which graphs a profile supports, and the call tree as Markdown |
 | `compare_` | Two profiles against each other: whether they are comparable, what moved, and the differential call tree |
-| `traces_` | Trace operations, the application's own notifications, exemplars, span trees and span-scoped flamegraphs |
+| `traces_` | Trace operations, the application's own notifications, exemplars, span trees, span-scoped flamegraphs, and the attributes that say which population a trace belonged to |
 | `jvm_` | The machine underneath: garbage collection, safepoints, JIT compilation, threads, thread dumps, native memory, the container, the JVM flags and what it was started with |
 | `http_` | The HTTP traffic the application served: percentiles, endpoints, status codes, slowest requests |
 | `jdbc_` | Statement timings and groups, and the connection pool in front of them |
@@ -63,8 +63,9 @@ installation.
 | `io_` | Socket and file I/O: bytes, targets and the slowest operations — the waiting a CPU graph cannot see |
 | `blocking_` | Contended monitors, waits, parks and virtual-thread pinning |
 | `timeline_` | When the samples landed: the busiest windows, and sub-second zoom inside one |
+| `memory_` | Allocation by type, and JFR-side leak candidates that need no heap dump |
 | `jfr_` | The profile's DuckDB tables — schema and read-only SQL |
-| `heap_` | Heap summary, class histogram, dominator tree, leak suspects, GC-root paths, and read-only SQL |
+| `heap_` | Heap summary, class histogram, dominator tree, leak suspects, GC-root paths, a two-dump diff, and read-only SQL |
 | `recordings_` | The one that writes: imports a recording file and builds a profile from it |
 
 `recordings_analyzeFile` takes an **absolute path**, and the file has to be on the machine Jeffrey

--- a/jeffrey-claude-plugin/skills/analyze-heap/SKILL.md
+++ b/jeffrey-claude-plugin/skills/analyze-heap/SKILL.md
@@ -105,7 +105,12 @@ every question to the user, stays here either way.
   makes a claim checkable.
 - Object ids are stable within one dump and meaningless across dumps. Carry the class name and
   the path between dumps, never an id.
-- A dump shows a state, not a trend. One dump cannot distinguish a leak from a large working set;
+- **Two dumps settle it.** `heap_diff` compares this dump against an earlier one class by class, ranked
+by growth: it is the one tool that separates a leak from a large working set, which no single-dump
+report can do. Pass the earlier dump as the baseline — backwards, every growth reads as a shrink.
+Both dumps have to be indexed first, and the tool says which one is not.
+
+A dump shows a state, not a trend. One dump cannot distinguish a leak from a large working set;
   say which of the two you are claiming, and ask for a second dump taken later when it matters.
 - If the repository is open alongside, read the real source of the retaining field before naming
   a cause. Do not infer a code path from a class name.

--- a/jeffrey-claude-plugin/skills/analyze-jfr/SKILL.md
+++ b/jeffrey-claude-plugin/skills/analyze-jfr/SKILL.md
@@ -40,15 +40,16 @@ A profile whose `event source` column reads `HEAP_DUMP` is a heap dump: switch t
 | `profiles_` | `list`, `get` (identity, recording window, size, source commit), `features`, `samplerHealth` (whether the samples can be trusted), `link` (the profile in the Jeffrey UI), `viewLink` (one named page) |
 | `flamegraph_` | `list` (which event types this profile can graph — call it first), `export` (the call tree as Markdown) |
 | `compare_` | `list` (whether two profiles are comparable at all — call it first), `movements` (what moved, ranked), `flamegraph` (the differential call tree) — the `compare-jfr` skill has the workflow |
-| `traces_` | `overview`, `operations`, `notifications`, `operationExport`, `slowestTraces`, `traceExport`, `spanFlamegraphExport`, `operationFlamegraphExport` |
+| `traces_` | `overview`, `operations`, `notifications`, `operationExport`, `slowestTraces`, `traceExport`, `spanFlamegraphExport`, `operationFlamegraphExport`, plus `attributeKeys`/`attributeValues`/`attributeSearch` |
 | `jvm_` | `sections` (call it first), `autoAnalysis`, `gc`, `safepoints`, `jit`, `threads`, `threadDumps`, `threadDump`, `nativeMemory`, `container`, `configuration`, `flags` — the machine underneath the application |
-| `http_` | `overview`, `endpoint` — the HTTP traffic the application served |
+| `http_` | `overview`, `endpoint` — HTTP traffic, `SERVER` (served) or `CLIENT` (called out) |
 | `jdbc_` | `overview`, `statementGroup`, `pools` — the queries it ran, and the pool in front of them |
-| `grpc_` | `overview`, `service`, `traffic` — gRPC latency, and the message sizes moved |
+| `grpc_` | `overview`, `service`, `traffic` — gRPC latency and message sizes, `SERVER` or `CLIENT` |
 | `methodtracing_` | `overview`, `slowest`, `timing` — instrumented method timings (JEP 520) |
 | `io_` | `overview`, `endpoints`, `slowest` — socket and file I/O, the waiting a CPU graph cannot see |
 | `blocking_` | `overview`, `monitors`, `pinnedThreads` — contended locks, waits, parks, virtual-thread pinning |
 | `timeline_` | `hotWindows` (when the samples landed), `zoom` (sub-second, inside one window) |
+| `memory_` | `allocations` (by type, not call site), `leakCandidates` (JFR-side, needs no heap dump) |
 | `jfr_` | `listTables`, `describeTable`, `listEventTypes`, `queryEvents`, `executeQuery`, `getProfileInfo` — raw DuckDB when no purpose-built tool fits; the `jfr-sql` skill has the schema |
 | `heap_` | Everything a heap dump answers — the `analyze-heap` skill has the order to run it in |
 | `recordings_` | `analyzeFile` (a file not in Jeffrey yet), `analyzeRecording` (uploaded but never analysed), `list` (the Quick Analysis store) |
@@ -183,10 +184,12 @@ Three things worth knowing before reading them:
 - **Slow requests whose statements are all fast are usually waiting for a connection.** That is
   `jdbc_pools`, and nothing in the statement view can show it — a pool with acquisition timeouts
   makes every query look fine while the request waits in front of them.
-- **Server-side only.** HTTP and gRPC read the server exchange events; there is no client-side data
-  behind the UI's client/server switch, so these tools take no direction argument. The per-second
-  chart series are left out on purpose — the percentiles carry the same information, and the shape
-  over time is what the `uiLink` on each answer is for.
+- **Both directions, and they are different questions.** `direction: SERVER` is what the application
+  was asked to do; `CLIENT` is what it asked of somebody else, where a slow figure belongs to a
+  dependency and the only local fixes are to call less often or stop waiting. They are gated
+  separately, so "no client-side data" means the recording captured no outbound calls, not that the
+  dashboard is broken. The per-second chart series are left out on purpose — the percentiles carry
+  the same information, and the shape over time is what `timeline_` and the `uiLink` are for.
 
 An event type the recording never captured is reported in words rather than as a zeroed dashboard:
 "no HTTP server data" is a finding about the profiler's configuration, not a healthy service.
@@ -223,6 +226,35 @@ time is.
 Both report whether the event type was recorded at all, because these events are threshold-gated: a
 recording can hold none because nothing blocked for long enough as well as because the profiler was
 never asked. The two are different findings and the tools distinguish them.
+
+## Which population, not which operation: trace attributes
+
+`traces_operations` groups by the shape of the request. That cannot answer the question most latency
+investigations actually end at — one population is slow and the rest is fine. The same endpoint,
+fast for almost everyone and terrible for one tenant, has a healthy average and a p99 nobody can
+locate.
+
+1. `traces_attributeKeys` — what the spans recorded. A key is the triple `(source, owner, key)`, and
+   the other two tools take all three; an `EVENT_FIELD` always has an owner, an `ATTRIBUTE` usually
+   does not.
+2. `traces_attributeValues` — one key split into its values, each with its own p50, p95, max and
+   error count. A value whose p95 stands apart from the rest names the population. Trace counts do
+   not sum to the profile's total: a trace whose spans recorded two values counts under both.
+3. `traces_attributeSearch` — the individual traces carrying one value, whose ids go to
+   `traces_traceExport`.
+
+An attribute says *which* population was slow and never *why*. The span tree of one of its traces
+says why.
+
+## Memory without a heap dump
+
+`memory_allocations` ranks the **types** allocated where the allocation flamegraph ranks the call
+**sites** — the other axis, and often the one that names the problem, since `byte[]` and `char[]` at
+the top read very differently from a domain class. `memory_leakCandidates` reads
+`jdk.OldObjectSample`: objects the JVM watched survive collections, which is leak evidence from a
+plain recording when nobody captured a dump and the process has gone. Its absence is not a clean
+bill of health — that sampler is off in most profiles, and the tool says so rather than reporting
+zero candidates.
 
 ## Hand the reading to the analyst
 

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/McpToolsetAssembler.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/McpToolsetAssembler.java
@@ -22,10 +22,13 @@ import cafe.jeffrey.microscope.core.mcp.tools.CompareMcpTools;
 import cafe.jeffrey.microscope.core.mcp.tools.FlamegraphMcpTools;
 import cafe.jeffrey.microscope.core.mcp.tools.BlockingMcpTools;
 import cafe.jeffrey.microscope.core.mcp.tools.GrpcMcpTools;
+import cafe.jeffrey.microscope.core.mcp.tools.HeapDiffMcpTools;
 import cafe.jeffrey.microscope.core.mcp.tools.IoMcpTools;
 import cafe.jeffrey.microscope.core.mcp.tools.HttpMcpTools;
 import cafe.jeffrey.microscope.core.mcp.tools.JdbcMcpTools;
+import cafe.jeffrey.microscope.core.mcp.tools.MemoryMcpTools;
 import cafe.jeffrey.microscope.core.mcp.tools.MethodTracingMcpTools;
+import cafe.jeffrey.microscope.core.mcp.tools.TraceAttributesMcpTools;
 import cafe.jeffrey.microscope.core.mcp.tools.TimelineMcpTools;
 import cafe.jeffrey.microscope.core.mcp.tools.JvmMcpTools;
 import cafe.jeffrey.microscope.core.mcp.tools.ProfileMcpTools;
@@ -91,6 +94,7 @@ public class McpToolsetAssembler {
     private static final String PREFIX_IO = "io";
     private static final String PREFIX_BLOCKING = "blocking";
     private static final String PREFIX_TIMELINE = "timeline";
+    private static final String PREFIX_MEMORY = "memory";
     private static final String PREFIX_HEAP = "heap";
     private static final String PREFIX_RECORDINGS = "recordings";
 
@@ -147,6 +151,14 @@ public class McpToolsetAssembler {
                         profileId -> new BlockingMcpTools(profileManager(contextCache, profileId))),
                 new ProfileScopedToolset<>(TimelineMcpTools.class, PREFIX_TIMELINE,
                         profileId -> new TimelineMcpTools(profileManager(contextCache, profileId))),
+                new ProfileScopedToolset<>(MemoryMcpTools.class, PREFIX_MEMORY,
+                        profileId -> new MemoryMcpTools(profileManager(contextCache, profileId))),
+                new ProfileScopedToolset<>(TraceAttributesMcpTools.class, PREFIX_TRACES,
+                        profileId -> new TraceAttributesMcpTools(profileManager(contextCache, profileId))),
+                new ProfileScopedToolset<>(HeapDiffMcpTools.class, PREFIX_HEAP,
+                        profileId -> new HeapDiffMcpTools(
+                                profileManager(contextCache, profileId),
+                                baselineId -> profileManager(contextCache, baselineId))),
                 new ProfileScopedToolset<>(HeapDumpMcpTools.class, PREFIX_HEAP,
                         profileId -> heapTools(contextCache, profileId))));
 

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/GrpcMcpTools.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/GrpcMcpTools.java
@@ -22,6 +22,7 @@ import cafe.jeffrey.microscope.core.mcp.LinkedOutput;
 import cafe.jeffrey.microscope.core.mcp.UiLinks;
 import cafe.jeffrey.profile.feature.FeatureType;
 import cafe.jeffrey.profile.manager.ProfileManager;
+import cafe.jeffrey.profile.manager.custom.ExchangeDirection;
 import cafe.jeffrey.profile.manager.custom.model.grpc.GrpcHeader;
 import cafe.jeffrey.profile.manager.custom.model.grpc.GrpcLargestCall;
 import cafe.jeffrey.profile.manager.custom.model.grpc.GrpcMethodInfo;
@@ -36,14 +37,15 @@ import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
  * The gRPC calls the profiled JVM served: latency, status codes, per-service breakdown, and - on its
  * own tool - message sizes, which is the dimension gRPC gets wrong more often than time.
  * <p>
- * Server-side only, for the same reason as {@link HttpMcpTools}: only one gRPC manager bean is
- * registered, over {@code Type.GRPC_SERVER_EXCHANGE}. The chart series are dropped from every answer.
+ * Both directions are answerable, like {@link HttpMcpTools}: SERVER is what this application was
+ * asked to do, CLIENT what it asked of somebody else. The chart series are dropped from every answer.
  */
 public class GrpcMcpTools {
 
@@ -51,15 +53,14 @@ public class GrpcMcpTools {
     private static final String SERVICES_VIEW = "technologies/grpc/services";
     private static final String TRAFFIC_VIEW = "technologies/grpc/traffic";
     private static final String MODE_PARAM = "mode";
-    private static final String SERVER_MODE = "server";
     private static final String SERVICE_PARAM = "service";
 
     private static final int MAX_SERVICES = 40;
 
     private static final String NO_GRPC_DATA =
-            "This profile holds no gRPC server data: the recording did not capture "
-                    + "jdk.GrpcServerExchange events. That is a profiler-configuration finding worth "
-                    + "reporting rather than evidence that the service handles no gRPC.";
+            "This profile holds no %s-side gRPC data: the recording did not capture %s events. That is "
+                    + "a profiler-configuration finding worth reporting rather than evidence that the "
+                    + "service handles no gRPC in that direction.";
 
     private static final String STEP_SERVICE =
             "For one service broken down by method, grpc_service takes a name from the services list "
@@ -86,12 +87,17 @@ public class GrpcMcpTools {
     @Tool(description = "The gRPC server dashboard: call count, response-time percentiles, success "
             + "rate and error count, the services ranked by traffic, the status-code breakdown and the "
             + "slowest individual calls. Start here for gRPC latency questions.")
-    public String overview() {
-        if (DashboardFeature.missing(profileManager, FeatureType.GRPC_SERVER_DASHBOARD)) {
-            return NO_GRPC_DATA;
+    public String overview(
+            @ToolParam(description = "Which side to report on: 'SERVER' for calls this application "
+                    + "answered (the default), 'CLIENT' for calls it made to somebody else.")
+            String direction) {
+
+        ExchangeDirection side = ExchangeDirection.from(direction);
+        if (DashboardFeature.missing(profileManager, feature(side))) {
+            return noData(side);
         }
 
-        GrpcOverviewData data = profileManager.custom().grpcManager().overviewData();
+        GrpcOverviewData data = profileManager.custom().grpcManager(side).overviewData();
         return LinkedOutput.json(new GrpcDashboard(
                 data.header(),
                 trim(data.services()),
@@ -102,7 +108,7 @@ public class GrpcMcpTools {
                         .when(data.header().errorCount() > 0, STEP_ERRORS)
                         .add(STEP_TRAFFIC)
                         .build(),
-                UiLinks.view(profileId(), OVERVIEW_VIEW, mode())));
+                UiLinks.view(profileId(), OVERVIEW_VIEW, mode(side))));
     }
 
     @Tool(description = "One gRPC service in detail, broken down by method: percentiles per method, "
@@ -111,13 +117,18 @@ public class GrpcMcpTools {
     public String service(
             @ToolParam(description = "Service name exactly as recorded, taken from the services list "
                     + "in grpc_overview.")
-            String service) {
+            String service,
+            @ToolParam(description = "Which side to report on: 'SERVER' for calls this application "
+                    + "answered (the default), 'CLIENT' for calls it made to somebody else.")
+            String direction) {
 
-        if (DashboardFeature.missing(profileManager, FeatureType.GRPC_SERVER_DASHBOARD)) {
-            return NO_GRPC_DATA;
+        ExchangeDirection side = ExchangeDirection.from(direction);
+        if (DashboardFeature.missing(profileManager, feature(side))) {
+            return noData(side);
         }
 
-        GrpcServiceDetailData data = profileManager.custom().grpcManager().serviceDetailData(service);
+        GrpcServiceDetailData data =
+                profileManager.custom().grpcManager(side).serviceDetailData(service);
         if (data.methods().isEmpty()) {
             return NO_SUCH_SERVICE.formatted(service);
         }
@@ -131,37 +142,53 @@ public class GrpcMcpTools {
                         .when(data.header().errorCount() > 0, STEP_ERRORS)
                         .add(STEP_TRAFFIC)
                         .build(),
-                UiLinks.view(profileId(), SERVICES_VIEW, serviceQuery(service))));
+                UiLinks.view(profileId(), SERVICES_VIEW, serviceQuery(side, service))));
     }
 
     @Tool(description = "gRPC message sizes rather than timings: bytes sent and received, average and "
             + "maximum request and response sizes, the size-bucket distribution and the largest "
             + "individual calls. This is where an oversized payload shows up - it will not be visible "
             + "in the latency percentiles until it is already a problem.")
-    public String traffic() {
-        if (DashboardFeature.missing(profileManager, FeatureType.GRPC_SERVER_DASHBOARD)) {
-            return NO_GRPC_DATA;
+    public String traffic(
+            @ToolParam(description = "Which side to report on: 'SERVER' for calls this application "
+                    + "answered (the default), 'CLIENT' for calls it made to somebody else.")
+            String direction) {
+
+        ExchangeDirection side = ExchangeDirection.from(direction);
+        if (DashboardFeature.missing(profileManager, feature(side))) {
+            return noData(side);
         }
 
-        GrpcTrafficData data = profileManager.custom().grpcManager().trafficData();
+        GrpcTrafficData data = profileManager.custom().grpcManager(side).trafficData();
         return LinkedOutput.json(new GrpcTraffic(
                 data.header(),
                 data.sizeBuckets(),
                 data.largestCalls(),
                 NextSteps.builder().add(STEP_TIMINGS).build(),
-                UiLinks.view(profileId(), TRAFFIC_VIEW, mode())));
+                UiLinks.view(profileId(), TRAFFIC_VIEW, mode(side))));
     }
 
-    private Map<String, String> mode() {
+    private static Map<String, String> mode(ExchangeDirection direction) {
         Map<String, String> query = UiLinks.query();
-        query.put(MODE_PARAM, SERVER_MODE);
+        query.put(MODE_PARAM, direction.name().toLowerCase(Locale.ROOT));
         return query;
     }
 
-    private Map<String, String> serviceQuery(String service) {
-        Map<String, String> query = mode();
+    private static Map<String, String> serviceQuery(ExchangeDirection direction, String service) {
+        Map<String, String> query = mode(direction);
         query.put(SERVICE_PARAM, service);
         return query;
+    }
+
+    private static FeatureType feature(ExchangeDirection direction) {
+        return direction == ExchangeDirection.SERVER
+                ? FeatureType.GRPC_SERVER_DASHBOARD
+                : FeatureType.GRPC_CLIENT_DASHBOARD;
+    }
+
+    private static String noData(ExchangeDirection direction) {
+        return NO_GRPC_DATA.formatted(
+                direction.name().toLowerCase(Locale.ROOT), direction.grpcEventType().code());
     }
 
     private static List<GrpcServiceInfo> trim(List<GrpcServiceInfo> services) {

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/HeapDiffMcpTools.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/HeapDiffMcpTools.java
@@ -1,0 +1,150 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.microscope.core.mcp.tools;
+
+import cafe.jeffrey.microscope.core.mcp.LinkedOutput;
+import cafe.jeffrey.microscope.core.mcp.UiLinks;
+import cafe.jeffrey.profile.heapdump.model.HeapDumpDiffReport;
+import cafe.jeffrey.profile.manager.ProfileManager;
+import cafe.jeffrey.profile.manager.heapdump.HeapDumpDiffService;
+import cafe.jeffrey.profile.manager.heapdump.HeapDumpManager;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * What grew between two heap dumps.
+ * <p>
+ * One dump shows a state, and a state cannot distinguish a leak from a large working set — the
+ * caveat every heap answer has to carry. Two dumps taken at different times can: a class whose
+ * instances climbed while the application did comparable work is the definition of the thing, and no
+ * single-dump report says it. This is the question the twenty-tool {@code heap_} family could not
+ * ask.
+ */
+public class HeapDiffMcpTools {
+
+    private static final String DIFF_VIEW = "heap-dump/diff";
+
+    private static final int DEFAULT_TOP = 30;
+    private static final int MAX_TOP = 200;
+
+    private static final String NO_PRIMARY_DUMP =
+            "This profile has no heap dump to compare. profiles_list shows which profiles are heap "
+                    + "dumps - their event source reads HEAP_DUMP.";
+
+    private static final String NO_BASELINE_DUMP =
+            "The baseline profile '%s' has no heap dump. A comparison needs two of them; "
+                    + "profiles_list shows which profiles are heap dumps.";
+
+    /**
+     * A dump that exists but has not been indexed is a different answer from one that does not exist,
+     * and the difference is actionable - the same distinction the heap_ family already makes.
+     */
+    private static final String NOT_INDEXED =
+            "The heap dump of %s is still being indexed. Open it once in the Jeffrey UI to build the "
+                    + "index, then try again - a comparison needs both dumps indexed.";
+
+    private static final String STEP_WHY_RETAINED =
+            "A class that grew is an observation. Why the new instances are still reachable is "
+                    + "heap_getPathToGCRoot on one of them, and that is what turns growth into a leak "
+                    + "claim.";
+    private static final String STEP_DOMINATORS =
+            "Shallow bytes are what this compares. What each class actually retains needs the "
+                    + "dominator tree: heap_getDominatorTreeRoots on either profile, once.";
+    private static final String STEP_WORKLOAD =
+            "Growth alone is not a leak - a bigger working set grows too. Say which of the two you are "
+                    + "claiming, and whether the two dumps covered comparable work.";
+
+    private final ProfileManager profileManager;
+    private final Function<String, ProfileManager> baselineResolver;
+
+    public HeapDiffMcpTools(
+            ProfileManager profileManager, Function<String, ProfileManager> baselineResolver) {
+
+        this.profileManager = profileManager;
+        this.baselineResolver = baselineResolver;
+    }
+
+    @Tool(description = "Compare this heap dump against an earlier one, class by class: how the "
+            + "instance counts and shallow bytes moved, ranked by growth. This is the definitive leak "
+            + "question - one dump cannot tell a leak from a large working set, and two can. Pass the "
+            + "earlier dump as the baseline; backwards, every growth reads as a shrink.")
+    public String diff(
+            @ToolParam(description = "Profile id of the earlier heap dump to measure against. The "
+                    + "profile this tool is called on is the later one.")
+            String baselineProfileId,
+            @ToolParam(description = "How many classes to rank (default 30, maximum 200)")
+            Integer topN) {
+
+        HeapDumpManager primary = profileManager.heapDumpManager();
+        if (!primary.heapDumpExists()) {
+            return NO_PRIMARY_DUMP;
+        }
+        if (!primary.isCacheReady()) {
+            return NOT_INDEXED.formatted("this profile");
+        }
+
+        String baselineId = requireBaseline(baselineProfileId);
+        HeapDumpManager baseline = baselineResolver.apply(baselineId).heapDumpManager();
+        if (!baseline.heapDumpExists()) {
+            return NO_BASELINE_DUMP.formatted(baselineId);
+        }
+        if (!baseline.isCacheReady()) {
+            return NOT_INDEXED.formatted("baseline profile " + baselineId);
+        }
+
+        HeapDumpDiffReport report = HeapDumpDiffService.diff(primary, baseline, boundedTop(topN));
+        return LinkedOutput.json(new HeapDiff(
+                report.primarySummary(),
+                report.baselineSummary(),
+                report.instanceCountDelta(),
+                report.shallowBytesDelta(),
+                report.entries(),
+                NextSteps.builder()
+                        .add(STEP_WHY_RETAINED)
+                        .add(STEP_DOMINATORS)
+                        .add(STEP_WORKLOAD)
+                        .build(),
+                UiLinks.view(profileManager.info().id(), DIFF_VIEW)));
+    }
+
+    private static String requireBaseline(String baselineProfileId) {
+        if (baselineProfileId == null || baselineProfileId.isBlank()) {
+            throw new IllegalArgumentException(
+                    "baselineProfileId is required: the earlier heap dump to measure against");
+        }
+        return baselineProfileId.trim();
+    }
+
+    private static int boundedTop(Integer topN) {
+        return topN == null ? DEFAULT_TOP : Math.clamp(topN, 1, MAX_TOP);
+    }
+
+    private record HeapDiff(
+            Object laterDump,
+            Object earlierDump,
+            long instanceCountDelta,
+            long shallowBytesDelta,
+            List<?> classes,
+            List<String> nextSteps,
+            String uiLink) {
+    }
+}

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/HttpMcpTools.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/HttpMcpTools.java
@@ -22,6 +22,7 @@ import cafe.jeffrey.microscope.core.mcp.LinkedOutput;
 import cafe.jeffrey.microscope.core.mcp.UiLinks;
 import cafe.jeffrey.profile.feature.FeatureType;
 import cafe.jeffrey.profile.manager.ProfileManager;
+import cafe.jeffrey.profile.manager.custom.ExchangeDirection;
 import cafe.jeffrey.profile.manager.custom.model.http.HttpHeader;
 import cafe.jeffrey.profile.manager.custom.model.http.HttpMethodStats;
 import cafe.jeffrey.profile.manager.custom.model.http.HttpOverviewData;
@@ -32,15 +33,17 @@ import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
- * The inbound HTTP traffic the profiled JVM served: how much of it there was, how slow it was, which
- * endpoints carried it and which individual requests were the worst.
+ * The HTTP traffic that crossed this JVM: how much of it there was, how slow it was, which endpoints
+ * carried it and which individual requests were the worst.
  * <p>
- * Only server-side exchanges exist here. {@code HttpManagerImpl} reads
- * {@code Type.HTTP_SERVER_EXCHANGE} and nothing else, so there is no client half to select and these
- * tools take no direction argument, even though the UI shows a client/server switch.
+ * Both directions are answerable and they are different questions. SERVER is what this application
+ * was asked to do; CLIENT is what it asked of somebody else, where a slow figure belongs to a
+ * dependency and the only local fixes are to call less often or to stop waiting. Averaging the two
+ * together would hide both.
  * <p>
  * The per-second response-time and request-count series that back the dashboard's charts are left out
  * of every answer: they are thousands of points describing a shape, which costs a large part of the
@@ -52,7 +55,6 @@ public class HttpMcpTools {
     private static final String OVERVIEW_VIEW = "technologies/http/overview";
     private static final String ENDPOINTS_VIEW = "technologies/http/endpoints";
     private static final String MODE_PARAM = "mode";
-    private static final String SERVER_MODE = "server";
     private static final String URI_PARAM = "uri";
 
     /**
@@ -63,13 +65,16 @@ public class HttpMcpTools {
     private static final int MAX_ENDPOINTS = 40;
 
     private static final String NO_HTTP_DATA =
-            "This profile holds no HTTP server data: the recording did not capture "
-                    + "jdk.HttpServerExchange events. That is a profiler-configuration finding worth "
-                    + "reporting - the application may well serve HTTP, but this recording cannot show it.";
+            "This profile holds no %s-side HTTP data: the recording did not capture %s events. That is "
+                    + "a profiler-configuration finding worth reporting - the application may well "
+                    + "handle HTTP in that direction, but this recording cannot show it.";
 
     private static final String STEP_ENDPOINT =
-            "This is the whole service. For one URI - its own percentiles, status codes and slowest "
-                    + "requests - http_endpoint takes a uri from the endpoints list above.";
+            "This is one whole direction. For a single URI - its own percentiles, status codes and "
+                    + "slowest requests - http_endpoint takes a uri from the endpoints list above.";
+    private static final String STEP_OTHER_SIDE =
+            "This is one side of the traffic. The other - what this application called out to, or what "
+                    + "it served - is the same tool with the other direction.";
     private static final String STEP_FRAMES =
             "Which frames burned the time inside a request is a flamegraph question, not an HTTP one: "
                     + "flamegraph_export with jdk.ExecutionSample.";
@@ -95,12 +100,17 @@ public class HttpMcpTools {
             + "rate and 4xx/5xx counts, plus the endpoints ranked by traffic, the status-code and "
             + "method breakdowns, and the slowest individual requests. Start here for 'is the service "
             + "slow' and 'which endpoint is the problem'.")
-    public String overview() {
-        if (DashboardFeature.missing(profileManager, FeatureType.HTTP_SERVER_DASHBOARD)) {
-            return NO_HTTP_DATA;
+    public String overview(
+            @ToolParam(description = "Which side to report on: 'SERVER' for requests this application "
+                    + "answered (the default), 'CLIENT' for requests it made to somebody else.")
+            String direction) {
+
+        ExchangeDirection side = ExchangeDirection.from(direction);
+        if (DashboardFeature.missing(profileManager, feature(side))) {
+            return noData(side);
         }
 
-        HttpOverviewData data = profileManager.custom().httpManager().overviewData();
+        HttpOverviewData data = profileManager.custom().httpManager(side).overviewData();
         return LinkedOutput.json(new HttpDashboard(
                 data.header(),
                 trim(data.uris()),
@@ -110,9 +120,10 @@ public class HttpMcpTools {
                 NextSteps.builder()
                         .add(STEP_ENDPOINT)
                         .when(failuresOccurred(data.header()), STEP_FAILURES)
+                        .add(STEP_OTHER_SIDE)
                         .add(STEP_FRAMES)
                         .build(),
-                UiLinks.view(profileId(), OVERVIEW_VIEW, mode())));
+                UiLinks.view(profileId(), OVERVIEW_VIEW, mode(side))));
     }
 
     @Tool(description = "One endpoint in detail: the same percentiles, status codes, methods and "
@@ -121,13 +132,17 @@ public class HttpMcpTools {
     public String endpoint(
             @ToolParam(description = "The URI exactly as the server recorded it, e.g. '/api/orders'. "
                     + "Take it from the endpoints list in http_overview.")
-            String uri) {
+            String uri,
+            @ToolParam(description = "Which side the endpoint belongs to: 'SERVER' (the default) or "
+                    + "'CLIENT'. Use the same one http_overview listed it under.")
+            String direction) {
 
-        if (DashboardFeature.missing(profileManager, FeatureType.HTTP_SERVER_DASHBOARD)) {
-            return NO_HTTP_DATA;
+        ExchangeDirection side = ExchangeDirection.from(direction);
+        if (DashboardFeature.missing(profileManager, feature(side))) {
+            return noData(side);
         }
 
-        HttpOverviewData data = profileManager.custom().httpManager().overviewData(uri);
+        HttpOverviewData data = profileManager.custom().httpManager(side).overviewData(uri);
         // The manager filters by URI while streaming, so an unmatched one yields an empty list rather
         // than an error. Reported as a bad argument, with real URIs to correct it from.
         if (data.uris().isEmpty()) {
@@ -145,17 +160,17 @@ public class HttpMcpTools {
                         .when(failuresOccurred(data.header()), STEP_FAILURES)
                         .add(STEP_FRAMES)
                         .build(),
-                UiLinks.view(profileId(), ENDPOINTS_VIEW, endpointQuery(uri))));
+                UiLinks.view(profileId(), ENDPOINTS_VIEW, endpointQuery(side, uri))));
     }
 
-    private Map<String, String> mode() {
+    private static Map<String, String> mode(ExchangeDirection direction) {
         Map<String, String> query = UiLinks.query();
-        query.put(MODE_PARAM, SERVER_MODE);
+        query.put(MODE_PARAM, direction.name().toLowerCase(Locale.ROOT));
         return query;
     }
 
-    private Map<String, String> endpointQuery(String uri) {
-        Map<String, String> query = mode();
+    private static Map<String, String> endpointQuery(ExchangeDirection direction, String uri) {
+        Map<String, String> query = mode(direction);
         query.put(URI_PARAM, uri);
         return query;
     }
@@ -164,6 +179,17 @@ public class HttpMcpTools {
      * Whether any request failed at all - not whether the failure rate is high, which would be a
      * verdict rather than a route.
      */
+    private static FeatureType feature(ExchangeDirection direction) {
+        return direction == ExchangeDirection.SERVER
+                ? FeatureType.HTTP_SERVER_DASHBOARD
+                : FeatureType.HTTP_CLIENT_DASHBOARD;
+    }
+
+    private static String noData(ExchangeDirection direction) {
+        return NO_HTTP_DATA.formatted(
+                direction.name().toLowerCase(Locale.ROOT), direction.httpEventType().code());
+    }
+
     private static boolean failuresOccurred(HttpHeader header) {
         return header.count4xx() > 0 || header.count5xx() > 0;
     }

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/MemoryMcpTools.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/MemoryMcpTools.java
@@ -1,0 +1,151 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.microscope.core.mcp.tools;
+
+import cafe.jeffrey.microscope.core.mcp.LinkedOutput;
+import cafe.jeffrey.microscope.core.mcp.UiLinks;
+import cafe.jeffrey.profile.manager.ProfileManager;
+import cafe.jeffrey.profile.manager.model.allocation.AllocatedType;
+import cafe.jeffrey.profile.manager.model.allocation.AllocationOverview;
+import cafe.jeffrey.profile.manager.model.leak.LeakCandidate;
+import cafe.jeffrey.profile.manager.model.leak.LeakOverview;
+import org.springframework.ai.tool.annotation.Tool;
+
+import java.util.List;
+
+/**
+ * The memory questions a JFR recording answers on its own, with no heap dump.
+ * <p>
+ * Two things that neither a flamegraph nor the {@code heap_} family covers. An allocation flamegraph
+ * ranks call <em>sites</em> — where the allocating code is; this ranks the <em>types</em> allocated,
+ * which is the other axis and often the one that names the problem ({@code byte[]} and
+ * {@code char[]} at the top read very differently from a domain class). And leak candidates come
+ * from {@code jdk.OldObjectSample}, objects the JVM watched survive collections: a leak signal from
+ * a plain recording, available when nobody captured a heap dump and the process is already gone.
+ * <p>
+ * The heap-occupancy series is deliberately not here. It is chart geometry, and the question it
+ * answers — when did memory climb — is {@code timeline_hotWindows} on an allocation event type,
+ * which returns windows a flamegraph can then be scoped to rather than a curve.
+ */
+public class MemoryMcpTools {
+
+    private static final String ALLOCATIONS_VIEW = "allocations";
+    private static final String LEAK_CANDIDATES_VIEW = "memory-issues/leak-candidates";
+
+    private static final int MAX_TYPES = 40;
+    private static final int MAX_CANDIDATES = 40;
+
+    private static final String NO_ALLOCATION_DATA =
+            "This profile recorded no allocation events, so there is nothing to attribute by type. "
+                    + "flamegraph_list names the event types the recording did capture; allocation "
+                    + "needs jdk.ObjectAllocationSample, or the older in/outside-TLAB pair.";
+
+    private static final String NO_LEAK_CANDIDATES =
+            "This profile carries no jdk.OldObjectSample events, so the JVM tracked no surviving "
+                    + "objects. That sampler is off in most profiles and is enabled per recording - its "
+                    + "absence says nothing about whether the application leaks. A heap dump answers "
+                    + "the same question from the other side; profiles_features says whether this "
+                    + "profile has one.";
+
+    private static final String STEP_WHERE =
+            "This says what was allocated, not where. The call paths are flamegraph_export with "
+                    + "jdk.ObjectAllocationSample and useWeight true.";
+    private static final String STEP_WHEN =
+            "When the allocation happened - and the window to scope a flamegraph to - is "
+                    + "timeline_hotWindows on the same event type.";
+    private static final String STEP_GC_COST =
+            "What the allocation cost in collector time is jvm_gc; churn and pause budget are "
+                    + "different measurements of the same cause.";
+    private static final String STEP_RETAINED =
+            "A candidate is an object that survived, not proof of a leak. What retains it needs a heap "
+                    + "dump: heap_getPathToGCRoot on the same class, when this installation has one.";
+    private static final String STEP_AGE =
+            "Age is the discriminator: an object sampled early and still alive at the end outlived "
+                    + "every collection in between, which a large short-lived working set does not.";
+
+    private final ProfileManager profileManager;
+
+    public MemoryMcpTools(ProfileManager profileManager) {
+        this.profileManager = profileManager;
+    }
+
+    @Tool(description = "What this application allocated, by type: total bytes, the split between TLAB "
+            + "and outside-TLAB, how many distinct types, and the types ranked by bytes. Complements "
+            + "the allocation flamegraph rather than repeating it - the flamegraph ranks the code "
+            + "doing the allocating, this ranks what came out of it, and the two disagree in useful "
+            + "ways when one call site allocates many types or one type comes from everywhere.")
+    public String allocations() {
+        AllocationOverview overview = profileManager.allocationManager().overview();
+        List<AllocatedType> types = profileManager.allocationManager().topTypes();
+        if (overview == null || (overview.totalBytes() == 0 && types.isEmpty())) {
+            return NO_ALLOCATION_DATA;
+        }
+
+        return LinkedOutput.json(new Allocations(
+                overview,
+                trimTypes(types),
+                NextSteps.builder().add(STEP_WHERE).add(STEP_WHEN).add(STEP_GC_COST).build(),
+                UiLinks.view(profileId(), ALLOCATIONS_VIEW)));
+    }
+
+    @Tool(description = "Objects the JVM sampled and then watched survive garbage collections, with "
+            + "their size and age: a leak signal from a plain recording, with no heap dump needed. "
+            + "Comes from jdk.OldObjectSample, so it is the only leak evidence available when nobody "
+            + "captured a dump and the process has gone. Age matters more than size here - an object "
+            + "still alive long after it was sampled outlived every collection since.")
+    public String leakCandidates() {
+        LeakOverview overview = profileManager.leakCandidatesManager().overview();
+        List<LeakCandidate> candidates = profileManager.leakCandidatesManager().candidates();
+        if (candidates.isEmpty()) {
+            return NO_LEAK_CANDIDATES;
+        }
+
+        return LinkedOutput.json(new LeakCandidates(
+                overview,
+                trimCandidates(candidates),
+                NextSteps.builder().add(STEP_AGE).add(STEP_RETAINED).build(),
+                UiLinks.view(profileId(), LEAK_CANDIDATES_VIEW)));
+    }
+
+    private static List<AllocatedType> trimTypes(List<AllocatedType> types) {
+        return types.size() <= MAX_TYPES ? types : types.subList(0, MAX_TYPES);
+    }
+
+    private static List<LeakCandidate> trimCandidates(List<LeakCandidate> candidates) {
+        return candidates.size() <= MAX_CANDIDATES ? candidates : candidates.subList(0, MAX_CANDIDATES);
+    }
+
+    private String profileId() {
+        return profileManager.info().id();
+    }
+
+    private record Allocations(
+            AllocationOverview overview,
+            List<AllocatedType> topTypes,
+            List<String> nextSteps,
+            String uiLink) {
+    }
+
+    private record LeakCandidates(
+            LeakOverview overview,
+            List<LeakCandidate> candidates,
+            List<String> nextSteps,
+            String uiLink) {
+    }
+}

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/TraceAttributesMcpTools.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/TraceAttributesMcpTools.java
@@ -1,0 +1,315 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.microscope.core.mcp.tools;
+
+import cafe.jeffrey.microscope.core.mcp.LinkedOutput;
+import cafe.jeffrey.microscope.core.mcp.UiLinks;
+import cafe.jeffrey.profile.manager.ProfileManager;
+import cafe.jeffrey.profile.manager.model.trace.TraceAttributeKeyRow;
+import cafe.jeffrey.profile.manager.model.trace.TraceAttributeSearchResult;
+import cafe.jeffrey.profile.manager.model.trace.TraceAttributeValues;
+import cafe.jeffrey.provider.profile.api.TraceAttributeCondition;
+import cafe.jeffrey.provider.profile.api.TraceAttributeKeyId;
+import cafe.jeffrey.provider.profile.api.TraceAttributeOperator;
+import cafe.jeffrey.provider.profile.api.TraceAttributeScope;
+import cafe.jeffrey.provider.profile.api.TraceAttributeSearchQuery;
+import cafe.jeffrey.provider.profile.api.TraceAttributeSource;
+import cafe.jeffrey.provider.profile.api.TraceAttributeValueQuery;
+import cafe.jeffrey.provider.profile.api.TraceAttributeValueSortField;
+import cafe.jeffrey.provider.profile.api.TraceSortField;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * The business dimensions a trace carried: which tenant, which customer, which feature flag.
+ * <p>
+ * Every other {@code traces_} tool aggregates by <em>operation</em> — the shape of the request. That
+ * cannot answer the question most latency investigations actually end at, which is that one
+ * population is slow and the rest is fine: the same endpoint, fast for almost everyone and terrible
+ * for one tenant, has a healthy average and a p99 nobody can locate. Attributes are how a trace says
+ * which population it belonged to, and this family groups by them.
+ */
+public class TraceAttributesMcpTools {
+
+    private static final String SEARCH_VIEW = "traces/attributes/search";
+    private static final String VALUES_VIEW = "traces/attributes/values";
+    private static final String KEY_PARAM = "key";
+    private static final String SOURCE_PARAM = "source";
+    private static final String OWNER_PARAM = "owner";
+    private static final String EVENT_TYPE_PARAM = "eventType";
+
+    private static final int DEFAULT_LIMIT = 25;
+    private static final int MAX_LIMIT = 200;
+
+    private static final String NO_ATTRIBUTES =
+            "This profile carries no trace attributes. They come from the Jeffrey tracing "
+                    + "instrumentation recording them on a span; a recording with traces but no "
+                    + "attributes has nothing to group by here. traces_operations still groups by "
+                    + "operation.";
+
+    private static final String NO_SUCH_KEY =
+            "No attribute key '%s' was recorded. traces_attributeKeys lists the keys this profile "
+                    + "holds, each with the source and owner that identify it.";
+
+    private static final String NOTHING_MATCHED =
+            "No trace matched. The key exists; this combination of operator and value did not occur. "
+                    + "traces_attributeValues lists the values that were actually recorded for a key.";
+
+    private static final String STEP_VALUES =
+            "traces_attributeValues breaks one key into its values with a latency profile each, which "
+                    + "is where a slow population separates from a healthy one.";
+    private static final String STEP_SEARCH =
+            "traces_attributeSearch finds the individual traces carrying one value, and their ids go "
+                    + "to traces_traceExport.";
+    private static final String STEP_EXPORT =
+            "traces_traceExport opens one of these traces span by span; the ids above are what it takes.";
+    private static final String STEP_NOT_THE_CAUSE =
+            "An attribute says which population was slow, never why. The span tree of one of its "
+                    + "traces says why.";
+
+    private final ProfileManager profileManager;
+
+    public TraceAttributesMcpTools(ProfileManager profileManager) {
+        this.profileManager = profileManager;
+    }
+
+    @Tool(description = "The attribute keys this recording's traces carried - tenant, customer, "
+            + "feature flag, whatever the application recorded on its spans - each with how many "
+            + "distinct values and traces it covers. Call this first: a key is identified by the "
+            + "triple (source, owner, key), and the other tools in this family take all three.")
+    public String attributeKeys(
+            @ToolParam(description = "Optional event type to restrict the keys to, e.g. "
+                    + "'jeffrey.HttpServerExchange'. Omit for every key in the profile.")
+            String eventType) {
+
+        List<TraceAttributeKeyRow> keys = eventType == null || eventType.isBlank()
+                ? profileManager.traceAttributesManager().keys()
+                : profileManager.traceAttributesManager().keysOf(eventType.trim());
+
+        if (keys.isEmpty()) {
+            return NO_ATTRIBUTES;
+        }
+
+        return LinkedOutput.json(new AttributeKeys(
+                keys,
+                NextSteps.builder().add(STEP_VALUES).add(STEP_SEARCH).build(),
+                UiLinks.view(profileId(), SEARCH_VIEW)));
+    }
+
+    @Tool(description = "One attribute key broken into its values, each with how many traces carried "
+            + "it and that value's own latency - total, p50, p95, max - and error count. This is the "
+            + "tool for 'it is slow for one customer': a value whose p95 stands apart from the rest "
+            + "names the population, which an operation-level percentile averages away. Trace counts "
+            + "do not sum to the profile's total, because a trace whose spans recorded two values "
+            + "counts under both.")
+    public String attributeValues(
+            @ToolParam(description = "The attribute key name, from traces_attributeKeys")
+            String key,
+            @ToolParam(description = "Where the key comes from, as traces_attributeKeys reported it: "
+                    + "ATTRIBUTE (the default), EVENT_FIELD, SPAN_SHAPE, NOTIFICATION_ATTRIBUTE or "
+                    + "NOTIFICATION_SHAPE")
+            String source,
+            @ToolParam(description = "The owner from traces_attributeKeys - for an EVENT_FIELD this is "
+                    + "the event type declaring it, and it is required there. Omit when the key row "
+                    + "showed none.")
+            String owner,
+            @ToolParam(description = "Optional event type to restrict to")
+            String eventType,
+            @ToolParam(description = "Order by one of: TOTAL_TIME (default), TRACES, P50, P95, MAX, "
+                    + "ERRORS, VALUE")
+            String sort,
+            @ToolParam(description = "Maximum number of values to return (default 25, maximum 200)")
+            Integer limit) {
+
+        TraceAttributeValueQuery query = new TraceAttributeValueQuery(
+                keyId(key, source, owner),
+                valueSort(sort),
+                true,
+                boundedLimit(limit),
+                blankToNull(eventType));
+
+        TraceAttributeValues values = profileManager.traceAttributesManager().values(query);
+        if (values.values().isEmpty()) {
+            return NO_SUCH_KEY.formatted(key);
+        }
+
+        return LinkedOutput.json(new AttributeValues(
+                key,
+                values.values(),
+                values.distinctValues(),
+                values.tracesWithoutKey(),
+                values.truncated(),
+                NextSteps.builder().add(STEP_SEARCH).add(STEP_NOT_THE_CAUSE).build(),
+                UiLinks.view(profileId(), VALUES_VIEW, keyQuery(key, source, owner, eventType))));
+    }
+
+    @Tool(description = "The individual traces carrying one attribute value, with their ids: 'find the "
+            + "traces where tenant is acme and tell me why they were slow'. The ids go straight to "
+            + "traces_traceExport. Use traces_attributeValues first to see which value is worth "
+            + "chasing - this returns traces, not a comparison between populations.")
+    public String attributeSearch(
+            @ToolParam(description = "The attribute key name, from traces_attributeKeys")
+            String key,
+            @ToolParam(description = "How to match: EQ (the default), NOT_EQ, CONTAINS, GT, GTE, LT, "
+                    + "LTE, or EXISTS for 'carried the key at all'")
+            String operator,
+            @ToolParam(description = "The value to match. Not needed for EXISTS.")
+            String value,
+            @ToolParam(description = "Key source as traces_attributeKeys reported it: ATTRIBUTE (the "
+                    + "default), EVENT_FIELD, SPAN_SHAPE, NOTIFICATION_ATTRIBUTE, NOTIFICATION_SHAPE")
+            String source,
+            @ToolParam(description = "Key owner, required for an EVENT_FIELD")
+            String owner,
+            @ToolParam(description = "TRACE (the default) matches when any span of the trace satisfies "
+                    + "the condition; SPAN requires one single span to satisfy it")
+            String scope,
+            @ToolParam(description = "Maximum number of traces to return (default 25, maximum 200)")
+            Integer limit) {
+
+        TraceAttributeCondition condition = new TraceAttributeCondition(
+                keyId(key, source, owner), operator(operator), blankToNull(value));
+
+        TraceAttributeSearchQuery query = new TraceAttributeSearchQuery(
+                List.of(condition),
+                scope(scope),
+                TraceSortField.DURATION,
+                true,
+                boundedLimit(limit),
+                0);
+
+        TraceAttributeSearchResult result = profileManager.traceAttributesManager().search(query);
+        if (result.matches().isEmpty()) {
+            return NOTHING_MATCHED;
+        }
+
+        return LinkedOutput.json(new AttributeSearch(
+                result.matches(),
+                result.totalMatching(),
+                NextSteps.builder().add(STEP_EXPORT).add(STEP_NOT_THE_CAUSE).build(),
+                UiLinks.view(profileId(), SEARCH_VIEW, keyQuery(key, source, owner, null))));
+    }
+
+    /**
+     * The triple that identifies a key. Rejected by name rather than defaulted when the source is
+     * unknown: guessing ATTRIBUTE for what was really an EVENT_FIELD silently returns nothing.
+     */
+    private static TraceAttributeKeyId keyId(String key, String source, String owner) {
+        if (key == null || key.isBlank()) {
+            throw new IllegalArgumentException("key is required; traces_attributeKeys lists them");
+        }
+        return new TraceAttributeKeyId(source(source), blankToNull(owner), key.trim());
+    }
+
+    private static TraceAttributeSource source(String value) {
+        if (value == null || value.isBlank()) {
+            return TraceAttributeSource.ATTRIBUTE;
+        }
+        try {
+            return TraceAttributeSource.valueOf(value.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Unknown attribute source '" + value
+                    + "'. Valid sources: ATTRIBUTE, EVENT_FIELD, SPAN_SHAPE, NOTIFICATION_ATTRIBUTE, "
+                    + "NOTIFICATION_SHAPE");
+        }
+    }
+
+    private static TraceAttributeOperator operator(String value) {
+        if (value == null || value.isBlank()) {
+            return TraceAttributeOperator.EQ;
+        }
+        try {
+            return TraceAttributeOperator.valueOf(value.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Unknown operator '" + value
+                    + "'. Valid operators: EQ, NOT_EQ, CONTAINS, GT, GTE, LT, LTE, EXISTS");
+        }
+    }
+
+    private static TraceAttributeScope scope(String value) {
+        if (value == null || value.isBlank()) {
+            return TraceAttributeScope.TRACE;
+        }
+        try {
+            return TraceAttributeScope.valueOf(value.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "Unknown scope '" + value + "'. Valid scopes: TRACE, SPAN");
+        }
+    }
+
+    private static TraceAttributeValueSortField valueSort(String value) {
+        if (value == null || value.isBlank()) {
+            return TraceAttributeValueSortField.TOTAL_TIME;
+        }
+        try {
+            return TraceAttributeValueSortField.valueOf(value.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Unknown sort '" + value
+                    + "'. Valid sorts: TOTAL_TIME, TRACES, P50, P95, MAX, ERRORS, VALUE");
+        }
+    }
+
+    private static Map<String, String> keyQuery(
+            String key, String source, String owner, String eventType) {
+
+        Map<String, String> query = UiLinks.query();
+        query.put(KEY_PARAM, key);
+        query.put(SOURCE_PARAM, source);
+        query.put(OWNER_PARAM, owner);
+        query.put(EVENT_TYPE_PARAM, eventType);
+        return query;
+    }
+
+    private static String blankToNull(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+
+    private static int boundedLimit(Integer limit) {
+        return limit == null ? DEFAULT_LIMIT : Math.clamp(limit, 1, MAX_LIMIT);
+    }
+
+    private String profileId() {
+        return profileManager.info().id();
+    }
+
+    private record AttributeKeys(
+            List<TraceAttributeKeyRow> keys, List<String> nextSteps, String uiLink) {
+    }
+
+    private record AttributeValues(
+            String key,
+            List<TraceAttributeValues.Row> values,
+            long distinctValues,
+            long tracesWithoutKey,
+            boolean truncated,
+            List<String> nextSteps,
+            String uiLink) {
+    }
+
+    private record AttributeSearch(
+            List<TraceAttributeSearchResult.Match> matches,
+            long totalMatching,
+            List<String> nextSteps,
+            String uiLink) {
+    }
+}

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/GrpcOverviewController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/GrpcOverviewController.java
@@ -26,6 +26,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
+import cafe.jeffrey.profile.manager.custom.ExchangeDirection;
 import cafe.jeffrey.profile.manager.custom.GrpcManager;
 import cafe.jeffrey.profile.manager.custom.model.grpc.GrpcOverviewData;
 import cafe.jeffrey.profile.manager.custom.model.grpc.GrpcServiceDetailData;
@@ -48,34 +49,39 @@ public class GrpcOverviewController {
     }
 
     @GetMapping
-    public GrpcOverviewData overviewData(@PathVariable("profileId") String profileId) {
+    public GrpcOverviewData overviewData(
+            @PathVariable("profileId") String profileId,
+            @RequestParam(value = "mode", required = false) String mode) {
         LOG.debug("Fetching gRPC overview");
-        return mgr(profileId).overviewData();
+        return mgr(profileId, mode).overviewData();
     }
 
     @GetMapping("/service")
     public GrpcServiceDetailData serviceDetail(
             @PathVariable("profileId") String profileId,
+            @RequestParam(value = "mode", required = false) String mode,
             @RequestParam("service") String service) {
         LOG.debug("Fetching gRPC service detail: service={}", service);
-        return mgr(profileId).serviceDetailData(URLDecoder.decode(service, UTF_8));
+        return mgr(profileId, mode).serviceDetailData(URLDecoder.decode(service, UTF_8));
     }
 
     @GetMapping("/traffic")
-    public GrpcTrafficData traffic(@PathVariable("profileId") String profileId) {
+    public GrpcTrafficData traffic(@PathVariable("profileId") String profileId,
+            @RequestParam(value = "mode", required = false) String mode) {
         LOG.debug("Fetching gRPC traffic data");
-        return mgr(profileId).trafficData();
+        return mgr(profileId, mode).trafficData();
     }
 
     @GetMapping("/traffic/service")
     public GrpcTrafficData trafficByService(
             @PathVariable("profileId") String profileId,
+            @RequestParam(value = "mode", required = false) String mode,
             @RequestParam("service") String service) {
         LOG.debug("Fetching gRPC traffic data for service: service={}", service);
-        return mgr(profileId).trafficData(URLDecoder.decode(service, UTF_8));
+        return mgr(profileId, mode).trafficData(URLDecoder.decode(service, UTF_8));
     }
 
-    private GrpcManager mgr(String profileId) {
-        return resolver.resolve(profileId).custom().grpcManager();
+    private GrpcManager mgr(String profileId, String mode) {
+        return resolver.resolve(profileId).custom().grpcManager(ExchangeDirection.from(mode));
     }
 }

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/HttpOverviewController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/web/controllers/profile/HttpOverviewController.java
@@ -26,6 +26,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import cafe.jeffrey.microscope.core.web.ProfileManagerResolver;
+import cafe.jeffrey.profile.manager.custom.ExchangeDirection;
 import cafe.jeffrey.profile.manager.custom.HttpManager;
 import cafe.jeffrey.profile.manager.custom.model.http.HttpOverviewData;
 import cafe.jeffrey.profile.manager.custom.model.http.HttpSingleUriData;
@@ -47,18 +48,21 @@ public class HttpOverviewController {
     }
 
     @GetMapping
-    public HttpOverviewData overviewData(@PathVariable("profileId") String profileId) {
+    public HttpOverviewData overviewData(
+            @PathVariable("profileId") String profileId,
+            @RequestParam(value = "mode", required = false) String mode) {
         LOG.debug("Fetching HTTP overview");
-        return mgr(profileId).overviewData();
+        return mgr(profileId, mode).overviewData();
     }
 
     @GetMapping("/single")
     public HttpSingleUriData singleUriData(
             @PathVariable("profileId") String profileId,
+            @RequestParam(value = "mode", required = false) String mode,
             @RequestParam("uri") String uri) {
         LOG.debug("Fetching HTTP single URI data: uri={}", uri);
         String decoded = URLDecoder.decode(uri, UTF_8);
-        HttpOverviewData data = mgr(profileId).overviewData(decoded);
+        HttpOverviewData data = mgr(profileId, mode).overviewData(decoded);
         return new HttpSingleUriData(
                 data.header(),
                 data.uris().getFirst(),
@@ -69,7 +73,7 @@ public class HttpOverviewController {
                 data.requestCountSerie());
     }
 
-    private HttpManager mgr(String profileId) {
-        return resolver.resolve(profileId).custom().httpManager();
+    private HttpManager mgr(String profileId, String mode) {
+        return resolver.resolve(profileId).custom().httpManager(ExchangeDirection.from(mode));
     }
 }

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/HttpMcpToolsTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/HttpMcpToolsTest.java
@@ -49,7 +49,9 @@ import java.time.Instant;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -78,7 +80,7 @@ class HttpMcpToolsTest {
                 Instant.EPOCH, Instant.EPOCH.plusSeconds(60), Instant.EPOCH, true, false, "recording-1"));
         when(profileManager.custom()).thenReturn(customManager);
         when(profileManager.featuresManager()).thenReturn(featuresManager);
-        when(customManager.httpManager()).thenReturn(httpManager);
+        when(customManager.httpManager(any())).thenReturn(httpManager);
         when(featuresManager.getDisabledFeatures()).thenReturn(List.of());
     }
 
@@ -113,7 +115,7 @@ class HttpMcpToolsTest {
         void carriesTheHeaderTotalsAndTheEndpoints() {
             when(httpManager.overviewData()).thenReturn(data(List.of(uri("/api/orders"))));
 
-            String out = tools().overview();
+            String out = tools().overview(null);
 
             assertTrue(out.contains("\"requestCount\":1200"), out);
             assertTrue(out.contains("/api/orders"), out);
@@ -128,7 +130,7 @@ class HttpMcpToolsTest {
         void leavesTheChartSeriesOut() {
             when(httpManager.overviewData()).thenReturn(data(List.of(uri("/api/orders"))));
 
-            String out = tools().overview();
+            String out = tools().overview(null);
 
             assertFalse(out.contains("responseTimeSerie"), out);
             assertFalse(out.contains("requestCountSerie"), out);
@@ -139,8 +141,8 @@ class HttpMcpToolsTest {
             when(httpManager.overviewData()).thenReturn(data(List.of(uri("/api/orders"))));
 
             assertTrue(
-                    tools().overview().contains("/profiles/p-1/technologies/http/overview?mode=server"),
-                    tools().overview());
+                    tools().overview(null).contains("/profiles/p-1/technologies/http/overview?mode=server"),
+                    tools().overview(null));
         }
 
         /**
@@ -152,9 +154,9 @@ class HttpMcpToolsTest {
             when(featuresManager.getDisabledFeatures())
                     .thenReturn(List.of(FeatureType.HTTP_SERVER_DASHBOARD));
 
-            String out = tools().overview();
+            String out = tools().overview(null);
 
-            assertTrue(out.contains("no HTTP server data"), out);
+            assertTrue(out.contains("no server-side HTTP data"), out);
             assertFalse(out.contains("requestCount"), out);
         }
     }
@@ -166,7 +168,7 @@ class HttpMcpToolsTest {
         void narrowsToTheRequestedUriAndLinksToItsDetail() {
             when(httpManager.overviewData("/api/orders")).thenReturn(data(List.of(uri("/api/orders"))));
 
-            String out = tools().endpoint("/api/orders");
+            String out = tools().endpoint("/api/orders", null);
 
             assertTrue(out.contains("\"endpoint\""), out);
             assertTrue(out.contains("uri=%2Fapi%2Forders"), out);
@@ -180,7 +182,7 @@ class HttpMcpToolsTest {
         void reportsAnUnknownUriInsteadOfFailing() {
             when(httpManager.overviewData("/nope")).thenReturn(data(List.of()));
 
-            String out = tools().endpoint("/nope");
+            String out = tools().endpoint("/nope", null);
 
             assertTrue(out.contains("No requests were recorded for '/nope'"), out);
         }
@@ -209,23 +211,23 @@ class HttpMcpToolsTest {
         void alwaysRoutesToTheEndpointDetail() {
             when(httpManager.overviewData()).thenReturn(withStatuses(0, 0));
 
-            assertTrue(tools().overview().contains("http_endpoint"));
+            assertTrue(tools().overview(null).contains("http_endpoint"));
         }
 
         @Test
         void namesTheFailureTrailOnlyWhenSomethingActuallyFailed() {
             when(httpManager.overviewData()).thenReturn(withStatuses(0, 0));
-            assertFalse(tools().overview().contains("traces_notifications"));
+            assertFalse(tools().overview(null).contains("traces_notifications"));
 
             when(httpManager.overviewData()).thenReturn(withStatuses(0, 3));
-            assertTrue(tools().overview().contains("traces_notifications"));
+            assertTrue(tools().overview(null).contains("traces_notifications"));
         }
 
         @Test
         void aClientErrorCountsAsSomethingHavingHappenedToo() {
             when(httpManager.overviewData()).thenReturn(withStatuses(11, 0));
 
-            assertTrue(tools().overview().contains("traces_notifications"));
+            assertTrue(tools().overview(null).contains("traces_notifications"));
         }
 
         /**
@@ -236,11 +238,59 @@ class HttpMcpToolsTest {
         void theGatedLineRoutesRatherThanJudging() {
             when(httpManager.overviewData()).thenReturn(withStatuses(0, 3));
 
-            String out = tools().overview().toLowerCase();
+            String out = tools().overview(null).toLowerCase();
 
             assertFalse(out.contains("too many"), out);
             assertFalse(out.contains("unacceptable"), out);
             assertFalse(out.contains("is high"), out);
+        }
+    }
+
+    /**
+     * The client half had a FeatureType and an event type and no manager behind it, so every client
+     * question was silently answered with server figures - or, once the tools gated on the server
+     * feature, refused outright.
+     */
+    @Nested
+    class Direction {
+
+        @Test
+        void readsTheClientSideWhenAskedFor() {
+            when(httpManager.overviewData()).thenReturn(data(List.of(uri("https://payments/charge"))));
+
+            String out = tools().overview("CLIENT");
+
+            assertTrue(out.contains("payments/charge"), out);
+            assertTrue(out.contains("mode=client"), out);
+        }
+
+        @Test
+        void defaultsToTheServerSide() {
+            when(httpManager.overviewData()).thenReturn(data(List.of(uri("/api/orders"))));
+
+            assertTrue(tools().overview(null).contains("mode=server"));
+        }
+
+        /**
+         * The two halves are gated separately: a recording with inbound traffic and no outbound calls
+         * must answer the client question with "not recorded", not with the inbound figures.
+         */
+        @Test
+        void gatesEachDirectionOnItsOwnFeature() {
+            when(featuresManager.getDisabledFeatures())
+                    .thenReturn(List.of(FeatureType.HTTP_CLIENT_DASHBOARD));
+            when(httpManager.overviewData()).thenReturn(data(List.of(uri("/api/orders"))));
+
+            assertTrue(tools().overview("CLIENT").contains("no client-side HTTP data"));
+            assertTrue(tools().overview("SERVER").contains("requestCount"));
+        }
+
+        @Test
+        void refusesAnUnknownDirectionByName() {
+            IllegalArgumentException thrown = assertThrows(
+                    IllegalArgumentException.class, () -> tools().overview("inbound"));
+
+            assertTrue(thrown.getMessage().contains("SERVER, CLIENT"), thrown.getMessage());
         }
     }
 }

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/GrpcOverviewControllerTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/GrpcOverviewControllerTest.java
@@ -30,6 +30,7 @@ import cafe.jeffrey.profile.manager.custom.GrpcManager;
 import cafe.jeffrey.shared.common.exception.Exceptions;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static cafe.jeffrey.microscope.core.web.MockMvcSupport.mockMvcTesterFor;
 
@@ -52,7 +53,7 @@ class GrpcOverviewControllerTest {
     void getsTraffic() {
         when(resolver.resolve("p-1")).thenReturn(profileManager);
         when(profileManager.custom()).thenReturn(customManager);
-        when(customManager.grpcManager()).thenReturn(grpcManager);
+        when(customManager.grpcManager(any())).thenReturn(grpcManager);
         when(grpcManager.trafficData()).thenReturn(null);
 
         MockMvcTester mvc = mockMvcTesterFor(new GrpcOverviewController(resolver));

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/HttpOverviewControllerTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/profile/HttpOverviewControllerTest.java
@@ -30,6 +30,7 @@ import cafe.jeffrey.profile.manager.custom.HttpManager;
 import cafe.jeffrey.shared.common.exception.Exceptions;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static cafe.jeffrey.microscope.core.web.MockMvcSupport.mockMvcTesterFor;
 
@@ -52,7 +53,7 @@ class HttpOverviewControllerTest {
     void getsOverview() {
         when(resolver.resolve("p-1")).thenReturn(profileManager);
         when(profileManager.custom()).thenReturn(customManager);
-        when(customManager.httpManager()).thenReturn(httpManager);
+        when(customManager.httpManager(any())).thenReturn(httpManager);
         when(httpManager.overviewData()).thenReturn(null);
 
         MockMvcTester mvc = mockMvcTesterFor(new HttpOverviewController(resolver));

--- a/jeffrey-microscope/profiles/profile-custom-events/src/main/java/cafe/jeffrey/profile/manager/custom/ExchangeDirection.java
+++ b/jeffrey-microscope/profiles/profile-custom-events/src/main/java/cafe/jeffrey/profile/manager/custom/ExchangeDirection.java
@@ -1,0 +1,74 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager.custom;
+
+import cafe.jeffrey.shared.common.model.Type;
+
+import java.util.Locale;
+
+/**
+ * Which side of a call an exchange dashboard reports on: what this application <em>served</em>, or
+ * what it <em>called out to</em>.
+ * <p>
+ * The two are different questions with different answers. A slow inbound endpoint is this
+ * application's problem; a slow outbound call is somebody else's, and the only thing this
+ * application can do about it is call less often or stop waiting for it. Reporting them together
+ * would average a dependency's latency into your own.
+ */
+public enum ExchangeDirection {
+
+    /** Requests this application received and answered. */
+    SERVER(Type.HTTP_SERVER_EXCHANGE, Type.GRPC_SERVER_EXCHANGE),
+
+    /** Requests this application made to somebody else. */
+    CLIENT(Type.HTTP_CLIENT_EXCHANGE, Type.GRPC_CLIENT_EXCHANGE);
+
+    private final Type httpEventType;
+    private final Type grpcEventType;
+
+    ExchangeDirection(Type httpEventType, Type grpcEventType) {
+        this.httpEventType = httpEventType;
+        this.grpcEventType = grpcEventType;
+    }
+
+    public Type httpEventType() {
+        return httpEventType;
+    }
+
+    public Type grpcEventType() {
+        return grpcEventType;
+    }
+
+    /**
+     * Parses the value the UI and the MCP tools use, case-insensitively. An unknown one is refused by
+     * name rather than silently falling back to SERVER, which would answer a client question with
+     * server figures.
+     */
+    public static ExchangeDirection from(String value) {
+        if (value == null || value.isBlank()) {
+            return SERVER;
+        }
+        try {
+            return valueOf(value.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "Unknown direction '" + value + "'. Valid directions: SERVER, CLIENT");
+        }
+    }
+}

--- a/jeffrey-microscope/profiles/profile-custom-events/src/main/java/cafe/jeffrey/profile/manager/custom/GrpcManager.java
+++ b/jeffrey-microscope/profiles/profile-custom-events/src/main/java/cafe/jeffrey/profile/manager/custom/GrpcManager.java
@@ -23,12 +23,16 @@ import cafe.jeffrey.profile.manager.custom.model.grpc.GrpcServiceDetailData;
 import cafe.jeffrey.profile.manager.custom.model.grpc.GrpcTrafficData;
 import cafe.jeffrey.shared.common.model.ProfileInfo;
 
-import java.util.function.Function;
 
 public interface GrpcManager {
 
     @FunctionalInterface
-    interface Factory extends Function<ProfileInfo, GrpcManager> {
+    /**
+     * Built per direction: the server and client halves read different event types, so a manager is
+     * bound to one of them rather than deciding per call.
+     */
+    interface Factory {
+        GrpcManager apply(ProfileInfo profileInfo, ExchangeDirection direction);
     }
 
     GrpcOverviewData overviewData();

--- a/jeffrey-microscope/profiles/profile-custom-events/src/main/java/cafe/jeffrey/profile/manager/custom/HttpManager.java
+++ b/jeffrey-microscope/profiles/profile-custom-events/src/main/java/cafe/jeffrey/profile/manager/custom/HttpManager.java
@@ -21,12 +21,16 @@ package cafe.jeffrey.profile.manager.custom;
 import cafe.jeffrey.shared.common.model.ProfileInfo;
 import cafe.jeffrey.profile.manager.custom.model.http.HttpOverviewData;
 
-import java.util.function.Function;
 
 public interface HttpManager {
 
     @FunctionalInterface
-    interface Factory extends Function<ProfileInfo, HttpManager> {
+    /**
+     * Built per direction: the server and client halves read different event types, so a manager is
+     * bound to one of them rather than deciding per call.
+     */
+    interface Factory {
+        HttpManager apply(ProfileInfo profileInfo, ExchangeDirection direction);
     }
 
     HttpOverviewData overviewData();

--- a/jeffrey-microscope/profiles/profile-custom-events/src/main/java/cafe/jeffrey/profile/manager/custom/HttpManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-custom-events/src/main/java/cafe/jeffrey/profile/manager/custom/HttpManagerImpl.java
@@ -34,10 +34,16 @@ public class HttpManagerImpl implements HttpManager {
 
     private final ProfileInfo profileInfo;
     private final ProfileEventStreamRepository eventStreamRepository;
+    private final Type eventType;
 
-    public HttpManagerImpl(ProfileInfo profileInfo, ProfileEventStreamRepository eventStreamRepository) {
+    public HttpManagerImpl(
+            ProfileInfo profileInfo,
+            ProfileEventStreamRepository eventStreamRepository,
+            Type eventType) {
+
         this.profileInfo = profileInfo;
         this.eventStreamRepository = eventStreamRepository;
+        this.eventType = eventType;
     }
 
     @Override
@@ -54,7 +60,7 @@ public class HttpManagerImpl implements HttpManager {
         RelativeTimeRange timeRange = new RelativeTimeRange(profileInfo.profilingStartEnd());
 
         EventQueryConfigurer configurer = new EventQueryConfigurer()
-                .withEventType(Type.HTTP_SERVER_EXCHANGE)
+                .withEventType(eventType)
                 .withTimeRange(timeRange)
                 .withJsonFields();
 

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/configuration/ProfileCustomFactoriesConfiguration.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/configuration/ProfileCustomFactoriesConfiguration.java
@@ -59,21 +59,23 @@ public class ProfileCustomFactoriesConfiguration {
 
     @Bean
     public HttpManager.Factory httpManagerFactory() {
-        return profileInfo -> {
+        return (profileInfo, direction) -> {
             DataSource dataSource = databaseManagerResolver.open(profileInfo);
             return new HttpManagerImpl(
-                    profileInfo, repositories.newEventStreamRepository(dataSource));
+                    profileInfo,
+                    repositories.newEventStreamRepository(dataSource),
+                    direction.httpEventType());
         };
     }
 
     @Bean
-    public GrpcManager.Factory grpcServerManagerFactory() {
-        return profileInfo -> {
+    public GrpcManager.Factory grpcManagerFactory() {
+        return (profileInfo, direction) -> {
             DataSource dataSource = databaseManagerResolver.open(profileInfo);
             return new GrpcManagerImpl(
                     profileInfo,
                     repositories.newEventStreamRepository(dataSource),
-                    Type.GRPC_SERVER_EXCHANGE);
+                    direction.grpcEventType());
         };
     }
 

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/ProfileCustomManager.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/ProfileCustomManager.java
@@ -18,6 +18,7 @@
 
 package cafe.jeffrey.profile.manager;
 
+import cafe.jeffrey.profile.manager.custom.ExchangeDirection;
 import cafe.jeffrey.profile.manager.custom.GrpcManager;
 import cafe.jeffrey.profile.manager.custom.HttpManager;
 import cafe.jeffrey.profile.manager.custom.JdbcPoolManager;
@@ -38,9 +39,14 @@ public interface ProfileCustomManager {
 
     JdbcStatementManager jdbcStatementManager();
 
-    HttpManager httpManager();
+    /**
+     * The HTTP dashboard for one direction. There is no direction-less accessor on purpose: the
+     * server and client halves answer different questions, and a caller that did not choose would
+     * silently get one of them.
+     */
+    HttpManager httpManager(ExchangeDirection direction);
 
-    GrpcManager grpcManager();
+    GrpcManager grpcManager(ExchangeDirection direction);
 
     MethodTracingManager methodTracingManager();
 }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/ProfileCustomManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/ProfileCustomManagerImpl.java
@@ -18,6 +18,7 @@
 
 package cafe.jeffrey.profile.manager;
 
+import cafe.jeffrey.profile.manager.custom.ExchangeDirection;
 import cafe.jeffrey.profile.manager.custom.GrpcManager;
 import cafe.jeffrey.profile.manager.custom.HttpManager;
 import cafe.jeffrey.profile.manager.custom.JdbcPoolManager;
@@ -65,13 +66,13 @@ public class ProfileCustomManagerImpl implements ProfileCustomManager {
     }
 
     @Override
-    public HttpManager httpManager() {
-        return httpManagerFactory.apply(parent.info());
+    public HttpManager httpManager(ExchangeDirection direction) {
+        return httpManagerFactory.apply(parent.info(), direction);
     }
 
     @Override
-    public GrpcManager grpcManager() {
-        return grpcManagerFactory.apply(parent.info());
+    public GrpcManager grpcManager(ExchangeDirection direction) {
+        return grpcManagerFactory.apply(parent.info(), direction);
     }
 
     @Override

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/parser/WeightExtractorRegistry.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/parser/WeightExtractorRegistry.java
@@ -19,11 +19,14 @@
 package cafe.jeffrey.profile.parser;
 
 import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordedFrame;
 import jdk.jfr.consumer.RecordedMethod;
+import jdk.jfr.consumer.RecordedStackTrace;
 import cafe.jeffrey.shared.common.model.Type;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 
 import static cafe.jeffrey.shared.common.model.Type.*;
 import java.util.Map;
@@ -87,14 +90,42 @@ public class WeightExtractorRegistry {
      * Null when the field is absent rather than falling back to the frame: the fallback is precisely
      * the wrong answer, and a silently wrong method name is worse than a missing one.
      */
+    /**
+     * The method a {@code jdk.MethodTrace} event was recorded for.
+     * <p>
+     * JEP 520 puts it in a {@code method} field, and that is read first. Not every recording carries
+     * one: an event written by a profiler that emits the type itself, or by a JDK that shipped the
+     * event before the field, arrives with only a start time, a duration and a stack. Those events
+     * are not unattributable — the traced method is the innermost frame of the stack the event was
+     * taken at, by construction, because the event is written from inside that method. Falling back
+     * to it is what keeps the Method Tracing dashboard from reporting a recording with real traces in
+     * it as having none: without an entity every record is dropped, and the totals come back zero
+     * while the events sit in the table.
+     */
     private static String extractTracedMethod(RecordedEvent event) {
-        if (!event.hasField(METHOD_FIELD)) {
+        if (event.hasField(METHOD_FIELD)) {
+            RecordedMethod method = event.getValue(METHOD_FIELD);
+            if (method != null) {
+                return format(method);
+            }
+        }
+        return topFrameMethod(event);
+    }
+
+    private static String topFrameMethod(RecordedEvent event) {
+        RecordedStackTrace stackTrace = event.getStackTrace();
+        if (stackTrace == null) {
             return null;
         }
-        RecordedMethod method = event.getValue(METHOD_FIELD);
-        if (method == null) {
+        List<RecordedFrame> frames = stackTrace.getFrames();
+        if (frames.isEmpty()) {
             return null;
         }
+        RecordedMethod method = frames.getFirst().getMethod();
+        return method == null ? null : format(method);
+    }
+
+    private static String format(RecordedMethod method) {
         return method.getType().getName() + METHOD_SEPARATOR + method.getName();
     }
 }

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpOverviewPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpOverviewPage.vue
@@ -105,7 +105,7 @@ onMounted(() => {
       <p>A call arrives naming a tool and a <code>profileId</code>. Jeffrey resolves that id to the profile's own DuckDB database, holds a lease on it for as long as the session stays active, runs the tool, and returns Markdown or a result table. The heavy machinery &mdash; the flamegraph builder, the trace analysis, the heap-dump index &mdash; is the same code the UI renders from, so what the model reads and what you see on screen cannot drift apart.</p>
 
       <h2 id="what-it-can-read">What It Can Read</h2>
-      <p>Seventy-nine tools in fifteen families:</p>
+      <p>Eighty-five tools in sixteen families:</p>
       <table>
         <thead>
           <tr>
@@ -132,7 +132,7 @@ onMounted(() => {
           </tr>
           <tr>
             <td><code>traces_</code></td>
-            <td>8</td>
+            <td>11</td>
             <td>Trace operations, exemplars, span trees and span-scoped flamegraphs</td>
           </tr>
           <tr>
@@ -176,14 +176,19 @@ onMounted(() => {
             <td>When the samples landed: the busiest windows ranked, and sub-second zoom inside one</td>
           </tr>
           <tr>
+            <td><code>memory_</code></td>
+            <td>2</td>
+            <td>Allocation by type rather than by call site, and JFR-side leak candidates that need no heap dump</td>
+          </tr>
+          <tr>
             <td><code>jfr_</code></td>
             <td>6</td>
             <td>The profile&rsquo;s DuckDB tables &mdash; schema, event types and read-only SQL</td>
           </tr>
           <tr>
             <td><code>heap_</code></td>
-            <td>20</td>
-            <td>Heap summary, class histogram, dominator tree, leak suspects, GC-root paths, read-only SQL</td>
+            <td>21</td>
+            <td>Heap summary, class histogram, dominator tree, leak suspects, GC-root paths, a two-dump diff, read-only SQL</td>
           </tr>
           <tr>
             <td><code>recordings_</code></td>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpToolsPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpToolsPage.vue
@@ -36,6 +36,7 @@ const headings = [
   { id: 'technologies', text: 'http_, jdbc_, grpc_, methodtracing_ — the technology dashboards', level: 2 },
   { id: 'waiting', text: 'io_, blocking_ — waiting rather than running', level: 2 },
   { id: 'timeline', text: 'timeline_ — when, not where', level: 2 },
+  { id: 'memory', text: 'memory_ — allocation and leaks without a heap dump', level: 2 },
   { id: 'jfr', text: 'jfr_ — the profile database', level: 2 },
   { id: 'heap', text: 'heap_ — heap dumps', level: 2 },
   { id: 'recordings', text: 'recordings_ — creating profiles', level: 2 },
@@ -231,6 +232,21 @@ const analyzeExample = `Analyze target/checkout-run.jfr and tell me where the ti
             <td>A flamegraph of the samples taken while one span was open</td>
           </tr>
           <tr>
+            <td><code>traces_attributeKeys</code></td>
+            <td><code>profileId</code>, <code>eventType?</code></td>
+            <td>The attribute keys the traces carried, each identified by its (source, owner, key) triple</td>
+          </tr>
+          <tr>
+            <td><code>traces_attributeValues</code></td>
+            <td><code>profileId</code>, <code>key</code>, <code>source?</code>, <code>owner?</code>, <code>eventType?</code>, <code>sort?</code>, <code>limit?</code></td>
+            <td>One key split into its values, each with its own p50, p95, max and error count</td>
+          </tr>
+          <tr>
+            <td><code>traces_attributeSearch</code></td>
+            <td><code>profileId</code>, <code>key</code>, <code>operator?</code>, <code>value?</code>, <code>source?</code>, <code>owner?</code>, <code>scope?</code>, <code>limit?</code></td>
+            <td>The individual traces carrying one value, with their ids</td>
+          </tr>
+          <tr>
             <td><code>traces_operationFlamegraphExport</code></td>
             <td><code>profileId</code>, <code>name</code>, <code>kind</code>, <code>eventType</code>, <code>graphEventType</code>, <code>threadMode?</code>, <code>useWeight?</code></td>
             <td>The same, aggregated over every trace of one operation</td>
@@ -411,7 +427,7 @@ const analyzeExample = `Analyze target/checkout-run.jfr and tell me where the ti
         These managers answer an event type that was never recorded with a well-formed empty result &mdash; zero statements, a perfect success rate. Every tool here checks first and says so in words instead, because &ldquo;the profiler did not capture this&rdquo; is a finding about the recording, not a clean bill of health for the database.
       </DocsCallout>
 
-      <p><strong>Server-side only.</strong> The HTTP and gRPC dashboards read <code>HTTP_SERVER_EXCHANGE</code> and <code>GRPC_SERVER_EXCHANGE</code>; there is no client-side manager behind the UI&rsquo;s client/server switch, so these tools take no direction argument.</p>
+      <p><strong>Both directions.</strong> <code>http_</code> and <code>grpc_</code> take a <code>direction</code> of <code>SERVER</code> (the default) or <code>CLIENT</code>, and they are different questions: SERVER is what the application was asked to do, CLIENT what it asked of somebody else, where a slow figure belongs to a dependency and the only local fixes are to call less often or stop waiting. The two are gated separately, so &ldquo;no client-side data&rdquo; means the recording captured no outbound calls.</p>
 
       <p><strong>No chart series.</strong> The per-second series that draw the dashboard&rsquo;s graphs are left out of every answer &mdash; thousands of points describing a shape the percentiles already summarise. The shape is what the UI link is for. SQL text is truncated for the same reason: it is there to identify a statement, not to be executed.</p>
 
@@ -493,6 +509,34 @@ const analyzeExample = `Analyze target/checkout-run.jfr and tell me where the ti
 
       <p>The workflow is three calls: <code>timeline_hotWindows</code> to find the window, <code>flamegraph_export</code> with its bounds to see what ran inside it, and <code>timeline_zoom</code> when a second is too coarse &mdash; a startup, or the inside of a spike.</p>
 
+      <h2 id="memory">memory_ &mdash; allocation and leaks without a heap dump</h2>
+      <p>Two memory questions a plain JFR recording answers on its own.</p>
+      <table>
+        <thead>
+          <tr>
+            <th>Tool</th>
+            <th>Arguments</th>
+            <th>Returns</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>memory_allocations</code></td>
+            <td><code>profileId</code></td>
+            <td>Total bytes, the TLAB split, distinct types, and the types ranked by bytes</td>
+          </tr>
+          <tr>
+            <td><code>memory_leakCandidates</code></td>
+            <td><code>profileId</code></td>
+            <td>Objects the JVM sampled and watched survive collections, with size and age</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p><strong>The other axis from a flamegraph.</strong> An allocation flamegraph ranks the call <em>sites</em> &mdash; where the allocating code is. This ranks the <em>types</em> allocated, and the two disagree usefully: <code>byte[]</code> and <code>char[]</code> at the top read very differently from a domain class, and one call site allocating many types looks nothing like one type coming from everywhere.</p>
+
+      <p><strong>Leak candidates come from <code>jdk.OldObjectSample</code></strong>, which is off in most recordings. Their absence says nothing about whether the application leaks, and the tool says exactly that rather than reporting zero candidates &mdash; the difference between &ldquo;measured and found nothing&rdquo; and &ldquo;never measured&rdquo; is the whole finding.</p>
+
       <h2 id="jfr">jfr_ &mdash; the profile database</h2>
       <p>Each profile is one DuckDB database. This family is the escape hatch for questions no purpose-built tool covers &mdash; distributions over time, correlations between event types, the cardinality of a field.</p>
 
@@ -548,6 +592,7 @@ const analyzeExample = `Analyze target/checkout-run.jfr and tell me where the ti
       </DocsCallout>
 
       <h2 id="heap">heap_ &mdash; heap dumps</h2>
+      <p><code>heap_diff</code> is the one that needs two profiles: it compares this dump against an earlier one class by class, ranked by growth, and is the only way to separate a leak from a large working set &mdash; a single dump shows a state, and a state cannot tell the two apart. Pass the earlier dump as <code>baselineProfileId</code>; backwards, every growth reads as a shrink. Both dumps have to be indexed first, and the tool says which one is not.</p>
       <p>Twenty tools against a parsed heap dump&rsquo;s own DuckDB index, separate from the profile&rsquo;s JFR database. Asking for them on a profile with no heap dump fails immediately with a message saying so, rather than deep inside the engine.</p>
 
       <p><strong>Reports</strong> &mdash; pre-computed, and faster and safer than reproducing them in SQL:</p>


### PR DESCRIPTION
The two defects the MCP audit found, plus the three gaps it ranked highest. **85 tools in 16 families**, up from 79 in 15.

## Two bugs

**The client half of HTTP and gRPC was never wired.** `HTTP_CLIENT_EXCHANGE` and `GRPC_CLIENT_EXCHANGE` exist as event types, both dashboards have a `FeatureType`, and `FeatureCheckers` already gates them on the right events — but `HttpManagerImpl` read the server type as a constant, only a server `GrpcManager` bean was registered, and the controllers ignored the `mode` the frontend has been sending all along. The UI's client/server switch moved and the figures did not.

A manager is now built per direction, which is the shape `GrpcManagerImpl` was already written for. The accessor takes an `ExchangeDirection` rather than defaulting, because a caller that did not choose would silently get one side. The halves are gated separately, so *"no client-side data"* now means the recording captured no outbound calls.

**Method tracing reported zero invocations on recordings that hold real events.** The traced method is read from `weight_entity`, and the extractor gave up unless the event carried a JEP 520 `method` field. Without an entity every record is dropped in the builder and the dashboard renders a page of zeroes — which reads as "nothing to see" rather than "not measured".

Not every recording has that field. Those events are not unattributable: the traced method is the innermost frame of the stack the event was taken at, because the event is written from inside it.

> Verified against a recording whose 160 `jdk.MethodTrace` rows all had a null `weight_entity` — confirmed by querying the profile DuckDB directly. The dashboard reported **0 invocations before and 160 after**, naming `DatabaseClient#query` (159 calls) and `JfrRecordingEventParser`.

## Three families

| Family | Why |
|---|---|
| `heap_diff` | What grew between two dumps. A single dump shows a *state*, and a state cannot separate a leak from a large working set; two can, and twenty `heap_` tools could not ask it. Missing and not-yet-indexed are different answers, as elsewhere in the family. |
| `memory_` | Allocation by **type** rather than by call site — the other axis from the flamegraph — and `jdk.OldObjectSample` leak candidates, which need no heap dump at all. |
| `traces_attribute*` | What `traces_operations` structurally cannot answer: *which population* was slow. An endpoint fine for everyone except one tenant has a healthy average and a p99 nobody can locate. |

The heap-occupancy series is deliberately still absent: it is chart geometry, and "when did memory climb" is `timeline_hotWindows`, which returns windows a flamegraph can be scoped to rather than a curve.

Absences are reported as absences: `memory_leakCandidates` says *that sampler was off* rather than returning zero candidates, because "measured and found nothing" and "never measured" are different findings.

## Verified against real data

Everything below ran against a Jeffrey self-instrumented recording and two real 5.7 GB heap dumps, in a scratch home directory:

- `memory_allocations` — 5.3 GB across 220 types, dominant `byte[]`, genuinely complementary to the flamegraph's call-site ranking
- `traces_attributeValues` — per-value p50/p95/max; `traces_attributeSearch` — 18 matching traces with real ids feeding `traces_traceExport`
- `heap_diff` — two dumps indexed (35.8M instances each) and diffed; identical dumps give zero deltas and no ranked classes, the correct identity result
- `http_overview` — `SERVER` returns 54 requests with a `mode=server` link, `CLIENT` is gated separately and names `jeffrey.HttpClientExchange`, and an unknown direction is refused by name
- `memory_leakCandidates` and `heap_diff` on a profile without the data return their guiding messages, not empty results

406 backend tests green, `vue-tsc` clean. Every tool appears in the tool reference and every registered prefix in `analyze-jfr`, both checked programmatically.

## Note

`heap_diff` is exercised against two *identical* dumps. The only other `.hprof` available locally is from an unrelated application, so a differing diff would have been noise rather than a check — the identity case is the cleanest assertion available here and proves the full path (two heap contexts, the service, the projection, the link).
