### PR TITLE
Sync the Jeffrey Pages docs with what the MCP server now advertises

### DIFF
--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpOtherClientsPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpOtherClientsPage.vue
@@ -90,7 +90,11 @@ const initializeResult = `{
   "id": 1,
   "result": {
     "protocolVersion": "2025-06-18",
-    "capabilities": { "tools": { "listChanged": false } },
+    "capabilities": {
+      "tools": { "listChanged": false },
+      "prompts": { "listChanged": false },
+      "resources": { "subscribe": false, "listChanged": false }
+    },
     "serverInfo": { "name": "jeffrey", "version": "1.0.0" }
   }
 }`;
@@ -203,11 +207,19 @@ const protocolError = `{
           </tr>
           <tr>
             <td><code>tools/list</code></td>
-            <td>Every tool with its description and JSON-Schema input</td>
+            <td>Every tool with its description, its JSON-Schema input (including <code>required</code> and <code>enum</code>) and its <code>annotations</code></td>
           </tr>
           <tr>
             <td><code>tools/call</code></td>
             <td>Runs one tool; the result is text content</td>
+          </tr>
+          <tr>
+            <td><code>prompts/list</code>, <code>prompts/get</code></td>
+            <td>The plugin&rsquo;s skills as prompts &mdash; see <a href="#prompts-and-resources">above</a></td>
+          </tr>
+          <tr>
+            <td><code>resources/list</code>, <code>resources/templates/list</code>, <code>resources/read</code></td>
+            <td>The catalogue, the per-profile templates, and the content behind a <code>jeffrey://</code> URI</td>
           </tr>
           <tr>
             <td><code>ping</code></td>
@@ -220,7 +232,11 @@ const protocolError = `{
         </tbody>
       </table>
 
-      <p>The default protocol version is <code>2025-06-18</code>; a version the client asks for is echoed back.</p>
+      <p>The server speaks <code>2024-11-05</code>, <code>2025-03-26</code> and <code>2025-06-18</code>, and <code>2025-06-18</code> is the default. <code>initialize</code> answers with the version the client asked for when it is one of those three, and with the default when it is not &mdash; echoing back an unrecognised version would promise a revision the server may not speak, so the client is told what it will actually get and decides from there.</p>
+
+      <DocsCallout type="info" title="Every tool says whether it writes">
+        Each spec in <code>tools/list</code> carries MCP <code>annotations</code>: <code>readOnlyHint</code>, <code>destructiveHint</code>, <code>idempotentHint</code> and <code>openWorldHint</code>. Almost everything Jeffrey exposes only reads a profile, and declares it. What does not is the <code>recordings_</code> family, which creates a profile, and <code>heap_prepare</code>, which builds a cache. <code>destructiveHint</code> is false throughout &mdash; nothing here deletes a profile, a recording or a dump &mdash; and <code>openWorldHint</code> marks the <code>hubs_</code> family, the only one that reaches a machine other than this installation. A client that gates approval on those hints does not need a hand-written deny-list.
+      </DocsCallout>
 
       <h2 id="a-session-by-hand">A Session by Hand</h2>
       <p>Everything below works with <code>curl</code>, which makes it a good way to check that the server is up before blaming a client.</p>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpOverviewPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpOverviewPage.vue
@@ -128,7 +128,7 @@ onMounted(() => {
           </tr>
           <tr>
             <td><code>compare_</code></td>
-            <td>4</td>
+            <td>3</td>
             <td>Two profiles against each other: whether they are comparable, what moved, and the differential call tree</td>
           </tr>
           <tr>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpToolsPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpToolsPage.vue
@@ -152,7 +152,11 @@ hubs_download { "sessionRef": "h1Y2ZnLX..." }
 
       <p><strong>Every tool except <code>profiles_list</code> and the <code>recordings_</code> and <code>hubs_</code> families takes a <code>profileId</code></strong>, and it is required. That is the id from <code>profiles_list</code>; nothing else works without one.</p>
 
-      <p><strong>Output is capped.</strong> A result is truncated at roughly 120,000 characters, with an explicit trailer saying so &mdash; a silently shortened flamegraph would be read as a complete one. The SQL tools cap rows as well, and say when they do. Aggregate in the query rather than pulling rows back to count them.</p>
+      <p><strong>Output is capped at 120,000 characters, and says so when it cuts.</strong> A silently shortened flamegraph would be read as a complete one, so nothing is trimmed quietly. A Markdown answer &mdash; the exports, the listings &mdash; ends with an explicit <code>TRUNCATED</code> line naming the cap and suggesting a narrower query. A JSON answer is trimmed <em>in the tree</em> instead of at a character count: the largest array is shortened until the document fits, so what comes back is still parseable rather than ending mid-token, and it carries a <code>_truncated</code> object saying how many elements each shortened array kept out of how many it had. The SQL tools cap rows as well, and say when they do. Aggregate in the query rather than pulling rows back to count them.</p>
+
+      <p><strong>The schema says what is required, and what the alternatives are.</strong> <code>tools/list</code> returns a JSON Schema per tool with a real <code>required</code> array &mdash; a missing argument is refused by the client before the call rather than deep inside Jeffrey &mdash; and parameters that are enumerations (<code>direction</code>, <code>kind</code>, <code>status</code>, <code>sortBy</code>, <code>page</code>, <code>report</code>) carry an <code>enum</code> rather than listing their values only in prose. In the tables below, an argument marked <code>name?</code> is one the schema leaves optional.</p>
+
+      <p><strong>Every tool declares what it does to the world.</strong> Each spec carries MCP <code>annotations</code> &mdash; <code>readOnlyHint</code>, <code>destructiveHint</code>, <code>idempotentHint</code>, <code>openWorldHint</code> &mdash; so a client can tell the handful that write from the great majority that only read, without reading a hundred descriptions. Nothing Jeffrey exposes is destructive: no tool deletes a profile, a recording or a dump. <code>openWorldHint</code> marks the <code>hubs_</code> family, which is the only one that reaches a machine other than this installation.</p>
 
       <p><strong>The Markdown exports carry their own reading instructions.</strong> <code>flamegraph_export</code>, <code>traces_traceExport</code> and <code>traces_operationExport</code> return documents that open by explaining what <code>self</code> means against <code>total</code>, what the frame tags mean, and what was pruned. Read the preamble the document gives you rather than assuming conventions from elsewhere &mdash; Jeffrey&rsquo;s <code>self</code> is a merged-interval computation, not a subtraction.</p>
 
@@ -439,7 +443,7 @@ hubs_download { "sessionRef": "h1Y2ZnLX..." }
           </tr>
           <tr>
             <td><code>traces_spanFlamegraphExport</code></td>
-            <td><code>profileId</code>, <code>traceId</code>, <code>spanId</code>, <code>eventType</code>, <code>selfOnly?</code>, <code>threadMode?</code>, <code>useWeight?</code></td>
+            <td><code>profileId</code>, <code>traceId</code>, <code>spanId</code>, <code>eventType?</code>, <code>selfOnly?</code>, <code>threadMode?</code>, <code>useWeight?</code></td>
             <td>A flamegraph of the samples taken while one span was open</td>
           </tr>
           <tr>
@@ -454,12 +458,12 @@ hubs_download { "sessionRef": "h1Y2ZnLX..." }
           </tr>
           <tr>
             <td><code>traces_attributeSearch</code></td>
-            <td><code>profileId</code>, <code>key</code>, <code>operator?</code>, <code>value?</code>, <code>source?</code>, <code>owner?</code>, <code>scope?</code>, <code>limit?</code></td>
+            <td><code>profileId</code>, <code>key</code>, <code>operator</code>, <code>value?</code>, <code>source?</code>, <code>owner?</code>, <code>scope?</code>, <code>limit?</code></td>
             <td>The individual traces carrying one value, with their ids</td>
           </tr>
           <tr>
             <td><code>traces_operationFlamegraphExport</code></td>
-            <td><code>profileId</code>, <code>name</code>, <code>kind</code>, <code>eventType</code>, <code>graphEventType</code>, <code>threadMode?</code>, <code>useWeight?</code></td>
+            <td><code>profileId</code>, <code>name</code>, <code>kind</code>, <code>eventType</code>, <code>graphEventType?</code>, <code>threadMode?</code>, <code>useWeight?</code></td>
             <td>The same, aggregated over every trace of one operation</td>
           </tr>
           <tr>
@@ -1034,7 +1038,7 @@ hubs_download { "sessionRef": "h1Y2ZnLX..." }
       </table>
 
       <DocsCallout type="info" title="The dominator tree is built lazily">
-        <code>dominator</code> and <code>retained_size</code> are empty until something asks for them, so a SQL query joining <code>retained_size</code> on a fresh dump returns nulls. Run <code>heap_getDominatorTreeRoots</code> once first. The bundled <code>heap-sql</code> skill covers the whole schema.
+        <code>dominator</code> and <code>retained_size</code> are empty until something builds them, so a SQL query joining <code>retained_size</code> on a fresh dump returns nulls rather than zeros. Build them first with <code>heap_prepare</code> and <code>report: "dominator"</code>, then watch <code>heap_status</code>; <code>heap_getDominatorTreeRoots</code> also triggers the build on a dump small enough to finish inside the call. The bundled <code>heap-sql</code> skill covers the whole schema.
       </DocsCallout>
 
       <p><strong>Examples.</strong> Arguments are shown as JSON; the tool name omits the server prefix.</p>
@@ -1066,7 +1070,7 @@ hubs_download { "sessionRef": "h1Y2ZnLX..." }
           <tr>
             <td><code>hubs_download</code></td>
             <td><code>sessionRef</code></td>
-            <td>Pulls that session in &mdash; its recording files merged into one, its heap dumps and logs alongside &mdash; and returns a <code>recordingId</code> for <code>recordings_analyzeRecording</code></td>
+            <td>Pulls that session in &mdash; its recording files merged into one, its heap dumps and logs alongside &mdash; and returns a <code>recordingId</code> for <code>recordings_analyzeRecording</code>. A transfer that outlasts the call comes back with a status saying so; call the tool again with the same <code>sessionRef</code> to check</td>
           </tr>
         </tbody>
       </table>
@@ -1076,6 +1080,8 @@ hubs_download { "sessionRef": "h1Y2ZnLX..." }
       <p><strong><code>withinLastMinutes</code> is an overlap, not a start time.</strong> A JVM that began recording three hours ago and is still running matches a sixty-minute window, because it <em>was</em> recording during it. That is what someone asking for "the last hour" means, and the opposite of what filtering on start time would return.</p>
 
       <p><strong>Downloading and analysing are two calls on purpose.</strong> <code>hubs_download</code> stops at a recording and hands back its id; <code>recordings_analyzeRecording</code> builds the profile. A single call covering a multi-gigabyte transfer <em>and</em> a full analysis is the shape that trips a client's tool timeout, and a timeout partway through says nothing about whether the work survived.</p>
+
+      <p><strong>The download itself is bounded too.</strong> It waits about forty-five seconds and then answers with a status saying the transfer continues, rather than holding the call open until the bytes land. It needs no separate status tool: it answers from the local store first, so calling <code>hubs_download</code> again with the same <code>sessionRef</code> <em>is</em> the poll, and a second call while the first is still running joins it rather than fetching the session twice.</p>
 
       <DocsCallout type="tip" title="Read the local column before downloading">
         A row whose <code>local</code> reads <code>profile:&lt;id&gt;</code> is already analysed and that id works immediately; <code>recording:&lt;id&gt;</code> is downloaded but not yet analysed. Jeffrey recognises a session it has seen before from the <code>origin.*</code> tags it wrote at download time, so a repeated <code>hubs_download</code> returns what is already there rather than moving the bytes again &mdash; but reading the column first saves the round trip.
@@ -1130,7 +1136,11 @@ hubs_download { "sessionRef": "h1Y2ZnLX..." }
         <code>path</code> must be <strong>absolute</strong> and must exist <strong>on the machine Jeffrey runs on</strong>. A relative path is rejected rather than guessed at &mdash; it would resolve against Jeffrey&rsquo;s working directory, not yours. A leading <code>~</code> is the one exception, and it expands against <em>Jeffrey&rsquo;s</em> home directory rather than the caller&rsquo;s, so it is only the same file when both are the same account on the same machine. For a Jeffrey in a container or on another host, mount or copy the file where Jeffrey can see it first.
       </DocsCallout>
 
-      <p>Two more things worth knowing. The call <strong>returns when the profile is built</strong>, which for a large recording is a wait rather than an acknowledgement. And each <code>recordings_analyzeFile</code> imports the file again and builds another profile &mdash; call <code>recordings_list</code> or <code>profiles_list</code> first if the same file may already be there.</p>
+      <DocsCallout type="warning" title="A large recording outlasts the call &mdash; poll, do not re-analyse">
+        Both analyse tools wait about <strong>forty-five seconds</strong> for the parse. A small recording finishes inside that and its <code>profileId</code> comes straight back, exactly as before. A large one comes back with a status of <code>running</code> while the parse carries on in the background, and <code>recordings_status</code> reports the stage it is on and the <code>profileId</code> once it lands. Poll that rather than calling the analyse tool again: a second <code>recordings_analyzeFile</code> imports the file a second time and leaves you with two profiles of one recording and no way to tell them apart. A second <code>recordings_analyzeRecording</code> for the same recording is safe &mdash; it joins the run already in flight rather than racing it.
+      </DocsCallout>
+
+      <p>One more thing worth knowing: each <code>recordings_analyzeFile</code> imports the file again and builds another profile &mdash; call <code>recordings_list</code> or <code>profiles_list</code> first if the same file may already be there.</p>
 
       <p>The family is advertised only while ingestion is enabled; see <router-link to="/docs/microscope-mcp/enabling">Enabling the Server</router-link> for the property and for why a shared installation might turn it off.</p>
 

--- a/jeffrey-pages/src/views/docs/microscope/configuration/MicroscopeConfigApplicationPropertiesPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/configuration/MicroscopeConfigApplicationPropertiesPage.vue
@@ -283,8 +283,57 @@ onMounted(() => {
               what it downloads needs the <code>recordings_</code> family. Read at startup.
             </td>
           </tr>
+          <tr>
+            <td><code>jeffrey.microscope.mcp.compute.enabled</code></td>
+            <td><code>true</code></td>
+            <td>
+              Advertises the tools that build something before they can answer &mdash; the heap-dump
+              index and its dominator tree, the cached heap reports, and the auto-analysis rule set:
+              <code>heap_prepare</code>, <code>heap_status</code> and the <code>compute</code> flag on
+              <code>jvm_autoAnalysis</code>. They read like every other tool, but each can hold a core
+              for minutes and a large heap while it works. Set to <code>false</code> on a Jeffrey that
+              shares a machine; the tools that only read what is already computed keep working. Read
+              at startup.
+            </td>
+          </tr>
+          <tr>
+            <td><code>jeffrey.microscope.mcp.families</code></td>
+            <td><em>empty</em></td>
+            <td>
+              Which tool families to advertise, comma-separated; empty means all of them. Families are
+              named by their tool prefix: <code>profiles</code>, <code>jfr</code>,
+              <code>flamegraph</code>, <code>compare</code>, <code>traces</code>, <code>jvm</code>,
+              <code>http</code>, <code>jdbc</code>, <code>grpc</code>, <code>methodtracing</code>,
+              <code>io</code>, <code>blocking</code>, <code>timeline</code>, <code>memory</code>,
+              <code>heap</code>, <code>recordings</code>, <code>hubs</code>. Worth setting only for a
+              client that pays for the whole tool list on every turn &mdash; Codex loads every schema
+              each time, where Claude Code fetches them on demand. A family named here but not built
+              (ingestion or compute off) is simply absent rather than a startup failure. Read at
+              startup.
+            </td>
+          </tr>
+          <tr>
+            <td><code>jeffrey.microscope.mcp.token</code></td>
+            <td><em>empty</em></td>
+            <td>
+              A bearer token the MCP endpoint requires, empty meaning none. With it set the endpoint
+              answers <code>403</code> to a request without
+              <code>Authorization: Bearer &lt;token&gt;</code>, and
+              <strong>Settings &rarr; Coding Agents (MCP)</strong> shows the client configuration with
+              the header already in it. Off by default because nothing else in Jeffrey is
+              authenticated and a token here would imply the rest of the API is protected too. Read at
+              startup. See
+              <router-link to="/docs/microscope-mcp/enabling#requiring-a-token">Requiring a Token</router-link>.
+            </td>
+          </tr>
         </tbody>
       </table>
+
+      <DocsCallout type="info">
+        <strong>The endpoint also refuses a foreign <code>Origin</code> on its own</strong>, whatever
+        these properties say &mdash; the DNS-rebinding check the MCP specification asks of a local HTTP
+        server. A CLI client sends no <code>Origin</code>, so Claude Code and Codex never notice.
+      </DocsCallout>
 
       <h2 id="ai-assistant">AI Assistant</h2>
       <table>


### PR DESCRIPTION
Six things #261 changed that the documentation still described the old way,
plus two counts that were simply wrong.

The Tool Reference said a capped result is cut at a character count. That is
still true of a Markdown answer, but a JSON one is now trimmed in the tree --
the largest array shortened until the document fits -- so it stays parseable
and carries a _truncated record of what it lost. Two more rules join it: the
schema now carries a real required array and an enum for the parameters that
are enumerations, and every tool declares MCP annotations, which is how a
client tells the few writers from the readers without a hand-written
deny-list.

Three argument rows disagreed with the schema they describe:
traces_spanFlamegraphExport.eventType and
traces_operationFlamegraphExport.graphEventType are optional, and
traces_attributeSearch.operator is required.

The recordings_ section still promised that the call returns when the profile
is built. It waits forty-five seconds and then hands back a status of running,
with recordings_status as the poll -- which the Codex and Skills pages already
said and the reference page, where somebody looks it up, did not. hubs_download
is bounded the same way, and calling it again with the same sessionRef is its
own poll. The heap SQL callout still sent a reader to
heap_getDominatorTreeRoots to build a dominator tree; heap_prepare is what does
that on a dump too large to finish inside a call.

Other Clients listed neither the prompts/* nor the resources/* methods its own
section below documents, showed an initialize result advertising only the tools
capability, and said an unrecognised protocol version is echoed back. It is
not: the server answers with one of the three revisions it speaks.

Application Properties documented three of the five MCP properties. compute,
families and token were missing entirely, and so was the Origin check the
endpoint makes whatever they are set to.

Counts: the overview gave compare_ four tools where it has three, which also
made its family table sum to a hundred against its own headline of ninety-nine.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JhkBtcksSti3NxUzrmN2pM