### PR TITLE
fix build: work around npm 10 crash resolving vitest peer chain

### DIFF
--- a/docker/Dockerfile-builder
+++ b/docker/Dockerfile-builder
@@ -1,5 +1,9 @@
 FROM node:22
 
+# node:22 bundles npm 10, whose dependency resolver crashes on optional peer chains
+# ("Cannot read properties of null (reading 'edgesOut')"). Fixed in npm 11.
+RUN npm install -g npm@11
+
 ARG MAVEN_VERSION=3.9.11
 ARG JAVA_MAJOR_VERSION=25
 ARG JAVA_VERSION=25

--- a/jeffrey-microscope/pages-microscope/pom.xml
+++ b/jeffrey-microscope/pages-microscope/pom.xml
@@ -58,6 +58,12 @@
                                      production-flavoured environment (NODE_ENV=production) would
                                      otherwise prune it and silently skip the check. -->
                                 <argument>--include=dev</argument>
+                                <!-- npm 10's dependency resolver crashes ("Cannot read properties
+                                     of null (reading 'edgesOut')") while walking the optional peer
+                                     chain vitest -> jsdom -> canvas. The bug is fixed in npm 11+,
+                                     but the builder image (node:22) still ships npm 10, so skip
+                                     the peer walk here. Drop this once the image carries npm 11+. -->
+                                <argument>--legacy-peer-deps</argument>
                             </arguments>
                         </configuration>
                     </execution>


### PR DESCRIPTION
The CI build failed in pages-microscope's npm-install step with
"Cannot read properties of null (reading 'edgesOut')". The crash is an
arborist bug in npm 10 (bundled with node:22, which the builder image is
based on) hit while walking the optional peer chain
vitest -> jsdom -> canvas. Nothing in the repository changed to cause it;
a registry-side release of jsdom moved its optional canvas peer and made
npm 10 trip over it.

Pass --legacy-peer-deps to the npm-install execution so the build is green
with the currently published builder image, and install npm 11 in the
builder image so the underlying bug goes away once that image is
republished.