### PR TITLE
Sync the docs with what the MCP server actually advertises

### DIFF
--- a/jeffrey-pages/src/views/docs/DocsMicroscopePage.vue
+++ b/jeffrey-pages/src/views/docs/DocsMicroscopePage.vue
@@ -138,7 +138,7 @@ onMounted(() => {
       </div>
 
       <h3 id="ai-integration">AI Integration</h3>
-      <p>The assistant is wired through Spring AI with pluggable Claude, ChatGPT, Ollama, and Claude Code providers, selected by <code>jeffrey.microscope.ai.provider</code> and <code>jeffrey.microscope.ai.model</code>. Two MCP servers expose the data: <code>duckdb-jfr-mcp</code> answers JFR questions by running OQL against the active profile's DuckDB, and <code>duckdb-heapdump-mcp</code> handles heap-dump queries. Configuration and capability detail live on the <router-link to="/docs/ai/overview">AI Overview</router-link> page. A third MCP server points the other way &mdash; it lets an outside Claude Code session read every analysed profile; see <router-link to="/docs/microscope-mcp">Microscope MCP</router-link>.</p>
+      <p>The assistant is wired through Spring AI with pluggable Claude, ChatGPT, Ollama, and Claude Code providers, selected by <code>jeffrey.microscope.ai.provider</code> and <code>jeffrey.microscope.ai.model</code>. Two MCP servers expose the data: <code>duckdb-jfr-mcp</code> answers JFR questions by running OQL against the active profile's DuckDB, and <code>duckdb-heapdump-mcp</code> handles heap-dump queries. Configuration and capability detail live on the <router-link to="/docs/ai/overview">AI Overview</router-link> page. A third MCP server points the other way &mdash; it lets an outside Claude Code session read every analysed profile, build one from a recording file, and pull a recording off a connected Jeffrey Hub to analyse; see <router-link to="/docs/microscope-mcp">Microscope MCP</router-link>.</p>
 
       <div class="arch-flow">
         <div class="flow-node"><i class="bi bi-chat-dots"></i><span>Assistant</span></div>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpAgentPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpAgentPage.vue
@@ -104,12 +104,12 @@ Notes: threshold 1%, weighted by bytes. Frames below 1% rolled into parents.`;
       <ul>
         <li><strong>No source.</strong> It has no file tools and cannot read your repository. It names the frame, never a file or a line &mdash; mapping frames onto the checkout is yours, and a guess made there would arrive looking measured.</li>
         <li><strong>No recommendations.</strong> It reports what the profile shows. Whether to change anything, and what, stays in your session where you can be asked.</li>
-        <li><strong>No writing.</strong> It cannot import a recording or build a profile. If the profile it was given does not exist or is not ready, it reports that and stops.</li>
+        <li><strong>No writing.</strong> It can neither import a recording from this machine nor pull one off a connected hub, so it cannot build a profile either way. If the profile it was given does not exist or is not ready, it reports that and stops.</li>
         <li><strong>No nesting.</strong> The skills it carries tell <em>their</em> reader to delegate export reading to the analyst; that instruction is written for your session, not for it. It does the reading itself and never spawns another agent.</li>
       </ul>
 
       <DocsCallout type="warning" title="Enforced in Claude Code, instructed in Codex">
-        The Claude Code subagent is denied file tools and the <code>recordings_</code> family in its own definition, so the first two rules hold whatever the model decides. Codex has no per-agent tool deny-list: its copy is sandboxed read-only against your files, and the rest is instruction. To make it a wall there, deny <code>recordings_</code> at the server with <code>disabled_tools</code> &mdash; the <router-link to="/docs/microscope-mcp/codex">Codex</router-link> page has the block.
+        The Claude Code subagent is denied file tools and both writing families &mdash; <code>recordings_</code> and <code>hubs_</code> &mdash; in its own definition, so the first two rules hold whatever the model decides. Codex has no per-agent tool deny-list: its copy is sandboxed read-only against your files, and the rest is instruction. To make it a wall there, deny both families at the server with <code>disabled_tools</code> &mdash; the <router-link to="/docs/microscope-mcp/codex">Codex</router-link> page has the block.
       </DocsCallout>
 
       <h2 id="delegating-to-it">Delegating to It</h2>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpClaudeCodePage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpClaudeCodePage.vue
@@ -106,7 +106,8 @@ const removal = `/plugin uninstall microscope@jeffrey`;
       <p><strong>Seven skills</strong>, which Claude picks up on its own when a question calls for them, and which you can also invoke directly:</p>
       <ul>
         <li><code>/microscope:analyze-jfr</code> &mdash; where to start and which family answers which question</li>
-        <li><code>/microscope:analyze-heap</code> &mdash; a heap dump end to end: what is holding the memory, what is leaking, and the order the twenty heap tools have to be run in</li>
+        <li><code>/microscope:analyze-heap</code> &mdash; a heap dump end to end: what is holding the memory, what is leaking, and the order the twenty-one heap tools have to be run in</li>
+        <li><code>/microscope:analyze-hub</code> &mdash; the recordings that never reached this machine: finds the session across the connected Jeffrey Hubs, pulls it in, and hands off to <code>analyze-jfr</code> or <code>analyze-heap</code></li>
         <li><code>/microscope:compare-jfr</code> &mdash; before against after: whether a change made it slower, which methods moved, and whether the two recordings were comparable in the first place</li>
         <li><code>/microscope:advise-jfr</code> &mdash; from a profile to a code change: hot frames mapped to your checkout, a recommendation, then the edit and a re-profile on request</li>
         <li><code>/microscope:jfr-sql</code> &mdash; the JFR schema and the DuckDB idioms that go with it</li>
@@ -117,17 +118,17 @@ const removal = `/plugin uninstall microscope@jeffrey`;
 
       <p><strong>One subagent</strong>, <code>microscope:profile-analyst</code>. A single <code>flamegraph_export</code> can run to 120,000 characters &mdash; the cap a tool result is truncated at &mdash; and answering a question properly often takes several of them. The analyst runs a sequence and returns only the findings: the hot frames with their <code>total</code> and <code>self</code> shares, or the retaining classes with their retained bytes and GC-root paths. Everything it read stays in its own context window rather than crowding out the conversation you are having.</p>
 
-      <p>The skills hand it the reading and keep what actually needs your session: mapping frames onto the checkout, the recommendation, and every question put to you. <code>advise-jfr</code> uses it hardest, sending CPU, wall-clock, allocation and blocking out as four parallel delegations instead of pulling four documents into one context. Its tools are the read-only MCP families and nothing else &mdash; no file access, no <code>recordings_</code> &mdash; so it can neither touch your repository nor create a profile. <router-link to="/docs/microscope-mcp/agent">The subagent reference</router-link> covers what it returns and when to read an export yourself instead.</p>
+      <p>The skills hand it the reading and keep what actually needs your session: mapping frames onto the checkout, the recommendation, and every question put to you. <code>advise-jfr</code> uses it hardest, sending CPU, wall-clock, allocation and blocking out as four parallel delegations instead of pulling four documents into one context. Its tools are the read-only MCP families and nothing else &mdash; no file access, no <code>recordings_</code>, no <code>hubs_</code> &mdash; so it can neither touch your repository nor create a profile. <router-link to="/docs/microscope-mcp/agent">The subagent reference</router-link> covers what it returns and when to read an export yourself instead.</p>
 
       <h2 id="permissions">Permissions</h2>
-      <p>Claude Code asks before each tool the first time. Every tool here reads except the <code>recordings_</code> family, which imports a recording file and builds a profile from it, so approving the whole family once is usually what you want &mdash; from the prompt, or up front with <code>/permissions</code>:</p>
+      <p>Claude Code asks before each tool the first time. Every tool here reads except the <code>recordings_</code> and <code>hubs_</code> families, which build a profile from a recording file on this machine or from a session on a connected hub, so approving the read-only families once is usually what you want &mdash; from the prompt, or up front with <code>/permissions</code>:</p>
       <DocsCodeBlock :code="permissionRule" language="bash" />
 
       <p>The name reads <code>mcp__plugin_&lt;plugin&gt;_&lt;server&gt;__&lt;tool&gt;</code>: the <code>microscope</code> plugin, the <code>jeffrey</code> server inside it. In a non-interactive run there is no prompt to answer, so the rule has to be passed explicitly or the run stalls:</p>
       <DocsCodeBlock :code="headlessRun" language="bash" />
 
       <h2 id="check-it-is-connected">Check It Is Connected</h2>
-      <p>Run <code>/mcp</code> in Claude Code. The <code>jeffrey</code> server should be listed as connected. If it is not, in order of likelihood: the MCP server is still off in Settings, Jeffrey is not on the address the plugin is pointed at, or Jeffrey is not running.</p>
+      <p>Run <code>/mcp</code> in Claude Code. The <code>jeffrey</code> server should be listed as connected. If it is not, in order of likelihood: this installation set <code>jeffrey.microscope.mcp.enabled=false</code> (Settings reports which way it is set, but does not change it), Jeffrey is not on the address the plugin is pointed at, or Jeffrey is not running.</p>
 
       <h2 id="updating-and-removing">Updating and Removing</h2>
       <p>Refresh the marketplace, then update the plugin from it &mdash; a restart of Claude Code applies the new version:</p>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpCodexPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpCodexPage.vue
@@ -62,7 +62,10 @@ const approvalRule = `[mcp_servers.jeffrey]
 default_tools_approval_mode = "auto"`;
 
 const ingestDenyRule = `[mcp_servers.jeffrey]
-disabled_tools = ["recordings_analyzeFile", "recordings_analyzeRecording"]`;
+disabled_tools = [
+  "recordings_analyzeFile", "recordings_analyzeRecording", "recordings_list",
+  "hubs_list", "hubs_sessions", "hubs_download",
+]`;
 
 const manualAdd = `codex mcp add jeffrey --url http://localhost:8585/api/internal/mcp`;
 
@@ -116,7 +119,8 @@ const removal = `codex plugin marketplace remove jeffrey`;
       <p>Registering the server by hand gives you the eighty-eight tools. The plugin adds the endpoint already configured, and <strong>seven skills</strong>, which Codex picks up on its own when a question calls for them and which you can also invoke directly with <code>$</code>:</p>
       <ul>
         <li><code>$analyze-jfr</code> &mdash; where to start and which family answers which question</li>
-        <li><code>$analyze-heap</code> &mdash; a heap dump end to end: what is holding the memory, what is leaking, and the order the twenty heap tools have to be run in</li>
+        <li><code>$analyze-heap</code> &mdash; a heap dump end to end: what is holding the memory, what is leaking, and the order the twenty-one heap tools have to be run in</li>
+        <li><code>$analyze-hub</code> &mdash; the recordings that never reached this machine: finds the session across the connected Jeffrey Hubs, pulls it in, and hands off to <code>analyze-jfr</code> or <code>analyze-heap</code></li>
         <li><code>$compare-jfr</code> &mdash; before against after: whether a change made it slower, which methods moved, and whether the two recordings were comparable in the first place</li>
         <li><code>$advise-jfr</code> &mdash; from a profile to a code change: hot frames mapped to your checkout, a recommendation, then the edit and a re-profile on request</li>
         <li><code>$jfr-sql</code> &mdash; the JFR schema and the DuckDB idioms that go with it</li>
@@ -133,17 +137,17 @@ const removal = `codex plugin marketplace remove jeffrey`;
 
       <p><code>~/.codex/agents/</code> makes it available in every repository; <code>.codex/agents/</code> inside a checkout scopes it to that one. The skills look for an agent by that name and delegate to it when one exists, and read the exports themselves when none does &mdash; so this step is optional, and skipping it costs context rather than correctness.</p>
 
-      <p>One difference worth knowing: the Claude Code subagent is denied the <code>recordings_</code> tools by its own definition, so it cannot create a profile even if it tried. Codex has no per-agent tool deny-list, so the Codex version is sandboxed read-only against your files and told not to write &mdash; an instruction rather than a wall. If that distinction matters to you, deny the family at the server instead:</p>
+      <p>One difference worth knowing: the Claude Code subagent is denied the <code>recordings_</code> and <code>hubs_</code> tools by its own definition, so it cannot create a profile even if it tried. Codex has no per-agent tool deny-list, so the Codex version is sandboxed read-only against your files and told not to write &mdash; an instruction rather than a wall. If that distinction matters to you, deny the family at the server instead:</p>
       <DocsCodeBlock :code="ingestDenyRule" language="toml" />
 
       <h2 id="approvals">Approvals</h2>
-      <p>Codex asks before each tool the first time. Every tool here reads except the <code>recordings_</code> family, which imports a recording file and builds a profile from it, so approving the server once is usually what you want:</p>
+      <p>Codex asks before each tool the first time. Every tool here reads except the <code>recordings_</code> and <code>hubs_</code> families, which build a profile from a recording file on this machine or from a session on a connected hub, so approving the server once is usually what you want:</p>
       <DocsCodeBlock :code="approvalRule" language="toml" />
 
       <p>Tool names arrive prefixed with the server they came from &mdash; <code>mcp__jeffrey__flamegraph_export</code> and so on. <code>enabled_tools</code> and <code>disabled_tools</code> on the same block narrow what the model sees at all, which is the sharper instrument when you want a strictly read-only Jeffrey for one machine regardless of what the server advertises.</p>
 
       <h2 id="check-it-is-connected">Check It Is Connected</h2>
-      <p>Run <code>codex mcp list</code>, or <code>/mcp</code> inside a session. The <code>jeffrey</code> server should be listed with its tools. If it is not, in order of likelihood: the session predates the install and needs restarting, the MCP server is off in Jeffrey's Settings, Jeffrey is not on <code>localhost:8585</code>, or Jeffrey is not running.</p>
+      <p>Run <code>codex mcp list</code>, or <code>/mcp</code> inside a session. The <code>jeffrey</code> server should be listed with its tools. If it is not, in order of likelihood: the session predates the install and needs restarting, this installation set <code>jeffrey.microscope.mcp.enabled=false</code> (Settings reports it, but does not change it), Jeffrey is not on <code>localhost:8585</code>, or Jeffrey is not running.</p>
 
       <p>A server that shows as connected but whose tools never appear is worth reporting upstream rather than debugging in Jeffrey &mdash; Codex's Streamable HTTP client has had that failure mode. <code>curl</code> against the endpoint settles which side is at fault; <router-link to="/docs/microscope-mcp/other-clients">Other Clients</router-link> has the exact request.</p>
 
@@ -190,8 +194,8 @@ const removal = `codex plugin marketplace remove jeffrey`;
           </tr>
           <tr>
             <td>Skills</td>
-            <td>Six, invoked <code>/microscope:analyze-jfr</code></td>
-            <td>The same six, invoked <code>$analyze-jfr</code></td>
+            <td>Seven, invoked <code>/microscope:analyze-jfr</code></td>
+            <td>The same seven, invoked <code>$analyze-jfr</code></td>
           </tr>
           <tr>
             <td>Endpoint</td>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpEnablingPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpEnablingPage.vue
@@ -97,7 +97,7 @@ const disabledProbe = `curl -s -o /dev/null -w '%{http_code}\\n' \\
       <DocsCodeBlock :code="disabledProbe" language="bash" />
 
       <h2 id="turning-ingestion-off">Turning Ingestion Off</h2>
-      <p>The <code>recordings_</code> family is the one that writes: it imports a recording file and builds a profile from it, which is what lets a coding-agent session analyse a <code>.jfr</code> straight out of your repository. It is on by default, together with the endpoint, and switches off on its own:</p>
+      <p>The <code>recordings_</code> family is one of the two that write: it imports a recording file and builds a profile from it, which is what lets a coding-agent session analyse a <code>.jfr</code> straight out of your repository. It is on by default, together with the endpoint, and switches off on its own:</p>
       <DocsCodeBlock :code="ingestToggle" language="properties" />
 
       <p>That leaves the server exactly as it was before ingestion existed &mdash; every profile still readable, nothing creatable. It is worth doing on a shared Jeffrey, for the reason in <a href="#security">Security</a> below: the path a client sends is opened by the <em>Jeffrey</em> process, on the machine Jeffrey runs on.</p>
@@ -140,9 +140,13 @@ const disabledProbe = `curl -s -o /dev/null -w '%{http_code}\\n' \\
 
       <p>Three things limit the blast radius even so. Every analysis tool is read-only &mdash; the one JFR tool that writes is deliberately not exposed, so an external client can read a profile's data but not rewrite it, and the SQL tools refuse a second statement after a semicolon rather than running it. The SQL engine itself is sandboxed: a profile database is opened with DuckDB's external file access and extension autoloading turned off, so a query is confined to that profile's tables and cannot read a file from the host or fetch anything over the network, however it is spelled. And the server has no shell: it answers questions about profiles, and does not run anything.</p>
 
-      <p>The <code>recordings_</code> family is the exception worth understanding, because it is the one place the server touches the filesystem. A client sends a <em>path</em>, not a file &mdash; a JFR recording routinely runs to hundreds of megabytes, and base64 through a JSON-RPC message would spend the client's whole context on bytes neither side ever reads. The path is therefore opened by the Jeffrey process, on the machine Jeffrey runs on, and Jeffrey copies whatever it finds there into the Quick Analysis store.</p>
+      <p>The <code>recordings_</code> family is the first of two exceptions worth understanding, because it is where the server touches this machine's filesystem. A client sends a <em>path</em>, not a file &mdash; a JFR recording routinely runs to hundreds of megabytes, and base64 through a JSON-RPC message would spend the client's whole context on bytes neither side ever reads. The path is therefore opened by the Jeffrey process, on the machine Jeffrey runs on, and Jeffrey copies whatever it finds there into the Quick Analysis store.</p>
 
       <p>On a loopback Jeffrey that is exactly what you want: the file in your repository is on the same disk, and the caller is you. On a shared installation it means a client that can reach the address can have Jeffrey read a file it chooses from that host &mdash; it must carry a recording extension and survive the parser, so it is a narrow door rather than an open one, but it is a door. If the address is reachable by anyone you would not hand a shell to, switch ingestion off with the property in <a href="#turning-ingestion-off">Turning Ingestion Off</a>.</p>
+
+      <p>The <code>hubs_</code> family is the second exception, and it points the other way: it is the one place the server reaches <em>off</em> this machine. A client that can reach the endpoint can list what every connected hub holds and have Jeffrey pull a session down &mdash; production stack traces, SQL statements and heap dumps included &mdash; onto the host Jeffrey runs on.</p>
+
+      <p>What bounds it is that the client cannot name an address. The hubs are the ones this installation was configured with, in a file or through its UI, so the reachable set is the operator's decision and not the caller's; there is no tool that adds one. What it does <em>not</em> bound is which of those hubs, so on an installation connected to production, endpoint access is production-recording access. Switch it off with the property in <a href="#turning-hub-access-off">Turning Hub Access Off</a> if that is not what you want.</p>
     </div>
 
     <DocsNavFooter />

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpOverviewPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpOverviewPage.vue
@@ -46,7 +46,7 @@ onMounted(() => {
     />
 
     <div class="docs-content">
-      <p class="docs-lede">Jeffrey Microscope serves an <strong>MCP server</strong> that an outside coding agent &mdash; an interactive Claude Code or Codex session in your own repository &mdash; can connect to. It turns every profile you have analysed into something a model can read directly: the catalogue, the DuckDB tables behind each profile, and flamegraph, trace and heap-dump exports. It can also take a recording file you have <em>not</em> analysed yet and build the profile for you.</p>
+      <p class="docs-lede">Jeffrey Microscope serves an <strong>MCP server</strong> that an outside coding agent &mdash; an interactive Claude Code or Codex session in your own repository &mdash; can connect to. It turns every profile you have analysed into something a model can read directly: the catalogue, the DuckDB tables behind each profile, and flamegraph, trace and heap-dump exports. It can also take a recording file you have <em>not</em> analysed yet and build the profile for you &mdash; or find one that never reached this machine at all, on a connected Jeffrey Hub, and pull it down first.</p>
 
       <DocsCallout type="info" title="Reading is read-only">
         Every analysis tool hands out data and nothing more &mdash; it cannot modify, rename or delete a profile, so data cleanup and frame renaming stay in the Jeffrey UI. The exceptions are the <code>recordings_</code> and <code>hubs_</code> families, which create profiles rather than changing them &mdash; from a local file, and from a recording still on a connected hub &mdash; and which an installation can switch off on their own.
@@ -208,7 +208,7 @@ onMounted(() => {
       <p>Analysis answers carry a link back to the view that shows them &mdash; the flamegraph with its filters applied, the operation on its slowest tab, the GC dashboard, the endpoint detail. The link is for you, not for Claude: a URL is nothing a model can analyse, which is exactly why it travels attached to an answer rather than behind a tool the model would reasonably never call.</p>
 
       <DocsCallout type="warning" title="Know what it exposes">
-        The endpoint is on by default and has no authentication yet &mdash; anyone who can reach the address can read every profile in that installation, and ask it to open a recording file from that machine. Jeffrey binds every interface by default, so on a shared network &ldquo;anyone who can reach the address&rdquo; is wider than it sounds until you bind it to loopback. <router-link to="/docs/microscope-mcp/enabling">Enabling the Server</router-link> covers how to expose it safely, how to turn ingestion off on its own, and how to switch the whole thing off.
+        The endpoint is on by default and has no authentication yet &mdash; anyone who can reach the address can read every profile in that installation, ask it to open a recording file from that machine, and have it pull a recording down from a connected hub. Jeffrey binds every interface by default, so on a shared network &ldquo;anyone who can reach the address&rdquo; is wider than it sounds until you bind it to loopback. <router-link to="/docs/microscope-mcp/enabling">Enabling the Server</router-link> covers how to expose it safely, how to turn ingestion and hub access off on their own, and how to switch the whole thing off.
       </DocsCallout>
 
       <h2 id="where-to-go-next">Where to Go Next</h2>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpSkillsPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpSkillsPage.vue
@@ -51,7 +51,8 @@ const askExamples = `# each of these loads a skill on its own - no slash command
 "analyse what production recorded in the last hour"      -> analyze-hub
 "did my change make it slower?"                          -> compare-jfr
 "what should I change in this repo to fix it?"           -> advise-jfr
-"how many events of each type are in the recording?"     -> jfr-sql`;
+"how many events of each type are in the recording?"     -> jfr-sql
+"which threads still reference that classloader?"        -> heap-sql`;
 
 const invoke = `# Claude Code
 /microscope:analyze-jfr
@@ -77,6 +78,7 @@ const advisePrompt = `advise on the most recent Jeffrey profile - what should I 
 const skillFrontmatter = `---
 name: analyze-jfr
 description: Analyses a JVM profile held by a running Jeffrey Microscope - CPU, ...
+allowed-tools: mcp__plugin_microscope_jeffrey__* mcp__jeffrey__*
 ---`;
 
 const eventsView = `-- correct
@@ -96,7 +98,7 @@ SELECT event_type, COUNT(*) FROM events_raw GROUP BY event_type`;
     <div class="docs-content">
       <p>The plugin ships seven skills and <router-link to="/docs/microscope-mcp/agent">one analyst agent</router-link>. The client loads a skill on its own when a question calls for it; you can also invoke any of them directly. Registering the MCP server by hand gives you the tools but not these.</p>
 
-      <p>The six are <a href="https://agentskills.io/specification" target="_blank" rel="noopener">Agent Skills</a> &mdash; one directory each, a <code>SKILL.md</code> with two frontmatter fields, and a body:</p>
+      <p>The seven are <a href="https://agentskills.io/specification" target="_blank" rel="noopener">Agent Skills</a> &mdash; one directory each, a <code>SKILL.md</code> whose front matter carries the two required fields plus the tools it may call, and a body:</p>
       <DocsCodeBlock :code="skillFrontmatter" language="yaml" />
 
       <p>That format is shared, so <router-link to="/docs/microscope-mcp/claude-code">Claude Code</router-link> and <router-link to="/docs/microscope-mcp/codex">Codex</router-link> load the same files out of the same directory rather than each getting a copy. Everything on this page applies to both; only the way you invoke one by hand differs.</p>
@@ -426,11 +428,11 @@ SELECT event_type, COUNT(*) FROM events_raw GROUP BY event_type`;
       </div>
 
       <h2 id="the-analyst">The Analyst They Delegate To</h2>
-      <p>Three of the skills do not read the big documents themselves. A single <code>flamegraph_export</code> can run to 120,000 characters, and a question worth asking usually takes several &mdash; four of them in <code>advise-jfr</code>, one per group. Pulled into the session, they leave little room for the thing that has to happen next: reading the actual source behind the frames.</p>
+      <p>Four of the skills do not read the big documents themselves. A single <code>flamegraph_export</code> can run to 120,000 characters, and a question worth asking usually takes several &mdash; four of them in <code>advise-jfr</code>, one per group. Pulled into the session, they leave little room for the thing that has to happen next: reading the actual source behind the frames.</p>
 
       <p>So there is an analyst agent, and the skills hand it the reading &mdash; <code>microscope:profile-analyst</code> from the Claude Code plugin, or the custom agent a Codex user copies in. It runs the sequence, follows the profile where it leads &mdash; deeper into a subtree, a lower threshold on one path, the GC-root path of the class the histogram named &mdash; and returns the findings alone. What it read stays in its context.</p>
 
-      <p>What it is not allowed to do is as much of the design as what it does: no file access and no <code>recordings_</code>, so it cannot map a frame to a line, edit anything, or build a profile. Mapping onto the checkout, the recommendation, and every question put to you stay in the session, where you can answer them. <router-link to="/docs/microscope-mcp/agent">The analyst reference</router-link> has the full contract &mdash; what it is given, the report shape it returns, and when to read an export yourself instead.</p>
+      <p>What it is not allowed to do is as much of the design as what it does: no file access, no <code>recordings_</code> and no <code>hubs_</code>, so it cannot map a frame to a line, edit anything, or build a profile from a file or from a hub. Mapping onto the checkout, the recommendation, and every question put to you stay in the session, where you can answer them. <router-link to="/docs/microscope-mcp/agent">The analyst reference</router-link> has the full contract &mdash; what it is given, the report shape it returns, and when to read an export yourself instead.</p>
 
       <h2 id="invoking-one-directly">Invoking One Directly</h2>
       <p>You do not normally have to. The agent loads the skill whose description matches the question, so plain English is enough:</p>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpToolsPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpToolsPage.vue
@@ -71,7 +71,7 @@ timeline_hotWindows  { "profileId": "019f885e-...",
 # 2. graph only that window
 flamegraph_export    { "profileId": "019f885e-...",
                        "eventType": "jdk.ObjectAllocationSample",
-                       "useWeight": true, "startMs": 31000, "endMs": 36000 }
+                       "useWeight": true, "startMs": 31000, "endMs": 32000 }
 
 # 3. below one second, for a startup or the inside of a spike
 timeline_zoom        { "profileId": "019f885e-...",
@@ -127,8 +127,8 @@ const analyzeExample = `Analyze target/checkout-run.jfr and tell me where the ti
 const hubsExample = `Analyse what production recorded in the last hour.`;
 
 const exHubs = `hubs_sessions { "hub": "production", "withinLastMinutes": 60 }
-#  -> | hub | project | started | duration | status | files | size | local | session_ref |
-#     | production | checkout | 2026-03-01T11:41Z | 18m3s | FINISHED | 4 | 240MB | | h1Y2ZnLX... |
+#  -> | hub | workspace | project | started | duration | status | files | size | local | session_ref |
+#     | production | default | checkout | 2026-03-01T11:41Z | 18m3s | FINISHED | 4 | 240MB | | h1Y2ZnLX... |
 
 hubs_download { "sessionRef": "h1Y2ZnLX..." }
 #  -> { "recordingId": "019f885e-...", "recordingFiles": 2, "artifactFiles": 2,
@@ -389,7 +389,7 @@ hubs_download { "sessionRef": "h1Y2ZnLX..." }
 
       <p><strong>The baseline is scaled onto the primary&rsquo;s recording length</strong> before any delta is taken, because a sampling profiler emits samples at a roughly fixed rate and a run that lasted twice as long carries twice as many of them. Both documents print the raw figure, the scaled figure and the factor, so the correction is visible rather than merely applied. It assumes a steady workload measured over time and is wrong for a fixed-size benchmark &mdash; there the share column is the honest one.</p>
 
-      <p><strong>A rename is not a regression.</strong> The diff matches method names level by level, so a renamed, moved or extracted method breaks the match and its work appears once as new and once as gone, often of near-identical size. Both documents list such pairs as candidate renames &mdash; suspicions for a reader holding the source diff to confirm, never a resolution, because weight alone cannot tell a rename from a coincidence.</p>
+      <p><strong>A rename is not a regression.</strong> The diff matches method names level by level, so a renamed, moved or extracted method breaks the match and its work appears once as new and once as gone, often of near-identical size. <code>compare_movements</code> lists such pairs under a candidate-renames heading &mdash; suspicions for a reader holding the source diff to confirm, never a resolution, because weight alone cannot tell a rename from a coincidence. <code>compare_flamegraph</code> does not pair them for you: it marks the two halves <code>[NEW]</code> and <code>[GONE]</code> and says in its preamble to check the diff you have and it does not.</p>
 
       <p>Pruning in <code>compare_flamegraph</code> is by <strong>movement</strong>, not by size: a subtree in which nothing changed is dropped however large it is, and unmoved ancestors are kept so the frames that did move can still be placed. Absence there means &ldquo;did not move&rdquo;, the opposite of what it means in <code>flamegraph_export</code>.</p>
 
@@ -468,7 +468,7 @@ hubs_download { "sessionRef": "h1Y2ZnLX..." }
       <p>A notification is the application&rsquo;s own account of what went wrong &mdash; a pool exhausted, a fallback taken &mdash; emitted by its own code, so it is a diagnosis where every other tool reports a measurement. The trace and operation exports carry a Notifications section of their own; <code>traces_notifications</code> is the profile-wide reading, and the place to start when <code>traces_overview</code> reports any <code>CRITICAL</code> or <code>HIGH</code> ones.</p>
 
       <DocsCallout type="info" title="Two event types, two different meanings">
-        On the flamegraph exports, <code>eventType</code> is the event that <em>opened the trace</em> (e.g. <code>jeffrey.HttpServerExchange</code>) while <code>graphEventType</code> is what to <em>graph</em> (e.g. <code>jdk.ExecutionSample</code>). They are never the same value.
+        On <code>traces_operationFlamegraphExport</code>, <code>eventType</code> is the event that <em>opened the trace</em> (e.g. <code>jeffrey.HttpServerExchange</code>) while <code>graphEventType</code> is what to <em>graph</em> (e.g. <code>jdk.ExecutionSample</code>). They are never the same value. <code>traces_spanFlamegraphExport</code> has no such split: the span is already identified by <code>traceId</code> and <code>spanId</code>, so its <code>eventType</code> is what to graph.
       </DocsCallout>
 
       <p><strong>Examples.</strong> Arguments are shown as JSON; the tool name omits the server prefix.</p>
@@ -552,7 +552,7 @@ hubs_download { "sessionRef": "h1Y2ZnLX..." }
       </table>
 
       <DocsCallout type="info" title="Every result says what it cannot answer">
-        Each dashboard comes back wrapped with a <code>nextSteps</code> list &mdash; the same idea as the reading instructions a flamegraph or trace export opens with. <code>jvm_gc</code> says that no event in it names the code that produced the garbage and points at the allocation flamegraph; <code>jvm_container</code> points back at per-thread CPU load; <code>jvm_configuration</code> says to prefer these values over a deployment manifest. Every other family now carries the same envelope. They route and never diagnose: no threshold decides whether they appear, and none of them claims the figures beside them are bad.
+        Each dashboard comes back wrapped with a <code>nextSteps</code> list &mdash; the same idea as the reading instructions a flamegraph or trace export opens with. <code>jvm_gc</code> says that no event in it names the code that produced the garbage and points at the allocation flamegraph; <code>jvm_container</code> points back at per-thread CPU load; <code>jvm_configuration</code> says to prefer these values over a deployment manifest. Every other analysis family carries the same envelope; the raw-SQL <code>jfr_</code> tools do not, and neither do <code>traces_operations</code> and <code>traces_notifications</code>. They route and never diagnose: no threshold decides whether they appear, and none of them claims the figures beside them are bad.
       </DocsCallout>
 
       <DocsCallout type="info" title="Call jvm_sections first">
@@ -579,12 +579,12 @@ hubs_download { "sessionRef": "h1Y2ZnLX..." }
         <tbody>
           <tr>
             <td><code>http_overview</code></td>
-            <td><code>profileId</code></td>
+            <td><code>profileId</code>, <code>direction?</code></td>
             <td>Requests, response-time percentiles, success rate, 4xx/5xx counts, endpoints by traffic, status and method breakdowns, slowest requests</td>
           </tr>
           <tr>
             <td><code>http_endpoint</code></td>
-            <td><code>profileId</code>, <code>uri</code></td>
+            <td><code>profileId</code>, <code>uri</code>, <code>direction?</code></td>
             <td>The same, narrowed to one URI</td>
           </tr>
           <tr>
@@ -604,17 +604,17 @@ hubs_download { "sessionRef": "h1Y2ZnLX..." }
           </tr>
           <tr>
             <td><code>grpc_overview</code></td>
-            <td><code>profileId</code></td>
+            <td><code>profileId</code>, <code>direction?</code></td>
             <td>Calls, response-time percentiles, success rate, services by traffic, status codes, slowest calls</td>
           </tr>
           <tr>
             <td><code>grpc_service</code></td>
-            <td><code>profileId</code>, <code>service</code></td>
+            <td><code>profileId</code>, <code>service</code>, <code>direction?</code></td>
             <td>One service broken down by method</td>
           </tr>
           <tr>
             <td><code>grpc_traffic</code></td>
-            <td><code>profileId</code></td>
+            <td><code>profileId</code>, <code>direction?</code></td>
             <td>Message sizes rather than timings: bytes moved, the size distribution, largest calls</td>
           </tr>
           <tr>
@@ -812,7 +812,7 @@ hubs_download { "sessionRef": "h1Y2ZnLX..." }
       </DocsCallout>
 
       <DocsCallout type="warning" title="Query the events view, not events_raw">
-        <code>jfr_listTables</code> shows both. <code>events</code> is a view over <code>events_raw</code> that splices back the one large string field the parser pools out of each row; querying <code>events_raw</code> silently returns truncated JSON in <code>fields</code>, with no error to warn you. The bundled <code>jfr-sql</code> skill carries this and the rest of the schema.
+        <code>jfr_listTables</code> lists tables only, so <code>events_raw</code> appears there and <code>events</code> does not &mdash; query <code>events</code> anyway. It is a view over <code>events_raw</code> that splices back the one large string field the parser pools out of each row; querying <code>events_raw</code> silently returns truncated JSON in <code>fields</code>, with no error to warn you. The bundled <code>jfr-sql</code> skill carries this and the rest of the schema.
       </DocsCallout>
 
       <p><strong>Examples.</strong> Arguments are shown as JSON; the tool name omits the server prefix.</p>
@@ -820,9 +820,12 @@ hubs_download { "sessionRef": "h1Y2ZnLX..." }
 
       <h2 id="heap">heap_ &mdash; heap dumps</h2>
       <p><code>heap_diff</code> is the one that needs two profiles: it compares this dump against an earlier one class by class, ranked by growth, and is the only way to separate a leak from a large working set &mdash; a single dump shows a state, and a state cannot tell the two apart. Pass the earlier dump as <code>baselineProfileId</code>; backwards, every growth reads as a shrink. Both dumps have to be indexed first, and the tool says which one is not.</p>
-      <p>Twenty tools against a parsed heap dump&rsquo;s own DuckDB index, separate from the profile&rsquo;s JFR database. Asking for them on a profile with no heap dump fails immediately with a message saying so, rather than deep inside the engine.</p>
+      <p>Twenty-one tools against a parsed heap dump&rsquo;s own DuckDB index, separate from the profile&rsquo;s JFR database. Asking for them on a profile with no heap dump fails immediately with a message saying so, rather than deep inside the engine.</p>
 
       <p><strong>Reports</strong> &mdash; pre-computed, and faster and safer than reproducing them in SQL:</p>
+      <DocsCallout type="warning" title="Three of these are computed by the UI, not by the tool">
+        <code>heap_getLeakSuspects</code>, <code>heap_getStringAnalysis</code> and <code>heap_getCollectionAnalysis</code> read a cached result. Until that analysis has been run once from the Jeffrey UI they answer that it has not been run yet, rather than computing it on the spot &mdash; the same arrangement as <code>jvm_autoAnalysis</code>. The other reports here are computed from the index on every call.
+      </DocsCallout>
       <table>
         <thead>
           <tr>
@@ -848,9 +851,14 @@ hubs_download { "sessionRef": "h1Y2ZnLX..." }
             <td>The largest individual objects by retained size</td>
           </tr>
           <tr>
+            <td><code>heap_diff</code></td>
+            <td><code>profileId</code>, <code>baselineProfileId</code>, <code>topN?</code></td>
+            <td>This dump against an earlier one, class by class, ranked by growth (default 30, maximum 200)</td>
+          </tr>
+          <tr>
             <td><code>heap_getLeakSuspects</code></td>
             <td><code>profileId</code></td>
-            <td>Leak-suspect analysis</td>
+            <td>Leak-suspect analysis, once it has been run from the UI</td>
           </tr>
           <tr>
             <td><code>heap_getClassLoaderLeakChains</code></td>
@@ -1050,7 +1058,7 @@ hubs_download { "sessionRef": "h1Y2ZnLX..." }
       <p>The file types are the ones Jeffrey analyses anywhere else: <code>.jfr</code>, <code>.jfr.lz4</code>, <code>.hprof</code>, <code>.hprof.gz</code>, <code>.pprof</code> and <code>.otlp</code>. A heap dump lands as a profile the <code>heap_</code> family answers about; the rest land as one the <code>jfr_</code>, <code>flamegraph_</code> and <code>traces_</code> families answer about. <code>profiles_features</code> tells you which you got.</p>
 
       <DocsCallout type="warning" title="The path is opened by Jeffrey, not by the client">
-        <code>path</code> must be <strong>absolute</strong> and must exist <strong>on the machine Jeffrey runs on</strong>. A relative path is rejected rather than guessed at &mdash; it would resolve against Jeffrey&rsquo;s working directory, not yours. For a Jeffrey in a container or on another host, mount or copy the file where Jeffrey can see it first.
+        <code>path</code> must be <strong>absolute</strong> and must exist <strong>on the machine Jeffrey runs on</strong>. A relative path is rejected rather than guessed at &mdash; it would resolve against Jeffrey&rsquo;s working directory, not yours. A leading <code>~</code> is the one exception, and it expands against <em>Jeffrey&rsquo;s</em> home directory rather than the caller&rsquo;s, so it is only the same file when both are the same account on the same machine. For a Jeffrey in a container or on another host, mount or copy the file where Jeffrey can see it first.
       </DocsCallout>
 
       <p>Two more things worth knowing. The call <strong>returns when the profile is built</strong>, which for a large recording is a wait rather than an acknowledgement. And each <code>recordings_analyzeFile</code> imports the file again and builds another profile &mdash; call <code>recordings_list</code> or <code>profiles_list</code> first if the same file may already be there.</p>

--- a/jeffrey-pages/src/views/docs/microscope/RecordingsPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/RecordingsPage.vue
@@ -151,6 +151,7 @@ onMounted(() => {
           <div class="step-content">
             <h4><i class="bi bi-cloud-arrow-down"></i> Auto-download from a project session</h4>
             <p>From a project's <strong>Instances</strong> view, open a session and click <strong>Download</strong>. The merged recording (plus heap dumps and logs) is streamed to local storage and shows up tagged with its origin.</p>
+            <p>A coding agent can do the same without the UI: the <router-link to="/docs/microscope-mcp/tools#hubs"><code>hubs_</code> tools</router-link> list the sessions across every connected hub and pull one down, writing the same origin tags. Those tags are what lets a later listing say a session is already here rather than fetching it twice.</p>
           </div>
         </div>
         <div class="workflow-step">

--- a/jeffrey-pages/src/views/docs/microscope/configuration/MicroscopeConfigApplicationPropertiesPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/configuration/MicroscopeConfigApplicationPropertiesPage.vue
@@ -271,6 +271,18 @@ onMounted(() => {
               at startup.
             </td>
           </tr>
+          <tr>
+            <td><code>jeffrey.microscope.mcp.hubs.enabled</code></td>
+            <td><code>true</code></td>
+            <td>
+              Advertises the <code>hubs_</code> tools, which list the recording sessions on the
+              connected <router-link to="/docs/hub">Jeffrey Hubs</router-link> and pull one in to be
+              analysed. Its own switch because it reaches <em>off</em> this machine where ingestion
+              reaches into it. Never advertised while
+              <code>jeffrey.microscope.mcp.ingest.enabled</code> is <code>false</code>, since analysing
+              what it downloads needs the <code>recordings_</code> family. Read at startup.
+            </td>
+          </tr>
         </tbody>
       </table>
 


### PR DESCRIPTION
Follow-up to #259, which merged before this landed. Documentation only — ten pages under `jeffrey-pages`, no code.

The audit ran against a dump of the live `McpToolsetAssembler` rather than against the previous prose, which turned up drift older than #259 as well as the gaps that PR left behind.

Ground truth first: all 88 tool names, and every parameter of each, now check out mechanically — no tool is missing from its family's section, no documented argument is invented, and no real argument goes unmentioned. The 17 family counts were verified the same way.

## Gaps #259 left

- `jeffrey.microscope.mcp.hubs.enabled` was missing from the application-properties reference entirely.
- **"Seven skills" headed a list of six** on both the Claude Code and Codex pages: `analyze-hub` was counted but never listed.
- The Codex `disabled_tools` block denied two `recordings_` tools while the prose beside it promised it denied both writing families. It now denies all six the subagent's own definition denies.
- Claims that the analyst cannot create a profile named only `recordings_`, which is no longer the whole reason it cannot.
- The enabling page called `recordings_` "the one place the server touches the filesystem". `hubs_` is the second exception and points the other way, so it gets its own security paragraph: the caller cannot name an address — the hubs are the operator's — but on an installation connected to production, endpoint access is production-recording access.

## Drift that predates #259

- `direction` is advertised on all five `http_`/`grpc_` tools and appeared in no Arguments cell, though the page's own prose and example already used it.
- `heap_diff` had prose but no row, and its `topN` was undocumented. The `heap_` family is 21 tools, not 20, in the three places that counted it.
- **`jfr_listTables` asks JDBC for `TABLE` only, and `events` is a view**, so it shows `events_raw` and not `events` — the opposite of what the callout warning about that exact trap said, steering readers into it. Documented as it behaves; making the listing include views is a code change worth its own decision, so it is not in here.
- The `nextSteps` envelope is not on "every other family": the raw-SQL `jfr_` tools carry none, nor do `traces_operations` and `traces_notifications`.
- The two-event-types callout holds for `traces_operationFlamegraphExport` only; `traces_spanFlamegraphExport` has no `graphEventType`.
- Only `compare_movements` lists candidate renames; `compare_flamegraph` marks `[NEW]`/`[GONE]` and leaves the pairing to the reader.
- Three `heap_` "pre-computed" reports answer "not run yet" until the UI has computed them, like `jvm_autoAnalysis`.
- `recordings_analyzeFile` expands a leading `~`, against Jeffrey's home and not the caller's, which the absolute-path callout flatly denied.
- Both clients' troubleshooting said the server can be off "in Settings"; Settings reports the property, it does not set it.

Two examples were wrong in ways only a reader following them would hit: the `hubs_sessions` sample dropped the `workspace` column the real table prints, and the timeline sample carried a different window into step 2 than step 1 returned.

## Left alone deliberately

The assembler javadoc's "twenty heap tools" is correct in its scope — the guard it documents wraps `HeapDumpMcpTools`, and `heap_diff` is a separate toolset. Verified (20 + 1) before leaving it.

## Verification

`jeffrey-pages` builds clean, which runs `vue-tsc`; the module has no lint config, so the build is the gate. The mechanical tool/parameter/skill coverage checks were re-run after rebasing onto the merged master and still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sTaZFW6hthQsEgnCmoU1f

---
_Generated by [Claude Code](https://claude.ai/code/session_015sTaZFW6hthQsEgnCmoU1f)_