### PR TITLE
Filter recording sessions on the hub by activity window, status and count

### DIFF
--- a/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/grpc/ProtoMappers.java
+++ b/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/grpc/ProtoMappers.java
@@ -20,10 +20,14 @@ package cafe.jeffrey.hub.core.grpc;
 
 import cafe.jeffrey.hub.api.v1.InstanceStatus;
 import cafe.jeffrey.hub.api.v1.RecordingStatus;
+import cafe.jeffrey.hub.api.v1.SessionFilter;
 import cafe.jeffrey.hub.api.v1.SettingsLevel;
 import cafe.jeffrey.hub.api.v1.WorkspaceStatus;
 import cafe.jeffrey.shared.common.model.EffectiveProfilerSettings;
 import cafe.jeffrey.shared.common.model.ProjectInstanceInfo;
+import cafe.jeffrey.shared.common.model.repository.RecordingSessionFilter;
+
+import java.time.Instant;
 
 /**
  * Shared domain-to-proto conversions for the hub gRPC services. Centralizes the null-to-empty-string
@@ -45,6 +49,28 @@ public abstract class ProtoMappers {
             case ACTIVE -> RecordingStatus.RECORDING_STATUS_ACTIVE;
             case FINISHED -> RecordingStatus.RECORDING_STATUS_FINISHED;
             case UNKNOWN -> RecordingStatus.RECORDING_STATUS_UNKNOWN;
+        };
+    }
+
+    /**
+     * Proto-to-domain conversion of a session filter. An unset bound stays open, an
+     * {@code UNSPECIFIED} status matches every status and a zero limit means no cap, so a
+     * default-instance filter converts to {@link RecordingSessionFilter#ALL}. An empty window
+     * surfaces as {@link IllegalArgumentException}, which the unary envelope reports as
+     * {@code INVALID_ARGUMENT}.
+     */
+    public static RecordingSessionFilter sessionFilter(SessionFilter filter) {
+        Instant activeFrom = filter.hasActiveFrom() ? Instant.ofEpochMilli(filter.getActiveFrom()) : null;
+        Instant activeTo = filter.hasActiveTo() ? Instant.ofEpochMilli(filter.getActiveTo()) : null;
+        return new RecordingSessionFilter(activeFrom, activeTo, statusFilter(filter.getStatus()), filter.getLimit());
+    }
+
+    private static cafe.jeffrey.shared.common.model.repository.RecordingStatus statusFilter(RecordingStatus status) {
+        return switch (status) {
+            case RECORDING_STATUS_ACTIVE -> cafe.jeffrey.shared.common.model.repository.RecordingStatus.ACTIVE;
+            case RECORDING_STATUS_FINISHED -> cafe.jeffrey.shared.common.model.repository.RecordingStatus.FINISHED;
+            case RECORDING_STATUS_UNKNOWN -> cafe.jeffrey.shared.common.model.repository.RecordingStatus.UNKNOWN;
+            case RECORDING_STATUS_UNSPECIFIED, UNRECOGNIZED -> null;
         };
     }
 

--- a/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/grpc/RepositoryGrpcService.java
+++ b/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/grpc/RepositoryGrpcService.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import cafe.jeffrey.hub.api.v1.*;
 import cafe.jeffrey.hub.core.manager.RepositoryManager;
+import cafe.jeffrey.shared.common.model.repository.RecordingSessionFilter;
 import cafe.jeffrey.shared.common.model.repository.RepositoryStatistics;
 
 import java.util.List;
@@ -41,12 +42,14 @@ public class RepositoryGrpcService extends RepositoryServiceGrpc.RepositoryServi
     public void listSessions(ListSessionsRequest request, StreamObserver<ListSessionsResponse> responseObserver) {
         GrpcUnary.respond(responseObserver, () -> {
             RepositoryManager repoManager = lookups.repositoryManagerForProject(request.getProjectId());
+            RecordingSessionFilter filter = ProtoMappers.sessionFilter(request.getFilter());
 
-            List<RecordingSession> sessions = repoManager.listRecordingSessions(true).stream()
+            List<RecordingSession> sessions = repoManager.listRecordingSessions(true, filter).stream()
                     .map(RepositoryGrpcService::toProto)
                     .toList();
 
-            LOG.debug("Listed sessions via gRPC: projectId={} count={}", request.getProjectId(), sessions.size());
+            LOG.debug("Listed sessions via gRPC: projectId={} filter={} count={}",
+                    request.getProjectId(), filter, sessions.size());
 
             return ListSessionsResponse.newBuilder()
                     .addAllSessions(sessions)

--- a/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/manager/RepositoryManager.java
+++ b/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/manager/RepositoryManager.java
@@ -22,6 +22,7 @@ import tools.jackson.databind.node.ObjectNode;
 import cafe.jeffrey.shared.common.model.ProjectInfo;
 import cafe.jeffrey.shared.common.model.RepositoryInfo;
 import cafe.jeffrey.shared.common.model.repository.RecordingSession;
+import cafe.jeffrey.shared.common.model.repository.RecordingSessionFilter;
 import cafe.jeffrey.shared.common.model.ProjectInstanceSessionInfo;
 import cafe.jeffrey.shared.common.model.repository.InstanceStats;
 import cafe.jeffrey.shared.common.model.repository.RepositoryStatistics;
@@ -66,12 +67,23 @@ public interface RepositoryManager {
     Optional<RecordingSession> findRecordingSessions(String recordingSessionId);
 
     /**
-     * Lists all recording sessions in the repository.
+     * Lists all recording sessions in the repository, newest first.
      *
      * @param withFiles whether to include file details in the sessions
      * @return list of recording sessions
      */
-    List<RecordingSession> listRecordingSessions(boolean withFiles);
+    default List<RecordingSession> listRecordingSessions(boolean withFiles) {
+        return listRecordingSessions(withFiles, RecordingSessionFilter.ALL);
+    }
+
+    /**
+     * Lists the recording sessions that satisfy the filter, newest first.
+     *
+     * @param withFiles whether to include file details in the sessions
+     * @param filter    the window, status and count constraints to apply
+     * @return list of matching recording sessions
+     */
+    List<RecordingSession> listRecordingSessions(boolean withFiles, RecordingSessionFilter filter);
 
     /**
      * Calculates comprehensive repository statistics including session counts,

--- a/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/manager/RepositoryManagerImpl.java
+++ b/jeffrey-hub/core-hub/src/main/java/cafe/jeffrey/hub/core/manager/RepositoryManagerImpl.java
@@ -38,6 +38,7 @@ import cafe.jeffrey.shared.common.model.ProjectInstanceInfo.ProjectInstanceStatu
 import cafe.jeffrey.shared.common.model.RepositoryInfo;
 import cafe.jeffrey.shared.common.model.repository.FileCategory;
 import cafe.jeffrey.shared.common.model.repository.RecordingSession;
+import cafe.jeffrey.shared.common.model.repository.RecordingSessionFilter;
 import cafe.jeffrey.shared.common.model.repository.RecordingStatus;
 import cafe.jeffrey.shared.common.model.repository.RepositoryFile;
 import cafe.jeffrey.shared.common.model.ProjectInstanceSessionInfo;
@@ -116,8 +117,8 @@ public class RepositoryManagerImpl implements RepositoryManager {
     }
 
     @Override
-    public List<RecordingSession> listRecordingSessions(boolean withFiles) {
-        return repositoryStorage.listSessions(withFiles);
+    public List<RecordingSession> listRecordingSessions(boolean withFiles, RecordingSessionFilter filter) {
+        return filter.apply(repositoryStorage.listSessions(withFiles));
     }
 
     @Override

--- a/jeffrey-hub/core-hub/src/test/java/cafe/jeffrey/hub/core/grpc/RepositoryGrpcServiceTest.java
+++ b/jeffrey-hub/core-hub/src/test/java/cafe/jeffrey/hub/core/grpc/RepositoryGrpcServiceTest.java
@@ -29,11 +29,13 @@ import cafe.jeffrey.hub.persistence.api.SessionWithRepository;
 import cafe.jeffrey.hub.persistence.api.ProjectRepository;
 import cafe.jeffrey.hub.persistence.api.HubPlatformRepositories;
 import cafe.jeffrey.shared.common.model.ProjectInfo;
+import cafe.jeffrey.shared.common.model.repository.RecordingSessionFilter;
 import cafe.jeffrey.shared.common.model.repository.RepositoryFile;
 import cafe.jeffrey.shared.common.model.repository.RepositoryStatistics;
 import cafe.jeffrey.shared.common.model.repository.RepositoryStatistics.FileTypeStats;
 import cafe.jeffrey.shared.common.model.repository.SupportedRecordingFile;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -70,7 +72,7 @@ class RepositoryGrpcServiceTest {
         @Test
         void returnsSessionList() throws Exception {
             var repoManager = mock(RepositoryManager.class);
-            when(repoManager.listRecordingSessions(true)).thenReturn(List.of(
+            when(repoManager.listRecordingSessions(true, RecordingSessionFilter.ALL)).thenReturn(List.of(
                     new cafe.jeffrey.shared.common.model.repository.RecordingSession(
                             SESSION_ID, "session-name", "inst-1",
                             FIXED_TIME, null,
@@ -124,7 +126,7 @@ class RepositoryGrpcServiceTest {
         @Test
         void returnsEmptyListWhenNoSessions() throws Exception {
             var repoManager = mock(RepositoryManager.class);
-            when(repoManager.listRecordingSessions(true)).thenReturn(List.of());
+            when(repoManager.listRecordingSessions(true, RecordingSessionFilter.ALL)).thenReturn(List.of());
 
             var stub = startServer(serviceWithProject(repoManager));
 
@@ -147,6 +149,78 @@ class RepositoryGrpcServiceTest {
                                     .build()));
 
             assertEquals(Status.Code.NOT_FOUND, ex.getStatus().getCode());
+        }
+
+        @Test
+        void filterFieldsReachTheRepositoryManager() throws Exception {
+            var repoManager = mock(RepositoryManager.class);
+            Instant from = FIXED_TIME.minus(Duration.ofHours(1));
+            var expected = new RecordingSessionFilter(
+                    from, FIXED_TIME, cafe.jeffrey.shared.common.model.repository.RecordingStatus.FINISHED, 5);
+            when(repoManager.listRecordingSessions(true, expected)).thenReturn(List.of(
+                    new cafe.jeffrey.shared.common.model.repository.RecordingSession(
+                            SESSION_ID, "session-name", null,
+                            from, FIXED_TIME,
+                            cafe.jeffrey.shared.common.model.repository.RecordingStatus.FINISHED,
+                            null, null, List.of(), false)));
+
+            var stub = startServer(serviceWithProject(repoManager));
+
+            ListSessionsResponse response = stub.listSessions(
+                    ListSessionsRequest.newBuilder()
+                            .setProjectId(PROJECT_ID)
+                            .setFilter(SessionFilter.newBuilder()
+                                    .setActiveFrom(from.toEpochMilli())
+                                    .setActiveTo(FIXED_TIME.toEpochMilli())
+                                    .setStatus(RecordingStatus.RECORDING_STATUS_FINISHED)
+                                    .setLimit(5))
+                            .build());
+
+            assertEquals(1, response.getSessionsCount());
+            assertEquals(SESSION_ID, response.getSessions(0).getId());
+            verify(repoManager).listRecordingSessions(true, expected);
+        }
+
+        @Test
+        void absentFilterListsEverything() throws Exception {
+            var repoManager = mock(RepositoryManager.class);
+            when(repoManager.listRecordingSessions(true, RecordingSessionFilter.ALL)).thenReturn(List.of());
+
+            var stub = startServer(serviceWithProject(repoManager));
+
+            stub.listSessions(ListSessionsRequest.newBuilder().setProjectId(PROJECT_ID).build());
+
+            verify(repoManager).listRecordingSessions(true, RecordingSessionFilter.ALL);
+        }
+
+        @Test
+        void emptyWindow_returnsInvalidArgument() throws Exception {
+            var stub = startServer(serviceWithProject(mock(RepositoryManager.class)));
+
+            StatusRuntimeException ex = assertThrows(StatusRuntimeException.class, () ->
+                    stub.listSessions(
+                            ListSessionsRequest.newBuilder()
+                                    .setProjectId(PROJECT_ID)
+                                    .setFilter(SessionFilter.newBuilder()
+                                            .setActiveFrom(FIXED_TIME.toEpochMilli())
+                                            .setActiveTo(FIXED_TIME.minusSeconds(1).toEpochMilli()))
+                                    .build()));
+
+            assertEquals(Status.Code.INVALID_ARGUMENT, ex.getStatus().getCode());
+        }
+
+        @Test
+        void negativeLimit_returnsInvalidArgument() throws Exception {
+            var stub = startServer(serviceWithProject(mock(RepositoryManager.class)));
+
+            StatusRuntimeException ex = assertThrows(StatusRuntimeException.class, () ->
+                    stub.listSessions(
+                            ListSessionsRequest.newBuilder()
+                                    .setProjectId(PROJECT_ID)
+                                    .setFilter(SessionFilter.newBuilder().setLimit(-1))
+                                    .build()));
+
+            assertEquals(Status.Code.INVALID_ARGUMENT, ex.getStatus().getCode());
         }
     }
 

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/ProjectRepositoryControllerTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/web/controllers/ProjectRepositoryControllerTest.java
@@ -25,10 +25,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
 import cafe.jeffrey.hub.client.manager.RepositoryManager;
 import cafe.jeffrey.shared.common.exception.Exceptions;
+import cafe.jeffrey.shared.common.model.repository.RecordingSession;
+import cafe.jeffrey.shared.common.model.repository.RecordingSessionFilter;
+import cafe.jeffrey.shared.common.model.repository.RecordingStatus;
 import cafe.jeffrey.shared.ui.workspace.bridge.RemoteProjectAccess;
 import cafe.jeffrey.shared.ui.workspace.controller.ProjectRepositoryController;
 
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.List;
@@ -49,7 +53,7 @@ class ProjectRepositoryControllerTest {
     @Test
     void listsEmptySessions() {
         when(projectAccess.repositoryManager("srv-1", "ws-1", "p-1")).thenReturn(repositoryManager);
-        when(repositoryManager.listRecordingSessions(true)).thenReturn(List.of());
+        when(repositoryManager.listRecordingSessions(true, RecordingSessionFilter.ALL)).thenReturn(List.of());
 
         Clock clock = Clock.fixed(Instant.parse("2026-04-26T12:00:00Z"), ZoneOffset.UTC);
         MockMvcTester mvc = mockMvcTesterFor(new ProjectRepositoryController(projectAccess, clock));
@@ -58,6 +62,28 @@ class ProjectRepositoryControllerTest {
                 .hasStatusOk()
                 .bodyJson()
                 .extractingPath("$").asArray().isEmpty();
+    }
+
+    @Test
+    void queryParametersBecomeTheSessionFilter() {
+        Instant now = Instant.parse("2026-04-26T12:00:00Z");
+        Instant hourAgo = now.minus(Duration.ofHours(1));
+        var expected = new RecordingSessionFilter(hourAgo, now, RecordingStatus.FINISHED, 3);
+        when(projectAccess.repositoryManager("srv-1", "ws-1", "p-1")).thenReturn(repositoryManager);
+        when(repositoryManager.listRecordingSessions(true, expected)).thenReturn(List.of(
+                new RecordingSession("s-1", "s-1", "inst-1", hourAgo, now,
+                        RecordingStatus.FINISHED, null, null, List.of(), false)));
+
+        Clock clock = Clock.fixed(now, ZoneOffset.UTC);
+        MockMvcTester mvc = mockMvcTesterFor(new ProjectRepositoryController(projectAccess, clock));
+
+        assertThat(mvc.get().uri("/api/internal/hubs/srv-1/workspaces/ws-1/projects/p-1/repository/sessions"
+                        + "?activeFrom=" + hourAgo.toEpochMilli()
+                        + "&activeTo=" + now.toEpochMilli()
+                        + "&status=FINISHED&limit=3"))
+                .hasStatusOk()
+                .bodyJson()
+                .extractingPath("$[0].id").asString().isEqualTo("s-1");
     }
 
     @Test

--- a/jeffrey-pages/src/views/docs/hub/HubGrpcApiPage.vue
+++ b/jeffrey-pages/src/views/docs/hub/HubGrpcApiPage.vue
@@ -220,7 +220,7 @@ onMounted(() => {
                   <span class="method rpc">RPC</span>
                   <code>ListSessions</code>
                 </div>
-                <p>List all recording sessions</p>
+                <p>List a project's recording sessions, newest first. An optional <code>SessionFilter</code> narrows the listing on the hub: <code>active_from</code>/<code>active_to</code> keep the sessions that were recording at any point inside the window (a still-running session always matches a window reaching the present), <code>status</code> keeps one status and <code>limit</code> caps the count</p>
               </div>
               <div class="endpoint-item">
                 <div class="endpoint-line">

--- a/shared/common/src/main/java/cafe/jeffrey/shared/common/model/repository/RecordingSessionFilter.java
+++ b/shared/common/src/main/java/cafe/jeffrey/shared/common/model/repository/RecordingSessionFilter.java
@@ -1,0 +1,123 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.shared.common.model.repository;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Narrows a recording-session listing. Every field is optional: a {@code null} bound, a
+ * {@code null} status or a zero limit does not restrict anything, so {@link #ALL} returns the
+ * listing unchanged.
+ *
+ * <p>The time window uses <em>overlap</em> semantics rather than "created inside the window": a
+ * session matches when it was recording at any point between {@code activeFrom} and
+ * {@code activeTo}. A JVM that started three hours ago and is still running therefore matches
+ * "the last hour", which is what a reader asking for recent recordings expects; a session that
+ * finished before the window opened does not.
+ *
+ * <p>The filter is applied on the hub, so the listing that travels over gRPC is already the one
+ * the caller asked for. {@link #apply(List)} expects the sessions newest first, which is how the
+ * hub storage sorts them; the limit keeps the newest ones.
+ *
+ * @param activeFrom the session must not have finished before this instant, or {@code null}
+ * @param activeTo   the session must have started before this instant, or {@code null}
+ * @param status     the session must be in this status, or {@code null} for any status
+ * @param limit      keep at most this many sessions, or {@link #NO_LIMIT}
+ */
+public record RecordingSessionFilter(
+        Instant activeFrom,
+        Instant activeTo,
+        RecordingStatus status,
+        int limit) {
+
+    public static final int NO_LIMIT = 0;
+
+    public static final RecordingSessionFilter ALL = new RecordingSessionFilter(null, null, null, NO_LIMIT);
+
+    public RecordingSessionFilter {
+        if (limit < NO_LIMIT) {
+            throw new IllegalArgumentException("Session limit must not be negative: limit=" + limit);
+        }
+        if (activeFrom != null && activeTo != null && activeFrom.isAfter(activeTo)) {
+            throw new IllegalArgumentException(
+                    "Session window is empty, activeFrom is after activeTo: active_from="
+                            + activeFrom + " active_to=" + activeTo);
+        }
+    }
+
+    /**
+     * Sessions that were recording at any point during the last {@code lookBack}, ending at
+     * {@code now}. The window is left open at the end so a session that starts between the
+     * hub's and the caller's clock readings is not lost.
+     */
+    public static RecordingSessionFilter activeWithinLast(Duration lookBack, Instant now) {
+        if (lookBack.isNegative()) {
+            throw new IllegalArgumentException("Look-back must not be negative: look_back=" + lookBack);
+        }
+        return new RecordingSessionFilter(now.minus(lookBack), null, null, NO_LIMIT);
+    }
+
+    public RecordingSessionFilter withStatus(RecordingStatus newStatus) {
+        return new RecordingSessionFilter(activeFrom, activeTo, newStatus, limit);
+    }
+
+    public RecordingSessionFilter withLimit(int newLimit) {
+        return new RecordingSessionFilter(activeFrom, activeTo, status, newLimit);
+    }
+
+    public boolean isUnrestricted() {
+        return activeFrom == null && activeTo == null && status == null && limit == NO_LIMIT;
+    }
+
+    /**
+     * Whether a single session satisfies the window and status constraints. The limit is a
+     * property of the whole listing and is not consulted here.
+     */
+    public boolean matches(RecordingSession session) {
+        if (status != null && session.status() != status) {
+            return false;
+        }
+        if (activeTo != null && session.createdAt().isAfter(activeTo)) {
+            return false;
+        }
+        if (activeFrom != null && session.finishedAt() != null && session.finishedAt().isBefore(activeFrom)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Keeps the sessions that {@link #matches(RecordingSession) match}, preserving their order,
+     * and cuts the result to {@link #limit()} when one is set.
+     *
+     * @param sessionsNewestFirst the full listing, newest session first
+     */
+    public List<RecordingSession> apply(List<RecordingSession> sessionsNewestFirst) {
+        if (isUnrestricted()) {
+            return sessionsNewestFirst;
+        }
+        var matching = sessionsNewestFirst.stream().filter(this::matches);
+        if (limit != NO_LIMIT) {
+            matching = matching.limit(limit);
+        }
+        return matching.toList();
+    }
+}

--- a/shared/common/src/test/java/cafe/jeffrey/shared/common/model/repository/RecordingSessionFilterTest.java
+++ b/shared/common/src/test/java/cafe/jeffrey/shared/common/model/repository/RecordingSessionFilterTest.java
@@ -1,0 +1,209 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.shared.common.model.repository;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RecordingSessionFilterTest {
+
+    private static final Instant NOW = Instant.parse("2026-03-01T12:00:00Z");
+    private static final Instant ONE_HOUR_AGO = NOW.minus(Duration.ofHours(1));
+
+    private static RecordingSession session(String id, Instant createdAt, Instant finishedAt) {
+        RecordingStatus status = finishedAt != null ? RecordingStatus.FINISHED : RecordingStatus.ACTIVE;
+        return new RecordingSession(id, id, "inst-1", createdAt, finishedAt, status, null, null, List.of(), false);
+    }
+
+    private static List<String> ids(List<RecordingSession> sessions) {
+        return sessions.stream().map(RecordingSession::id).toList();
+    }
+
+    @Nested
+    class Window {
+
+        private final RecordingSessionFilter lastHour = new RecordingSessionFilter(ONE_HOUR_AGO, NOW, null, 0);
+
+        @Test
+        void stillRunningSessionStartedLongAgoOverlapsTheWindow() {
+            RecordingSession running = session("running", NOW.minus(Duration.ofHours(3)), null);
+
+            assertTrue(lastHour.matches(running));
+        }
+
+        @Test
+        void sessionFinishedInsideTheWindowMatches() {
+            RecordingSession finished = session("finished", NOW.minus(Duration.ofHours(3)), NOW.minus(Duration.ofMinutes(30)));
+
+            assertTrue(lastHour.matches(finished));
+        }
+
+        @Test
+        void sessionStartedAndFinishedInsideTheWindowMatches() {
+            RecordingSession inside = session("inside", NOW.minus(Duration.ofMinutes(50)), NOW.minus(Duration.ofMinutes(10)));
+
+            assertTrue(lastHour.matches(inside));
+        }
+
+        @Test
+        void sessionFinishedBeforeTheWindowOpenedDoesNotMatch() {
+            RecordingSession old = session("old", NOW.minus(Duration.ofHours(5)), NOW.minus(Duration.ofHours(2)));
+
+            assertFalse(lastHour.matches(old));
+        }
+
+        @Test
+        void sessionStartedAfterTheWindowClosedDoesNotMatch() {
+            RecordingSession future = session("future", NOW.plus(Duration.ofMinutes(1)), null);
+
+            assertFalse(lastHour.matches(future));
+        }
+
+        @Test
+        void boundsAreInclusive() {
+            RecordingSession finishedOnOpen = session("on-open", NOW.minus(Duration.ofHours(5)), ONE_HOUR_AGO);
+            RecordingSession startedOnClose = session("on-close", NOW, null);
+
+            assertTrue(lastHour.matches(finishedOnOpen));
+            assertTrue(lastHour.matches(startedOnClose));
+        }
+
+        @Test
+        void openEndedWindowOnlyChecksTheSetBound() {
+            RecordingSessionFilter since = new RecordingSessionFilter(ONE_HOUR_AGO, null, null, 0);
+            RecordingSessionFilter until = new RecordingSessionFilter(null, ONE_HOUR_AGO, null, 0);
+            RecordingSession recent = session("recent", NOW.minus(Duration.ofMinutes(5)), null);
+            RecordingSession old = session("old", NOW.minus(Duration.ofHours(5)), NOW.minus(Duration.ofHours(2)));
+
+            assertTrue(since.matches(recent));
+            assertFalse(since.matches(old));
+            assertFalse(until.matches(recent));
+            assertTrue(until.matches(old));
+        }
+
+        @Test
+        void activeWithinLastLeavesTheEndOpen() {
+            RecordingSessionFilter filter = RecordingSessionFilter.activeWithinLast(Duration.ofHours(1), NOW);
+
+            assertEquals(ONE_HOUR_AGO, filter.activeFrom());
+            assertEquals(null, filter.activeTo());
+            // A session that starts after the caller read its clock is still picked up.
+            assertTrue(filter.matches(session("later", NOW.plus(Duration.ofSeconds(5)), null)));
+        }
+    }
+
+    @Nested
+    class Status {
+
+        @Test
+        void nullStatusMatchesEveryStatus() {
+            RecordingSessionFilter any = new RecordingSessionFilter(null, null, null, 0);
+
+            assertTrue(any.matches(session("active", NOW, null)));
+            assertTrue(any.matches(session("finished", NOW, NOW)));
+        }
+
+        @Test
+        void statusRestrictsToThatStatusOnly() {
+            RecordingSessionFilter activeOnly = RecordingSessionFilter.ALL.withStatus(RecordingStatus.ACTIVE);
+
+            assertTrue(activeOnly.matches(session("active", NOW, null)));
+            assertFalse(activeOnly.matches(session("finished", NOW, NOW)));
+        }
+    }
+
+    @Nested
+    class Apply {
+
+        private final List<RecordingSession> newestFirst = List.of(
+                session("s4-running", NOW.minus(Duration.ofMinutes(10)), null),
+                session("s3-recent", NOW.minus(Duration.ofMinutes(50)), NOW.minus(Duration.ofMinutes(20))),
+                session("s2-old", NOW.minus(Duration.ofHours(4)), NOW.minus(Duration.ofHours(3))),
+                session("s1-older", NOW.minus(Duration.ofHours(8)), NOW.minus(Duration.ofHours(7))));
+
+        @Test
+        void unrestrictedFilterReturnsTheSameListInstance() {
+            assertTrue(RecordingSessionFilter.ALL.isUnrestricted());
+            assertSame(newestFirst, RecordingSessionFilter.ALL.apply(newestFirst));
+        }
+
+        @Test
+        void windowKeepsOrderAndDropsNonMatching() {
+            RecordingSessionFilter lastHour = new RecordingSessionFilter(ONE_HOUR_AGO, NOW, null, 0);
+
+            assertEquals(List.of("s4-running", "s3-recent"), ids(lastHour.apply(newestFirst)));
+        }
+
+        @Test
+        void limitKeepsTheNewestSessions() {
+            RecordingSessionFilter newestTwo = RecordingSessionFilter.ALL.withLimit(2);
+
+            assertFalse(newestTwo.isUnrestricted());
+            assertEquals(List.of("s4-running", "s3-recent"), ids(newestTwo.apply(newestFirst)));
+        }
+
+        @Test
+        void limitAppliesAfterTheOtherConstraints() {
+            RecordingSessionFilter oneFinished = RecordingSessionFilter.ALL
+                    .withStatus(RecordingStatus.FINISHED)
+                    .withLimit(1);
+
+            assertEquals(List.of("s3-recent"), ids(oneFinished.apply(newestFirst)));
+        }
+    }
+
+    @Nested
+    class Validation {
+
+        @Test
+        void rejectsNegativeLimit() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> new RecordingSessionFilter(null, null, null, -1));
+        }
+
+        @Test
+        void rejectsWindowWhoseStartIsAfterItsEnd() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> new RecordingSessionFilter(NOW, ONE_HOUR_AGO, null, 0));
+        }
+
+        @Test
+        void rejectsNegativeLookBack() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> RecordingSessionFilter.activeWithinLast(Duration.ofMinutes(-1), NOW));
+        }
+
+        @Test
+        void acceptsAnInstantWindow() {
+            RecordingSessionFilter atInstant = new RecordingSessionFilter(NOW, NOW, null, 0);
+
+            assertTrue(atInstant.matches(session("running", ONE_HOUR_AGO, null)));
+        }
+    }
+}

--- a/shared/hub-api/src/main/proto/jeffrey/hub/api/v1/repository_service.proto
+++ b/shared/hub-api/src/main/proto/jeffrey/hub/api/v1/repository_service.proto
@@ -10,7 +10,9 @@ import "jeffrey/hub/api/v1/common.proto";
 // Manages the recording repository — JFR files, heap dumps, and other artifacts
 // organized into recording sessions. Provides session listing, statistics, and deletion.
 service RepositoryService {
-  // Lists all recording sessions for a project, optionally including finished ones.
+  // Lists the recording sessions of a project, newest first. An optional filter narrows the
+  // listing to sessions that were recording inside a time window, to one status, or to the
+  // newest N, so a caller asking for "the last hour" gets exactly those sessions back.
   rpc ListSessions(ListSessionsRequest) returns (ListSessionsResponse);
 
   // Gets detailed information about a single recording session, including its files.
@@ -32,6 +34,23 @@ service RepositoryService {
 
 message ListSessionsRequest {
   string project_id = 1;
+  // Narrows the listing. Absent, or with every field unset, returns every session.
+  SessionFilter filter = 2;
+}
+
+// Constraints on a session listing. Every field is optional and an unset field does not
+// restrict anything; set fields are combined with AND.
+message SessionFilter {
+  // Only sessions that were recording at some point between active_from and active_to
+  // (epoch millis). A session overlaps the window when it started at or before active_to and
+  // had not finished before active_from, so a session that is still running always matches a
+  // window that reaches the present. Either bound may be left unset to leave that side open.
+  optional int64 active_from = 1;
+  optional int64 active_to = 2;
+  // Only sessions in this status. RECORDING_STATUS_UNSPECIFIED matches every status.
+  RecordingStatus status = 3;
+  // Return at most this many sessions, newest first. Zero means no cap.
+  int32 limit = 4;
 }
 
 message ListSessionsResponse {

--- a/shared/hub-client/src/main/java/cafe/jeffrey/hub/client/ClientProtoMappers.java
+++ b/shared/hub-client/src/main/java/cafe/jeffrey/hub/client/ClientProtoMappers.java
@@ -45,6 +45,21 @@ public abstract class ClientProtoMappers {
         };
     }
 
+    /**
+     * Domain-to-proto status for a filter, where {@code null} means "any status" and maps to
+     * {@code UNSPECIFIED}.
+     */
+    public static cafe.jeffrey.hub.api.v1.RecordingStatus recordingStatus(RecordingStatus status) {
+        if (status == null) {
+            return cafe.jeffrey.hub.api.v1.RecordingStatus.RECORDING_STATUS_UNSPECIFIED;
+        }
+        return switch (status) {
+            case ACTIVE -> cafe.jeffrey.hub.api.v1.RecordingStatus.RECORDING_STATUS_ACTIVE;
+            case FINISHED -> cafe.jeffrey.hub.api.v1.RecordingStatus.RECORDING_STATUS_FINISHED;
+            case UNKNOWN -> cafe.jeffrey.hub.api.v1.RecordingStatus.RECORDING_STATUS_UNKNOWN;
+        };
+    }
+
     public static WorkspaceStatus workspaceStatus(cafe.jeffrey.hub.api.v1.WorkspaceStatus status) {
         return switch (status) {
             case WORKSPACE_STATUS_AVAILABLE -> WorkspaceStatus.AVAILABLE;

--- a/shared/hub-client/src/main/java/cafe/jeffrey/hub/client/RepositoryClient.java
+++ b/shared/hub-client/src/main/java/cafe/jeffrey/hub/client/RepositoryClient.java
@@ -26,6 +26,7 @@ import cafe.jeffrey.hub.api.v1.*;
 import cafe.jeffrey.hub.client.dto.RecordingSessionResponse;
 import cafe.jeffrey.hub.client.dto.RepositoryFileResponse;
 import cafe.jeffrey.hub.client.dto.RepositoryStatisticsResponse;
+import cafe.jeffrey.shared.common.model.repository.RecordingSessionFilter;
 import cafe.jeffrey.shared.common.model.repository.SupportedRecordingFile;
 
 import java.util.List;
@@ -41,14 +42,36 @@ public class RepositoryClient {
     }
 
     public List<RecordingSessionResponse> recordingSessions(String projectId) {
+        return recordingSessions(projectId, RecordingSessionFilter.ALL);
+    }
+
+    /**
+     * Lists the sessions of a project that satisfy the filter, newest first. The filter travels
+     * to the hub, so only the matching sessions come back over the wire.
+     */
+    public List<RecordingSessionResponse> recordingSessions(String projectId, RecordingSessionFilter filter) {
         ListSessionsResponse response = stub.listSessions(
                 ListSessionsRequest.newBuilder()
                         .setProjectId(projectId)
+                        .setFilter(toProto(filter))
                         .build());
 
         return response.getSessionsList().stream()
                 .map(RepositoryClient::toSessionResponse)
                 .toList();
+    }
+
+    private static SessionFilter toProto(RecordingSessionFilter filter) {
+        SessionFilter.Builder builder = SessionFilter.newBuilder()
+                .setStatus(ClientProtoMappers.recordingStatus(filter.status()))
+                .setLimit(filter.limit());
+        if (filter.activeFrom() != null) {
+            builder.setActiveFrom(filter.activeFrom().toEpochMilli());
+        }
+        if (filter.activeTo() != null) {
+            builder.setActiveTo(filter.activeTo().toEpochMilli());
+        }
+        return builder.build();
     }
 
     public RecordingSessionResponse recordingSession(String sessionId) {

--- a/shared/hub-client/src/main/java/cafe/jeffrey/hub/client/manager/RemoteRepositoryManager.java
+++ b/shared/hub-client/src/main/java/cafe/jeffrey/hub/client/manager/RemoteRepositoryManager.java
@@ -27,6 +27,7 @@ import cafe.jeffrey.shared.common.filesystem.TempDirectory;
 import cafe.jeffrey.shared.common.model.ProjectInfo;
 import cafe.jeffrey.shared.common.model.repository.FileCategory;
 import cafe.jeffrey.shared.common.model.repository.RecordingSession;
+import cafe.jeffrey.shared.common.model.repository.RecordingSessionFilter;
 import cafe.jeffrey.shared.common.model.repository.RepositoryStatistics;
 import cafe.jeffrey.shared.common.model.repository.StreamedRecordingFile;
 
@@ -55,8 +56,8 @@ public class RemoteRepositoryManager implements RepositoryManager {
     }
 
     @Override
-    public List<RecordingSession> listRecordingSessions(boolean withFiles) {
-        return repositoryClient.recordingSessions(projectInfo.id()).stream()
+    public List<RecordingSession> listRecordingSessions(boolean withFiles, RecordingSessionFilter filter) {
+        return repositoryClient.recordingSessions(projectInfo.id(), filter).stream()
                 .map(RecordingSessionResponse::from)
                 .toList();
     }

--- a/shared/hub-client/src/main/java/cafe/jeffrey/hub/client/manager/RepositoryManager.java
+++ b/shared/hub-client/src/main/java/cafe/jeffrey/hub/client/manager/RepositoryManager.java
@@ -19,6 +19,7 @@
 package cafe.jeffrey.hub.client.manager;
 
 import cafe.jeffrey.shared.common.model.repository.RecordingSession;
+import cafe.jeffrey.shared.common.model.repository.RecordingSessionFilter;
 import cafe.jeffrey.shared.common.model.repository.RepositoryStatistics;
 import cafe.jeffrey.shared.common.model.repository.StreamedRecordingFile;
 
@@ -26,7 +27,18 @@ import java.util.List;
 
 public interface RepositoryManager {
 
-    List<RecordingSession> listRecordingSessions(boolean withFiles);
+    /**
+     * Lists every recording session of the project, newest first.
+     */
+    default List<RecordingSession> listRecordingSessions(boolean withFiles) {
+        return listRecordingSessions(withFiles, RecordingSessionFilter.ALL);
+    }
+
+    /**
+     * Lists the recording sessions that satisfy the filter, newest first. The filter is
+     * evaluated by the hub, so the response carries only the sessions asked for.
+     */
+    List<RecordingSession> listRecordingSessions(boolean withFiles, RecordingSessionFilter filter);
 
     RepositoryStatistics calculateRepositoryStatistics();
 

--- a/shared/hub-client/src/test/java/cafe/jeffrey/hub/client/RepositoryClientTest.java
+++ b/shared/hub-client/src/test/java/cafe/jeffrey/hub/client/RepositoryClientTest.java
@@ -1,0 +1,139 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.hub.client;
+
+import cafe.jeffrey.hub.api.v1.ListSessionsRequest;
+import cafe.jeffrey.hub.api.v1.ListSessionsResponse;
+import cafe.jeffrey.hub.api.v1.RecordingSession;
+import cafe.jeffrey.hub.api.v1.RecordingStatus;
+import cafe.jeffrey.hub.api.v1.RepositoryServiceGrpc;
+import cafe.jeffrey.hub.api.v1.SessionFilter;
+import cafe.jeffrey.hub.client.dto.RecordingSessionResponse;
+import cafe.jeffrey.microscope.grpc.client.GrpcHubConnection;
+import cafe.jeffrey.shared.common.model.repository.RecordingSessionFilter;
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RepositoryClientTest {
+
+    private static final String PROJECT_ID = "proj-1";
+    private static final Instant NOW = Instant.parse("2026-03-01T12:00:00Z");
+
+    /**
+     * Records the last request so a test can assert what the client put on the wire, and answers
+     * with one canned session so the response mapping is exercised too.
+     */
+    private static final class CapturingRepositoryService extends RepositoryServiceGrpc.RepositoryServiceImplBase {
+
+        private final AtomicReference<ListSessionsRequest> lastRequest = new AtomicReference<>();
+
+        @Override
+        public void listSessions(ListSessionsRequest request, StreamObserver<ListSessionsResponse> observer) {
+            lastRequest.set(request);
+            observer.onNext(ListSessionsResponse.newBuilder()
+                    .addSessions(RecordingSession.newBuilder()
+                            .setId("session-1")
+                            .setName("session-1")
+                            .setCreatedAt(NOW.toEpochMilli())
+                            .setStatus(RecordingStatus.RECORDING_STATUS_ACTIVE))
+                    .build());
+            observer.onCompleted();
+        }
+    }
+
+    private final CapturingRepositoryService service = new CapturingRepositoryService();
+
+    private Server server;
+    private ManagedChannel channel;
+    private RepositoryClient client;
+
+    @BeforeEach
+    void start() throws IOException {
+        String name = InProcessServerBuilder.generateName();
+        server = InProcessServerBuilder.forName(name).directExecutor().addService(service).build().start();
+        channel = InProcessChannelBuilder.forName(name).directExecutor().build();
+        client = new RepositoryClient(new GrpcHubConnection(channel) { });
+    }
+
+    @AfterEach
+    void stop() {
+        channel.shutdownNow();
+        server.shutdownNow();
+    }
+
+    @Nested
+    class RecordingSessions {
+
+        @Test
+        void unfilteredListingSendsAnEmptyFilter() {
+            List<RecordingSessionResponse> sessions = client.recordingSessions(PROJECT_ID);
+
+            ListSessionsRequest sent = service.lastRequest.get();
+            assertEquals(PROJECT_ID, sent.getProjectId());
+            assertEquals(SessionFilter.getDefaultInstance(), sent.getFilter());
+            assertEquals(1, sessions.size());
+            assertEquals("session-1", sessions.getFirst().id());
+        }
+
+        @Test
+        void filterBoundsStatusAndLimitTravelToTheHub() {
+            Instant from = NOW.minus(Duration.ofHours(1));
+            var filter = new RecordingSessionFilter(
+                    from, NOW, cafe.jeffrey.shared.common.model.repository.RecordingStatus.FINISHED, 3);
+
+            client.recordingSessions(PROJECT_ID, filter);
+
+            SessionFilter sent = service.lastRequest.get().getFilter();
+            assertTrue(sent.hasActiveFrom());
+            assertEquals(from.toEpochMilli(), sent.getActiveFrom());
+            assertTrue(sent.hasActiveTo());
+            assertEquals(NOW.toEpochMilli(), sent.getActiveTo());
+            assertEquals(RecordingStatus.RECORDING_STATUS_FINISHED, sent.getStatus());
+            assertEquals(3, sent.getLimit());
+        }
+
+        @Test
+        void openBoundsStayUnsetOnTheWire() {
+            client.recordingSessions(PROJECT_ID, RecordingSessionFilter.activeWithinLast(Duration.ofHours(1), NOW));
+
+            SessionFilter sent = service.lastRequest.get().getFilter();
+            assertTrue(sent.hasActiveFrom());
+            assertFalse(sent.hasActiveTo());
+            assertEquals(RecordingStatus.RECORDING_STATUS_UNSPECIFIED, sent.getStatus());
+            assertEquals(0, sent.getLimit());
+        }
+    }
+}

--- a/shared/recordings-core/pom.xml
+++ b/shared/recordings-core/pom.xml
@@ -59,5 +59,22 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/shared/recordings-core/src/main/java/cafe/jeffrey/recordings/core/RecordingsDownloadManager.java
+++ b/shared/recordings-core/src/main/java/cafe/jeffrey/recordings/core/RecordingsDownloadManager.java
@@ -22,7 +22,21 @@ import java.util.List;
 
 public interface RecordingsDownloadManager {
 
-    void mergeAndDownloadSession(String recordingSessionId);
+    /**
+     * Downloads every finished file of the session and stores it as one local recording.
+     *
+     * @param recordingSessionId the upstream session to download
+     * @return id of the recording created in the local store, so the caller can go on to
+     * analyse it without having to search the store for whatever appeared last
+     */
+    String mergeAndDownloadSession(String recordingSessionId);
 
-    void mergeAndDownloadRecordings(String recordingSessionId, List<String> rawRecordingIds);
+    /**
+     * Downloads the named files of the session and stores them as one local recording.
+     *
+     * @param recordingSessionId the upstream session to download
+     * @param rawRecordingIds    ids of the files to take from that session
+     * @return id of the recording created in the local store
+     */
+    String mergeAndDownloadRecordings(String recordingSessionId, List<String> rawRecordingIds);
 }

--- a/shared/recordings-core/src/main/java/cafe/jeffrey/recordings/core/RemoteRecordingsDownloadManager.java
+++ b/shared/recordings-core/src/main/java/cafe/jeffrey/recordings/core/RemoteRecordingsDownloadManager.java
@@ -96,7 +96,7 @@ public class RemoteRecordingsDownloadManager implements RecordingsDownloadManage
     }
 
     @Override
-    public void mergeAndDownloadSession(String recordingSessionId) {
+    public String mergeAndDownloadSession(String recordingSessionId) {
         RecordingSessionResponse recordingSession = repositoryClient.recordingSession(
                 recordingSessionId);
 
@@ -105,11 +105,11 @@ public class RemoteRecordingsDownloadManager implements RecordingsDownloadManage
                 .filter(RepositoryFile::isFinished)
                 .toList();
 
-        processRecordingSession(recordingSessionId, files);
+        return processRecordingSession(recordingSessionId, files);
     }
 
     @Override
-    public void mergeAndDownloadRecordings(String recordingSessionId, List<String> fileIds) {
+    public String mergeAndDownloadRecordings(String recordingSessionId, List<String> fileIds) {
         RecordingSessionResponse recordingSession = repositoryClient.recordingSession(
                 recordingSessionId);
 
@@ -120,11 +120,11 @@ public class RemoteRecordingsDownloadManager implements RecordingsDownloadManage
                 .filter(file -> requestedFileIds.contains(file.id()))
                 .toList();
 
-        processRecordingSession(recordingSessionId, files);
+        return processRecordingSession(recordingSessionId, files);
     }
 
     // TODO: Simplify this behaviour
-    private void processRecordingSession(String recordingSessionId, List<RepositoryFile> files) {
+    private String processRecordingSession(String recordingSessionId, List<RepositoryFile> files) {
         // At least one recording file must be present, otherwise nothing to merge and download
         // 0...n additional recording files can be present (e.g. HeapDump, logs, etc.)
         if (files.stream().noneMatch(RepositoryFile::isRecordingFile)) {
@@ -158,7 +158,7 @@ public class RemoteRecordingsDownloadManager implements RecordingsDownloadManage
                     .toList();
 
             // Persist into Recordings storage with origin tags
-            persistToRecordings(recordingSessionId, recordingPath, artifactPaths);
+            return persistToRecordings(recordingSessionId, recordingPath, artifactPaths);
         }
     }
 
@@ -186,8 +186,9 @@ public class RemoteRecordingsDownloadManager implements RecordingsDownloadManage
      * @param recordingSessionId the recording session ID
      * @param fileIds            the list of file IDs to download
      * @param progressCallback   callback for receiving progress updates
+     * @return id of the recording created in the local store
      */
-    public void mergeAndDownloadRecordingsWithProgress(
+    public String mergeAndDownloadRecordingsWithProgress(
             String recordingSessionId,
             List<String> fileIds,
             ProgressCallback progressCallback) {
@@ -202,10 +203,10 @@ public class RemoteRecordingsDownloadManager implements RecordingsDownloadManage
                 .filter(file -> requestedFileIds.contains(file.id()))
                 .toList();
 
-        processRecordingSessionWithProgress(recordingSession, files, progressCallback);
+        return processRecordingSessionWithProgress(recordingSession, files, progressCallback);
     }
 
-    private void processRecordingSessionWithProgress(
+    private String processRecordingSessionWithProgress(
             RecordingSessionResponse recordingSession,
             List<RepositoryFile> files,
             ProgressCallback progressCallback) {
@@ -348,11 +349,14 @@ public class RemoteRecordingsDownloadManager implements RecordingsDownloadManage
             progressCallback.onProcessing();
 
             // Persist into Recordings storage with origin tags
-            persistToRecordings(recordingSessionId, recordingPath, artifactPaths);
+            String recordingId = persistToRecordings(recordingSessionId, recordingPath, artifactPaths);
 
             // Completed successfully
             progressCallback.onComplete();
-            LOG.info("Parallel download completed: sessionId={} artifacts={}", recordingSessionId, artifactPaths.size());
+            LOG.info("Parallel download completed: sessionId={} recordingId={} artifacts={}",
+                    recordingSessionId, recordingId, artifactPaths.size());
+
+            return recordingId;
 
         } catch (CancellationException e) {
             LOG.info("Download cancelled: sessionId={}", recordingSessionId);
@@ -413,12 +417,14 @@ public class RemoteRecordingsDownloadManager implements RecordingsDownloadManage
     /**
      * Persist the merged recording + any artifact files into Recordings storage,
      * tagged with the {@code origin.*} system tags from {@link #originContext}.
+     *
+     * @return id of the newly created local recording
      */
-    private void persistToRecordings(
+    private String persistToRecordings(
             String recordingSessionId, Path recordingPath, List<Path> artifactPaths) {
 
         Map<String, String> originTags = originContext.toTagMap(recordingSessionId);
-        recordingsManager.createDownloadedRecording(
+        return recordingsManager.createDownloadedRecording(
                 recordingSessionId, recordingPath, artifactPaths, originTags);
     }
 }

--- a/shared/recordings-core/src/test/java/cafe/jeffrey/recordings/core/RemoteRecordingsDownloadManagerTest.java
+++ b/shared/recordings-core/src/test/java/cafe/jeffrey/recordings/core/RemoteRecordingsDownloadManagerTest.java
@@ -1,0 +1,188 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.recordings.core;
+
+import cafe.jeffrey.hub.client.RecordingStreamClient;
+import cafe.jeffrey.hub.client.RepositoryClient;
+import cafe.jeffrey.hub.client.dto.RecordingSessionResponse;
+import cafe.jeffrey.hub.client.dto.RepositoryFileResponse;
+import cafe.jeffrey.hub.client.manager.TempDirProvider;
+import cafe.jeffrey.recordings.core.download.ProgressCallback;
+import cafe.jeffrey.recordings.core.manager.RecordingsCoreManager;
+import cafe.jeffrey.shared.common.filesystem.TempDirectory;
+import cafe.jeffrey.shared.common.model.repository.RecordingStatus;
+import cafe.jeffrey.shared.common.model.repository.SupportedRecordingFile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the one thing every download path owes its caller: the id of the recording it created.
+ * Without it a caller that wants to analyse what it just downloaded has to guess which entry in
+ * the local store is the new one.
+ */
+class RemoteRecordingsDownloadManagerTest {
+
+    private static final String SESSION_ID = "session-1";
+    private static final String RECORDING_ID = "local-recording-1";
+    private static final Instant CREATED_AT = Instant.parse("2026-03-01T12:00:00Z");
+
+    private final RepositoryClient repositoryClient = mock(RepositoryClient.class);
+    private final RecordingStreamClient streamClient = mock(RecordingStreamClient.class);
+    private final RecordingsCoreManager recordingsManager = mock(RecordingsCoreManager.class);
+
+    private final OriginContext originContext =
+            new OriginContext("cfg-prod", "Production", "ws-1", "workspace", "p-1", "checkout");
+
+    @TempDir
+    Path tempRoot;
+
+    private RemoteRecordingsDownloadManager manager;
+
+    @BeforeEach
+    void setUp() {
+        TempDirProvider tempDirProvider = () -> new TempDirectory(tempRoot.resolve("download"));
+        manager = new RemoteRecordingsDownloadManager(
+                tempDirProvider, streamClient, repositoryClient, recordingsManager, originContext, "checkout");
+
+        when(recordingsManager.createDownloadedRecording(any(), any(), anyList(), any()))
+                .thenReturn(RECORDING_ID);
+    }
+
+    private static RepositoryFileResponse file(
+            String id, String name, SupportedRecordingFile type, RecordingStatus status) {
+        return new RepositoryFileResponse(
+                id, name, CREATED_AT.toEpochMilli(), 1024L, type, status, type == SupportedRecordingFile.JFR);
+    }
+
+    private static RecordingSessionResponse session(RepositoryFileResponse... files) {
+        return new RecordingSessionResponse(
+                SESSION_ID, "session-name", "inst-1",
+                CREATED_AT.toEpochMilli(), CREATED_AT.plusSeconds(60).toEpochMilli(),
+                RecordingStatus.FINISHED, 60_000L, List.of(files), false);
+    }
+
+    /**
+     * A downloaded file as the stream client hands it over. {@code ByteArrayResource} reports no
+     * filename on its own, and the download code names its temp file from that.
+     */
+    private static Resource resource(String filename) {
+        return new ByteArrayResource("recording-bytes".getBytes(StandardCharsets.UTF_8)) {
+            @Override
+            public String getFilename() {
+                return filename;
+            }
+        };
+    }
+
+    @Nested
+    class MergeAndDownloadSession {
+
+        @Test
+        void returnsTheIdOfTheRecordingItCreated() {
+            when(repositoryClient.recordingSession(SESSION_ID)).thenReturn(session(
+                    file("f-1", "recording.jfr", SupportedRecordingFile.JFR, RecordingStatus.FINISHED)));
+            when(streamClient.downloadRecordings(eq(SESSION_ID), anyList()))
+                    .thenReturn(CompletableFuture.completedFuture(resource("recording.jfr")));
+
+            String recordingId = manager.mergeAndDownloadSession(SESSION_ID);
+
+            assertEquals(RECORDING_ID, recordingId);
+        }
+
+        @Test
+        void tagsTheRecordingWithTheUpstreamSessionId() {
+            when(repositoryClient.recordingSession(SESSION_ID)).thenReturn(session(
+                    file("f-1", "recording.jfr", SupportedRecordingFile.JFR, RecordingStatus.FINISHED)));
+            when(streamClient.downloadRecordings(eq(SESSION_ID), anyList()))
+                    .thenReturn(CompletableFuture.completedFuture(resource("recording.jfr")));
+
+            manager.mergeAndDownloadSession(SESSION_ID);
+
+            Map<String, String> expectedTags = originContext.toTagMap(SESSION_ID);
+            verify(recordingsManager).createDownloadedRecording(
+                    eq(SESSION_ID), any(), anyList(), eq(expectedTags));
+        }
+    }
+
+    @Nested
+    class MergeAndDownloadRecordings {
+
+        @Test
+        void returnsTheIdOfTheRecordingItCreated() {
+            when(repositoryClient.recordingSession(SESSION_ID)).thenReturn(session(
+                    file("f-1", "recording.jfr", SupportedRecordingFile.JFR, RecordingStatus.FINISHED),
+                    file("f-2", "heap.hprof", SupportedRecordingFile.HEAP_DUMP, RecordingStatus.FINISHED)));
+            when(streamClient.downloadRecordings(eq(SESSION_ID), anyList()))
+                    .thenReturn(CompletableFuture.completedFuture(resource("recording.jfr")));
+            when(streamClient.downloadArtifactFile(SESSION_ID, "f-2"))
+                    .thenReturn(CompletableFuture.completedFuture(resource("heap.hprof")));
+
+            String recordingId = manager.mergeAndDownloadRecordings(SESSION_ID, List.of("f-1", "f-2"));
+
+            assertEquals(RECORDING_ID, recordingId);
+        }
+    }
+
+    @Nested
+    class MergeAndDownloadRecordingsWithProgress {
+
+        @Test
+        void returnsTheIdOfTheRecordingItCreated() throws IOException {
+            when(repositoryClient.recordingSession(SESSION_ID)).thenReturn(session(
+                    file("f-1", "recording.jfr", SupportedRecordingFile.JFR, RecordingStatus.FINISHED)));
+            doAnswer(invocation -> {
+                RecordingStreamClient.InputStreamConsumer consumer = invocation.getArgument(2);
+                try (InputStream in = resource("recording.jfr").getInputStream()) {
+                    consumer.accept(in, 15L);
+                }
+                return null;
+            }).when(streamClient).streamRecordings(eq(SESSION_ID), anyList(), any());
+
+            ProgressCallback progress = mock(ProgressCallback.class);
+
+            String recordingId = manager.mergeAndDownloadRecordingsWithProgress(
+                    SESSION_ID, List.of("f-1"), progress);
+
+            assertEquals(RECORDING_ID, recordingId);
+            verify(progress).onComplete();
+        }
+    }
+}

--- a/shared/ui/workspaces/src/main/java/cafe/jeffrey/shared/ui/workspace/controller/ProjectRepositoryController.java
+++ b/shared/ui/workspaces/src/main/java/cafe/jeffrey/shared/ui/workspace/controller/ProjectRepositoryController.java
@@ -29,12 +29,16 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 import cafe.jeffrey.recordings.core.RecordingsDownloadManager;
 import cafe.jeffrey.hub.client.dto.RecordingSessionResponse;
 import cafe.jeffrey.hub.client.dto.RepositoryStatisticsResponse;
 import cafe.jeffrey.hub.client.manager.RepositoryManager;
+import cafe.jeffrey.shared.common.InstantUtils;
+import cafe.jeffrey.shared.common.model.repository.RecordingSessionFilter;
+import cafe.jeffrey.shared.common.model.repository.RecordingStatus;
 import cafe.jeffrey.shared.common.model.repository.RepositoryStatistics;
 import cafe.jeffrey.shared.common.model.repository.StreamedRecordingFile;
 import cafe.jeffrey.shared.ui.workspace.bridge.RemoteProjectAccess;
@@ -64,16 +68,31 @@ public class ProjectRepositoryController {
         this.clock = clock;
     }
 
+    /**
+     * Lists the project's recording sessions, newest first. All query parameters are optional and
+     * narrow the listing on the hub: {@code activeFrom}/{@code activeTo} (epoch millis) keep the
+     * sessions that were recording inside the window, {@code status} keeps one status and
+     * {@code limit} caps the count. Without parameters every session is returned.
+     */
     @GetMapping("/sessions")
     public List<RecordingSessionResponse> listRepositorySessions(
             @PathVariable("hubId") String hubId,
             @PathVariable("workspaceId") String workspaceId,
-            @PathVariable("projectId") String projectId) {
+            @PathVariable("projectId") String projectId,
+            @RequestParam(value = "activeFrom", required = false) Long activeFrom,
+            @RequestParam(value = "activeTo", required = false) Long activeTo,
+            @RequestParam(value = "status", required = false) RecordingStatus status,
+            @RequestParam(value = "limit", defaultValue = "0") int limit) {
+        RecordingSessionFilter filter = new RecordingSessionFilter(
+                InstantUtils.fromEpochMilli(activeFrom),
+                InstantUtils.fromEpochMilli(activeTo),
+                status,
+                limit);
         var result = projectAccess.repositoryManager(hubId, workspaceId, projectId)
-                .listRecordingSessions(true).stream()
+                .listRecordingSessions(true, filter).stream()
                 .map(s -> RecordingSessionResponse.from(s, clock))
                 .toList();
-        LOG.debug("Listed repository sessions: projectId={} count={}", projectId, result.size());
+        LOG.debug("Listed repository sessions: projectId={} filter={} count={}", projectId, filter, result.size());
         return result;
     }
 


### PR DESCRIPTION
ListSessions could only return every session of a project, so any caller
that wanted "the recordings from the last hour" had to pull the whole
listing and sift it locally. The upcoming MCP tools for pulling recordings
from a hub need that question answered in one call, with the semantics
spelled out once rather than re-derived by every client.

ListSessionsRequest gains an optional SessionFilter: active_from/active_to,
a status and a limit. Every field is optional and unset fields do not
restrict, so an absent filter keeps the old behaviour. The window uses
overlap semantics, pinned by RecordingSessionFilter in shared/common and
its tests: a session matches when it was recording at any point inside the
window, so a JVM that started three hours ago and is still running matches
"the last hour", while a session that finished before the window opened
does not. The hub applies the filter after its storage has sorted sessions
newest first and marked the latest one ACTIVE, so status filtering sees the
same statuses the unfiltered listing reports, and the limit keeps the
newest sessions. An empty window or a negative limit is INVALID_ARGUMENT.

Microscope threads the same record through RepositoryClient and the
client-side RepositoryManager, and GET .../repository/sessions accepts the
filter as optional activeFrom/activeTo/status/limit query parameters. The
one-argument listings stay as defaults delegating to the unrestricted
filter, so existing callers and their tests are untouched.

Claude-Session: https://claude.ai/code/session_015sTaZFW6hthQsEgnCmoU1f