### PR TITLE
Compute Auto Analysis when a recording is imported

### DIFF
--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/JvmMcpTools.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/JvmMcpTools.java
@@ -92,11 +92,14 @@ public class JvmMcpTools {
             + "answer.";
 
     private static final String AUTO_ANALYSIS_NOT_COMPUTED = "Auto Analysis has not been computed for "
-            + "this profile yet. Call this tool again with compute true to run it — it reads the whole "
-            + "recording through the JMC rule set, which takes a while and is cached afterwards. It can "
-            + "also be run from the Auto Analysis page in the Jeffrey UI; call profiles_link for the "
-            + "URL. Meanwhile the other jvm_ sections answer the same subsystems directly from the "
-            + "parsed events.";
+            + "this profile yet. It is normally computed when a recording is imported, so this means "
+            + "one of: the profile predates that, its recording file is no longer on disk, the warm-up "
+            + "failed, or it is still running. Call this tool again with compute true to run it — it "
+            + "reads the whole recording through the JMC rule set, which takes a while and is cached "
+            + "afterwards; a call arriving while a run is already in progress joins that run rather "
+            + "than starting a second one. It can also be run from the Auto Analysis page in the "
+            + "Jeffrey UI; call profiles_link for the URL. Meanwhile the other jvm_ sections answer "
+            + "the same subsystems directly from the parsed events.";
 
     private static final String NO_SUCH_GC_PAGE = "No garbage-collection page named '%s'. The pages "
             + "are: %s.";
@@ -173,14 +176,17 @@ public class JvmMcpTools {
     @Tool(description = "Jeffrey's Auto Analysis: the JMC rule set run over the whole recording, as "
             + "findings with a severity, an explanation and a suggested fix. The cheapest first "
             + "question about any profile — each finding names a subsystem worth following up in. "
-            + "Cached once computed, and read from that cache here. When nothing has computed it yet, "
-            + "pass compute true to run it: that reads the whole recording through the rule set, which "
-            + "is slow and unbounded in memory, so it is asked for rather than assumed.")
+            + "Computed when the recording is imported and cached, so this is normally a cache read. "
+            + "For a profile that missed that — imported before Jeffrey warmed it, or whose recording "
+            + "file has since gone — pass compute true to run it: that reads the whole recording "
+            + "through the rule set, which is slow and unbounded in memory, so it is asked for rather "
+            + "than assumed.")
     public String autoAnalysis(
             @ToolParam(required = false, description = "Run the rule set now if it has not been run "
-                    + "before. Off by default because it reads the entire recording through the JMC "
-                    + "toolkit, which on a large one takes a while and holds a lot of heap. Ignored "
-                    + "when the analysis is already computed, which is then simply returned")
+                    + "before. Rarely needed, since a profile is warmed at import. Off by default "
+                    + "because it reads the entire recording through the JMC toolkit, which on a "
+                    + "large one takes a while and holds a lot of heap. Ignored when the analysis is "
+                    + "already computed, which is then simply returned")
             Boolean compute) {
 
         if (!autoAnalysisSection.isComputed()) {

--- a/jeffrey-microscope/profiles/profile-management/pom.xml
+++ b/jeffrey-microscope/profiles/profile-management/pom.xml
@@ -173,6 +173,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/ProfileInitStages.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/ProfileInitStages.java
@@ -61,7 +61,7 @@ public final class ProfileInitStages {
     public static final String CHECKPOINT = "checkpoint";
 
     /**
-     * Starts the thread bands. The stage covers starting them, not
+     * Starts the thread bands and the auto analysis. The stage covers starting them, not
      * finishing them: they are caches, and the profile is usable without them.
      */
     public static final String WARMUP = "warmup";

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/ProfileInitializerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/ProfileInitializerImpl.java
@@ -195,8 +195,8 @@ public class ProfileInitializerImpl implements ProfileInitializer {
 
         // Last, and deliberately not waited for. Everything above leaves the profile queryable --
         // events, traces, event types, threads are all written -- so this is the point the profile
-        // is usable, and the caller enables it as soon as we return. The warmed views' frame trees and
-        // the thread bands are caches: warming them eagerly is worth doing, but making every user
+        // is usable, and the caller enables it as soon as we return. The thread bands and the auto
+        // analysis are caches: warming them eagerly is worth doing, but making every user
         // wait for them before they can open a flamegraph is not. The stage therefore measures
         // starting the warming, not finishing it; the warming holds its own lease until it is done.
         run.runStage(ProfileInitStages.WARMUP, () -> profileDataInitializer.initialize(profileManager));

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/configuration/ProfileAnalysisConfiguration.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/configuration/ProfileAnalysisConfiguration.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import cafe.jeffrey.profile.manager.AutoAnalysisManager;
 import cafe.jeffrey.profile.manager.AutoAnalysisManagerImpl;
+import cafe.jeffrey.profile.parser.data.AutoAnalysisDataProvider;
 import cafe.jeffrey.profile.manager.EventViewerManager;
 import cafe.jeffrey.profile.manager.EventViewerManagerImpl;
 import cafe.jeffrey.profile.manager.FlagsManager;
@@ -92,7 +93,8 @@ public class ProfileAnalysisConfiguration {
                 recordingPathResolver = () -> findRecording(recordingsPath, profileInfo.recordingId());
             }
 
-            return new AutoAnalysisManagerImpl(cacheRepository, recordingPathResolver);
+            return new AutoAnalysisManagerImpl(
+                    cacheRepository, recordingPathResolver, AutoAnalysisDataProvider::generate);
         };
     }
 

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/AutoAnalysisManager.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/AutoAnalysisManager.java
@@ -30,8 +30,24 @@ public interface AutoAnalysisManager {
     interface Factory extends Function<ProfileInfo, AutoAnalysisManager> {
     }
 
+    /**
+     * The findings already computed for this profile, read from the profile's cache. Empty when
+     * nothing has computed them yet -- the analysis is warmed when the profile is imported, so this
+     * is normally populated by the time anyone asks.
+     */
     List<AutoAnalysisResult> analysisResults();
 
+    /**
+     * Whether the analysis can be run at all, which comes down to whether the recording file the JMC
+     * rule set reads is still on disk. Asked before warming so a profile whose recording is gone is
+     * skipped quietly rather than failing.
+     */
+    boolean canGenerate();
+
+    /**
+     * Runs the rule set and caches the findings. Single-flight: a caller arriving while a run is in
+     * progress joins that run instead of starting a second one.
+     */
     List<AutoAnalysisResult> generate();
 
 }

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/AutoAnalysisManagerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/AutoAnalysisManagerImpl.java
@@ -22,7 +22,6 @@ import tools.jackson.core.type.TypeReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import cafe.jeffrey.profile.common.analysis.AutoAnalysisResult;
-import cafe.jeffrey.profile.parser.data.AutoAnalysisDataProvider;
 import cafe.jeffrey.provider.profile.api.ProfileCacheRepository;
 import cafe.jeffrey.shared.common.CacheKey;
 
@@ -30,6 +29,8 @@ import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class AutoAnalysisManagerImpl implements AutoAnalysisManager {
@@ -42,13 +43,28 @@ public class AutoAnalysisManagerImpl implements AutoAnalysisManager {
 
     private final ProfileCacheRepository cacheRepository;
     private final Supplier<Optional<Path>> recordingPathResolver;
+    private final Function<Path, List<AutoAnalysisResult>> ruleSet;
 
+    /**
+     * Guards the single in-flight run. Held only while a run is being handed out or cleared, never
+     * while the rule set is running -- a second caller parks on the future, not on this monitor.
+     */
+    private final Object inFlightLock = new Object();
+    private CompletableFuture<List<AutoAnalysisResult>> inFlight;
+
+    /**
+     * @param ruleSet what actually evaluates the rules over a recording file. A collaborator rather
+     *                than a static call so the single-flight behaviour below can be tested without a
+     *                recording on disk.
+     */
     public AutoAnalysisManagerImpl(
             ProfileCacheRepository cacheRepository,
-            Supplier<Optional<Path>> recordingPathResolver) {
+            Supplier<Optional<Path>> recordingPathResolver,
+            Function<Path, List<AutoAnalysisResult>> ruleSet) {
 
         this.cacheRepository = cacheRepository;
         this.recordingPathResolver = recordingPathResolver;
+        this.ruleSet = ruleSet;
     }
 
     @Override
@@ -58,13 +74,55 @@ public class AutoAnalysisManagerImpl implements AutoAnalysisManager {
     }
 
     @Override
+    public boolean canGenerate() {
+        return recordingPathResolver.get().isPresent();
+    }
+
+    /**
+     * Single-flight on purpose: the run loads the entire recording into the JMC item model, so two
+     * concurrent runs of the same profile would hold two copies of it at once. The profile's warm-up
+     * starts one when the recording is imported, and the Auto Analysis page's button and the MCP
+     * tool's {@code compute} flag can both arrive while it is still going.
+     */
+    @Override
     public List<AutoAnalysisResult> generate() {
+        CompletableFuture<List<AutoAnalysisResult>> run;
+        boolean owner = false;
+
+        synchronized (inFlightLock) {
+            if (inFlight == null) {
+                inFlight = new CompletableFuture<>();
+                owner = true;
+            }
+            run = inFlight;
+        }
+
+        if (!owner) {
+            LOG.debug("Auto analysis already running, joining it");
+            return run.join();
+        }
+
+        try {
+            List<AutoAnalysisResult> results = runRuleSet();
+            run.complete(results);
+            return results;
+        } catch (RuntimeException | Error e) {
+            run.completeExceptionally(e);
+            throw e;
+        } finally {
+            synchronized (inFlightLock) {
+                inFlight = null;
+            }
+        }
+    }
+
+    private List<AutoAnalysisResult> runRuleSet() {
         Path recordingPath = recordingPathResolver.get()
                 .orElseThrow(() -> new IllegalStateException("Recording file not found"));
 
-        LOG.info("Generating auto analysis on-demand: recording={}", recordingPath);
+        LOG.info("Generating auto analysis: recording={}", recordingPath);
 
-        List<AutoAnalysisResult> results = AutoAnalysisDataProvider.generate(recordingPath).stream()
+        List<AutoAnalysisResult> results = ruleSet.apply(recordingPath).stream()
                 .sorted(Comparator.comparing(a -> a.severity().order()))
                 .toList();
 

--- a/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/action/ProfileDataInitializerImpl.java
+++ b/jeffrey-microscope/profiles/profile-management/src/main/java/cafe/jeffrey/profile/manager/action/ProfileDataInitializerImpl.java
@@ -38,6 +38,7 @@ public class ProfileDataInitializerImpl implements ProfileDataInitializer {
     private static final Logger LOG = LoggerFactory.getLogger(ProfileDataInitializerImpl.class);
 
     private static final String SPAN_THREAD_VIEWER = "threads.rows";
+    private static final String SPAN_AUTO_ANALYSIS = "analysis.autoAnalysis";
 
     private final DatabaseManager databaseManager;
     private final Executor executor;
@@ -57,8 +58,9 @@ public class ProfileDataInitializerImpl implements ProfileDataInitializer {
         ProfileInfo profileInfo = profileManager.info();
 
         // pprof/OTLP profiles are stack-sample imports visualized only as flamegraphs (generated on
-        // demand). The views below -- the thread viewer -- are JFR-specific and read JFR-shaped
-        // fields these imports don't have, so they are skipped for such sources.
+        // demand). The views below -- the thread viewer and the auto analysis -- are JFR-specific:
+        // one reads JFR-shaped fields these imports don't have, the other hands the recording file
+        // to the JMC rule set, which only understands JFR. Both are skipped for such sources.
         if (profileInfo.eventSource().isFlamegraphOnlyImport()) {
             LOG.info("Skipping JFR-specific initialization for a flamegraph-only profile: "
                             + "profile_id={} profile_name={} event_source={}",
@@ -78,12 +80,34 @@ public class ProfileDataInitializerImpl implements ProfileDataInitializer {
         CompletableFuture<Void> threads = warm(SPAN_THREAD_VIEWER, "Thread Viewer", profileInfo,
                 () -> profileManager.threadManager().threadRows());
 
-        return CompletableFuture.allOf(threads)
+        // Auto Analysis is a cache like the thread bands, but it is the only one that does not read
+        // the profile database: the JMC rule set loads the original recording file a second time.
+        // That is why it used to wait for someone to press a button -- and why warming it here is
+        // worth the second parse, since until it is computed the summary dashboard, the MCP
+        // jvm_autoAnalysis tool and the IDE recording panel all show nothing rather than findings.
+        // Skipped without complaint when the recording file is no longer on disk.
+        CompletableFuture<Void> autoAnalysis = warmAutoAnalysis(profileManager, profileInfo);
+
+        return CompletableFuture.allOf(threads, autoAnalysis)
                 .whenComplete((_, _) -> {
                     lease.close();
                     LOG.info("Cached views of the profile have been warmed: profile_id={} profile_name={}",
                             profileInfo.id(), profileInfo.name());
                 });
+    }
+
+    private CompletableFuture<Void> warmAutoAnalysis(
+            ProfileManager profileManager, ProfileInfo profileInfo) {
+
+        if (!profileManager.autoAnalysisManager().canGenerate()) {
+            LOG.info("Skipping auto analysis, the recording file is not available: "
+                            + "profile_id={} profile_name={}",
+                    profileInfo.id(), profileInfo.name());
+            return CompletableFuture.completedFuture(null);
+        }
+
+        return warm(SPAN_AUTO_ANALYSIS, "Auto Analysis", profileInfo,
+                () -> profileManager.autoAnalysisManager().generate());
     }
 
     /**

--- a/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/AutoAnalysisManagerImplTest.java
+++ b/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/AutoAnalysisManagerImplTest.java
@@ -1,0 +1,211 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.manager;
+
+import tools.jackson.core.type.TypeReference;
+import cafe.jeffrey.profile.common.analysis.AnalysisResult.Severity;
+import cafe.jeffrey.profile.common.analysis.AutoAnalysisResult;
+import cafe.jeffrey.provider.profile.api.ProfileCacheRepository;
+import cafe.jeffrey.shared.common.CacheKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AutoAnalysisManagerImplTest {
+
+    private static final Path RECORDING = Path.of("/recordings/app.jfr");
+
+    private final ProfileCacheRepository cacheRepository = mock(ProfileCacheRepository.class);
+
+    private static AutoAnalysisResult result(String rule, Severity severity) {
+        return new AutoAnalysisResult(rule, severity, "explanation", "summary", "solution", "50");
+    }
+
+    private AutoAnalysisManagerImpl manager(
+            Supplier<Optional<Path>> resolver, Function<Path, List<AutoAnalysisResult>> ruleSet) {
+
+        return new AutoAnalysisManagerImpl(cacheRepository, resolver, ruleSet);
+    }
+
+    private AutoAnalysisManagerImpl manager(Function<Path, List<AutoAnalysisResult>> ruleSet) {
+        return manager(() -> Optional.of(RECORDING), ruleSet);
+    }
+
+    @Nested
+    @DisplayName("Availability")
+    class Availability {
+
+        @Test
+        @DisplayName("follows whether the recording file resolves")
+        void followsTheResolver() {
+            assertTrue(manager(_ -> List.of()).canGenerate());
+            assertFalse(manager(Optional::empty, _ -> List.of()).canGenerate());
+        }
+
+        @Test
+        @DisplayName("generating without a recording fails rather than caching an empty analysis")
+        void generatingWithoutARecordingFails() {
+            AutoAnalysisManagerImpl manager = manager(Optional::empty, _ -> List.of());
+
+            assertThrows(IllegalStateException.class, manager::generate);
+            verify(cacheRepository, never()).put(any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("Generating")
+    class Generating {
+
+        @Test
+        @DisplayName("orders the findings by severity and caches them")
+        void ordersAndCaches() {
+            List<AutoAnalysisResult> unordered = List.of(
+                    result("ignored", Severity.IGNORE),
+                    result("passed", Severity.OK),
+                    result("warned", Severity.WARNING),
+                    result("informed", Severity.INFO));
+
+            List<AutoAnalysisResult> results = manager(recording -> {
+                assertEquals(RECORDING, recording);
+                return unordered;
+            }).generate();
+
+            assertEquals(
+                    List.of("warned", "informed", "passed", "ignored"),
+                    results.stream().map(AutoAnalysisResult::rule).toList());
+            verify(cacheRepository).put(eq(CacheKey.PROFILE_AUTO_ANALYSIS), eq(results));
+        }
+    }
+
+    @Nested
+    @DisplayName("Single flight")
+    class SingleFlight {
+
+        /**
+         * The point of the guard: a run holds the whole recording in the JMC item model, so a second
+         * concurrent run would hold a second copy of it. The warm-up starts one at import, and the
+         * page's button or the MCP tool can arrive while it is still going.
+         */
+        @Test
+        @DisplayName("a caller arriving mid-run joins it instead of starting a second one")
+        void concurrentCallersShareOneRun() throws Exception {
+            CountDownLatch release = new CountDownLatch(1);
+            CountDownLatch started = new CountDownLatch(1);
+            AtomicInteger runs = new AtomicInteger();
+
+            AutoAnalysisManagerImpl manager = manager(_ -> {
+                runs.incrementAndGet();
+                started.countDown();
+                try {
+                    release.await(5, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                return List.of(result("warned", Severity.WARNING));
+            });
+
+            ExecutorService executor = Executors.newFixedThreadPool(2);
+            List<List<AutoAnalysisResult>> outcomes = new ArrayList<>(List.of(List.of(), List.of()));
+            AtomicReference<Thread> joiner = new AtomicReference<>();
+            try {
+                var first = executor.submit(manager::generate);
+                assertTrue(started.await(2, TimeUnit.SECONDS), "the first run never started");
+
+                var second = executor.submit(() -> {
+                    joiner.set(Thread.currentThread());
+                    return manager.generate();
+                });
+
+                // The second caller parks on the run in flight rather than evaluating anything.
+                await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+                    Thread thread = joiner.get();
+                    assertTrue(thread != null && (thread.getState() == Thread.State.WAITING
+                                    || thread.getState() == Thread.State.TIMED_WAITING),
+                            "the second caller is not parked on the run in flight");
+                });
+                assertEquals(1, runs.get(), "the second caller started a run of its own");
+
+                release.countDown();
+                outcomes.set(0, first.get(5, TimeUnit.SECONDS));
+                outcomes.set(1, second.get(5, TimeUnit.SECONDS));
+            } finally {
+                release.countDown();
+                executor.shutdownNow();
+            }
+
+            assertEquals(1, runs.get(), "the rule set ran more than once");
+            assertEquals(outcomes.get(0), outcomes.get(1));
+        }
+
+        @Test
+        @DisplayName("a failed run is not remembered, so the next caller can try again")
+        void aFailedRunDoesNotPoisonTheNextOne() {
+            AtomicInteger runs = new AtomicInteger();
+            AutoAnalysisManagerImpl manager = manager(_ -> {
+                if (runs.incrementAndGet() == 1) {
+                    throw new IllegalStateException("rules blew up");
+                }
+                return List.of(result("warned", Severity.WARNING));
+            });
+
+            assertThrows(IllegalStateException.class, manager::generate);
+            assertEquals(1, manager.generate().size());
+            assertEquals(2, runs.get());
+        }
+    }
+
+    @Nested
+    @DisplayName("Reading")
+    class Reading {
+
+        @Test
+        @DisplayName("an analysis that was never computed reads as empty, not as a failure")
+        void emptyWhenNeverComputed() {
+            when(cacheRepository.get(eq(CacheKey.PROFILE_AUTO_ANALYSIS), any(TypeReference.class)))
+                    .thenReturn(Optional.empty());
+
+            assertEquals(List.of(), manager(_ -> List.of()).analysisResults());
+        }
+    }
+}

--- a/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/action/ProfileDataInitializerImplTest.java
+++ b/jeffrey-microscope/profiles/profile-management/src/test/java/cafe/jeffrey/profile/manager/action/ProfileDataInitializerImplTest.java
@@ -18,12 +18,14 @@
 
 package cafe.jeffrey.profile.manager.action;
 
+import cafe.jeffrey.profile.manager.AutoAnalysisManager;
 import cafe.jeffrey.profile.manager.ProfileManager;
 import cafe.jeffrey.profile.manager.thread.ThreadManager;
 import cafe.jeffrey.shared.common.model.ProfileInfo;
 import cafe.jeffrey.shared.common.model.RecordingEventSource;
 import cafe.jeffrey.shared.persistence.DatabaseLease;
 import cafe.jeffrey.shared.persistence.DatabaseManager;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -52,6 +54,7 @@ class ProfileDataInitializerImplTest {
     private static final String PROFILE_ID = "profile-1";
 
     private final ThreadManager threadManager = mock(ThreadManager.class);
+    private final AutoAnalysisManager autoAnalysisManager = mock(AutoAnalysisManager.class);
 
     /** Records whether the lease taken for the warming was handed back. */
     private final AtomicBoolean leaseReleased = new AtomicBoolean();
@@ -74,7 +77,13 @@ class ProfileDataInitializerImplTest {
         ProfileManager profileManager = mock(ProfileManager.class);
         when(profileManager.info()).thenReturn(profileInfo);
         when(profileManager.threadManager()).thenReturn(threadManager);
+        when(profileManager.autoAnalysisManager()).thenReturn(autoAnalysisManager);
         return profileManager;
+    }
+
+    @BeforeEach
+    void recordingIsOnDisk() {
+        when(autoAnalysisManager.canGenerate()).thenReturn(true);
     }
 
     @Nested
@@ -91,6 +100,7 @@ class ProfileDataInitializerImplTest {
                     .get(5, TimeUnit.SECONDS);
 
             verify(threadManager).threadRows();
+            verify(autoAnalysisManager).generate();
             assertEquals(1, leasesTaken.get());
             assertTrue(leaseReleased.get(), "the warming lease was never released");
         }
@@ -152,6 +162,50 @@ class ProfileDataInitializerImplTest {
     }
 
     @Nested
+    @DisplayName("Auto analysis")
+    class AutoAnalysis {
+
+        /**
+         * The rule set reads the original recording file, not the profile database. A profile whose
+         * recording is gone cannot produce one, and saying so is not a warm-up failure.
+         */
+        @Test
+        @DisplayName("is skipped when the recording file is gone, without failing the warm-up")
+        void skippedWhenTheRecordingIsGone() throws Exception {
+            when(autoAnalysisManager.canGenerate()).thenReturn(false);
+
+            ProfileDataInitializerImpl initializer =
+                    new ProfileDataInitializerImpl(databaseManager(), Runnable::run);
+
+            initializer.initialize(profileManager(RecordingEventSource.JDK))
+                    .get(5, TimeUnit.SECONDS);
+
+            verify(autoAnalysisManager, never()).generate();
+            verify(threadManager).threadRows();
+            assertTrue(leaseReleased.get());
+        }
+
+        /**
+         * The two warms are independent: the analysis is the expensive one and the likeliest to
+         * blow up, and it must not take the thread bands or the lease with it.
+         */
+        @Test
+        @DisplayName("a failing analysis still leaves the thread bands warmed and the lease released")
+        void failureDoesNotAffectTheOtherWarm() throws Exception {
+            when(autoAnalysisManager.generate()).thenThrow(new IllegalStateException("rules blew up"));
+
+            ProfileDataInitializerImpl initializer =
+                    new ProfileDataInitializerImpl(databaseManager(), Runnable::run);
+
+            initializer.initialize(profileManager(RecordingEventSource.JDK))
+                    .get(5, TimeUnit.SECONDS);
+
+            verify(threadManager).threadRows();
+            assertTrue(leaseReleased.get(), "a failed analysis stranded the lease");
+        }
+    }
+
+    @Nested
     @DisplayName("Flamegraph-only imports")
     class FlamegraphOnlyImports {
 
@@ -166,6 +220,7 @@ class ProfileDataInitializerImplTest {
                     .get(5, TimeUnit.SECONDS);
 
             verify(threadManager, never()).threadRows();
+            verify(autoAnalysisManager, never()).generate();
             verify(databaseManager, never()).acquire(any());
             assertEquals(0, leasesTaken.get());
         }

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpToolsPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpToolsPage.vue
@@ -605,8 +605,8 @@ hubs_download { "sessionRef": "h1Y2ZnLX..." }
         A recording holds only what the profiler was told to capture. Every section reports whether this profile carries its events, and a section asked for anyway is refused naming the events it needed &mdash; a dashboard rendered from events that were never recorded is a page of zeroes, which reads like a finding rather than like an absence.
       </DocsCallout>
 
-      <DocsCallout type="warning" title="Auto analysis is read from a cache, not computed here">
-        Generating it loads the whole recording through the JMC toolkit, which is bounded neither in time nor in memory by anything the server controls &mdash; a poor trade inside a tool whose point is being cheap. The Auto Analysis page in the Jeffrey UI computes and caches it; every call afterwards is a cache read. Until then the tool says so, and the other sections still answer.
+      <DocsCallout type="info" title="Auto analysis is read from a cache, not computed here">
+        Generating it loads the whole recording through the JMC toolkit a second time, which is bounded neither in time nor in memory by anything the server controls &mdash; a poor trade inside a tool whose point is being cheap. So Jeffrey computes it when the recording is imported, as part of the same warm-up that builds the thread bands, and caches it: by the time a client asks, the cache is normally already warm. A profile that missed that &mdash; imported before Jeffrey warmed it, or whose recording file has since gone &mdash; makes the tool say so, and <code>compute: true</code> runs it on the spot. A call arriving while a run is already in flight joins that run rather than starting a second one. Either way the other sections still answer.
       </DocsCallout>
 
       <p><strong>Examples.</strong> Arguments are shown as JSON; the tool name omits the server prefix.</p>


### PR DESCRIPTION
Auto Analysis was the one analysis a profile did not arrive with. It sat behind a **Run Analysis** button, and until someone pressed it four other readers did a pure cache read and silently showed nothing:

| Reader | |
|---|---|
| Summary dashboard verdict tile | `ProfileSummaryDashboard.vue` |
| MCP `jvm_autoAnalysis` / `jvm_sections` | `JvmMcpTools`, `AutoAnalysisSection` |
| MCP `profiles_summary` (`autoAnalysisPending`) | `ProfileMcpTools` |
| IntelliJ recording panel's finding lines | `IdeRecordingLookup` |

The last one matters most: the panel's whole allowance is four figures *plus* those lines, and it was showing the figures and nothing else.

## The approach

Warm it the way the thread bands already are. Both are BLOBs in the same per-profile `cache` table, and `ProfileDataInitializerImpl` already runs that warm fire-and-forget on the bulk pool under the `WARMUP` stage, treating a failure as a slower profile rather than a broken one. Auto Analysis becomes the second thing it warms, in parallel, under the same lease.

It is the only one of those caches that does **not** read the profile database: `AutoAnalysisDataProvider` hands the original recording file to the JMC rule set, which re-parses the whole `.jfr` through `JfrLoaderToolkit.loadEvents` — bounded neither in time nor in memory. That cost is what put it behind a button, and it does not go away; it moves off the user's click and onto a pool an import already cannot queue ahead of an interactive request with. `jeffrey.microscope.profile.data-initializer.enabled` still switches the whole warm-up off, and the button remains for a profile the warm skipped or failed.

## What the warm needed that the manager did not have

- **`canGenerate()`** — the rule set reads the recording file, so a profile whose recording is gone cannot produce an analysis. Asked before warming, it is skipped quietly instead of throwing `IllegalStateException` into the warm and emitting a `PROFILE_VIEW_WARMUP_FAILED` notification for something that is not a failure.
- **`generate()` is now single-flight** — the one real hazard this change introduces: open the page mid-warm, press the button, and two full JFR loads sit in heap at once. A caller arriving during a run now joins it, which also makes the warm, the button and the MCP `compute` flag converge on one run. The rule set became an injected `Function<Path, List<AutoAnalysisResult>>` so that is testable.

## Deliberate non-changes

- **No new pipeline stage.** `WARMUP` already means "start the caches, do not wait"; a stage would promise a duration the pipeline cannot measure, since the work outlives it.
- **No size guard and no new property.** The existing data-initializer switch already covers a memory-tight install.
- **The frontend is untouched.** Its `idle` hero is still the right answer for a profile imported before this, a warm-up switched off, a warm that failed, or a recording no longer on disk. Opening the page mid-warm shows the hero, and pressing the button joins the run in flight rather than duplicating it.

Also updates the MCP tool descriptions and the `microscope-mcp` docs page, both of which told clients that nothing computes this until a human opens the UI page.

## Tests

- New `AutoAnalysisManagerImplTest` — availability follows the resolver, findings are ordered by severity and cached, a caller arriving mid-run parks on it rather than starting a second, a failed run is not remembered.
- `ProfileDataInitializerImplTest` — the analysis is warmed for a JDK profile, skipped when the recording is gone, and a failing analysis still leaves the thread bands warmed and the lease released.
- Full suites green for `profile-management` and `core-microscope` (1508 tests in the latter). One test-scoped `awaitility` dependency added to `profile-management`, matching how `common-profile` and its siblings already declare it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzmwhK4kBmoE6UziKwoyF9