### PR TITLE
Make the Microscope MCP contract honest, and test the parts that were not

### DIFF
--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/ExternalMcpController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/ExternalMcpController.java
@@ -20,6 +20,7 @@ package cafe.jeffrey.microscope.core.mcp;
 
 import cafe.jeffrey.profile.mcp.AbstractMcpStreamableHttpController;
 import cafe.jeffrey.profile.mcp.McpServerFeatures;
+import cafe.jeffrey.shared.common.Json;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -52,6 +53,9 @@ import tools.jackson.databind.JsonNode;
 @RestController
 @RequestMapping("/api/internal/mcp")
 public class ExternalMcpController extends AbstractMcpStreamableHttpController {
+
+    /** Where a refused request is told why, outside the JSON-RPC envelope it never entered. */
+    private static final String REFUSAL_FIELD = "error";
 
     private final McpToolsetAssembler assembler;
     private final ExternalMcpProperties properties;
@@ -90,7 +94,11 @@ public class ExternalMcpController extends AbstractMcpStreamableHttpController {
         }
         String refusal = guard.refusalReason(httpRequest);
         if (refusal != null) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+            // The reason travels with the refusal. A bare 403 from a server that is otherwise
+            // answering is the kind of thing somebody debugs a proxy over; the sentence says it was
+            // the origin check and nothing else.
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(Json.createObject().put(REFUSAL_FIELD, refusal));
         }
         return dispatch(request, features);
     }

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/LinkedOutput.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/LinkedOutput.java
@@ -69,26 +69,31 @@ public final class LinkedOutput {
      * export is exactly the one whose reader most needs to know what to do with it.
      */
     public static String of(String body, List<String> nextSteps, String url) {
-        return of(appendNextSteps(McpToolOutput.capped(body), nextSteps), url);
+        return LINK_BLOCK.formatted(cappedWithNextSteps(body, nextSteps), url);
     }
 
     /**
      * The same, for a link that cannot reproduce everything the answer was built with.
      */
     public static String of(String body, List<String> nextSteps, String url, String note) {
-        return of(appendNextSteps(McpToolOutput.capped(body), nextSteps), url, note);
+        return LINK_BLOCK_WITH_NOTE.formatted(cappedWithNextSteps(body, nextSteps), note, url);
     }
 
     /**
-     * Appended to an already-capped body: {@link #of(String, String)} caps again, which is a no-op on
-     * a string that already fits and keeps these steps out of the truncated region either way.
+     * The body capped, with the routing after it — capped exactly once.
+     * <p>
+     * Capping twice is what this avoids, and it is not a hypothetical: an oversized body comes back
+     * from {@link McpToolOutput#capped(String)} already <em>at</em> the limit plus its truncation
+     * note, so appending anything and capping again cuts the note and the steps straight back off.
+     * The steps were being dropped from precisely the answers they were added for.
      */
-    private static String appendNextSteps(String cappedBody, List<String> nextSteps) {
+    private static String cappedWithNextSteps(String body, List<String> nextSteps) {
+        String capped = McpToolOutput.capped(body);
         if (nextSteps.isEmpty()) {
-            return cappedBody;
+            return capped;
         }
 
-        StringBuilder builder = new StringBuilder(cappedBody)
+        StringBuilder builder = new StringBuilder(capped)
                 .append(System.lineSeparator())
                 .append(System.lineSeparator())
                 .append(NEXT_STEPS_HEADING);

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/McpPromptRegistry.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/McpPromptRegistry.java
@@ -118,8 +118,14 @@ public class McpPromptRegistry implements McpPromptProvider {
      * Deliberately not a YAML parser. The frontmatter Jeffrey's skills carry is two scalar keys and
      * sometimes a third, and a parser would be a dependency and a schema for a format that already has
      * one — the plugin's. A file that does not look like a skill is skipped rather than guessed at.
+     * <p>
+     * Package-private rather than private so its edge cases can be exercised directly: the input is a
+     * file written elsewhere in the repository, and the failure mode of every hand-rolled parser is to
+     * return something plausible for input it did not anticipate.
+     *
+     * @return the prompt, or {@code null} when the content does not look like a skill at all
      */
-    private static McpPrompt parse(String content) {
+    static McpPrompt parse(String content) {
         String normalized = content.stripLeading();
         if (!normalized.startsWith(FRONTMATTER_DELIMITER)) {
             return null;

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/BlockingMcpTools.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/BlockingMcpTools.java
@@ -114,8 +114,8 @@ public class BlockingMcpTools {
         }
 
         return LinkedOutput.json(new Monitors(
-                trimContention(contention),
-                trimWaits(waits),
+                ToolArguments.firstOf(contention, MAX_ROWS),
+                ToolArguments.firstOf(waits, MAX_ROWS),
                 NextSteps.builder().add(STEP_FRAMES).add(STEP_OVERVIEW).build(),
                 UiLinks.view(profileId(), BLOCKING_VIEW)));
     }
@@ -131,7 +131,7 @@ public class BlockingMcpTools {
         }
 
         return LinkedOutput.json(new Pinned(
-                trimPinned(pinned),
+                ToolArguments.firstOf(pinned, MAX_ROWS),
                 NextSteps.builder().add(STEP_PIN_CAUSE).add(STEP_OVERVIEW).build(),
                 UiLinks.view(profileId(), VIRTUAL_THREADS_VIEW)));
     }
@@ -146,18 +146,6 @@ public class BlockingMcpTools {
                 && !overview.hasParks()
                 && !overview.hasSleeps()
                 && !overview.hasPinned();
-    }
-
-    private static List<ContentionStat> trimContention(List<ContentionStat> stats) {
-        return stats.size() <= MAX_ROWS ? stats : stats.subList(0, MAX_ROWS);
-    }
-
-    private static List<MonitorWaitStat> trimWaits(List<MonitorWaitStat> stats) {
-        return stats.size() <= MAX_ROWS ? stats : stats.subList(0, MAX_ROWS);
-    }
-
-    private static List<PinnedThreadEntry> trimPinned(List<PinnedThreadEntry> entries) {
-        return entries.size() <= MAX_ROWS ? entries : entries.subList(0, MAX_ROWS);
     }
 
     private String profileId() {

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/CompareMcpTools.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/CompareMcpTools.java
@@ -18,7 +18,6 @@
 
 package cafe.jeffrey.microscope.core.mcp.tools;
 
-import cafe.jeffrey.flamegraph.ai.AiExportConfig;
 import cafe.jeffrey.flamegraph.ai.WeightContext;
 import cafe.jeffrey.profile.common.config.GraphComponents;
 import cafe.jeffrey.profile.common.config.GraphParameters;
@@ -40,6 +39,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Two profiles of the same application, compared — the question a reader in their own repository
@@ -123,7 +123,7 @@ public class CompareMcpTools {
 
         Set<String> comparableCodes = comparable.stream()
                 .map(ComparableType::eventType)
-                .collect(LinkedHashSet::new, Set::add, Set::addAll);
+                .collect(Collectors.toCollection(LinkedHashSet::new));
 
         List<String> onlyInPrimary = exclusiveTypes(primaryManager, comparableCodes);
         List<String> onlyInBaseline = exclusiveTypes(baseline, comparableCodes);
@@ -175,7 +175,9 @@ public class CompareMcpTools {
         ProfileManager baseline = baseline(baselineProfileId);
         GraphParameters params = params(eventType, startMs, endMs, useWeight, excludeIdle, excludeNonJava);
         return LinkedOutput.of(
-                diffManager(baseline).rankedMovements(params, boundedLimit(limit)),
+                diffManager(baseline).rankedMovements(
+                        params,
+                        ToolArguments.boundedLimit(limit, DEFAULT_MOVEMENT_LIMIT, MAX_MOVEMENT_LIMIT)),
                 List.of(STEP_DRILL, STEP_RENAME),
                 UiLinks.profile(primaryManager.info().id()));
     }
@@ -214,7 +216,8 @@ public class CompareMcpTools {
         ProfileManager baseline = baseline(baselineProfileId);
         GraphParameters params = params(eventType, startMs, endMs, useWeight, excludeIdle, excludeNonJava);
         return LinkedOutput.of(
-                diffManager(baseline).generateAiExport(params, aiExportConfig(thresholdPct)),
+                diffManager(baseline).generateAiExport(
+                        params, FlamegraphMcpTools.aiExportConfig(thresholdPct)),
                 List.of(STEP_WHOLE, STEP_RENAME),
                 UiLinks.profile(primaryManager.info().id()));
     }
@@ -259,24 +262,6 @@ public class CompareMcpTools {
                 .withGraphType(GraphType.DIFFERENTIAL)
                 .withGraphComponents(GraphComponents.FLAMEGRAPH_ONLY)
                 .build();
-    }
-
-    private static AiExportConfig aiExportConfig(Double thresholdPct) {
-        if (thresholdPct == null) {
-            return null;
-        }
-        if (!(thresholdPct > 0.0 && thresholdPct < 100.0)) {
-            throw new IllegalArgumentException(
-                    "thresholdPct must be between 0 and 100 (exclusive): " + thresholdPct);
-        }
-        return new AiExportConfig(thresholdPct);
-    }
-
-    private static int boundedLimit(Integer limit) {
-        if (limit == null || limit < 1) {
-            return DEFAULT_MOVEMENT_LIMIT;
-        }
-        return Math.min(limit, MAX_MOVEMENT_LIMIT);
     }
 
     /**

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/FlamegraphMcpTools.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/FlamegraphMcpTools.java
@@ -239,8 +239,11 @@ public class FlamegraphMcpTools {
     /**
      * A per-call threshold override, or {@code null} to keep the one the server was configured with.
      * Validated here rather than deep in the generator so a bad argument fails as a bad argument.
+     * <p>
+     * Shared with {@link CompareMcpTools}, whose differential export takes the same argument and has
+     * to reject the same values — two copies of one range check is one copy too many to keep in step.
      */
-    private static AiExportConfig aiExportConfig(Double thresholdPct) {
+    static AiExportConfig aiExportConfig(Double thresholdPct) {
         if (thresholdPct == null) {
             return null;
         }

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/GrpcMcpTools.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/GrpcMcpTools.java
@@ -34,6 +34,7 @@ import cafe.jeffrey.profile.manager.custom.model.grpc.GrpcSizeBucket;
 import cafe.jeffrey.profile.manager.custom.model.grpc.GrpcSlowCall;
 import cafe.jeffrey.profile.manager.custom.model.grpc.GrpcStatusStats;
 import cafe.jeffrey.profile.manager.custom.model.grpc.GrpcTrafficData;
+import cafe.jeffrey.profile.mcp.McpToolOutput;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
 
@@ -79,6 +80,9 @@ public class GrpcMcpTools {
             "No calls were recorded for service '%s'. Call grpc_overview and take a name from its "
                     + "services list.";
 
+    private static final String NO_SERVICE_RECOVERY =
+            "Call grpc_overview and take a name from its services list.";
+
     private final ProfileManager profileManager;
 
     public GrpcMcpTools(ProfileManager profileManager) {
@@ -102,7 +106,7 @@ public class GrpcMcpTools {
         GrpcOverviewData data = profileManager.custom().grpcManager(side).overviewData();
         return LinkedOutput.json(new GrpcDashboard(
                 data.header(),
-                trim(data.services()),
+                ToolArguments.firstOf(data.services(), MAX_SERVICES),
                 data.statusCodes(),
                 data.slowCalls(),
                 NextSteps.builder()
@@ -117,7 +121,7 @@ public class GrpcMcpTools {
             + "the status codes it returned and its slowest calls. Use it after grpc_overview has "
             + "named the service worth looking at.")
     public String service(
-            @ToolParam(required = false, description = "Service name exactly as recorded, taken from the services list "
+            @ToolParam(required = true, description = "Service name exactly as recorded, taken from the services list "
                     + "in grpc_overview.")
             String service,
             @ToolParam(required = false, description = "Which side to report on: 'SERVER' for calls this application "
@@ -125,15 +129,19 @@ public class GrpcMcpTools {
             @ToolParamValues({"SERVER", "CLIENT"})
             String direction) {
 
+        // Insisted on rather than passed through: the manager reads a null service as "no filter", so
+        // an omitted one would return every service's methods under the heading of one service.
+        String name = ToolArguments.required(service, "service", NO_SERVICE_RECOVERY);
+
         ExchangeDirection side = ExchangeDirection.from(direction);
         if (DashboardFeature.missing(profileManager, feature(side))) {
             return noData(side);
         }
 
         GrpcServiceDetailData data =
-                profileManager.custom().grpcManager(side).serviceDetailData(service);
+                profileManager.custom().grpcManager(side).serviceDetailData(name);
         if (data.methods().isEmpty()) {
-            return NO_SUCH_SERVICE.formatted(service);
+            return McpToolOutput.error(NO_SUCH_SERVICE.formatted(name));
         }
 
         return LinkedOutput.json(new GrpcServiceDetail(
@@ -145,7 +153,7 @@ public class GrpcMcpTools {
                         .when(data.header().errorCount() > 0, STEP_ERRORS)
                         .add(STEP_TRAFFIC)
                         .build(),
-                UiLinks.view(profileId(), SERVICES_VIEW, serviceQuery(side, service))));
+                UiLinks.view(profileId(), SERVICES_VIEW, serviceQuery(side, name))));
     }
 
     @Tool(description = "gRPC message sizes rather than timings: bytes sent and received, average and "
@@ -193,10 +201,6 @@ public class GrpcMcpTools {
     private static String noData(ExchangeDirection direction) {
         return NO_GRPC_DATA.formatted(
                 direction.name().toLowerCase(Locale.ROOT), direction.grpcEventType().code());
-    }
-
-    private static List<GrpcServiceInfo> trim(List<GrpcServiceInfo> services) {
-        return services.size() <= MAX_SERVICES ? services : services.subList(0, MAX_SERVICES);
     }
 
     private String profileId() {

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/HttpMcpTools.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/HttpMcpTools.java
@@ -30,6 +30,7 @@ import cafe.jeffrey.profile.manager.custom.model.http.HttpOverviewData;
 import cafe.jeffrey.profile.manager.custom.model.http.HttpSlowRequest;
 import cafe.jeffrey.profile.manager.custom.model.http.HttpStatusStats;
 import cafe.jeffrey.profile.manager.custom.model.http.HttpUriInfo;
+import cafe.jeffrey.profile.mcp.McpToolOutput;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
 
@@ -91,6 +92,9 @@ public class HttpMcpTools {
             "No requests were recorded for '%s'. The URI has to match exactly what the server saw - "
                     + "call http_overview and take one from its endpoints list.";
 
+    private static final String NO_URI_RECOVERY =
+            "Call http_overview and take a URI from its endpoints list.";
+
     private final ProfileManager profileManager;
 
     public HttpMcpTools(ProfileManager profileManager) {
@@ -115,7 +119,7 @@ public class HttpMcpTools {
         HttpOverviewData data = profileManager.custom().httpManager(side).overviewData();
         return LinkedOutput.json(new HttpDashboard(
                 data.header(),
-                trim(data.uris()),
+                ToolArguments.firstOf(data.uris(), MAX_ENDPOINTS),
                 data.statusCodes(),
                 data.methods(),
                 data.slowRequests(),
@@ -132,7 +136,7 @@ public class HttpMcpTools {
             + "slowest requests as the overview, but for a single URI. Use it after http_overview has "
             + "named the endpoint worth looking at.")
     public String endpoint(
-            @ToolParam(required = false, description = "The URI exactly as the server recorded it, e.g. '/api/orders'. "
+            @ToolParam(required = true, description = "The URI exactly as the server recorded it, e.g. '/api/orders'. "
                     + "Take it from the endpoints list in http_overview.")
             String uri,
             @ToolParam(required = false, description = "Which side the endpoint belongs to: 'SERVER' (the default) or "
@@ -140,16 +144,21 @@ public class HttpMcpTools {
             @ToolParamValues({"SERVER", "CLIENT"})
             String direction) {
 
+        // Insisted on rather than passed through: the manager reads a null uri as "no filter", so an
+        // omitted one would produce the whole dashboard and this tool would hand back its busiest
+        // endpoint as though it were the one that was asked for.
+        String endpoint = ToolArguments.required(uri, "uri", NO_URI_RECOVERY);
+
         ExchangeDirection side = ExchangeDirection.from(direction);
         if (DashboardFeature.missing(profileManager, feature(side))) {
             return noData(side);
         }
 
-        HttpOverviewData data = profileManager.custom().httpManager(side).overviewData(uri);
+        HttpOverviewData data = profileManager.custom().httpManager(side).overviewData(endpoint);
         // The manager filters by URI while streaming, so an unmatched one yields an empty list rather
         // than an error. Reported as a bad argument, with real URIs to correct it from.
         if (data.uris().isEmpty()) {
-            return NO_SUCH_ENDPOINT.formatted(uri);
+            return McpToolOutput.error(NO_SUCH_ENDPOINT.formatted(endpoint));
         }
 
         return LinkedOutput.json(new HttpEndpointDetail(
@@ -163,7 +172,7 @@ public class HttpMcpTools {
                         .when(failuresOccurred(data.header()), STEP_FAILURES)
                         .add(STEP_FRAMES)
                         .build(),
-                UiLinks.view(profileId(), ENDPOINTS_VIEW, endpointQuery(side, uri))));
+                UiLinks.view(profileId(), ENDPOINTS_VIEW, endpointQuery(side, endpoint))));
     }
 
     private static Map<String, String> mode(ExchangeDirection direction) {
@@ -179,8 +188,8 @@ public class HttpMcpTools {
     }
 
     /**
-     * Whether any request failed at all - not whether the failure rate is high, which would be a
-     * verdict rather than a route.
+     * Which dashboard feature carries this direction. The two are recorded independently, so a profile
+     * can hold one and not the other.
      */
     private static FeatureType feature(ExchangeDirection direction) {
         return direction == ExchangeDirection.SERVER
@@ -193,12 +202,12 @@ public class HttpMcpTools {
                 direction.name().toLowerCase(Locale.ROOT), direction.httpEventType().code());
     }
 
+    /**
+     * Whether any request failed at all - not whether the failure rate is high, which would be a
+     * verdict rather than a route.
+     */
     private static boolean failuresOccurred(HttpHeader header) {
         return header.count4xx() > 0 || header.count5xx() > 0;
-    }
-
-    private static List<HttpUriInfo> trim(List<HttpUriInfo> uris) {
-        return uris.size() <= MAX_ENDPOINTS ? uris : uris.subList(0, MAX_ENDPOINTS);
     }
 
     private String profileId() {

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/HubsMcpTools.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/HubsMcpTools.java
@@ -143,25 +143,25 @@ public class HubsMcpTools {
 
         Map<String, Optional<String>> versions = probeAll(hubs);
 
-        StringBuilder out = new StringBuilder(512);
-        out.append("| hub | hub_id | address | source | status | hub_version |\n");
-        out.append("|---|---|---|---|---|---|\n");
+        MarkdownTable table = MarkdownTable.withColumns(
+                "hub", "hub_id", "address", "source", "status", "hub_version");
         for (HubManager hub : hubs) {
             HubInfo info = hub.info();
             Optional<String> version = versions.getOrDefault(info.hubId(), Optional.empty());
-            out.append("| ").append(sanitize(info.name()))
-                    .append(" | ").append(info.hubId())
-                    .append(" | ").append(address(info))
-                    .append(" | ").append(info.source() == null ? "" : info.source().name().toLowerCase(Locale.ROOT))
-                    .append(" | ").append(version.isPresent() ? STATUS_OK : STATUS_UNREACHABLE)
-                    .append(" | ").append(version.orElse(""))
-                    .append(" |\n");
+            table.row(
+                    info.name(),
+                    info.hubId(),
+                    address(info),
+                    info.source() == null ? "" : info.source().name().toLowerCase(Locale.ROOT),
+                    version.isPresent() ? STATUS_OK : STATUS_UNREACHABLE,
+                    version.orElse(""));
         }
-        out.append("\nA hub marked `").append(STATUS_UNREACHABLE)
-                .append("` did not answer just now, so hubs_sessions can list nothing from it. A hub "
-                        + "whose source is `config` is declared in this installation's configuration "
-                        + "and cannot be removed from the UI.\n");
-        return McpToolOutput.capped(out.toString());
+        return table
+                .note("A hub marked `" + STATUS_UNREACHABLE + "` did not answer just now, so "
+                        + "hubs_sessions can list nothing from it. A hub whose source is `config` is "
+                        + "declared in this installation's configuration and cannot be removed from "
+                        + "the UI.")
+                .render();
     }
 
     @Tool(description = "Recording sessions across every connected Jeffrey Hub, newest first, in one "
@@ -190,7 +190,7 @@ public class HubsMcpTools {
             @ToolParam(required = false, description = "Most rows to return across all hubs. Default 50, maximum 500")
             Integer limit) {
 
-        int rowLimit = boundedLimit(limit);
+        int rowLimit = ToolArguments.boundedLimit(limit, DEFAULT_LIMIT, MAX_LIMIT);
         HubScanFilter filter = new HubScanFilter(
                 hub, workspace, project, sessionFilter(withinLastMinutes, status, rowLimit));
 
@@ -201,26 +201,24 @@ public class HubsMcpTools {
 
         DownloadedSessionIndex local = DownloadedSessionIndex.build(recordingsManager);
 
-        StringBuilder out = new StringBuilder(2048);
-        out.append("| hub | workspace | project | started | duration | status | files | size | local | session_ref |\n");
-        out.append("|---|---|---|---|---|---|---|---|---|---|\n");
+        MarkdownTable table = MarkdownTable.withColumns(
+                "hub", "workspace", "project", "started", "duration", "status", "files", "size",
+                "local", "session_ref");
         for (HubSessionScan.Row row : result.rows()) {
             RecordingSession session = row.session();
-            out.append("| ").append(sanitize(row.hubName()))
-                    .append(" | ").append(sanitize(row.workspaceName()))
-                    .append(" | ").append(sanitize(row.projectName()))
-                    .append(" | ").append(session.createdAt())
-                    .append(" | ").append(duration(session))
-                    .append(" | ").append(session.status())
-                    .append(" | ").append(session.files() == null ? 0 : session.files().size())
-                    .append(" | ").append(size(session.totalSizeBytes()))
-                    .append(" | ").append(localColumn(local, row.ref()))
-                    .append(" | ").append(row.ref().encode())
-                    .append(" |\n");
+            table.row(
+                    row.hubName(),
+                    row.workspaceName(),
+                    row.projectName(),
+                    session.createdAt(),
+                    duration(session),
+                    session.status(),
+                    session.files() == null ? 0 : session.files().size(),
+                    size(session.totalSizeBytes()),
+                    localColumn(local, row.ref()),
+                    row.ref().encode());
         }
-
-        out.append('\n').append(footer(result));
-        return McpToolOutput.capped(out.toString());
+        return table.note(footer(result)).render();
     }
 
     @Tool(description = "Download one recording session from its hub into this Jeffrey, merging the "
@@ -258,9 +256,12 @@ public class HubsMcpTools {
         if (transferred.isEmpty()) {
             // Nothing to poll but this tool: it answers from the local store first, so calling it again
             // with the same ref reports the finished copy once the transfer lands.
+            // Names travel unescaped here. Replacing a pipe is a Markdown-cell concern, and these
+            // two answers are JSON, where the serialiser escapes what needs escaping and a mangled
+            // name is simply the wrong name.
             return McpToolOutput.json(new DownloadInProgress(
                     ref.sessionId(),
-                    sanitize(session.name()),
+                    session.name(),
                     session.totalSizeBytes(),
                     DOWNLOAD_STILL_RUNNING));
         }
@@ -269,9 +270,9 @@ public class HubsMcpTools {
         List<RepositoryFile> finished = finishedFiles(session);
         return McpToolOutput.json(new DownloadedSession(
                 recordingId,
-                sanitize(session.name()),
-                sanitize(hubInfo.name()),
-                sanitize(project.info().name()),
+                session.name(),
+                hubInfo.name(),
+                project.info().name(),
                 ref.sessionId(),
                 (int) finished.stream().filter(RepositoryFile::isRecordingFile).count(),
                 (int) finished.stream().filter(RepositoryFile::isArtifactFile).count(),
@@ -347,13 +348,6 @@ public class HubsMcpTools {
         }
         throw new IllegalArgumentException(
                 "Unknown session status: " + status + ". Use ACTIVE or FINISHED, or omit it for both.");
-    }
-
-    private static int boundedLimit(Integer limit) {
-        if (limit == null || limit < 1) {
-            return DEFAULT_LIMIT;
-        }
-        return Math.min(limit, MAX_LIMIT);
     }
 
     private static String emptyResult(Integer withinLastMinutes) {
@@ -506,16 +500,6 @@ public class HubsMcpTools {
             return Math.round(bytes / (1024.0 * 1024)) + "MB";
         }
         return String.format(Locale.ROOT, "%.1fGB", bytes / (1024.0 * 1024 * 1024));
-    }
-
-    /**
-     * Keeps a name on one table row: a pipe in a project or hub name would otherwise split the cell.
-     */
-    private static String sanitize(String value) {
-        if (value == null) {
-            return "";
-        }
-        return value.replace('|', '/').replace('\n', ' ').replace('\r', ' ');
     }
 
     /**

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/IoMcpTools.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/IoMcpTools.java
@@ -111,7 +111,7 @@ public class IoMcpTools {
 
         return LinkedOutput.json(new IoEndpoints(
                 ioKind.name(),
-                trim(endpoints),
+                ToolArguments.firstOf(endpoints, MAX_ENDPOINTS),
                 NextSteps.builder().add(STEP_SLOWEST).add(STEP_OTHER_KIND).build(),
                 UiLinks.view(profileId(), view(ioKind))));
     }
@@ -155,10 +155,6 @@ public class IoMcpTools {
 
     private static String view(IoKind kind) {
         return kind == IoKind.SOCKET ? SOCKET_VIEW : FILE_VIEW;
-    }
-
-    private static List<IoEndpoint> trim(List<IoEndpoint> endpoints) {
-        return endpoints.size() <= MAX_ENDPOINTS ? endpoints : endpoints.subList(0, MAX_ENDPOINTS);
     }
 
     private String profileId() {

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/JdbcMcpTools.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/JdbcMcpTools.java
@@ -28,6 +28,7 @@ import cafe.jeffrey.profile.manager.custom.model.jdbc.statement.JdbcHeader;
 import cafe.jeffrey.profile.manager.custom.model.jdbc.statement.JdbcOperationStats;
 import cafe.jeffrey.profile.manager.custom.model.jdbc.statement.JdbcOverviewData;
 import cafe.jeffrey.profile.manager.custom.model.jdbc.statement.JdbcSlowStatement;
+import cafe.jeffrey.profile.mcp.McpToolOutput;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
 
@@ -85,6 +86,9 @@ public class JdbcMcpTools {
             "No statements were recorded for group '%s'. Call jdbc_overview and take a name from its "
                     + "groups list.";
 
+    private static final String NO_GROUP_RECOVERY =
+            "Call jdbc_overview and take a name from its groups list.";
+
     private final ProfileManager profileManager;
 
     public JdbcMcpTools(ProfileManager profileManager) {
@@ -108,21 +112,25 @@ public class JdbcMcpTools {
             + "the overview, narrowed to a single group. Use it after jdbc_overview has named the "
             + "group worth looking at.")
     public String statementGroup(
-            @ToolParam(required = false, description = "Group name exactly as recorded, taken from the groups list in "
+            @ToolParam(required = true, description = "Group name exactly as recorded, taken from the groups list in "
                     + "jdbc_overview.")
             String group) {
+
+        // Insisted on rather than passed through: the manager reads a null group as "no filter", so an
+        // omitted one would return the whole statement dashboard under the heading of one group.
+        String name = ToolArguments.required(group, "group", NO_GROUP_RECOVERY);
 
         if (DashboardFeature.missing(profileManager, FeatureType.JDBC_STATEMENTS_DASHBOARD)) {
             return NO_STATEMENT_DATA;
         }
 
-        JdbcOverviewData data = profileManager.custom().jdbcStatementManager().overviewData(group);
+        JdbcOverviewData data = profileManager.custom().jdbcStatementManager().overviewData(name);
         if (data.groups().isEmpty() && data.slowStatements().isEmpty()) {
-            return NO_SUCH_GROUP.formatted(group);
+            return McpToolOutput.error(NO_SUCH_GROUP.formatted(name));
         }
 
         return LinkedOutput.json(
-                dashboard(data, UiLinks.view(profileId(), STATEMENT_GROUPS_VIEW, groupQuery(group))));
+                dashboard(data, UiLinks.view(profileId(), STATEMENT_GROUPS_VIEW, groupQuery(name))));
     }
 
     @Tool(description = "The JDBC connection pools: their configured minimum and maximum sizes against "
@@ -148,7 +156,7 @@ public class JdbcMcpTools {
         return new JdbcDashboard(
                 data.header(),
                 data.operations(),
-                trim(data.groups()),
+                ToolArguments.firstOf(data.groups(), MAX_GROUPS),
                 data.slowStatements().stream().map(JdbcMcpTools::readable).toList(),
                 NextSteps.builder()
                         .add(STEP_GROUP)
@@ -165,10 +173,6 @@ public class JdbcMcpTools {
     private static boolean contentionOccurred(List<JdbcPoolData> pools) {
         return pools.stream().anyMatch(pool ->
                 pool.statistics().timeoutsCount() > 0 || pool.statistics().maxPendingThreadCount() > 0);
-    }
-
-    private static List<JdbcGroup> trim(List<JdbcGroup> groups) {
-        return groups.size() <= MAX_GROUPS ? groups : groups.subList(0, MAX_GROUPS);
     }
 
     /**

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/MarkdownTable.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/MarkdownTable.java
@@ -1,0 +1,122 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package cafe.jeffrey.microscope.core.mcp.tools;
+
+import cafe.jeffrey.profile.mcp.McpToolOutput;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A catalogue answer written as a Markdown table, with a note under it saying how to read the columns
+ * that need it.
+ * <p>
+ * The three catalogue tools — the profiles, the recordings, the hub sessions — answer with a table
+ * rather than with JSON, because a reader scans these and a model picks one id out of them. Each of
+ * the three had built its own by appending pipes to a {@link StringBuilder}, and each carried its own
+ * copy of the one rule that actually matters: a value containing a pipe splits the cell it is in, so a
+ * recording someone named {@code checkout | before} silently shifts every column after it and the ids
+ * in that row stop being the ids the download tool takes.
+ * <p>
+ * Escaping is therefore not left to the caller. It happens on the way into a cell, once, here.
+ */
+final class MarkdownTable {
+
+    private static final String CELL_SEPARATOR = " | ";
+    private static final String ROW_PREFIX = "| ";
+    private static final String ROW_SUFFIX = " |";
+    private static final char PIPE = '|';
+    private static final char PIPE_REPLACEMENT = '/';
+    private static final char SPACE = ' ';
+    private static final String HEADER_RULE_CELL = "---";
+
+    private final StringBuilder out = new StringBuilder(1024);
+    private final int columns;
+
+    private MarkdownTable(List<String> headers) {
+        this.columns = headers.size();
+        appendRow(headers);
+        appendRow(headers.stream().map(header -> HEADER_RULE_CELL).toList());
+    }
+
+    static MarkdownTable withColumns(String... headers) {
+        return new MarkdownTable(List.of(headers));
+    }
+
+    /**
+     * One row. Values are rendered with {@link String#valueOf}, so a caller passes what it has —
+     * an {@code Instant}, a {@code long}, an enum — without spelling out the conversion; {@code null}
+     * becomes an empty cell rather than the word "null".
+     *
+     * @throws IllegalArgumentException when the row does not match the header, which is a rendering
+     *                                  mistake that would otherwise show up as a misaligned table
+     */
+    MarkdownTable row(Object... values) {
+        if (values.length != columns) {
+            throw new IllegalArgumentException(
+                    "Row has " + values.length + " cells but the table has " + columns + " columns");
+        }
+        List<String> cells = new ArrayList<>(values.length);
+        for (Object value : values) {
+            cells.add(cell(value));
+        }
+        appendRow(cells);
+        return this;
+    }
+
+    /**
+     * A line under the table explaining a column that needs it — what an empty cell means, which tool
+     * takes the id in it. These are the difference between a table a model can act on and one it has
+     * to guess about.
+     */
+    MarkdownTable note(String note) {
+        out.append(System.lineSeparator()).append(note);
+        if (!note.endsWith(System.lineSeparator())) {
+            out.append(System.lineSeparator());
+        }
+        return this;
+    }
+
+    /**
+     * The rendered table, capped like any other tool result.
+     */
+    String render() {
+        return McpToolOutput.capped(out.toString());
+    }
+
+    private void appendRow(List<String> cells) {
+        out.append(ROW_PREFIX)
+                .append(String.join(CELL_SEPARATOR, cells))
+                .append(ROW_SUFFIX)
+                .append('\n');
+    }
+
+    /**
+     * Keeps a value inside the cell it belongs to. A pipe would split the row; a newline or a carriage
+     * return would end the table where it stands and leave the remaining rows as prose.
+     */
+    private static String cell(Object value) {
+        if (value == null) {
+            return "";
+        }
+        String text = String.valueOf(value);
+        return text.replace(PIPE, PIPE_REPLACEMENT)
+                .replace('\n', SPACE)
+                .replace('\r', SPACE);
+    }
+}

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/MemoryMcpTools.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/MemoryMcpTools.java
@@ -99,7 +99,7 @@ public class MemoryMcpTools {
 
         return LinkedOutput.json(new Allocations(
                 overview,
-                trimTypes(types),
+                ToolArguments.firstOf(types, MAX_TYPES),
                 NextSteps.builder().add(STEP_WHERE).add(STEP_WHEN).add(STEP_GC_COST).build(),
                 UiLinks.view(profileId(), ALLOCATIONS_VIEW)));
     }
@@ -118,17 +118,9 @@ public class MemoryMcpTools {
 
         return LinkedOutput.json(new LeakCandidates(
                 overview,
-                trimCandidates(candidates),
+                ToolArguments.firstOf(candidates, MAX_CANDIDATES),
                 NextSteps.builder().add(STEP_AGE).add(STEP_RETAINED).build(),
                 UiLinks.view(profileId(), LEAK_CANDIDATES_VIEW)));
-    }
-
-    private static List<AllocatedType> trimTypes(List<AllocatedType> types) {
-        return types.size() <= MAX_TYPES ? types : types.subList(0, MAX_TYPES);
-    }
-
-    private static List<LeakCandidate> trimCandidates(List<LeakCandidate> candidates) {
-        return candidates.size() <= MAX_CANDIDATES ? candidates : candidates.subList(0, MAX_CANDIDATES);
     }
 
     private String profileId() {

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/ProfileMcpTools.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/ProfileMcpTools.java
@@ -222,7 +222,7 @@ public class ProfileMcpTools {
             + "URL is for them, not for you: it carries nothing you can analyse and reading it back "
             + "tells you nothing, so call this to end an explanation, not to gather information.")
     public String viewLink(
-            @ToolParam(required = false, description = "Which view to open. One of: dashboard, auto-analysis, overview, "
+            @ToolParam(required = true, description = "Which view to open. One of: dashboard, auto-analysis, overview, "
                     + "event-types, flags, garbage-collection, garbage-collection/timeseries, "
                     + "garbage-collection/configuration, allocations, nmt, native-memory, "
                     + "memory-issues/leak-candidates, thread-statistics, threads-timeline, "
@@ -239,17 +239,18 @@ public class ProfileMcpTools {
                     + "object; ignored by every other view.")
             String objectId) {
 
-        if (!VIEWS.contains(view)) {
+        if (view == null || !VIEWS.contains(view.trim())) {
             throw new IllegalArgumentException(
                     "Unknown view '" + view + "'. Valid views: "
                             + String.join(", ", VIEWS.stream().sorted().toList()));
         }
+        String requested = view.trim();
 
         Map<String, String> query = UiLinks.query();
-        if (GC_ROOT_PATH_VIEW.equals(view)) {
+        if (GC_ROOT_PATH_VIEW.equals(requested)) {
             query.put(OBJECT_ID_PARAM, objectId);
         }
-        return UiLinks.view(profileManager.info().id(), view, query);
+        return UiLinks.view(profileManager.info().id(), requested, query);
     }
 
     /**

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/ProfilesMcpTools.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/ProfilesMcpTools.java
@@ -19,7 +19,6 @@
 package cafe.jeffrey.microscope.core.mcp.tools;
 
 import cafe.jeffrey.microscope.persistence.api.MicroscopeCoreRepositories;
-import cafe.jeffrey.profile.mcp.McpToolOutput;
 import cafe.jeffrey.shared.common.model.ProfileInfo;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
@@ -63,7 +62,7 @@ public class ProfilesMcpTools {
 
         List<ProfileInfo> profiles = coreRepositories.findAllProfiles().stream()
                 .filter(profile -> matches(profile, search))
-                .limit(boundedLimit(limit))
+                .limit(ToolArguments.boundedLimit(limit, DEFAULT_LIST_LIMIT, MAX_LIST_LIMIT))
                 .toList();
 
         if (profiles.isEmpty()) {
@@ -72,26 +71,27 @@ public class ProfilesMcpTools {
                     : "No profile matches: " + search;
         }
 
-        StringBuilder out = new StringBuilder(1024);
-        out.append("| profile_id | name | project | event source | recorded | duration | ready | modified |\n");
-        out.append("|---|---|---|---|---|---|---|---|\n");
+        MarkdownTable table = MarkdownTable.withColumns(
+                "profile_id", "name", "project", "event source", "recorded", "duration", "ready",
+                "modified");
         for (ProfileInfo profile : profiles) {
-            out.append("| ").append(profile.id())
-                    .append(" | ").append(sanitize(profile.name()))
-                    .append(" | ").append(projectOf(profile))
-                    .append(" | ").append(profile.eventSource())
-                    .append(" | ").append(profile.profilingStartedAt())
-                    .append(" | ").append(profile.duration())
-                    .append(" | ").append(readiness(profile))
-                    .append(" | ").append(profile.modified() ? "yes" : "no")
-                    .append(" |\n");
+            table.row(
+                    profile.id(),
+                    profile.name(),
+                    projectOf(profile),
+                    profile.eventSource(),
+                    profile.profilingStartedAt(),
+                    profile.duration(),
+                    readiness(profile),
+                    profile.modified() ? "yes" : "no");
         }
-        out.append("\nA `modified` profile has had frames renamed or collapsed, so its frame names may "
-                + "differ from the source code.\n");
-        out.append("A profile listed as `building` has a row but not yet its events: its recording is "
-                + "still being parsed. Its id is real, and every analysis tool will answer emptily "
-                + "until it is `yes` - recordings_status says when.\n");
-        return McpToolOutput.capped(out.toString());
+        return table
+                .note("A `modified` profile has had frames renamed or collapsed, so its frame names may "
+                        + "differ from the source code.")
+                .note("A profile listed as `building` has a row but not yet its events: its recording is "
+                        + "still being parsed. Its id is real, and every analysis tool will answer "
+                        + "emptily until it is `yes` - recordings_status says when.")
+                .render();
     }
 
     /**
@@ -104,13 +104,6 @@ public class ProfilesMcpTools {
      */
     private static String readiness(ProfileInfo profile) {
         return profile.enabled() ? "yes" : "building";
-    }
-
-    private static long boundedLimit(Integer limit) {
-        if (limit == null || limit < 1) {
-            return DEFAULT_LIST_LIMIT;
-        }
-        return Math.min(limit, MAX_LIST_LIMIT);
     }
 
     private static boolean matches(ProfileInfo profile, String search) {

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/RecordingsMcpTools.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/RecordingsMcpTools.java
@@ -163,20 +163,20 @@ public class RecordingsMcpTools {
             return NO_RECORDINGS;
         }
 
-        StringBuilder out = new StringBuilder(1024);
-        out.append("| recording_id | name | event source | recorded | profile_id |\n");
-        out.append("|---|---|---|---|---|\n");
+        MarkdownTable table = MarkdownTable.withColumns(
+                "recording_id", "name", "event source", "recorded", "profile_id");
         for (Recording recording : recordings) {
-            out.append("| ").append(recording.id())
-                    .append(" | ").append(sanitize(recording.recordingName()))
-                    .append(" | ").append(recording.eventSource())
-                    .append(" | ").append(recording.recordingStartedAt())
-                    .append(" | ").append(recording.hasProfile() ? recording.profileId() : "")
-                    .append(" |\n");
+            table.row(
+                    recording.id(),
+                    recording.recordingName(),
+                    recording.eventSource(),
+                    recording.recordingStartedAt(),
+                    recording.hasProfile() ? recording.profileId() : "");
         }
-        out.append("\nA row with an empty `profile_id` has not been analysed yet - pass its "
-                + "`recording_id` to recordings_analyzeRecording.\n");
-        return McpToolOutput.capped(out.toString());
+        return table
+                .note("A row with an empty `profile_id` has not been analysed yet - pass its "
+                        + "`recording_id` to recordings_analyzeRecording.")
+                .render();
     }
 
 
@@ -315,16 +315,6 @@ public class RecordingsMcpTools {
     private static String eventSourceOf(Recording recording) {
         RecordingEventSource eventSource = recording.eventSource();
         return eventSource == null ? RecordingEventSource.UNKNOWN.name() : eventSource.name();
-    }
-
-    /**
-     * Keeps a name on one table row: a pipe in a recording name would otherwise split the cell.
-     */
-    private static String sanitize(String value) {
-        if (value == null) {
-            return "";
-        }
-        return value.replace('|', '/').replace('\n', ' ').replace('\r', ' ');
     }
 
     /**

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/ToolArguments.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/ToolArguments.java
@@ -1,0 +1,87 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package cafe.jeffrey.microscope.core.mcp.tools;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The three things nearly every tool does to its arguments before it can use them: insist on the ones
+ * it cannot work without, bound the ones that decide how much comes back, and cap a list before it is
+ * rendered.
+ * <p>
+ * Each of these existed once per family — five copies of {@code boundedLimit} with three different
+ * off-by-one conventions between them, and a {@code trim} written out separately for every element
+ * type it was called with. That is a lot of surface for decisions that are the family's contract with
+ * the model rather than anything specific to garbage collection or JDBC.
+ * <p>
+ * The refusal messages matter more here than the validation does. A model recovers from a bad call
+ * only by reading what came back, so every message names the argument and the tool that produces a
+ * good value for it, rather than reporting that something was wrong.
+ */
+final class ToolArguments {
+
+    private ToolArguments() {
+    }
+
+    /**
+     * An argument the tool genuinely cannot proceed without.
+     * <p>
+     * Worth stating even where the schema marks it required: a client is free to send the call
+     * anyway, and a tool that reads past a missing selector answers a different question from the one
+     * it was asked — which is worse than refusing, because nothing in the answer says so.
+     *
+     * @param recovery how to obtain a good value, e.g. the tool that lists them
+     */
+    static String required(String value, String argument, String recovery) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(argument + " is required. " + recovery);
+        }
+        return value.trim();
+    }
+
+    /**
+     * A row cap the caller may lower but not raise: a model asking for everything is asking for its
+     * own context to be spent on one answer.
+     *
+     * @param fallback what an omitted or nonsensical limit means
+     * @param max      the most this tool will return however large the request
+     */
+    static int boundedLimit(Integer limit, int fallback, int max) {
+        if (limit == null || limit < 1) {
+            return fallback;
+        }
+        return Math.min(limit, max);
+    }
+
+    /**
+     * The head of a list that has no bound of its own — endpoint and class counts are unbounded in
+     * principle, since a service that puts identifiers in its paths produces one row per request.
+     */
+    static <T> List<T> firstOf(List<T> values, int max) {
+        if (values.size() <= max) {
+            return values;
+        }
+        // Copied rather than handed over as a subList view: the head outlives the rendering call, and
+        // a view of a list somebody else still holds is a surprise waiting to happen. An ArrayList
+        // copy rather than List.copyOf, which would additionally refuse a null element and turn a
+        // rendering into a failure over something the row builder should answer for.
+        return Collections.unmodifiableList(new ArrayList<>(values.subList(0, max)));
+    }
+}

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/TraceAttributesMcpTools.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/TraceAttributesMcpTools.java
@@ -145,7 +145,7 @@ public class TraceAttributesMcpTools {
                 keyId(key, source, owner),
                 valueSort(sort),
                 true,
-                boundedLimit(limit),
+                ToolArguments.boundedLimit(limit, DEFAULT_LIMIT, MAX_LIMIT),
                 blankToNull(eventType));
 
         TraceAttributeValues values = profileManager.traceAttributesManager().values(query);
@@ -194,7 +194,7 @@ public class TraceAttributesMcpTools {
                 scope(scope),
                 TraceSortField.DURATION,
                 true,
-                boundedLimit(limit),
+                ToolArguments.boundedLimit(limit, DEFAULT_LIMIT, MAX_LIMIT),
                 0);
 
         TraceAttributeSearchResult result = profileManager.traceAttributesManager().search(query);
@@ -282,10 +282,6 @@ public class TraceAttributesMcpTools {
 
     private static String blankToNull(String value) {
         return value == null || value.isBlank() ? null : value.trim();
-    }
-
-    private static int boundedLimit(Integer limit) {
-        return limit == null ? DEFAULT_LIMIT : Math.clamp(limit, 1, MAX_LIMIT);
     }
 
     private String profileId() {

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/TracesMcpTools.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/TracesMcpTools.java
@@ -158,7 +158,7 @@ public class TracesMcpTools {
                 Boolean.TRUE.equals(errorsOnly),
                 sortField(sort),
                 true,
-                boundedLimit(limit, DEFAULT_OPERATIONS_LIMIT),
+                ToolArguments.boundedLimit(limit, DEFAULT_OPERATIONS_LIMIT, MAX_LIMIT),
                 0);
 
         TraceOperationsPage page = traceManager().operations(query);
@@ -240,7 +240,7 @@ public class TracesMcpTools {
                 source,
                 search,
                 optionalOperationId(name, kind, eventType),
-                boundedLimit(limit, DEFAULT_NOTIFICATIONS_LIMIT));
+                ToolArguments.boundedLimit(limit, DEFAULT_NOTIFICATIONS_LIMIT, MAX_LIMIT));
 
         List<TraceNotificationGroupRow> groups = traceManager().notifications(query);
         if (groups.isEmpty()) {
@@ -267,7 +267,8 @@ public class TracesMcpTools {
 
         return LinkedOutput.json(new SlowestTracesResult(
                 traceManager().tracesOfOperation(
-                        operationId(name, kind, eventType), boundedLimit(limit, DEFAULT_TRACES_LIMIT)),
+                        operationId(name, kind, eventType),
+                        ToolArguments.boundedLimit(limit, DEFAULT_TRACES_LIMIT, MAX_LIMIT)),
                 NextSteps.builder().add(STEP_EXEMPLAR).build(),
                 operationUrl(name, kind, eventType, SLOWEST_TAB)));
     }
@@ -301,7 +302,9 @@ public class TracesMcpTools {
             String traceId,
             @ToolParam(required = true, description = "Span id as a 16-character hex string, from the span tree in traces_traceExport")
             String spanId,
-            @ToolParam(required = false, description = "Event type to graph, e.g. 'jdk.ExecutionSample'")
+            @ToolParam(required = true, description = "Event type to graph, e.g. 'jdk.ExecutionSample' for on-CPU time "
+                    + "or 'jdk.ObjectAllocationSample' for allocation. flamegraph_list names the ones "
+                    + "this profile recorded.")
             String eventType,
             @ToolParam(required = false, description = "Cut the span's children out of the window, so the graph shows only "
                     + "the work the span did itself")
@@ -330,8 +333,9 @@ public class TracesMcpTools {
             String kind,
             @ToolParam(required = true, description = "Event type that opened the trace, e.g. 'jeffrey.HttpServerExchange'")
             String eventType,
-            @ToolParam(required = false, description = "Event type to graph, e.g. 'jdk.ExecutionSample'. Different from "
-                    + "eventType, which identifies the operation.")
+            @ToolParam(required = true, description = "Event type to graph, e.g. 'jdk.ExecutionSample'. Different from "
+                    + "eventType, which identifies the operation: this one names the samples to draw, "
+                    + "and flamegraph_list names the ones this profile recorded.")
             String graphEventType,
             @ToolParam(required = false, description = "Split the graph per thread instead of aggregating")
             Boolean threadMode,
@@ -349,6 +353,11 @@ public class TracesMcpTools {
     /**
      * A span-scoped flamegraph, built exactly as the drawn one next to it in the UI so the two describe
      * the same samples.
+     * <p>
+     * The event type to graph is required rather than defaulted. There is no answer that is right for
+     * every profile — a recording made with the CPU-time sampler carries no {@code jdk.ExecutionSample}
+     * at all — and a default would draw an empty graph for exactly those profiles, which reads as "this
+     * span ran no code" rather than as "you asked for samples this recording does not hold".
      */
     private String exportScoped(
             SpanScope scope, String graphEventType, Boolean threadMode, Boolean useWeight, String url) {
@@ -439,13 +448,6 @@ public class TracesMcpTools {
             throw new IllegalArgumentException("Unknown sort field: " + sort
                     + ". One of: TOTAL_TIME, P50, P95, P99, MAX, COUNT, ERRORS, NOTIFICATIONS, NAME.");
         }
-    }
-
-    private static int boundedLimit(Integer limit, int fallback) {
-        if (limit == null || limit < 1) {
-            return fallback;
-        }
-        return Math.min(limit, MAX_LIMIT);
     }
 
     private static String requireText(String value, String argument) {

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/jvm/JvmSections.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/jvm/JvmSections.java
@@ -68,7 +68,9 @@ public class JvmSections {
     }
 
     /**
-     * The named section, or null when this profile cannot answer it.
+     * The section registered under that id, or null when no section goes by it — which is a wiring
+     * mistake rather than something about this profile. Whether the profile can <em>answer</em> the
+     * section is a separate question, and {@link #isAvailable} is the one that asks it.
      */
     public JvmSection get(String id) {
         return sections.get(id);

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/ExternalMcpControllerTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/ExternalMcpControllerTest.java
@@ -101,6 +101,10 @@ class ExternalMcpControllerTest {
                     .extractingPath("$.result.protocolVersion").asString().isEqualTo("2025-06-18");
         }
 
+        /**
+         * Names rather than positions: the order a family is listed in is stable (the index sorts by
+         * method name), but what this asserts is that both tools reached the client.
+         */
         @Test
         void listsTheAssembledTools() {
             when(assembler.toolset()).thenReturn(new ReflectiveToolset(new SampleTools(), "sample"));
@@ -108,7 +112,8 @@ class ExternalMcpControllerTest {
             assertThat(mvcWith(true).post().uri(URI).contentType(APPLICATION_JSON).content(TOOLS_LIST))
                     .hasStatusOk()
                     .bodyJson()
-                    .extractingPath("$.result.tools[0].name").asString().isEqualTo("sample_ping");
+                    .extractingPath("$.result.tools[*].name").asArray()
+                    .containsExactly("sample_boom", "sample_ping");
         }
 
         @Test

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/LinkedOutputTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/LinkedOutputTest.java
@@ -1,0 +1,112 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package cafe.jeffrey.microscope.core.mcp;
+
+import cafe.jeffrey.profile.mcp.McpToolOutput;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LinkedOutputTest {
+
+    private static final String URL = "http://localhost:8585/profiles/p-1";
+
+    @Test
+    void putsTheLinkUnderTheAnswer() {
+        String out = LinkedOutput.of("the answer", URL);
+
+        assertTrue(out.startsWith("the answer"), out);
+        assertTrue(out.endsWith("Open in Jeffrey: " + URL), out);
+    }
+
+    @Test
+    void saysWhatTheLinkCannotReproduce() {
+        String out = LinkedOutput.of("the answer", URL, "full recording");
+
+        assertTrue(out.contains("Open in Jeffrey (full recording): " + URL), out);
+    }
+
+    @Test
+    void writesTheNextStepsAsAList() {
+        String out = LinkedOutput.of("the answer", List.of("first", "second"), URL);
+
+        assertTrue(out.contains("Where to go next:"), out);
+        assertTrue(out.contains("- first"), out);
+        assertTrue(out.contains("- second"), out);
+        assertTrue(out.indexOf("- first") < out.indexOf("Open in Jeffrey"), out);
+    }
+
+    @Test
+    void leavesTheHeadingOutWhenThereIsNowhereToGo() {
+        assertEquals(
+                LinkedOutput.of("the answer", URL),
+                LinkedOutput.of("the answer", List.of(), URL));
+    }
+
+    /**
+     * The reason this exists as a type rather than as string concatenation at each call site. The cap
+     * truncates at its limit, so a link appended before the cap is cut off exactly the oversized
+     * answers whose reader most needs the interactive view — and the routing below it goes with it.
+     */
+    @Nested
+    class OversizedAnswers {
+
+        private final String oversized = "x".repeat(McpToolOutput.MAX_CHARS + 5_000);
+
+        @Test
+        void keepsTheLinkOnAnAnswerThatHadToBeCut() {
+            String out = LinkedOutput.of(oversized, URL);
+
+            assertTrue(out.contains("TRUNCATED"), "the cut is announced");
+            assertTrue(out.endsWith("Open in Jeffrey: " + URL), "and the link survives it");
+        }
+
+        @Test
+        void keepsTheNextStepsOnAnAnswerThatHadToBeCut() {
+            String out = LinkedOutput.of(oversized, List.of("go here next"), URL);
+
+            assertTrue(out.contains("TRUNCATED"), out.substring(out.length() - 400));
+            assertTrue(out.contains("- go here next"), out.substring(out.length() - 400));
+            assertTrue(out.endsWith("Open in Jeffrey: " + URL), out.substring(out.length() - 400));
+        }
+
+        @Test
+        void keepsTheNoteOnAnAnswerThatHadToBeCut() {
+            String out = LinkedOutput.of(oversized, List.of("go here next"), URL, "full recording");
+
+            assertTrue(out.endsWith("Open in Jeffrey (full recording): " + URL), out.substring(
+                    out.length() - 400));
+        }
+    }
+
+    /**
+     * A JSON answer carries its link as a field of the value instead, because appending it as text
+     * would leave the result no longer parseable.
+     */
+    @Test
+    void rendersAJsonAnswerWithoutAppendingAnything() {
+        assertEquals("{\"uiLink\":\"" + URL + "\"}", LinkedOutput.json(new Linked(URL)));
+    }
+
+    private record Linked(String uiLink) {
+    }
+}

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/McpPromptRegistryTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/McpPromptRegistryTest.java
@@ -1,0 +1,180 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package cafe.jeffrey.microscope.core.mcp;
+
+import cafe.jeffrey.profile.mcp.McpPrompt;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The prompts are the plugin's own skill files, copied onto the classpath by the build. Two things are
+ * worth holding: that the hand-rolled frontmatter reader does not quietly invent a prompt out of
+ * something that is not one, and that the real files still parse — a skill whose frontmatter changes
+ * shape would otherwise vanish from the server with nothing said.
+ */
+class McpPromptRegistryTest {
+
+    @Nested
+    class Parsing {
+
+        @Test
+        void readsTheNameDescriptionAndBody() {
+            McpPrompt prompt = McpPromptRegistry.parse("""
+                    ---
+                    name: analyze-jfr
+                    description: What this skill is for.
+                    ---
+
+                    # Body
+
+                    The instructions.
+                    """);
+
+            assertEquals("analyze-jfr", prompt.name());
+            assertEquals("What this skill is for.", prompt.description());
+            assertTrue(prompt.text().startsWith("# Body"), prompt.text());
+        }
+
+        @Test
+        void ignoresFrontmatterKeysItDoesNotKnow() {
+            McpPrompt prompt = McpPromptRegistry.parse("""
+                    ---
+                    name: jfr-sql
+                    allowed-tools: mcp__jeffrey__*
+                    description: Runs SQL.
+                    ---
+                    Body.
+                    """);
+
+            assertEquals("jfr-sql", prompt.name());
+            assertEquals("Runs SQL.", prompt.description());
+        }
+
+        @Test
+        void unquotesAQuotedValue() {
+            McpPrompt prompt = McpPromptRegistry.parse("""
+                    ---
+                    name: "heap-sql"
+                    description: "Runs SQL against a heap dump."
+                    ---
+                    Body.
+                    """);
+
+            assertEquals("heap-sql", prompt.name());
+            assertEquals("Runs SQL against a heap dump.", prompt.description());
+        }
+
+        @Test
+        void titlesTheNameForAMenu() {
+            assertEquals("Analyze Jfr", McpPromptRegistry.parse("""
+                    ---
+                    name: analyze-jfr
+                    description: d
+                    ---
+                    b
+                    """).title());
+        }
+
+        /**
+         * A file that is not a skill is skipped rather than guessed at. Returning half a prompt would
+         * put a nameless entry in every client's menu.
+         */
+        @Nested
+        class Refusals {
+
+            @Test
+            void refusesAFileWithNoFrontmatter() {
+                assertNull(McpPromptRegistry.parse("# Just a document\n\nwith no frontmatter.\n"));
+            }
+
+            @Test
+            void refusesAnUnterminatedFrontmatter() {
+                assertNull(McpPromptRegistry.parse("---\nname: x\ndescription: y\n"));
+            }
+
+            @Test
+            void refusesFrontmatterWithoutAName() {
+                assertNull(McpPromptRegistry.parse("---\ndescription: y\n---\nbody\n"));
+            }
+
+            @Test
+            void refusesFrontmatterWithoutADescription() {
+                assertNull(McpPromptRegistry.parse("---\nname: x\n---\nbody\n"));
+            }
+
+            @Test
+            void refusesAnEmptyValue() {
+                assertNull(McpPromptRegistry.parse("---\nname:\ndescription: y\n---\nbody\n"));
+            }
+        }
+    }
+
+    /**
+     * Against the skills the build actually copied in, so a change to one of them that this reader
+     * cannot follow fails here rather than in somebody's client.
+     */
+    @Nested
+    class TheRealSkills {
+
+        private final McpPromptRegistry registry = new McpPromptRegistry();
+
+        @Test
+        void loadsEveryPluginSkill() {
+            List<McpPrompt> prompts = registry.prompts();
+
+            assertFalse(prompts.isEmpty(), "the build copies the plugin's skills onto the classpath");
+            assertTrue(prompts.stream().anyMatch(prompt -> prompt.name().equals("analyze-jfr")),
+                    prompts.stream().map(McpPrompt::name).toList().toString());
+        }
+
+        @Test
+        void everyPromptCarriesEnoughForAClientToShowIt() {
+            for (McpPrompt prompt : registry.prompts()) {
+                assertFalse(prompt.name().isBlank(), "a prompt needs a name");
+                assertFalse(prompt.title().isBlank(), "a prompt needs a title for a menu");
+                assertFalse(prompt.description().isBlank(), "a prompt needs a description");
+                assertFalse(prompt.text().isBlank(), "a prompt with no body is not a workflow");
+            }
+        }
+
+        @Test
+        void looksOnePromptUpByName() {
+            assertEquals("analyze-jfr", registry.prompt("analyze-jfr").name());
+        }
+
+        /**
+         * The message is the client's only route back to a working call, so it lists what does exist.
+         */
+        @Test
+        void refusesAnUnknownPromptNamingTheOnesItHas() {
+            IllegalArgumentException thrown =
+                    assertThrows(IllegalArgumentException.class, () -> registry.prompt("no-such-skill"));
+
+            assertTrue(thrown.getMessage().contains("no-such-skill"), thrown.getMessage());
+            assertTrue(thrown.getMessage().contains("analyze-jfr"), thrown.getMessage());
+        }
+    }
+}

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/McpRequestGuardTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/McpRequestGuardTest.java
@@ -1,0 +1,135 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package cafe.jeffrey.microscope.core.mcp;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * The one check the MCP specification asks of a local HTTP server. A page in the user's browser can
+ * post to localhost from any origin, so a server that ignores {@code Origin} can be driven by a site
+ * the user merely visited.
+ */
+class McpRequestGuardTest {
+
+    private static final String SERVER_NAME = "localhost";
+    private static final int SERVER_PORT = 8585;
+
+    private final McpRequestGuard guard = new McpRequestGuard();
+
+    private static MockHttpServletRequest request(String origin) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setServerName(SERVER_NAME);
+        request.setServerPort(SERVER_PORT);
+        if (origin != null) {
+            request.addHeader("Origin", origin);
+        }
+        return request;
+    }
+
+    @Nested
+    class Served {
+
+        /**
+         * A coding agent sends no Origin at all, which is why refusing a foreign one costs Claude Code
+         * and Codex nothing.
+         */
+        @Test
+        void servesARequestWithNoOriginAtAll() {
+            assertNull(guard.refusalReason(request(null)));
+        }
+
+        @Test
+        void servesARequestWithABlankOrigin() {
+            assertNull(guard.refusalReason(request("  ")));
+        }
+
+        @Test
+        void servesAPageJeffreyItselfServed() {
+            assertNull(guard.refusalReason(request("http://localhost:8585")));
+        }
+
+        @Test
+        void comparesTheHostCaseInsensitively() {
+            assertNull(guard.refusalReason(request("http://LOCALHOST:8585")));
+        }
+    }
+
+    @Nested
+    class Refused {
+
+        @Test
+        void refusesASiteTheUserHappenedToBeOn() {
+            assertNotNull(guard.refusalReason(request("https://evil.example")));
+        }
+
+        /**
+         * A different port on the same host is a different origin, and on a developer's machine it is
+         * very often a different application.
+         */
+        @Test
+        void refusesTheSameHostOnAnotherPort() {
+            assertNotNull(guard.refusalReason(request("http://localhost:3000")));
+        }
+
+        /**
+         * The loopback address and the name that resolves to it are different origins to a browser,
+         * so they are different origins here.
+         */
+        @Test
+        void refusesTheLoopbackAddressWhenJeffreyWasReachedByName() {
+            assertNotNull(guard.refusalReason(request("http://127.0.0.1:8585")));
+        }
+
+        @Test
+        void refusesAnOriginWithNoHost() {
+            assertNotNull(guard.refusalReason(request("null")));
+        }
+
+        @Test
+        void refusesSomethingThatIsNotAUriAtAll() {
+            assertNotNull(guard.refusalReason(request("http://[not a uri")));
+        }
+
+        /**
+         * A default port is the port, so an origin that omits it still has to match.
+         */
+        @Test
+        void refusesAnOriginWhoseDefaultPortIsNotJeffreysPort() {
+            assertNotNull(guard.refusalReason(request("http://localhost")));
+        }
+    }
+
+    /**
+     * Jeffrey behind a reverse proxy on 443 is reached without a port, and the page it serves posts
+     * back from exactly that origin.
+     */
+    @Test
+    void servesAnOriginOnTheDefaultPortWhenJeffreyIsThere() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setServerName("jeffrey.example");
+        request.setServerPort(443);
+        request.addHeader("Origin", "https://jeffrey.example");
+
+        assertNull(guard.refusalReason(request));
+    }
+}

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/McpResourcesTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/McpResourcesTest.java
@@ -1,0 +1,191 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package cafe.jeffrey.microscope.core.mcp;
+
+import cafe.jeffrey.profile.mcp.CompositeToolset;
+import cafe.jeffrey.profile.mcp.McpResource;
+import cafe.jeffrey.profile.mcp.McpResourceProvider;
+import cafe.jeffrey.profile.mcp.ReflectiveToolset;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Reading a resource runs the tool that would have answered the equivalent call, so what matters here
+ * is that a URI is routed to the right tool with the right arguments — and that one this server does
+ * not serve is refused rather than resolved to the nearest thing.
+ */
+class McpResourcesTest {
+
+    private final RecordingProfileTools profileTools = new RecordingProfileTools();
+    private final RecordingFlamegraphTools flamegraphTools = new RecordingFlamegraphTools();
+
+    /**
+     * The real toolset over stub tool classes, so a read goes through the dispatch a live call would.
+     */
+    private final McpResources resources = new McpResources(new CompositeToolset(List.of(
+            new ReflectiveToolset(profileTools, "profiles"),
+            new ReflectiveToolset(flamegraphTools, "flamegraph"))));
+
+    @Nested
+    class Catalogue {
+
+        @Test
+        void offersTheProfileListAsAConcreteResource() {
+            List<McpResource> offered = resources.resources();
+
+            assertEquals(1, offered.size());
+            assertEquals("jeffrey://profiles", offered.getFirst().uri());
+        }
+
+        /**
+         * Per-profile resources are templates rather than concrete: one entry per event type of every
+         * profile would be a list nobody reads and almost none of which anybody wants.
+         */
+        @Test
+        void offersThePerProfileResourcesAsTemplates() {
+            List<String> uris = resources.templates().stream().map(McpResource::uri).toList();
+
+            assertEquals(
+                    List.of("jeffrey://profile/{profileId}/summary",
+                            "jeffrey://profile/{profileId}/flamegraph/{eventType}"),
+                    uris);
+        }
+
+        @Test
+        void readsTheCatalogueThroughTheListTool() {
+            McpResourceProvider.Contents contents = resources.read("jeffrey://profiles");
+
+            assertEquals("listed", contents.text());
+            assertEquals(McpResource.TEXT_MARKDOWN, contents.mimeType());
+        }
+    }
+
+    @Nested
+    class Routing {
+
+        @Test
+        void readsAProfileSummaryThroughTheSummaryTool() {
+            McpResourceProvider.Contents contents = resources.read("jeffrey://profile/p-1/summary");
+
+            assertEquals("p-1", profileTools.summarisedProfileId);
+            assertEquals(McpResource.APPLICATION_JSON, contents.mimeType());
+        }
+
+        @Test
+        void readsAFlamegraphThroughTheExportTool() {
+            resources.read("jeffrey://profile/p-1/flamegraph/jdk.ExecutionSample");
+
+            assertEquals("p-1", flamegraphTools.exportedProfileId);
+            assertEquals("jdk.ExecutionSample", flamegraphTools.exportedEventType);
+        }
+
+        /**
+         * An event type carries dots and a profile id could carry anything, so a client is entitled to
+         * percent-encode either.
+         */
+        @Test
+        void decodesAPercentEncodedSegment()  {
+            resources.read("jeffrey://profile/p%2F1/flamegraph/jdk.ObjectAllocationSample");
+
+            assertEquals("p/1", flamegraphTools.exportedProfileId);
+        }
+    }
+
+    /**
+     * Guessing which resource a near-miss meant would answer a question nobody asked, so every shape
+     * this server does not serve is refused with the ones it does.
+     */
+    @Nested
+    class Refusals {
+
+        @Test
+        void refusesAUriWithADifferentScheme() {
+            assertRefused("https://example.test/profiles");
+        }
+
+        @Test
+        void refusesAProfileUriWithNoView() {
+            assertRefused("jeffrey://profile/p-1");
+        }
+
+        @Test
+        void refusesAnUnknownViewName() {
+            assertRefused("jeffrey://profile/p-1/histogram");
+        }
+
+        @Test
+        void refusesAFlamegraphUriWithNoEventType() {
+            assertRefused("jeffrey://profile/p-1/flamegraph");
+        }
+
+        @Test
+        void refusesNull() {
+            assertRefused(null);
+        }
+
+        private void assertRefused(String uri) {
+            IllegalArgumentException thrown =
+                    assertThrows(IllegalArgumentException.class, () -> resources.read(uri));
+
+            assertTrue(thrown.getMessage().contains("jeffrey://profiles"), thrown.getMessage());
+        }
+    }
+
+    /**
+     * The two tools a resource read can reach, recording what they were asked for.
+     */
+    public static class RecordingProfileTools {
+
+        private String summarisedProfileId;
+
+        @Tool(description = "Every analysed profile")
+        public String list() {
+            return "listed";
+        }
+
+        @Tool(description = "One profile in summary")
+        public String summary(
+                @ToolParam(required = true, description = "which profile") String profileId) {
+            this.summarisedProfileId = profileId;
+            return "{}";
+        }
+    }
+
+    public static class RecordingFlamegraphTools {
+
+        private String exportedProfileId;
+        private String exportedEventType;
+
+        @Tool(description = "One flamegraph as Markdown")
+        public String export(
+                @ToolParam(required = true, description = "which profile") String profileId,
+                @ToolParam(required = true, description = "which event type") String eventType) {
+            this.exportedProfileId = profileId;
+            this.exportedEventType = eventType;
+            return "# flamegraph";
+        }
+    }
+}

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/SpringAiToolBindingTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/SpringAiToolBindingTest.java
@@ -1,0 +1,248 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package cafe.jeffrey.microscope.core.mcp;
+
+import cafe.jeffrey.profile.mcp.ReflectiveToolset;
+import cafe.jeffrey.shared.common.Json;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.ai.tool.method.MethodToolCallback;
+import org.springframework.ai.tool.support.ToolDefinitions;
+import tools.jackson.databind.JsonNode;
+
+import java.lang.reflect.Method;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The other half of the conformance question. {@link SpringAiToolConformanceTest} asks whether the two
+ * readings <em>describe</em> a tool the same way; this asks whether they <em>call</em> it the same way.
+ * <p>
+ * A schema that matches and a binder that does not is the worse failure of the two: the model is told
+ * the truth about the arguments and then the tool receives something else. Jeffrey binds arguments
+ * itself, in {@code ToolParamTypes}, so the binding is a second copied contract — and this runs the
+ * same method through Spring AI's own {@link MethodToolCallback} and through Jeffrey's toolset with
+ * identical JSON, comparing what the tool actually received.
+ * <p>
+ * The fixture rather than the real families, deliberately: a real tool needs a live profile database,
+ * and what is under test here is the binder, which is shared by all of them and has no idea what a
+ * profile is.
+ */
+class SpringAiToolBindingTest {
+
+    private final BindingProbe jeffreyTarget = new BindingProbe();
+    private final BindingProbe springAiTarget = new BindingProbe();
+
+    private final ReflectiveToolset jeffrey = new ReflectiveToolset(jeffreyTarget, "probe");
+
+    /**
+     * The same call, made both ways.
+     *
+     * @return what each side reported the tool received
+     */
+    private Bound bind(String methodName, String jsonArguments) {
+        String viaJeffrey = jeffrey.call("probe_" + methodName, Json.readTree(jsonArguments));
+        String viaSpringAi = unwrap(springAiCallback(methodName).call(jsonArguments));
+        return new Bound(viaJeffrey, viaSpringAi);
+    }
+
+    private record Bound(String viaJeffrey, String viaSpringAi) {
+
+        void agree() {
+            assertEquals(viaSpringAi, viaJeffrey,
+                    "Spring AI and Jeffrey bound the same JSON arguments differently");
+        }
+    }
+
+    private MethodToolCallback springAiCallback(String methodName) {
+        Method method = Stream.of(BindingProbe.class.getMethods())
+                .filter(candidate -> candidate.getName().equals(methodName))
+                .findFirst()
+                .orElseThrow();
+        return MethodToolCallback.builder()
+                .toolDefinition(ToolDefinitions.from(method))
+                .toolMethod(method)
+                .toolObject(springAiTarget)
+                .build();
+    }
+
+    /**
+     * Spring AI runs a result through its result converter, which renders a {@code String} as a JSON
+     * string. Jeffrey hands the same value to the MCP content block as it is, so the two are compared
+     * on the value rather than on its rendering.
+     */
+    private static String unwrap(String converted) {
+        JsonNode node = Json.readTree(converted);
+        return node.isString() ? node.asString() : converted;
+    }
+
+    @Nested
+    class Strings {
+
+        @Test
+        void bindsAStringArgument() {
+            bind("echo", "{\"value\":\"hello\"}").agree();
+        }
+
+        @Test
+        void bindsAStringCarryingJsonPunctuation() {
+            bind("echo", "{\"value\":\"a \\\"quoted\\\" {value}\"}").agree();
+        }
+
+        @Test
+        void bindsAnOmittedOptionalStringAsNull() {
+            bind("echo", "{}").agree();
+        }
+    }
+
+    @Nested
+    class Numbers {
+
+        @Test
+        void bindsABoxedInteger() {
+            bind("boxedNumbers", "{\"count\":42,\"size\":7,\"ratio\":0.25}").agree();
+        }
+
+        @Test
+        void bindsOmittedBoxedNumbersAsNull() {
+            bind("boxedNumbers", "{}").agree();
+        }
+
+        @Test
+        void bindsPrimitiveNumbers() {
+            bind("primitiveNumbers", "{\"count\":42,\"size\":7,\"ratio\":0.25}").agree();
+        }
+
+        @Test
+        void bindsANegativeValue() {
+            bind("boxedNumbers", "{\"count\":-1,\"size\":-2,\"ratio\":-0.5}").agree();
+        }
+
+        /**
+         * The type that had Jeffrey advertising a number and binding a string, which is the defect the
+         * single parameter table was introduced to make impossible.
+         */
+        @Test
+        void bindsAFloat() {
+            bind("floats", "{\"ratio\":0.25}").agree();
+        }
+    }
+
+    @Nested
+    class Booleans {
+
+        @Test
+        void bindsABoxedBoolean() {
+            bind("flags", "{\"boxed\":true,\"primitive\":true}").agree();
+        }
+
+        @Test
+        void bindsAnOmittedBoxedBooleanAsNull() {
+            bind("flags", "{\"primitive\":true}").agree();
+        }
+
+        @Test
+        void bindsFalseAsFalseRatherThanAsAbsent() {
+            bind("flags", "{\"boxed\":false,\"primitive\":false}").agree();
+        }
+    }
+
+    @Nested
+    class Enums {
+
+        @Test
+        void bindsAnEnumByName() {
+            bind("sort", "{\"order\":\"DESC\"}").agree();
+        }
+
+        @Test
+        void bindsAnOmittedEnumAsNull() {
+            bind("sort", "{}").agree();
+        }
+    }
+
+    @Test
+    void bindsEveryArgumentOfAWideSignatureAtOnce() {
+        bind("wide", """
+                {"text":"x","count":1,"size":2,"ratio":0.5,"flag":true,"order":"ASC"}""").agree();
+    }
+
+    /**
+     * Every parameter shape a Jeffrey tool is allowed to declare, reporting exactly what it received so
+     * the two binders can be compared on the values rather than on a side effect.
+     */
+    public static class BindingProbe {
+
+        @Tool(description = "Reports the string it was given")
+        public String echo(@ToolParam(required = false, description = "a string") String value) {
+            return "value=" + value;
+        }
+
+        @Tool(description = "Reports the boxed numbers it was given")
+        public String boxedNumbers(
+                @ToolParam(required = false, description = "an integer") Integer count,
+                @ToolParam(required = false, description = "a long") Long size,
+                @ToolParam(required = false, description = "a double") Double ratio) {
+            return "count=" + count + " size=" + size + " ratio=" + ratio;
+        }
+
+        @Tool(description = "Reports the primitive numbers it was given")
+        public String primitiveNumbers(
+                @ToolParam(required = false, description = "an int") int count,
+                @ToolParam(required = false, description = "a long") long size,
+                @ToolParam(required = false, description = "a double") double ratio) {
+            return "count=" + count + " size=" + size + " ratio=" + ratio;
+        }
+
+        @Tool(description = "Reports the float it was given")
+        public String floats(@ToolParam(required = false, description = "a float") Float ratio) {
+            return "ratio=" + ratio;
+        }
+
+        @Tool(description = "Reports the booleans it was given")
+        public String flags(
+                @ToolParam(required = false, description = "boxed") Boolean boxed,
+                @ToolParam(required = false, description = "primitive") boolean primitive) {
+            return "boxed=" + boxed + " primitive=" + primitive;
+        }
+
+        @Tool(description = "Reports the enum it was given")
+        public String sort(@ToolParam(required = false, description = "an order") Order order) {
+            return "order=" + order;
+        }
+
+        @Tool(description = "Reports every shape at once")
+        public String wide(
+                @ToolParam(required = false, description = "text") String text,
+                @ToolParam(required = false, description = "count") Integer count,
+                @ToolParam(required = false, description = "size") Long size,
+                @ToolParam(required = false, description = "ratio") Double ratio,
+                @ToolParam(required = false, description = "flag") Boolean flag,
+                @ToolParam(required = false, description = "order") Order order) {
+            return "text=" + text + " count=" + count + " size=" + size
+                    + " ratio=" + ratio + " flag=" + flag + " order=" + order;
+        }
+    }
+
+    public enum Order {
+        ASC, DESC
+    }
+}

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/SpringAiToolConformanceTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/SpringAiToolConformanceTest.java
@@ -1,0 +1,451 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package cafe.jeffrey.microscope.core.mcp;
+
+import cafe.jeffrey.microscope.core.mcp.tools.BlockingMcpTools;
+import cafe.jeffrey.microscope.core.mcp.tools.CompareMcpTools;
+import cafe.jeffrey.microscope.core.mcp.tools.EventTypeMcpTools;
+import cafe.jeffrey.microscope.core.mcp.tools.FlamegraphMcpTools;
+import cafe.jeffrey.microscope.core.mcp.tools.GrpcMcpTools;
+import cafe.jeffrey.microscope.core.mcp.tools.HeapComputeMcpTools;
+import cafe.jeffrey.microscope.core.mcp.tools.HeapDiffMcpTools;
+import cafe.jeffrey.microscope.core.mcp.tools.HeapOqlMcpTools;
+import cafe.jeffrey.microscope.core.mcp.tools.HttpMcpTools;
+import cafe.jeffrey.microscope.core.mcp.tools.HubsMcpTools;
+import cafe.jeffrey.microscope.core.mcp.tools.IoMcpTools;
+import cafe.jeffrey.microscope.core.mcp.tools.JdbcMcpTools;
+import cafe.jeffrey.microscope.core.mcp.tools.JvmMcpTools;
+import cafe.jeffrey.microscope.core.mcp.tools.MemoryMcpTools;
+import cafe.jeffrey.microscope.core.mcp.tools.MethodTracingMcpTools;
+import cafe.jeffrey.microscope.core.mcp.tools.ProfileMcpTools;
+import cafe.jeffrey.microscope.core.mcp.tools.ProfilesMcpTools;
+import cafe.jeffrey.microscope.core.mcp.tools.RecordingsMcpTools;
+import cafe.jeffrey.microscope.core.mcp.tools.TimelineMcpTools;
+import cafe.jeffrey.microscope.core.mcp.tools.TraceAttributesMcpTools;
+import cafe.jeffrey.microscope.core.mcp.tools.TracesMcpTools;
+import cafe.jeffrey.profile.ai.duckdb.heapdump.tools.HeapDumpMcpTools;
+import cafe.jeffrey.profile.ai.duckdb.jfr.tools.DuckDbMcpTools;
+import cafe.jeffrey.profile.mcp.McpToolSpec;
+import cafe.jeffrey.profile.mcp.ProfileScopedToolset;
+import cafe.jeffrey.shared.common.Json;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.ai.tool.definition.ToolDefinition;
+import org.springframework.ai.tool.support.ToolDefinitions;
+import org.springframework.ai.tool.support.ToolUtils;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.type.filter.RegexPatternTypeFilter;
+import tools.jackson.databind.JsonNode;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Holds Jeffrey's hand-rolled tool layer to Spring AI's own reading of the same annotations.
+ * <p>
+ * Jeffrey does not use Spring AI's MCP server. It borrows only the {@link Tool}/{@link ToolParam}
+ * annotations and re-derives everything from them itself — the tool name, the description, the JSON
+ * Schema — because it needs a profile-scoped toolset and a prefixed name that Spring AI's own
+ * machinery does not produce. The annotations are therefore a contract Jeffrey has copied rather than
+ * one it enforces, and a copied contract drifts: the reason this file exists is that it already had.
+ * <p>
+ * So every {@code @Tool} method the MCP server serves is put through both readings and the two are
+ * compared. Spring AI's {@link ToolDefinitions}/{@link ToolUtils} are the oracle, and the assertions
+ * below say exactly where Jeffrey is allowed to differ and where it is not. Where they legitimately
+ * diverge — the prefixed name, the synthetic {@code profileId}, the required-by-default rule — the
+ * divergence is pinned here in one place instead of being rediscovered per family.
+ * <p>
+ * This is the whole surface at once: no other test covers every family, and a family added to the
+ * tools package without being added here is caught by
+ * {@link Coverage#coversEveryToolFamilyOnTheClasspath()}.
+ */
+class SpringAiToolConformanceTest {
+
+    /**
+     * Every {@code @Tool} class reachable over MCP — the families the external endpoint assembles,
+     * plus the two the Claude Code endpoint serves directly.
+     */
+    private static final List<Class<?>> TOOL_CLASSES = List.of(
+            ProfilesMcpTools.class,
+            ProfileMcpTools.class,
+            EventTypeMcpTools.class,
+            DuckDbMcpTools.class,
+            FlamegraphMcpTools.class,
+            CompareMcpTools.class,
+            TracesMcpTools.class,
+            TraceAttributesMcpTools.class,
+            JvmMcpTools.class,
+            HttpMcpTools.class,
+            JdbcMcpTools.class,
+            GrpcMcpTools.class,
+            MethodTracingMcpTools.class,
+            IoMcpTools.class,
+            BlockingMcpTools.class,
+            TimelineMcpTools.class,
+            MemoryMcpTools.class,
+            HeapDiffMcpTools.class,
+            HeapOqlMcpTools.class,
+            HeapDumpMcpTools.class,
+            HeapComputeMcpTools.class,
+            RecordingsMcpTools.class,
+            HubsMcpTools.class);
+
+    /** Where a {@code @Tool} class may live and still be reachable over MCP. */
+    private static final List<String> TOOL_PACKAGES = List.of(
+            "cafe.jeffrey.microscope.core.mcp.tools",
+            "cafe.jeffrey.profile.ai.duckdb.jfr.tools",
+            "cafe.jeffrey.profile.ai.duckdb.heapdump.tools");
+
+    private static final String TEST_PREFIX = "test";
+
+    private static final String SCHEMA_PROPERTIES = "properties";
+    private static final String SCHEMA_REQUIRED = "required";
+    private static final String SCHEMA_TYPE = "type";
+    private static final String SCHEMA_DESCRIPTION = "description";
+
+    /**
+     * Added by {@link ProfileScopedToolset} to every schema and consumed by the toolset itself, so it
+     * has no counterpart in Spring AI's reading of the method.
+     */
+    private static final String SYNTHETIC_PROFILE_ID = ProfileScopedToolset.PROFILE_ID_ARGUMENT;
+
+    /**
+     * One {@code @Tool} method, read both ways.
+     */
+    private record ToolMethod(Class<?> type, Method method, McpToolSpec jeffrey, ToolDefinition springAi) {
+
+        @Override
+        public String toString() {
+            return type.getSimpleName() + "." + method.getName();
+        }
+
+        JsonNode jeffreySchema() {
+            return jeffrey.inputSchema();
+        }
+
+        JsonNode springAiSchema() {
+            return Json.readTree(springAi.inputSchema());
+        }
+    }
+
+    /**
+     * Jeffrey's own reading of every tool method, obtained through the real toolset.
+     * <p>
+     * {@link ProfileScopedToolset} is used for all of them, including the families that are registered
+     * un-scoped: it takes a {@code Class} rather than an instance and never resolves a target while
+     * only the specs are being read, which is what lets this sweep cover classes whose constructors
+     * want a live profile database.
+     */
+    static Stream<ToolMethod> toolMethods() {
+        List<ToolMethod> methods = new ArrayList<>();
+        for (Class<?> type : TOOL_CLASSES) {
+            ProfileScopedToolset<?> toolset = new ProfileScopedToolset<>(
+                    type, TEST_PREFIX, profileId -> {
+                        throw new UnsupportedOperationException("specs need no target");
+                    });
+            for (McpToolSpec spec : toolset.specs()) {
+                Method method = declaredToolMethod(type, spec.name());
+                methods.add(new ToolMethod(type, method, spec, ToolDefinitions.from(method)));
+            }
+        }
+        return methods.stream();
+    }
+
+    private static Method declaredToolMethod(Class<?> type, String prefixedName) {
+        String methodName = prefixedName.substring(TEST_PREFIX.length() + 1);
+        return Stream.of(type.getMethods())
+                .filter(candidate -> candidate.getName().equals(methodName))
+                .filter(candidate -> candidate.isAnnotationPresent(Tool.class))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("No @Tool method " + methodName + " on " + type));
+    }
+
+    /**
+     * What the model is told the tool is called and what it does. Jeffrey prefixes the name with its
+     * family; the rest has to match, because it is the same annotation being read twice.
+     */
+    @Nested
+    class Identity {
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("cafe.jeffrey.microscope.core.mcp.SpringAiToolConformanceTest#toolMethods")
+        void theNameIsSpringAisNameUnderJeffreysPrefix(ToolMethod tool) {
+            assertEquals(
+                    TEST_PREFIX + "_" + ToolUtils.getToolName(tool.method()),
+                    tool.jeffrey().name(),
+                    "Jeffrey derives the tool name from the method; Spring AI would honour an explicit "
+                            + "@Tool(name=...) that Jeffrey ignores");
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("cafe.jeffrey.microscope.core.mcp.SpringAiToolConformanceTest#toolMethods")
+        void theDescriptionIsTheOneSpringAiWouldRead(ToolMethod tool) {
+            assertEquals(tool.springAi().description(), tool.jeffrey().description());
+        }
+
+        /**
+         * Jeffrey renders a result straight into the MCP content block, so a tool that returned
+         * something else would reach the model as whatever {@code toString} happened to produce.
+         */
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("cafe.jeffrey.microscope.core.mcp.SpringAiToolConformanceTest#toolMethods")
+        void theToolReturnsAString(ToolMethod tool) {
+            assertEquals(String.class, tool.method().getReturnType());
+        }
+    }
+
+    /**
+     * The schema is the tool's contract with the model, and the half most likely to drift: Jeffrey
+     * generates it by hand where Spring AI generates it from the same annotations.
+     */
+    @Nested
+    class Schema {
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("cafe.jeffrey.microscope.core.mcp.SpringAiToolConformanceTest#toolMethods")
+        void bothReadTheSameArguments(ToolMethod tool) {
+            assertEquals(
+                    propertyNames(tool.springAiSchema()),
+                    withoutSyntheticArgument(propertyNames(tool.jeffreySchema())),
+                    "the two readings disagree about which arguments the tool takes");
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("cafe.jeffrey.microscope.core.mcp.SpringAiToolConformanceTest#toolMethods")
+        void bothGiveEachArgumentTheSameType(ToolMethod tool) {
+            JsonNode springAi = tool.springAiSchema().get(SCHEMA_PROPERTIES);
+            JsonNode jeffrey = tool.jeffreySchema().get(SCHEMA_PROPERTIES);
+
+            for (String name : propertyNames(tool.springAiSchema())) {
+                assertEquals(
+                        springAi.get(name).get(SCHEMA_TYPE).asString(),
+                        jeffrey.get(name).get(SCHEMA_TYPE).asString(),
+                        "argument '" + name + "' is advertised as two different JSON types");
+            }
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("cafe.jeffrey.microscope.core.mcp.SpringAiToolConformanceTest#toolMethods")
+        void bothCarryTheSameArgumentDescriptions(ToolMethod tool) {
+            JsonNode springAi = tool.springAiSchema().get(SCHEMA_PROPERTIES);
+            JsonNode jeffrey = tool.jeffreySchema().get(SCHEMA_PROPERTIES);
+
+            for (String name : propertyNames(tool.springAiSchema())) {
+                JsonNode expected = springAi.get(name).get(SCHEMA_DESCRIPTION);
+                JsonNode actual = jeffrey.get(name).get(SCHEMA_DESCRIPTION);
+                assertEquals(
+                        expected == null ? null : expected.asString(),
+                        actual == null ? null : actual.asString(),
+                        "argument '" + name + "' is described differently to the model");
+            }
+        }
+    }
+
+    /**
+     * The one place the two readings genuinely disagree, and the rule that keeps the disagreement
+     * from mattering.
+     * <p>
+     * Spring AI treats a parameter as required unless {@code @ToolParam(required = false)} says
+     * otherwise — and treats a parameter with no annotation at all as required. Jeffrey inverts that:
+     * only an explicit {@code required = true} makes an argument required, on the reasoning that an
+     * unannotated parameter carries no contract to inherit one from.
+     * <p>
+     * Left alone, that would mean the same method advertising two different contracts — Spring AI's
+     * in-process tool-calling path demanding an argument the MCP path calls optional. It does not,
+     * because of the rule asserted below: every tool parameter states its own requiredness. With that
+     * held, the two readings cannot disagree, and the divergence stays theoretical.
+     */
+    @Nested
+    class Requiredness {
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("cafe.jeffrey.microscope.core.mcp.SpringAiToolConformanceTest#toolMethods")
+        void everyArgumentDeclaresWhetherItIsRequired(ToolMethod tool) {
+            for (Parameter parameter : tool.method().getParameters()) {
+                ToolParam declared = parameter.getAnnotation(ToolParam.class);
+                assertTrue(declared != null,
+                        "argument '" + parameter.getName() + "' carries no @ToolParam, so Spring AI "
+                                + "reads it as required and Jeffrey reads it as optional");
+            }
+        }
+
+        /**
+         * With every argument declaring itself, the two readings must now agree exactly.
+         */
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("cafe.jeffrey.microscope.core.mcp.SpringAiToolConformanceTest#toolMethods")
+        void bothRequireTheSameArguments(ToolMethod tool) {
+            assertEquals(
+                    requiredNames(tool.springAiSchema()),
+                    withoutSyntheticArgument(requiredNames(tool.jeffreySchema())),
+                    "the two readings disagree about which arguments a caller must supply");
+        }
+
+    }
+
+    /**
+     * Spring AI refuses a toolset carrying one name twice, and so does Jeffrey. Asserted against the
+     * real families rather than against a fixture, because the failure it prevents — one of two
+     * overloads permanently unreachable — is silent.
+     */
+    @Nested
+    class Uniqueness {
+
+        @Test
+        void noFamilyCarriesOneToolNameTwice() {
+            for (Class<?> type : TOOL_CLASSES) {
+                List<String> names = Stream.of(type.getMethods())
+                        .filter(method -> method.isAnnotationPresent(Tool.class))
+                        .map(ToolUtils::getToolName)
+                        .sorted()
+                        .toList();
+
+                assertEquals(names.size(), Set.copyOf(names).size(),
+                        type.getSimpleName() + " declares one @Tool name more than once");
+            }
+        }
+
+        // Uniqueness *across* families is not asserted here. It depends on the prefix each family is
+        // registered under, which is the assembler's business rather than the class's, and
+        // CompositeToolset already refuses a duplicate when the real server is built —
+        // McpToolsetAssemblerTest does exactly that.
+    }
+
+    /**
+     * A family added to the server and not to this file would be silently exempt from everything
+     * above, which is the failure mode of every hand-maintained list.
+     */
+    @Nested
+    class Coverage {
+
+        /**
+         * Found by scanning rather than read off a second hand-maintained list: the point is to catch
+         * a family somebody adds to the tools package and forgets to add here, and a list that has to
+         * be updated to notice a missing update would not catch anything.
+         */
+        @Test
+        void coversEveryToolFamilyOnTheClasspath() {
+            List<String> onClasspath = scanForToolClasses().stream()
+                    .map(Class::getSimpleName)
+                    .sorted()
+                    .toList();
+            List<String> covered = TOOL_CLASSES.stream()
+                    .map(Class::getSimpleName)
+                    .sorted()
+                    .toList();
+
+            assertEquals(onClasspath, covered,
+                    "a @Tool family exists that this conformance sweep does not cover");
+        }
+
+        @Test
+        void everyFamilyContributesAtLeastOneTool() {
+            for (Class<?> type : TOOL_CLASSES) {
+                long tools = Stream.of(type.getMethods())
+                        .filter(method -> method.isAnnotationPresent(Tool.class))
+                        .count();
+                assertTrue(tools > 0, type.getSimpleName() + " advertises no tools at all");
+            }
+        }
+
+        /**
+         * A floor rather than a count: the point is that the enumeration is still finding the surface,
+         * and a test that had to be edited every time a tool was added would be edited without being
+         * read.
+         */
+        @Test
+        void theSweepIsNotVacuous() {
+            assertTrue(toolMethods().count() >= 80,
+                    "the MCP server advertises around a hundred tools; a much smaller sweep means the "
+                            + "enumeration silently stopped finding them");
+        }
+    }
+
+    /**
+     * Every class carrying a {@code @Tool} method in the packages the MCP families live in.
+     */
+    private static List<Class<?>> scanForToolClasses() {
+        ClassPathScanningCandidateComponentProvider scanner =
+                new ClassPathScanningCandidateComponentProvider(false);
+        scanner.addIncludeFilter(new RegexPatternTypeFilter(Pattern.compile(".*")));
+
+        List<Class<?>> found = new ArrayList<>();
+        for (String basePackage : TOOL_PACKAGES) {
+            for (BeanDefinition candidate : scanner.findCandidateComponents(basePackage)) {
+                Class<?> type = resolve(candidate.getBeanClassName());
+                boolean declaresTools = Stream.of(type.getMethods())
+                        .anyMatch(method -> method.isAnnotationPresent(Tool.class));
+                if (declaresTools) {
+                    found.add(type);
+                }
+            }
+        }
+        return found;
+    }
+
+    private static Class<?> resolve(String className) {
+        try {
+            return Class.forName(className);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Scanned a class that cannot be loaded: " + className, e);
+        }
+    }
+
+    private static List<String> propertyNames(JsonNode schema) {
+        JsonNode properties = schema.get(SCHEMA_PROPERTIES);
+        if (properties == null) {
+            return List.of();
+        }
+        return properties.propertyStream()
+                .map(Map.Entry::getKey)
+                .sorted()
+                .toList();
+    }
+
+    private static List<String> requiredNames(JsonNode schema) {
+        JsonNode required = schema.get(SCHEMA_REQUIRED);
+        if (required == null) {
+            return List.of();
+        }
+        List<String> names = new ArrayList<>();
+        for (JsonNode entry : required) {
+            names.add(entry.asString());
+        }
+        names.sort(Comparator.naturalOrder());
+        return names;
+    }
+
+    private static List<String> withoutSyntheticArgument(List<String> names) {
+        return names.stream().filter(name -> !SYNTHETIC_PROFILE_ID.equals(name)).toList();
+    }
+}

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/BoundedJobsTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/BoundedJobsTest.java
@@ -1,0 +1,185 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package cafe.jeffrey.microscope.core.mcp.tools;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What keeps a client from turning one import or one multi-gigabyte transfer into two: work is keyed
+ * by what the caller already holds, and a second call for the same key joins the first rather than
+ * starting a rival.
+ */
+class BoundedJobsTest {
+
+    private static final Duration GENEROUS = Duration.ofSeconds(10);
+    private static final Duration IMMEDIATE = Duration.ofMillis(50);
+
+    @Nested
+    class Construction {
+
+        @Test
+        void refusesABudgetThatIsNotPositive() {
+            assertThrows(IllegalArgumentException.class, () -> new BoundedJobs<>(Duration.ZERO));
+            assertThrows(IllegalArgumentException.class,
+                    () -> new BoundedJobs<>(Duration.ofSeconds(-1)));
+            assertThrows(IllegalArgumentException.class, () -> new BoundedJobs<>(null));
+        }
+    }
+
+    @Nested
+    class InsideTheBudget {
+
+        @Test
+        void handsBackTheResultOfWorkThatFinishedInTime() {
+            BoundedJobs<String, String> jobs = new BoundedJobs<>(GENEROUS);
+
+            assertEquals(Optional.of("done"), jobs.runWithin("r-1", () -> "done"));
+        }
+
+        /**
+         * The failure the caller sees is the one the work threw. Reporting the ExecutionException
+         * wrapper instead would give every failure the same message and hide the one saying which
+         * file could not be parsed.
+         */
+        @Test
+        void reportsTheFailureTheWorkActuallyThrew() {
+            BoundedJobs<String, String> jobs = new BoundedJobs<>(GENEROUS);
+
+            IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+                    () -> jobs.runWithin("r-1", () -> {
+                        throw new IllegalArgumentException("recording is not a JFR file");
+                    }));
+
+            assertEquals("recording is not a JFR file", thrown.getMessage());
+        }
+
+        /**
+         * A failed job must not be remembered as in flight, or the tool would report a transfer that
+         * is running when nothing is.
+         */
+        @Test
+        void forgetsAJobThatFailed() {
+            BoundedJobs<String, String> jobs = new BoundedJobs<>(GENEROUS);
+
+            assertThrows(IllegalStateException.class, () -> jobs.runWithin("r-1", () -> {
+                throw new IllegalStateException("hub stopped answering");
+            }));
+
+            await().atMost(5, SECONDS).untilAsserted(() -> assertFalse(jobs.isRunning("r-1")));
+        }
+
+        @Test
+        void forgetsAJobThatSucceeded() {
+            BoundedJobs<String, String> jobs = new BoundedJobs<>(GENEROUS);
+            jobs.runWithin("r-1", () -> "done");
+
+            await().atMost(5, SECONDS).untilAsserted(() -> assertFalse(jobs.isRunning("r-1")));
+        }
+    }
+
+    @Nested
+    class PastTheBudget {
+
+        /**
+         * Not a failure: the work carries on and the caller is told how to follow it, which is what
+         * stops a client from retrying and starting the whole transfer again.
+         */
+        @Test
+        void handsBackNothingWhileTheWorkContinues() throws InterruptedException {
+            BoundedJobs<String, String> jobs = new BoundedJobs<>(IMMEDIATE);
+            CountDownLatch release = new CountDownLatch(1);
+
+            Optional<String> answer = jobs.runWithin("r-1", () -> {
+                awaitQuietly(release);
+                return "done";
+            });
+
+            assertTrue(answer.isEmpty());
+            assertTrue(jobs.isRunning("r-1"));
+            release.countDown();
+            await().atMost(5, SECONDS).untilAsserted(() -> assertFalse(jobs.isRunning("r-1")));
+        }
+
+        /**
+         * The whole point of the key. A second call for the same recording joins the first; without
+         * this it would import the same file, or pull the same session, a second time.
+         */
+        @Test
+        void joinsWorkAlreadyRunningForTheSameKey() throws InterruptedException {
+            BoundedJobs<String, String> jobs = new BoundedJobs<>(IMMEDIATE);
+            CountDownLatch release = new CountDownLatch(1);
+            AtomicInteger started = new AtomicInteger();
+
+            jobs.runWithin("r-1", () -> {
+                started.incrementAndGet();
+                awaitQuietly(release);
+                return "done";
+            });
+            Optional<String> second = jobs.runWithin("r-1", () -> {
+                started.incrementAndGet();
+                return "a rival";
+            });
+
+            assertTrue(second.isEmpty());
+            assertEquals(1, started.get(), "the second call must not have started its own work");
+            release.countDown();
+            await().atMost(5, SECONDS).untilAsserted(() -> assertFalse(jobs.isRunning("r-1")));
+        }
+
+        @Test
+        void runsDifferentKeysIndependently() throws InterruptedException {
+            BoundedJobs<String, String> jobs = new BoundedJobs<>(IMMEDIATE);
+            CountDownLatch release = new CountDownLatch(1);
+
+            jobs.runWithin("r-1", () -> {
+                awaitQuietly(release);
+                return "slow";
+            });
+
+            assertEquals(Optional.of("quick"), jobs.runWithin("r-2", () -> "quick"));
+            release.countDown();
+        }
+    }
+
+    @Test
+    void reportsNothingRunningForAKeyItHasNeverSeen() {
+        assertFalse(new BoundedJobs<String, String>(GENEROUS).isRunning("never-asked-for"));
+    }
+
+    private static void awaitQuietly(CountDownLatch latch) {
+        try {
+            latch.await(10, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/HttpMcpToolsTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/HttpMcpToolsTest.java
@@ -186,6 +186,32 @@ class HttpMcpToolsTest {
 
             assertTrue(out.contains("No requests were recorded for '/nope'"), out);
         }
+
+        /**
+         * The manager reads a null uri as "no filter", so an omitted one used to produce the whole
+         * dashboard and this tool handed back its busiest endpoint as though it were the one asked
+         * for - an answer to a different question, with nothing in it saying so.
+         */
+        @Test
+        void refusesAMissingUriRatherThanReportingTheBusiestEndpoint() {
+            IllegalArgumentException thrown = assertThrows(
+                    IllegalArgumentException.class, () -> tools().endpoint(null, null));
+
+            assertTrue(thrown.getMessage().contains("uri is required"), thrown.getMessage());
+            assertTrue(thrown.getMessage().contains("http_overview"), thrown.getMessage());
+        }
+
+        @Test
+        void refusesABlankUriTheSameWay() {
+            assertThrows(IllegalArgumentException.class, () -> tools().endpoint("  ", null));
+        }
+
+        @Test
+        void trimsTheUriBeforeMatching() {
+            when(httpManager.overviewData("/api/orders")).thenReturn(data(List.of(uri("/api/orders"))));
+
+            assertTrue(tools().endpoint("  /api/orders  ", null).contains("\"endpoint\""));
+        }
     }
 
     /**

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/MarkdownTableTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/MarkdownTableTest.java
@@ -1,0 +1,113 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package cafe.jeffrey.microscope.core.mcp.tools;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MarkdownTableTest {
+
+    @Test
+    void rendersAHeaderRuleAndRows() {
+        String out = MarkdownTable.withColumns("id", "name")
+                .row("p-1", "checkout")
+                .render();
+
+        assertEquals("""
+                | id | name |
+                | --- | --- |
+                | p-1 | checkout |
+                """, out);
+    }
+
+    /**
+     * The rule the three catalogue tools each used to carry a copy of, and the reason this type
+     * exists: a name with a pipe in it shifts every column after it, and the ids in that row stop
+     * being the ids the next tool takes.
+     */
+    @Nested
+    class Escaping {
+
+        @Test
+        void keepsAPipeInsideItsCell() {
+            String out = MarkdownTable.withColumns("name", "id")
+                    .row("checkout | before", "p-1")
+                    .render();
+
+            assertTrue(out.contains("| checkout / before | p-1 |"), out);
+        }
+
+        @Test
+        void keepsANewlineFromEndingTheTable() {
+            String out = MarkdownTable.withColumns("name", "id")
+                    .row("first\nsecond", "p-1")
+                    .render();
+
+            assertTrue(out.contains("| first second | p-1 |"), out);
+        }
+
+        @Test
+        void rendersANullCellAsEmptyRatherThanAsTheWordNull() {
+            String out = MarkdownTable.withColumns("name", "id")
+                    .row(null, "p-1")
+                    .render();
+
+            assertTrue(out.contains("|  | p-1 |"), out);
+            assertFalse(out.contains("null"), out);
+        }
+
+        @Test
+        void rendersWhateverTheCallerHasWithoutAskingForAConversion() {
+            String out = MarkdownTable.withColumns("recorded", "files")
+                    .row(Instant.EPOCH, 3)
+                    .render();
+
+            assertTrue(out.contains("| 1970-01-01T00:00:00Z | 3 |"), out);
+        }
+    }
+
+    @Test
+    void refusesARowThatDoesNotMatchTheHeader() {
+        MarkdownTable table = MarkdownTable.withColumns("id", "name");
+
+        IllegalArgumentException thrown =
+                assertThrows(IllegalArgumentException.class, () -> table.row("only-one"));
+
+        assertTrue(thrown.getMessage().contains("2 columns"), thrown.getMessage());
+    }
+
+    @Test
+    void putsEachNoteOnItsOwnLineUnderTheTable() {
+        String out = MarkdownTable.withColumns("id")
+                .row("p-1")
+                .note("first note")
+                .note("second note")
+                .render();
+
+        assertTrue(out.contains("first note"), out);
+        assertTrue(out.contains("second note"), out);
+        assertTrue(out.indexOf("first note") < out.indexOf("second note"), out);
+    }
+}

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/ToolArgumentsTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/ToolArgumentsTest.java
@@ -1,0 +1,116 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package cafe.jeffrey.microscope.core.mcp.tools;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ToolArgumentsTest {
+
+    @Nested
+    class Required {
+
+        @Test
+        void returnsTheValueTrimmed() {
+            assertEquals("orders", ToolArguments.required("  orders  ", "group", "recovery"));
+        }
+
+        /**
+         * A model recovers from a bad call only by reading what came back, so a refusal names the
+         * argument and the tool that produces a good value for it.
+         */
+        @Test
+        void namesTheArgumentAndHowToObtainOne() {
+            IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+                    () -> ToolArguments.required(null, "group", "Call jdbc_overview."));
+
+            assertTrue(thrown.getMessage().contains("group is required"), thrown.getMessage());
+            assertTrue(thrown.getMessage().contains("Call jdbc_overview."), thrown.getMessage());
+        }
+
+        @Test
+        void treatsBlankAsMissing() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> ToolArguments.required("   ", "group", "recovery"));
+        }
+    }
+
+    @Nested
+    class BoundedLimit {
+
+        @Test
+        void usesTheFallbackWhenNoLimitWasGiven() {
+            assertEquals(50, ToolArguments.boundedLimit(null, 50, 500));
+        }
+
+        @Test
+        void usesTheFallbackForANonsensicalLimit() {
+            assertEquals(50, ToolArguments.boundedLimit(0, 50, 500));
+            assertEquals(50, ToolArguments.boundedLimit(-3, 50, 500));
+        }
+
+        @Test
+        void honoursALimitInsideTheRange() {
+            assertEquals(7, ToolArguments.boundedLimit(7, 50, 500));
+        }
+
+        /**
+         * A model asking for everything is asking for its own context to be spent on one answer, so
+         * the ceiling is the tool's rather than the caller's.
+         */
+        @Test
+        void capsALimitAboveTheCeiling() {
+            assertEquals(500, ToolArguments.boundedLimit(100_000, 50, 500));
+        }
+    }
+
+    @Nested
+    class FirstOf {
+
+        @Test
+        void leavesAListThatAlreadyFitsAlone() {
+            List<String> rows = List.of("a", "b");
+            assertSame(rows, ToolArguments.firstOf(rows, 40));
+        }
+
+        @Test
+        void keepsTheHeadOfAnOversizedList() {
+            List<String> rows = List.of("a", "b", "c", "d");
+
+            assertEquals(List.of("a", "b"), ToolArguments.firstOf(rows, 2));
+        }
+
+        @Test
+        void handsBackAListThatDoesNotViewTheOriginal() {
+            List<String> rows = new ArrayList<>(List.of("a", "b", "c"));
+
+            List<String> head = ToolArguments.firstOf(rows, 2);
+            rows.clear();
+
+            assertEquals(List.of("a", "b"), head);
+        }
+    }
+}

--- a/jeffrey-microscope/profiles/mcp-server/src/main/java/cafe/jeffrey/profile/mcp/McpToolOutput.java
+++ b/jeffrey-microscope/profiles/mcp-server/src/main/java/cafe/jeffrey/profile/mcp/McpToolOutput.java
@@ -111,14 +111,15 @@ public final class McpToolOutput {
         ObjectNode truncated = Json.createObject();
         String rendered = Json.toString(tree);
         for (int pass = 0; pass < MAX_TRIM_PASSES && rendered.length() > MAX_CHARS; pass++) {
-            ArrayNode largest = largestArray(tree);
-            if (largest == null || largest.isEmpty()) {
+            NamedArray largest = largestArray(tree);
+            if (largest == null || largest.node().isEmpty()) {
                 break;
             }
-            int before = largest.size();
+            ArrayNode node = largest.node();
+            int before = node.size();
             int keep = Math.max(1, (int) (before * TRIM_RATIO));
-            while (largest.size() > keep) {
-                largest.remove(largest.size() - 1);
+            while (node.size() > keep) {
+                node.remove(node.size() - 1);
             }
             recordTrim(truncated, largest, before);
             rendered = Json.toString(tree);
@@ -134,33 +135,70 @@ public final class McpToolOutput {
     /**
      * Notes one trimmed array under the name of the field holding it, falling back to a counter when the
      * array is nested somewhere without a name of its own.
+     * <p>
+     * The name is what makes the record worth carrying. "slowRequests: kept 20 of 500" tells a reader
+     * which of the answer's lists they are seeing part of; a bare counter tells them only that
+     * something was cut, which they could already see from the field being there at all.
      */
-    private static void recordTrim(ObjectNode truncated, ArrayNode trimmed, int originalSize) {
-        String label = ARRAY_LABEL_PREFIX + (truncated.size() + 1);
-        ObjectNode entry = truncated.putObject(label);
-        entry.put(TRUNCATED_KEPT, trimmed.size());
-        entry.put(TRUNCATED_ORIGINAL, originalSize);
+    private static void recordTrim(ObjectNode truncated, NamedArray trimmed, int originalSize) {
+        String label = trimmed.name() == null
+                ? ARRAY_LABEL_PREFIX + (truncated.size() + 1)
+                : trimmed.name();
+
+        // The same list can be the biggest one twice over. Its record is then updated rather than
+        // written again: two entries for one field would read as two lists having been cut, and the
+        // second one's "original" would be the size it had already been trimmed to.
+        ObjectNode entry = truncated.has(label)
+                ? (ObjectNode) truncated.get(label)
+                : truncated.putObject(label).put(TRUNCATED_ORIGINAL, originalSize);
+        entry.put(TRUNCATED_KEPT, trimmed.node().size());
     }
 
     /**
-     * The array holding the most elements anywhere in the tree — the one whose loss buys the most room.
+     * The array holding the most elements anywhere in the tree — the one whose loss buys the most room
+     * — together with the field name it sits under, where it has one.
      */
-    private static ArrayNode largestArray(JsonNode node) {
-        ArrayNode largest = null;
-        Deque<JsonNode> pending = new ArrayDeque<>();
-        pending.push(node);
+    private static NamedArray largestArray(JsonNode root) {
+        NamedArray largest = null;
+        Deque<NamedArray> pending = new ArrayDeque<>();
+        pending.push(new NamedArray(null, root));
         while (!pending.isEmpty()) {
-            JsonNode current = pending.pop();
-            if (current.isArray() && (largest == null || current.size() > largest.size())) {
-                largest = (ArrayNode) current;
+            NamedArray current = pending.pop();
+            JsonNode value = current.value();
+            if (value.isArray() && (largest == null || value.size() > largest.node().size())) {
+                largest = current;
             }
-            for (JsonNode child : current) {
-                if (child.isArray() || child.isObject()) {
-                    pending.push(child);
+            if (value.isObject()) {
+                // An object names its children; an array does not, so its elements inherit its own
+                // name and a trimmed one is still reported under the field a reader can find.
+                value.propertyStream()
+                        .filter(property -> isContainer(property.getValue()))
+                        .forEach(property ->
+                                pending.push(new NamedArray(property.getKey(), property.getValue())));
+            } else {
+                for (JsonNode child : value) {
+                    if (isContainer(child)) {
+                        pending.push(new NamedArray(current.name(), child));
+                    }
                 }
             }
         }
         return largest;
+    }
+
+    private static boolean isContainer(JsonNode node) {
+        return node.isObject() || node.isArray();
+    }
+
+    /**
+     * A node in the tree, with the object field it hangs off — {@code null} at the root and anywhere
+     * an array's own elements are being walked.
+     */
+    private record NamedArray(String name, JsonNode value) {
+
+        ArrayNode node() {
+            return (ArrayNode) value;
+        }
     }
 
     /**

--- a/jeffrey-microscope/profiles/mcp-server/src/main/java/cafe/jeffrey/profile/mcp/ToolMethodIndex.java
+++ b/jeffrey-microscope/profiles/mcp-server/src/main/java/cafe/jeffrey/profile/mcp/ToolMethodIndex.java
@@ -20,6 +20,7 @@ package cafe.jeffrey.profile.mcp;
 import cafe.jeffrey.shared.common.Json;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.ai.tool.support.ToolUtils;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ArrayNode;
 import tools.jackson.databind.node.ObjectNode;
@@ -96,7 +97,11 @@ final class ToolMethodIndex {
             Set<String> excludedMethods,
             McpToolAnnotations defaultAnnotations) {
         for (Method method : toolMethods(targetType, excludedMethods)) {
-            String toolName = prefix + TOOL_NAME_SEPARATOR + method.getName();
+            // The name and the description are Spring AI's own reading of the annotation rather than a
+            // second one written here. Jeffrey adds the family prefix and nothing else, so a tool that
+            // names itself with @Tool(name=...) is called what it says, instead of being silently
+            // advertised under its method name.
+            String toolName = prefix + TOOL_NAME_SEPARATOR + ToolUtils.getToolName(method);
             Method previous = methodsByToolName.putIfAbsent(toolName, method);
             if (previous != null) {
                 // Two overloads of one @Tool method. MCP addresses a tool by name alone, so one of the
@@ -105,23 +110,27 @@ final class ToolMethodIndex {
                 // one, so the family refuses to assemble.
                 throw new IllegalStateException(
                         "Duplicate MCP tool name '" + toolName + "' in " + targetType.getName()
-                                + ": a @Tool method must not be overloaded.");
+                                + ": a @Tool method must not be overloaded, and two of them must not "
+                                + "declare the same @Tool(name=...).");
             }
             specs.add(new McpToolSpec(
                     toolName,
-                    method.getAnnotation(Tool.class).description(),
+                    ToolUtils.getToolDescription(method),
                     buildInputSchema(method, syntheticParams),
                     annotationsOf(method, defaultAnnotations)));
         }
     }
 
     /**
-     * The {@code @Tool} methods of a class, by name.
+     * The {@code @Tool} methods of a class, in the order they are advertised.
      * <p>
      * Sorted, because {@link Class#getMethods()} makes no promise about order — the JVM is free to
      * return them differently between runs of the same build. Unsorted, the order a family's tools
      * appear in {@code tools/list} is what a model reads first, and it could change under a client
      * without a line of Jeffrey changing.
+     * <p>
+     * {@code excludedMethods} names Java methods rather than tools, because that is what a caller
+     * excluding one is looking at.
      */
     private static List<Method> toolMethods(Class<?> targetType, Set<String> excludedMethods) {
         List<Method> methods = new ArrayList<>();
@@ -130,7 +139,7 @@ final class ToolMethodIndex {
                 methods.add(method);
             }
         }
-        methods.sort(Comparator.comparing(Method::getName));
+        methods.sort(Comparator.comparing(ToolUtils::getToolName));
         return methods;
     }
 

--- a/jeffrey-microscope/profiles/mcp-server/src/main/java/cafe/jeffrey/profile/mcp/ToolMethodIndex.java
+++ b/jeffrey-microscope/profiles/mcp-server/src/main/java/cafe/jeffrey/profile/mcp/ToolMethodIndex.java
@@ -27,12 +27,11 @@ import tools.jackson.databind.node.ObjectNode;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Indexes the {@link Tool}-annotated methods of a class into MCP tool specs, and binds JSON arguments
@@ -44,6 +43,10 @@ import java.util.stream.Collectors;
  * Tool names are {@code <prefix>_<methodName>}. Argument names rely on {@code -parameters} being enabled
  * at compile time (it is, in the project's compiler configuration). All {@link Tool} methods are expected
  * to return a {@link String}.
+ * <p>
+ * Two things are rejected here rather than left to fail later, both because the failure would otherwise
+ * be silent or far from its cause: two {@code @Tool} methods that would share one tool name, and a
+ * parameter of a type {@link ToolParamTypes} cannot carry across JSON.
  */
 final class ToolMethodIndex {
 
@@ -54,12 +57,6 @@ final class ToolMethodIndex {
     private static final String SCHEMA_REQUIRED = "required";
     private static final String SCHEMA_DESCRIPTION = "description";
     private static final String SCHEMA_ENUM = "enum";
-
-    private static final String JSON_TYPE_OBJECT = "object";
-    private static final String JSON_TYPE_STRING = "string";
-    private static final String JSON_TYPE_INTEGER = "integer";
-    private static final String JSON_TYPE_NUMBER = "number";
-    private static final String JSON_TYPE_BOOLEAN = "boolean";
 
     private final Map<String, Method> methodsByToolName = new LinkedHashMap<>();
     private final List<McpToolSpec> specs = new ArrayList<>();
@@ -98,19 +95,43 @@ final class ToolMethodIndex {
             List<SyntheticParam> syntheticParams,
             Set<String> excludedMethods,
             McpToolAnnotations defaultAnnotations) {
-        for (Method method : targetType.getMethods()) {
-            Tool tool = method.getAnnotation(Tool.class);
-            if (tool == null || excludedMethods.contains(method.getName())) {
-                continue;
-            }
+        for (Method method : toolMethods(targetType, excludedMethods)) {
             String toolName = prefix + TOOL_NAME_SEPARATOR + method.getName();
-            methodsByToolName.put(toolName, method);
+            Method previous = methodsByToolName.putIfAbsent(toolName, method);
+            if (previous != null) {
+                // Two overloads of one @Tool method. MCP addresses a tool by name alone, so one of the
+                // two could never be reached however the model called it, and tools/list would carry
+                // the name twice. There is no correct behaviour to fall back on, only a quieter wrong
+                // one, so the family refuses to assemble.
+                throw new IllegalStateException(
+                        "Duplicate MCP tool name '" + toolName + "' in " + targetType.getName()
+                                + ": a @Tool method must not be overloaded.");
+            }
             specs.add(new McpToolSpec(
                     toolName,
-                    tool.description(),
+                    method.getAnnotation(Tool.class).description(),
                     buildInputSchema(method, syntheticParams),
                     annotationsOf(method, defaultAnnotations)));
         }
+    }
+
+    /**
+     * The {@code @Tool} methods of a class, by name.
+     * <p>
+     * Sorted, because {@link Class#getMethods()} makes no promise about order — the JVM is free to
+     * return them differently between runs of the same build. Unsorted, the order a family's tools
+     * appear in {@code tools/list} is what a model reads first, and it could change under a client
+     * without a line of Jeffrey changing.
+     */
+    private static List<Method> toolMethods(Class<?> targetType, Set<String> excludedMethods) {
+        List<Method> methods = new ArrayList<>();
+        for (Method method : targetType.getMethods()) {
+            if (method.isAnnotationPresent(Tool.class) && !excludedMethods.contains(method.getName())) {
+                methods.add(method);
+            }
+        }
+        methods.sort(Comparator.comparing(Method::getName));
+        return methods;
     }
 
     /**
@@ -149,30 +170,28 @@ final class ToolMethodIndex {
         for (int i = 0; i < parameters.length; i++) {
             Parameter parameter = parameters[i];
             JsonNode value = arguments == null ? null : arguments.get(parameter.getName());
-            args[i] = convert(value, parameter.getType());
+            args[i] = ToolParamTypes.convert(value, parameter.getType());
         }
         return args;
     }
 
     private static ObjectNode buildInputSchema(Method method, List<SyntheticParam> syntheticParams) {
         ObjectNode schema = Json.createObject();
-        schema.put(SCHEMA_TYPE, JSON_TYPE_OBJECT);
+        schema.put(SCHEMA_TYPE, ToolParamTypes.JSON_TYPE_OBJECT);
         ObjectNode properties = schema.putObject(SCHEMA_PROPERTIES);
+        List<String> requiredNames = new ArrayList<>();
 
         for (SyntheticParam synthetic : syntheticParams) {
             ObjectNode property = properties.putObject(synthetic.name());
-            property.put(SCHEMA_TYPE, JSON_TYPE_STRING);
+            property.put(SCHEMA_TYPE, ToolParamTypes.JSON_TYPE_STRING);
             property.put(SCHEMA_DESCRIPTION, synthetic.description());
-        }
-
-        List<String> requiredNames = new ArrayList<>();
-        for (SyntheticParam synthetic : syntheticParams) {
             requiredNames.add(synthetic.name());
         }
 
         for (Parameter parameter : method.getParameters()) {
+            requireSupportedType(method, parameter);
             ObjectNode property = properties.putObject(parameter.getName());
-            property.put(SCHEMA_TYPE, jsonType(parameter.getType()));
+            property.put(SCHEMA_TYPE, ToolParamTypes.jsonType(parameter.getType()));
             ToolParam toolParam = parameter.getAnnotation(ToolParam.class);
             if (toolParam != null && !toolParam.description().isBlank()) {
                 property.put(SCHEMA_DESCRIPTION, toolParam.description());
@@ -192,6 +211,24 @@ final class ToolMethodIndex {
             }
         }
         return schema;
+    }
+
+    /**
+     * Refuses a parameter type the toolset cannot carry, at the moment the family is indexed.
+     * <p>
+     * Left to the call, it would be advertised under whatever type the schema guessed and then fail
+     * inside {@code Method.invoke} with a message naming neither the tool nor the argument. Here it
+     * fails where a developer is looking, and names both.
+     */
+    private static void requireSupportedType(Method method, Parameter parameter) {
+        if (!ToolParamTypes.supports(parameter.getType())) {
+            throw new IllegalStateException(
+                    "Tool " + method.getDeclaringClass().getSimpleName() + "." + method.getName()
+                            + " declares parameter '" + parameter.getName() + "' of unsupported type "
+                            + parameter.getType().getName()
+                            + ". A @Tool parameter must be a String, a boxed or primitive number or "
+                            + "boolean, or an enum.");
+        }
     }
 
     /**
@@ -215,77 +252,9 @@ final class ToolMethodIndex {
             return List.of(declared.value());
         }
         if (parameter.getType().isEnum()) {
-            return Arrays.stream(parameter.getType().getEnumConstants())
-                    .map(constant -> ((Enum<?>) constant).name())
-                    .toList();
+            return ToolParamTypes.constants(parameter.getType());
         }
         return List.of();
-    }
-
-    private static Object convert(JsonNode value, Class<?> type) {
-        boolean missing = value == null || value.isNull();
-        if (type == String.class) {
-            return missing ? null : value.asString();
-        }
-        if (type == int.class) {
-            return missing ? 0 : value.asInt();
-        }
-        if (type == Integer.class) {
-            return missing ? null : value.asInt();
-        }
-        if (type == long.class) {
-            return missing ? 0L : value.asLong();
-        }
-        if (type == Long.class) {
-            return missing ? null : value.asLong();
-        }
-        if (type == boolean.class) {
-            return missing ? Boolean.FALSE : value.asBoolean();
-        }
-        if (type == Boolean.class) {
-            return missing ? null : value.asBoolean();
-        }
-        if (type == double.class) {
-            return missing ? 0d : value.asDouble();
-        }
-        if (type == Double.class) {
-            return missing ? null : value.asDouble();
-        }
-        if (type.isEnum()) {
-            return missing ? null : enumConstant(type, value.asString());
-        }
-        // Fallback: pass the raw text (or null) for any other type.
-        return missing ? null : value.asString();
-    }
-
-    /**
-     * Resolves an enum argument by name, refusing an unknown one with the alternatives spelled out —
-     * the schema already carries them, but a client is free to ignore it and the message is what the
-     * model actually reads.
-     */
-    private static Object enumConstant(Class<?> type, String name) {
-        for (Object constant : type.getEnumConstants()) {
-            if (((Enum<?>) constant).name().equalsIgnoreCase(name)) {
-                return constant;
-            }
-        }
-        String allowed = Arrays.stream(type.getEnumConstants())
-                .map(constant -> ((Enum<?>) constant).name())
-                .collect(Collectors.joining(", "));
-        throw new IllegalArgumentException("Unknown value '" + name + "'. Expected one of: " + allowed);
-    }
-
-    private static String jsonType(Class<?> type) {
-        if (type == int.class || type == Integer.class || type == long.class || type == Long.class) {
-            return JSON_TYPE_INTEGER;
-        }
-        if (type == boolean.class || type == Boolean.class) {
-            return JSON_TYPE_BOOLEAN;
-        }
-        if (type == double.class || type == Double.class || type == float.class || type == Float.class) {
-            return JSON_TYPE_NUMBER;
-        }
-        return JSON_TYPE_STRING;
     }
 
     /**

--- a/jeffrey-microscope/profiles/mcp-server/src/main/java/cafe/jeffrey/profile/mcp/ToolParamTypes.java
+++ b/jeffrey-microscope/profiles/mcp-server/src/main/java/cafe/jeffrey/profile/mcp/ToolParamTypes.java
@@ -1,0 +1,146 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package cafe.jeffrey.profile.mcp;
+
+import tools.jackson.databind.JsonNode;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * The parameter types a {@code @Tool} method may declare: what each is advertised as in the JSON
+ * Schema, and how each is read back out of a call's arguments.
+ * <p>
+ * One table answers both questions, and that is the point of the type. They were previously two
+ * independent ladders, which is a shape that can disagree — and did: {@code float} was advertised as
+ * a JSON {@code number} and then bound as a {@code String}, so a tool declaring one would have been
+ * offered to the model and then failed inside {@code Method.invoke} with an argument-type mismatch
+ * that named neither the tool nor the parameter. A single entry per type cannot drift that way.
+ * <p>
+ * The set is deliberately closed. A tool parameter of any other type is rejected when its family is
+ * indexed rather than when a model calls it, so the mistake surfaces at startup — where a developer
+ * is looking — instead of many turns into somebody's session.
+ */
+final class ToolParamTypes {
+
+    static final String JSON_TYPE_OBJECT = "object";
+    static final String JSON_TYPE_STRING = "string";
+    static final String JSON_TYPE_INTEGER = "integer";
+    static final String JSON_TYPE_NUMBER = "number";
+    static final String JSON_TYPE_BOOLEAN = "boolean";
+
+    /**
+     * How one parameter type crosses the JSON boundary.
+     *
+     * @param jsonType what {@code tools/list} advertises the parameter as
+     * @param read     the value when the caller supplied one
+     * @param absent   the value when the caller did not. A primitive cannot take {@code null}, so it
+     *                 takes its own zero; a boxed type takes {@code null}, which is what lets a tool
+     *                 tell "not given" from "given as zero"
+     */
+    private record Binding(String jsonType, Function<JsonNode, Object> read, Object absent) {
+    }
+
+    private static final Map<Class<?>, Binding> BINDINGS = Map.ofEntries(
+            Map.entry(String.class, new Binding(JSON_TYPE_STRING, JsonNode::asString, null)),
+            Map.entry(int.class, new Binding(JSON_TYPE_INTEGER, JsonNode::asInt, 0)),
+            Map.entry(Integer.class, new Binding(JSON_TYPE_INTEGER, JsonNode::asInt, null)),
+            Map.entry(long.class, new Binding(JSON_TYPE_INTEGER, JsonNode::asLong, 0L)),
+            Map.entry(Long.class, new Binding(JSON_TYPE_INTEGER, JsonNode::asLong, null)),
+            Map.entry(boolean.class, new Binding(JSON_TYPE_BOOLEAN, JsonNode::asBoolean, Boolean.FALSE)),
+            Map.entry(Boolean.class, new Binding(JSON_TYPE_BOOLEAN, JsonNode::asBoolean, null)),
+            Map.entry(double.class, new Binding(JSON_TYPE_NUMBER, JsonNode::asDouble, 0d)),
+            Map.entry(Double.class, new Binding(JSON_TYPE_NUMBER, JsonNode::asDouble, null)),
+            Map.entry(float.class,
+                    new Binding(JSON_TYPE_NUMBER, node -> (float) node.asDouble(), 0f)),
+            Map.entry(Float.class,
+                    new Binding(JSON_TYPE_NUMBER, node -> (float) node.asDouble(), null)));
+
+    private ToolParamTypes() {
+    }
+
+    /**
+     * Whether a tool may declare a parameter of this type at all. An {@code enum} always may: its
+     * constants are the allowed values, and the schema carries them.
+     */
+    static boolean supports(Class<?> type) {
+        return BINDINGS.containsKey(type) || type.isEnum();
+    }
+
+    /**
+     * What the schema calls this type. An {@code enum} travels as a string with an {@code enum}
+     * constraint beside it.
+     */
+    static String jsonType(Class<?> type) {
+        Binding binding = BINDINGS.get(type);
+        if (binding != null) {
+            return binding.jsonType();
+        }
+        return JSON_TYPE_STRING;
+    }
+
+    /**
+     * Reads one argument. A missing or explicitly null value yields the type's absent value rather
+     * than throwing: a parameter the schema marks optional is expected to arrive unset.
+     */
+    static Object convert(JsonNode value, Class<?> type) {
+        boolean missing = value == null || value.isNull();
+        if (type.isEnum()) {
+            return missing ? null : enumConstant(type, value.asString());
+        }
+
+        Binding binding = BINDINGS.get(type);
+        if (binding == null) {
+            // Unreachable through a toolset, which rejects such a parameter when it indexes the
+            // family. Stated rather than assumed, so a future caller that skips the index is told.
+            throw new IllegalStateException("Unsupported tool parameter type: " + type.getName());
+        }
+        return missing ? binding.absent() : binding.read().apply(value);
+    }
+
+    /**
+     * Resolves an enum argument by name, refusing an unknown one with the alternatives spelled out —
+     * the schema already carries them, but a client is free to ignore it and the message is what the
+     * model actually reads.
+     */
+    private static Object enumConstant(Class<?> type, String name) {
+        for (Object constant : type.getEnumConstants()) {
+            if (((Enum<?>) constant).name().equalsIgnoreCase(name)) {
+                return constant;
+            }
+        }
+        throw new IllegalArgumentException(
+                "Unknown value '" + name + "'. Expected one of: " + constantNames(type));
+    }
+
+    /**
+     * The constants of an {@code enum} parameter, in declaration order — the {@code enum} constraint
+     * of its schema, and the alternatives a refusal names.
+     */
+    static String constantNames(Class<?> type) {
+        return String.join(", ", constants(type));
+    }
+
+    static List<String> constants(Class<?> type) {
+        return Arrays.stream(type.getEnumConstants())
+                .map(constant -> ((Enum<?>) constant).name())
+                .toList();
+    }
+}

--- a/jeffrey-microscope/profiles/mcp-server/src/test/java/cafe/jeffrey/profile/mcp/McpToolOutputTest.java
+++ b/jeffrey-microscope/profiles/mcp-server/src/test/java/cafe/jeffrey/profile/mcp/McpToolOutputTest.java
@@ -105,6 +105,23 @@ class McpToolOutputTest {
         assertTrue(first.get("kept").asInt() < 20_000);
     }
 
+    /**
+     * Which list was cut is the part a reader needs. An answer carrying several of them, reporting
+     * only that "an array" lost rows, leaves them no better off than the field's own length did.
+     */
+    @Test
+    void namesTheFieldWhoseListWasTrimmed() {
+        List<String> rows = new ArrayList<>();
+        for (int i = 0; i < 20_000; i++) {
+            rows.add("row-" + i + "-with-enough-text-to-push-the-document-past-the-cap");
+        }
+
+        JsonNode parsed = Json.readTree(McpToolOutput.json(new Dashboard("cpu", rows)));
+
+        assertTrue(parsed.get("_truncated").has("rows"),
+                "the trimmed list is reported under the field holding it");
+    }
+
     @Test
     void aJsonResultThatFitsIsLeftExactlyAsItWas() {
         String rendered = McpToolOutput.json(new Dashboard("cpu", List.of("a", "b")));

--- a/jeffrey-microscope/profiles/mcp-server/src/test/java/cafe/jeffrey/profile/mcp/ToolMethodIndexTest.java
+++ b/jeffrey-microscope/profiles/mcp-server/src/test/java/cafe/jeffrey/profile/mcp/ToolMethodIndexTest.java
@@ -61,6 +61,41 @@ class ToolMethodIndexTest {
         }
     }
 
+    /**
+     * The name and description come from Spring AI's own reading of the annotation, so an explicit
+     * name is honoured rather than silently replaced by the method's. Jeffrey contributes the family
+     * prefix and nothing else.
+     */
+    @Nested
+    class Naming {
+
+        @Test
+        void honoursAnExplicitToolName() {
+            ReflectiveToolset toolset = new ReflectiveToolset(new NamedTools(), "test");
+
+            assertEquals(
+                    List.of("test_run_query"),
+                    toolset.specs().stream().map(McpToolSpec::name).toList());
+        }
+
+        @Test
+        void dispatchesOnTheDeclaredNameRatherThanTheMethodName() {
+            ReflectiveToolset toolset = new ReflectiveToolset(new NamedTools(), "test");
+
+            assertEquals("ran", toolset.call("test_run_query", Json.createObject()));
+            assertThrows(IllegalArgumentException.class,
+                    () -> toolset.call("test_execute", Json.createObject()));
+        }
+
+        @Test
+        void fallsBackToTheMethodNameWhenNoneIsDeclared() {
+            ReflectiveToolset toolset = new ReflectiveToolset(new NumericTools(), "test");
+
+            assertTrue(toolset.specs().stream()
+                    .anyMatch(spec -> spec.name().equals("test_alpha")));
+        }
+    }
+
     @Nested
     class Schema {
 
@@ -133,6 +168,14 @@ class ToolMethodIndexTest {
                 @ToolParam(required = false, description = "primitive") double primitive,
                 @ToolParam(required = false, description = "boxed") Double boxed) {
             return primitive + "/" + boxed;
+        }
+    }
+
+    static class NamedTools {
+
+        @Tool(name = "run_query", description = "A tool that names itself")
+        public String execute() {
+            return "ran";
         }
     }
 

--- a/jeffrey-microscope/profiles/mcp-server/src/test/java/cafe/jeffrey/profile/mcp/ToolMethodIndexTest.java
+++ b/jeffrey-microscope/profiles/mcp-server/src/test/java/cafe/jeffrey/profile/mcp/ToolMethodIndexTest.java
@@ -1,0 +1,160 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package cafe.jeffrey.profile.mcp;
+
+import cafe.jeffrey.shared.common.Json;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import tools.jackson.databind.node.ObjectNode;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The contract a tool family is held to when it is indexed, and what a caller can rely on afterwards.
+ */
+class ToolMethodIndexTest {
+
+    /**
+     * Everything a family does wrong is refused while it is being assembled, not when a model happens
+     * to call the offending tool — which on an MCP server means during somebody's session, with a
+     * message that names neither the tool nor the mistake.
+     */
+    @Nested
+    class Rejections {
+
+        @Test
+        void refusesTwoToolMethodsThatWouldShareOneName() {
+            IllegalStateException e = assertThrows(IllegalStateException.class,
+                    () -> new ReflectiveToolset(new OverloadedTools(), "test"));
+            assertTrue(e.getMessage().contains("test_query"));
+            assertTrue(e.getMessage().contains("overloaded"));
+        }
+
+        @Test
+        void refusesAParameterTypeThatCannotCrossJson() {
+            IllegalStateException e = assertThrows(IllegalStateException.class,
+                    () -> new ReflectiveToolset(new UnsupportedParamTools(), "test"));
+            assertTrue(e.getMessage().contains("window"));
+            assertTrue(e.getMessage().contains("java.time.Duration"));
+        }
+    }
+
+    @Nested
+    class Schema {
+
+        private final ReflectiveToolset toolset = new ReflectiveToolset(new NumericTools(), "test");
+
+        /**
+         * {@code Class#getMethods} promises no order at all, so an unsorted index could hand two runs
+         * of the same build a differently ordered {@code tools/list} — and the order is what a model
+         * reads first.
+         */
+        @Test
+        void listsToolsInAStableOrder() {
+            assertEquals(
+                    List.of("test_alpha", "test_beta", "test_gamma"),
+                    toolset.specs().stream().map(McpToolSpec::name).toList());
+        }
+
+        /**
+         * The schema's type and the binding come from one table, so a parameter cannot be advertised
+         * as one thing and read as another.
+         */
+        @Test
+        void advertisesAFloatingPointParameterAsANumber() {
+            ObjectNode properties = (ObjectNode) specOf("test_beta").inputSchema().get("properties");
+            assertEquals("number", properties.get("ratio").get("type").asString());
+        }
+
+        private McpToolSpec specOf(String name) {
+            return toolset.specs().stream()
+                    .filter(spec -> spec.name().equals(name))
+                    .findFirst()
+                    .orElseThrow();
+        }
+    }
+
+    @Nested
+    class Binding {
+
+        private final ReflectiveToolset toolset = new ReflectiveToolset(new NumericTools(), "test");
+
+        @Test
+        void bindsAFloatingPointArgumentRatherThanFailingInsideTheCall() {
+            assertEquals("0.25", toolset.call("test_beta", Json.createObject().put("ratio", 0.25)));
+        }
+
+        /**
+         * A primitive cannot hold null, so an omitted one takes its own zero; a boxed one takes null,
+         * which is what lets a tool tell "not given" from "given as zero".
+         */
+        @Test
+        void distinguishesAnOmittedBoxedArgumentFromAnOmittedPrimitive() {
+            assertEquals("0.0/null", toolset.call("test_gamma", Json.createObject()));
+        }
+    }
+
+    static class NumericTools {
+
+        @Tool(description = "First, alphabetically")
+        public String alpha() {
+            return "alpha";
+        }
+
+        @Tool(description = "Takes a float")
+        public String beta(@ToolParam(required = false, description = "a ratio") float ratio) {
+            return String.valueOf(ratio);
+        }
+
+        @Tool(description = "Takes both shapes of a number")
+        public String gamma(
+                @ToolParam(required = false, description = "primitive") double primitive,
+                @ToolParam(required = false, description = "boxed") Double boxed) {
+            return primitive + "/" + boxed;
+        }
+    }
+
+    static class OverloadedTools {
+
+        @Tool(description = "Query by name")
+        public String query(@ToolParam(required = false, description = "name") String name) {
+            return name;
+        }
+
+        @Tool(description = "Query by id")
+        public String query(@ToolParam(required = false, description = "id") Integer id) {
+            return String.valueOf(id);
+        }
+    }
+
+    static class UnsupportedParamTools {
+
+        @Tool(description = "Takes something JSON cannot carry")
+        public String scan(
+                @ToolParam(required = false, description = "how long") Duration window) {
+            return String.valueOf(window);
+        }
+    }
+}

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpToolsPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpToolsPage.vue
@@ -443,7 +443,7 @@ hubs_download { "sessionRef": "h1Y2ZnLX..." }
           </tr>
           <tr>
             <td><code>traces_spanFlamegraphExport</code></td>
-            <td><code>profileId</code>, <code>traceId</code>, <code>spanId</code>, <code>eventType?</code>, <code>selfOnly?</code>, <code>threadMode?</code>, <code>useWeight?</code></td>
+            <td><code>profileId</code>, <code>traceId</code>, <code>spanId</code>, <code>eventType</code>, <code>selfOnly?</code>, <code>threadMode?</code>, <code>useWeight?</code></td>
             <td>A flamegraph of the samples taken while one span was open</td>
           </tr>
           <tr>
@@ -463,7 +463,7 @@ hubs_download { "sessionRef": "h1Y2ZnLX..." }
           </tr>
           <tr>
             <td><code>traces_operationFlamegraphExport</code></td>
-            <td><code>profileId</code>, <code>name</code>, <code>kind</code>, <code>eventType</code>, <code>graphEventType?</code>, <code>threadMode?</code>, <code>useWeight?</code></td>
+            <td><code>profileId</code>, <code>name</code>, <code>kind</code>, <code>eventType</code>, <code>graphEventType</code>, <code>threadMode?</code>, <code>useWeight?</code></td>
             <td>The same, aggregated over every trace of one operation</td>
           </tr>
           <tr>
@@ -477,7 +477,7 @@ hubs_download { "sessionRef": "h1Y2ZnLX..." }
       <p>A notification is the application&rsquo;s own account of what went wrong &mdash; a pool exhausted, a fallback taken &mdash; emitted by its own code, so it is a diagnosis where every other tool reports a measurement. The trace and operation exports carry a Notifications section of their own; <code>traces_notifications</code> is the profile-wide reading, and the place to start when <code>traces_overview</code> reports any <code>CRITICAL</code> or <code>HIGH</code> ones.</p>
 
       <DocsCallout type="info" title="Two event types, two different meanings">
-        On <code>traces_operationFlamegraphExport</code>, <code>eventType</code> is the event that <em>opened the trace</em> (e.g. <code>jeffrey.HttpServerExchange</code>) while <code>graphEventType</code> is what to <em>graph</em> (e.g. <code>jdk.ExecutionSample</code>). They are never the same value. <code>traces_spanFlamegraphExport</code> has no such split: the span is already identified by <code>traceId</code> and <code>spanId</code>, so its <code>eventType</code> is what to graph.
+        On <code>traces_operationFlamegraphExport</code>, <code>eventType</code> is the event that <em>opened the trace</em> (e.g. <code>jeffrey.HttpServerExchange</code>) while <code>graphEventType</code> is what to <em>graph</em> (e.g. <code>jdk.ExecutionSample</code>). They are never the same value. <code>traces_spanFlamegraphExport</code> has no such split: the span is already identified by <code>traceId</code> and <code>spanId</code>, so its <code>eventType</code> is what to graph. Both are required: there is no event type that is right to graph for every profile &mdash; a recording made with the CPU-time sampler carries no <code>jdk.ExecutionSample</code> at all &mdash; and a default would draw an empty graph for exactly those profiles.
       </DocsCallout>
 
       <p><strong>Examples.</strong> Arguments are shown as JSON; the tool name omits the server prefix.</p>


### PR DESCRIPTION
Five tools advertised an argument as optional and then could not work
without it. Three of those did not fail — they answered a different
question: the HTTP, JDBC and gRPC managers read a null selector as "no
filter", so http_endpoint with no uri returned the busiest endpoint of
the whole dashboard labelled as the one that was asked for. The other two,
the traces flamegraph exports, threw on an argument their own schema said
was optional. profiles_viewLink did the same. All six now say what they
mean, and the three selectors are insisted on with a message naming the
tool that produces a good value.

In the protocol layer, the JSON-Schema type and the argument binding were
two independent ladders that had already drifted: a float parameter was
advertised as a number and bound as a String, so a tool declaring one
would be offered to the model and then fail inside Method.invoke naming
neither the tool nor the argument. They are one table now, and a parameter
type it cannot carry is refused when the family is indexed rather than
when somebody calls it. Two overloaded @Tool methods were silently
collapsing into one dispatchable name while both appeared in tools/list;
that is refused at construction, the way CompositeToolset already refuses
a duplicate across families. Tool order came from Class#getMethods, which
promises nothing, so what a model read first could change between runs of
one build; it is sorted.

LinkedOutput existed to keep the link and the routing out of the truncated
region, and capped twice — an oversized body comes back already at the
limit plus its truncation note, so appending the next steps and capping
again cut them straight back off. They were dropped from precisely the
answers they were added for. A JSON result that had to lose rows now names
the field whose list was trimmed instead of calling it "array1".

The duplication went the same way: one MarkdownTable that escapes a cell
once instead of three copies of a pipe-replacing sanitize, and one
ToolArguments for the five boundedLimit variants and the eight trims. The
hub download answers had been running JSON values through the Markdown
escape, mangling a session name for a reason that does not apply there.

Tests: 250 to 329 across the two modules. New coverage for the frontmatter
reader (against the real plugin skills, so a skill that changes shape
fails here rather than vanishing from the server), the resource URI
routing, the Origin guard, BoundedJobs, and the two new collaborators.
The LinkedOutput truncation bug was found by writing its test.

Docs updated for the two traces exports whose event type is now required.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011yNLSpiU5gwuNXQTKEsUBG