### PR TITLE
Keep the plugin at 1.0.0

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "microscope",
       "source": "./jeffrey-claude-plugin",
-      "version": "1.1.0",
+      "version": "1.0.0",
       "description": "Analyze JVM recordings with a running Jeffrey Microscope: point it at a JFR file or heap dump to build a profile, then read flamegraphs, traces, the JVM and technology dashboards, and heap-dump reports without leaving the terminal.",
       "author": {
         "name": "Petr Bouda",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "microscope",
       "source": "./jeffrey-claude-plugin",
-      "version": "1.1.0",
+      "version": "1.0.0",
       "description": "Analyze JVM recordings with a running Jeffrey Microscope: point it at a JFR file or heap dump to build a profile, then read flamegraphs, traces, the JVM and technology dashboards, and heap-dump reports without leaving the terminal.",
       "author": {
         "name": "Petr Bouda",

--- a/jeffrey-claude-plugin/.claude-plugin/plugin.json
+++ b/jeffrey-claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "microscope",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "description": "Analyze JVM recordings with a running Jeffrey Microscope — point it at a JFR file or heap dump to build a profile, then list analysed recordings, query their DuckDB tables, and pull flamegraph, trace and heap-dump exports without leaving the terminal.",
   "author": {
     "name": "Petr Bouda",

--- a/jeffrey-claude-plugin/.codex-plugin/plugin.json
+++ b/jeffrey-claude-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "microscope",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "description": "Analyze JVM recordings with a running Jeffrey Microscope — point it at a JFR file or heap dump to build a profile, then list analysed recordings, query their DuckDB tables, and pull flamegraph, trace and heap-dump exports without leaving the terminal.",
   "author": {
     "name": "Petr Bouda",

--- a/jeffrey-claude-plugin/README.md
+++ b/jeffrey-claude-plugin/README.md
@@ -180,7 +180,7 @@ jeffrey-claude-plugin/
 ```
 
 The directory keeps its `jeffrey-claude-plugin` name so existing installs and marketplace entries
-keep resolving; it has served both clients since 1.1.0.
+keep resolving; it serves both clients.
 
 ## Security
 

--- a/jeffrey-claude-plugin/plugin.json
+++ b/jeffrey-claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "microscope",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "description": "Analyze JVM recordings with a running Jeffrey Microscope — point it at a JFR file or heap dump to build a profile, then list analysed recordings, query their DuckDB tables, and pull flamegraph, trace and heap-dump exports without leaving the terminal.",
   "author": {
     "name": "Petr Bouda",


### PR DESCRIPTION
The Codex work in #255 bumped every plugin manifest to `1.1.0` on the way past. The version belongs to a release, not to a branch, so this puts all five back to what master carried before: both plugin manifests, the Codex-native one, and both marketplace entries. The README stops dating two-client support to a version that was never cut.

Six lines, no behaviour change:

```
 .agents/plugins/marketplace.json                 | 2 +-
 .claude-plugin/marketplace.json                  | 2 +-
 jeffrey-claude-plugin/.claude-plugin/plugin.json | 2 +-
 jeffrey-claude-plugin/.codex-plugin/plugin.json  | 2 +-
 jeffrey-claude-plugin/README.md                  | 2 +-
 jeffrey-claude-plugin/plugin.json                | 2 +-
```

## Verification

`build/scripts/validate-agent-plugin.py` (which checks, among other things, that all four manifests and both marketplaces agree on a version), `claude plugin validate .` and `claude plugin validate ./jeffrey-claude-plugin --strict` all pass on the rebased tree.

## One consequence

`1.0.0` is what most installs already carry, so the marketplace entry's version does not move even though the plugin's contents did in #255. If a client decides "update available" by comparing versions rather than content, an existing install may report itself up to date and keep the older skills until it is reinstalled. The fix for that is a deliberate bump at release time rather than one carried along by a feature branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpFLWfpRVKic9aoYBSzx4U

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpFLWfpRVKic9aoYBSzx4U)_