### PR TITLE
Upgrade MCP protocol to 2025-11-25 and improve version negotiation

### DIFF
--- a/jeffrey-intellij-plugin/src/main/java/cafe/jeffrey/ide/plugin/idea/recording/MicroscopeClient.java
+++ b/jeffrey-intellij-plugin/src/main/java/cafe/jeffrey/ide/plugin/idea/recording/MicroscopeClient.java
@@ -205,6 +205,19 @@ public final class MicroscopeClient implements AutoCloseable {
         return MicroscopeJson.parseBuild(response.body(), PipelineBuild.Pipeline.PROFILE_INIT);
     }
 
+    /**
+     * Whether this client is already pointed at an address, compared the way the constructor stores
+     * one so a trailing slash is not a different server.
+     *
+     * <p>What it is for: a panel re-reads the configured address every time its tab comes forward,
+     * and replacing the client is not free. A new one is a new connection pool and a new selector
+     * thread, and closing the old one drops a warm keep-alive connection for a fresh connect a
+     * moment later — churn a server on this machine sees as a connection opened and abandoned.
+     */
+    public boolean isPointedAt(String url) {
+        return baseUrl.equals(trimTrailingSlash(url));
+    }
+
     /** The Microscope page for a profile. */
     public String profileUrl(String profileId) {
         return baseUrl + PROFILES + profileId;

--- a/jeffrey-intellij-plugin/src/main/java/cafe/jeffrey/ide/plugin/idea/recording/RecordingPanel.java
+++ b/jeffrey-intellij-plugin/src/main/java/cafe/jeffrey/ide/plugin/idea/recording/RecordingPanel.java
@@ -191,12 +191,29 @@ public final class RecordingPanel extends JBPanel<RecordingPanel> implements Pan
      * found recordings is kept, so switching tabs does not re-ask about every file each time.
      */
     public void refresh() {
-        MicroscopeClient previous = client;
-        client = new MicroscopeClient(JeffreySettings.getInstance().microscopeUrl());
-        closeLater(previous);
+        adoptConfiguredAddress();
         candidatesStale = true;
         renderer.showLoading();
         query();
+    }
+
+    /**
+     * Replaces the client when, and only when, the configured address has changed.
+     *
+     * <p>A refresh is the tab coming forward, which happens on every switch between editors, and an
+     * address almost never changes between two of them. Rebuilding regardless meant a new connection
+     * pool and a new selector thread each time, and closing the old client dropped its warm
+     * connection for a fresh connect immediately after: from Microscope's side, a stream of
+     * connections opened and abandoned.
+     */
+    private void adoptConfiguredAddress() {
+        String configured = JeffreySettings.getInstance().microscopeUrl();
+        MicroscopeClient previous = client;
+        if (previous.isPointedAt(configured)) {
+            return;
+        }
+        client = new MicroscopeClient(configured);
+        closeLater(previous);
     }
 
     /**

--- a/jeffrey-intellij-plugin/src/test/java/cafe/jeffrey/ide/plugin/idea/recording/MicroscopeClientTest.java
+++ b/jeffrey-intellij-plugin/src/test/java/cafe/jeffrey/ide/plugin/idea/recording/MicroscopeClientTest.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
@@ -158,6 +159,19 @@ public class MicroscopeClientTest {
                 "a blank baseline must not leave an empty parameter behind",
                 baseUrl + "/profiles/profile-1/flamegraphs/differential",
                 client.viewUrl("profile-1", "flamegraphs/differential", null));
+    }
+
+    @Test
+    public void recognisesTheAddressItIsAlreadyPointedAt() {
+        MicroscopeClient client = new MicroscopeClient(baseUrl);
+
+        assertTrue(client.isPointedAt(baseUrl));
+        // The panel re-reads the configured address on every tab switch, and a trailing slash typed
+        // into the settings field is the same server: answering "no" here would throw away a warm
+        // connection pool and open a new one for nothing.
+        assertTrue(client.isPointedAt(baseUrl + "/"));
+        assertFalse(client.isPointedAt(baseUrl + "1"));
+        assertFalse(client.isPointedAt("http://localhost:9999"));
     }
 
     @Test

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/ExternalMcpControllerTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/ExternalMcpControllerTest.java
@@ -222,7 +222,31 @@ class ExternalMcpControllerTest {
             assertThat(mvcWith(true).post().uri(URI).contentType(APPLICATION_JSON).content(future))
                     .hasStatusOk()
                     .bodyJson()
-                    .extractingPath("$.result.protocolVersion").asString().isEqualTo("2025-06-18");
+                    .extractingPath("$.result.protocolVersion").asString().isEqualTo("2025-11-25");
+        }
+
+        /**
+         * The header is the strict half of the same question, and the refusal is what a client that
+         * speaks the current revision reads before falling back to the handshake above. Over real
+         * HTTP because it is the header rather than the body that decides, and a controller that
+         * stopped passing it would look fine everywhere else.
+         */
+        @Test
+        void refusesTheCurrentRevisionInTheHeaderAndSaysWhatItSpeaks() {
+            assertThat(mvcWith(true).post().uri(URI)
+                    .header("MCP-Protocol-Version", "2026-07-28")
+                    .contentType(APPLICATION_JSON).content(INITIALIZE))
+                    .hasStatus(HttpStatus.BAD_REQUEST)
+                    .bodyJson()
+                    .extractingPath("$.error.message").asString().contains("2025-11-25");
+        }
+
+        @Test
+        void servesTheNewestRevisionItImplements() {
+            assertThat(mvcWith(true).post().uri(URI)
+                    .header("MCP-Protocol-Version", "2025-11-25")
+                    .contentType(APPLICATION_JSON).content(INITIALIZE))
+                    .hasStatusOk();
         }
 
         @Test

--- a/jeffrey-microscope/profiles/mcp-server/src/main/java/cafe/jeffrey/profile/mcp/AbstractMcpStreamableHttpController.java
+++ b/jeffrey-microscope/profiles/mcp-server/src/main/java/cafe/jeffrey/profile/mcp/AbstractMcpStreamableHttpController.java
@@ -26,6 +26,8 @@ import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ArrayNode;
 import tools.jackson.databind.node.ObjectNode;
 
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -43,14 +45,23 @@ import java.util.Set;
 public abstract class AbstractMcpStreamableHttpController {
 
     private static final String JSONRPC_VERSION = "2.0";
-    private static final String DEFAULT_PROTOCOL_VERSION = "2025-06-18";
+
+    /** The newest revision this server implements, and what an unrecognised one is answered with. */
+    private static final String DEFAULT_PROTOCOL_VERSION = "2025-11-25";
 
     /**
-     * The revisions this server implements. The envelope has not changed across them in any way Jeffrey
-     * uses, so an older client is served as it asks; anything else is answered with the default.
+     * The revisions this server implements, oldest first. The envelope has not changed across them in
+     * any way Jeffrey uses — the additions between them (icons, tasks, elicitation, authorization
+     * discovery) are all optional and none are things this server sends — so an older client is
+     * served as it asks; anything else is answered with the default.
+     * <p>
+     * They are all <em>handshake</em> revisions: a session opens with {@code initialize}. From
+     * {@code 2026-07-28} the protocol works differently — every request carries its own version in
+     * {@code _meta}, {@code server/discover} is mandatory, and sessions are gone — and this server
+     * implements none of that. Ordered, because the set is also the sentence a refusal carries.
      */
-    private static final Set<String> SUPPORTED_PROTOCOL_VERSIONS =
-            Set.of("2024-11-05", "2025-03-26", DEFAULT_PROTOCOL_VERSION);
+    private static final Set<String> SUPPORTED_PROTOCOL_VERSIONS = Collections.unmodifiableSet(
+            new LinkedHashSet<>(List.of("2024-11-05", "2025-03-26", "2025-06-18", DEFAULT_PROTOCOL_VERSION)));
     private static final String SERVER_NAME = "jeffrey";
     private static final String SERVER_VERSION = "1.0.0";
 
@@ -109,10 +120,26 @@ public abstract class AbstractMcpStreamableHttpController {
     private static final String ROLE_USER = "user";
     private static final String TOOL_ERROR_PREFIX = "Error: ";
 
+    /**
+     * Plain JSON-RPC codes, and a refused protocol version deliberately leaves through
+     * {@link #ERROR_INVALID_REQUEST} rather than through {@code -32022}
+     * ({@code UnsupportedProtocolVersionError}, from {@code 2026-07-28}) even though that code
+     * describes the refusal better.
+     * <p>
+     * A client that speaks both eras decides what this server is from the <em>body</em> of the 400 it
+     * gets back: a recognised modern error means "modern server, retry with a version it listed", and
+     * anything else means "older server, fall back to {@code initialize}". This server only has the
+     * handshake, so it must read as the second. Answering {@code -32022} would send a client that
+     * would otherwise work into a retry loop over versions none of which this server implements.
+     * Upgrade the code only together with the rest of the modern protocol.
+     */
     private static final int ERROR_INVALID_REQUEST = -32600;
     private static final int ERROR_METHOD_NOT_FOUND = -32601;
     private static final int ERROR_INVALID_PARAMS = -32602;
     private static final int ERROR_INTERNAL = -32603;
+
+    /** The supported revisions as a client-readable list, built once. */
+    private static final String SUPPORTED_VERSIONS_SENTENCE = String.join(", ", SUPPORTED_PROTOCOL_VERSIONS);
 
     private final Logger log = LoggerFactory.getLogger(getClass());
 
@@ -136,12 +163,18 @@ public abstract class AbstractMcpStreamableHttpController {
         if (protocolVersionHeader != null
                 && !protocolVersionHeader.isBlank()
                 && !SUPPORTED_PROTOCOL_VERSIONS.contains(protocolVersionHeader)) {
-            log.warn("Refused an MCP request naming an unsupported protocol: version={}",
-                    protocolVersionHeader);
+            // Routine rather than wrong: a client that speaks both eras opens with the newest version
+            // it has, and reads the refusal as "this server is older" before falling back to
+            // `initialize`. Logged so the fallback is visible when a client fails for some other
+            // reason, not because anything here needs attention.
+            log.info("An MCP client asked for a protocol revision this server does not implement,"
+                            + " and will fall back to initialize: version={} supported={}",
+                    protocolVersionHeader, SUPPORTED_VERSIONS_SENTENCE);
             return ResponseEntity.badRequest().body(error(
                     null,
                     ERROR_INVALID_REQUEST,
-                    "Unsupported MCP protocol version: " + protocolVersionHeader));
+                    "Unsupported MCP protocol version: " + protocolVersionHeader
+                            + ". This server implements " + SUPPORTED_VERSIONS_SENTENCE));
         }
 
         if (request == null || (!request.isObject() && !request.isArray())) {

--- a/jeffrey-microscope/profiles/mcp-server/src/test/java/cafe/jeffrey/profile/mcp/AbstractMcpStreamableHttpControllerTest.java
+++ b/jeffrey-microscope/profiles/mcp-server/src/test/java/cafe/jeffrey/profile/mcp/AbstractMcpStreamableHttpControllerTest.java
@@ -44,6 +44,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class AbstractMcpStreamableHttpControllerTest {
 
     private static final String PROTOCOL_VERSION = "2025-06-18";
+
+    /** What this server implements, newest last. All of them open a session with {@code initialize}. */
+    private static final List<String> SUPPORTED_VERSIONS =
+            List.of("2024-11-05", "2025-03-26", PROTOCOL_VERSION, "2025-11-25");
     private static final String PING = """
             {"jsonrpc":"2.0","id":1,"method":"ping"}""";
 
@@ -144,6 +148,58 @@ class AbstractMcpStreamableHttpControllerTest {
 
             assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
             assertEquals(-32600, response.getBody().get("error").get("code").asInt());
+        }
+
+        /**
+         * The refusal has to look like a server from the handshake era, because that is what decides
+         * whether a client that speaks both eras falls back or keeps retrying. It reads the body of
+         * the 400: a recognised modern error (-32022 {@code UnsupportedProtocolVersionError}, -32020
+         * {@code HeaderMismatch}) means "modern server, retry with a version it listed", anything
+         * else means "older server, open with {@code initialize}". This server only has the
+         * handshake, so -32022 here would send a working client into a retry loop.
+         */
+        @Test
+        void refusesTheCurrentRevisionAsAServerFromTheHandshakeEra() {
+            ResponseEntity<JsonNode> response = envelope.dispatch(
+                    Json.readTree(PING),
+                    "2026-07-28",
+                    features);
+
+            assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+            assertEquals(-32600, response.getBody().get("error").get("code").asInt(),
+                    "-32022 would identify this as a modern server, which it is not");
+            assertFalse(response.getBody().get("error").has("data"),
+                    "a `supported` list under `data` is the modern error's shape");
+        }
+
+        /**
+         * Not decoration: a client refused this way has no machine-readable list to fall back on, so
+         * the sentence is the only place a person can see what the server would have accepted.
+         */
+        @Test
+        void namesWhatItDoesImplementInTheRefusal() {
+            ResponseEntity<JsonNode> response = envelope.dispatch(
+                    Json.readTree(PING),
+                    "2026-07-28",
+                    features);
+
+            String message = response.getBody().get("error").get("message").asString();
+            for (String version : SUPPORTED_VERSIONS) {
+                assertTrue(message.contains(version), () -> message + " does not name " + version);
+            }
+        }
+
+        /**
+         * Every handshake revision, pinned. Adding one is a claim that the envelope is unchanged
+         * across it; removing one drops a client that has no way to negotiate upward.
+         */
+        @Test
+        void servesEveryHandshakeRevision() {
+            for (String version : SUPPORTED_VERSIONS) {
+                ResponseEntity<JsonNode> response = envelope.dispatch(Json.readTree(PING), version, features);
+
+                assertEquals(HttpStatus.OK, response.getStatusCode(), "not served: " + version);
+            }
         }
 
         @Test

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpOtherClientsPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpOtherClientsPage.vue
@@ -76,20 +76,24 @@ const mcpJson = `{
   }
 }`;
 
+const versionProbe =
+  'An MCP client asked for a protocol revision this server does not implement, and will fall back' +
+  ' to initialize: version=2026-07-28 supported=2024-11-05, 2025-03-26, 2025-06-18, 2025-11-25';
+
 const initialize = `curl -s -X POST http://localhost:8585/api/internal/mcp \\
   -H 'Content-Type: application/json' \\
   -d '{
     "jsonrpc": "2.0",
     "id": 1,
     "method": "initialize",
-    "params": { "protocolVersion": "2025-06-18" }
+    "params": { "protocolVersion": "2025-11-25" }
   }'`;
 
 const initializeResult = `{
   "jsonrpc": "2.0",
   "id": 1,
   "result": {
-    "protocolVersion": "2025-06-18",
+    "protocolVersion": "2025-11-25",
     "capabilities": {
       "tools": { "listChanged": false },
       "prompts": { "listChanged": false },
@@ -236,7 +240,11 @@ const protocolError = `{
         </tbody>
       </table>
 
-      <p>The server speaks <code>2024-11-05</code>, <code>2025-03-26</code> and <code>2025-06-18</code>, and <code>2025-06-18</code> is the default. <code>initialize</code> answers with the version the client asked for when it is one of those three, and with the default when it is not &mdash; echoing back an unrecognised version would promise a revision the server may not speak, so the client is told what it will actually get and decides from there.</p>
+      <p>The server speaks <code>2024-11-05</code>, <code>2025-03-26</code>, <code>2025-06-18</code> and <code>2025-11-25</code>, and <code>2025-11-25</code> is the default. <code>initialize</code> answers with the version the client asked for when it is one of those four, and with the default when it is not &mdash; echoing back an unrecognised version would promise a revision the server may not speak, so the client is told what it will actually get and decides from there.</p>
+
+      <p>Those are the revisions that open a session with <code>initialize</code>. From <code>2026-07-28</code> MCP works differently: there is no handshake, every request declares its own version in <code>_meta</code> and in the <code>MCP-Protocol-Version</code> header, and <code>server/discover</code> is mandatory. Jeffrey does not implement that yet. A client that speaks both eras tries the newer one first, and Jeffrey answers <code>400</code> with a plain JSON-RPC <code>-32600</code> naming what it does speak; the client reads a non-modern error as &ldquo;this server uses the handshake&rdquo; and opens with <code>initialize</code> instead, which is why a current client still works. A modern-only client does not, and the server log says so once per client:</p>
+
+      <DocsCodeBlock :code="versionProbe" language="text" />
 
       <DocsCallout type="info" title="Every tool says whether it writes">
         Each spec in <code>tools/list</code> carries MCP <code>annotations</code>: <code>readOnlyHint</code>, <code>destructiveHint</code>, <code>idempotentHint</code> and <code>openWorldHint</code>. Almost everything Jeffrey exposes only reads a profile, and declares it. Six tools do not: <code>recordings_analyzeFile</code> and <code>recordings_analyzeRecording</code>, which create a profile, <code>heap_prepare</code>, which builds a cache, <code>hubs_download</code>, which pulls a recording off another machine and creates one here, and <code>ide_link</code> and <code>ide_open</code>, which act on the editor running beside Jeffrey. Every tool answers for itself, not for its family: <code>recordings_list</code>, <code>recordings_status</code> and <code>heap_status</code> only read, and say so. <code>destructiveHint</code> is false throughout &mdash; nothing here deletes a profile, a recording or a dump &mdash; and <code>openWorldHint</code> marks the <code>hubs_</code> and <code>ide_</code> families, the two that reach outside this installation. A client that gates approval on those hints does not need a hand-written deny-list.


### PR DESCRIPTION
## Summary
Updates the MCP protocol version from 2025-06-18 to 2025-11-25 and improves version negotiation to handle clients that speak both the handshake era (pre-2026-07-28) and the modern era (2026-07-28+). The server now explicitly lists all supported versions in refusal messages to help clients fall back gracefully.

## Key Changes

**Protocol Version Updates:**
- Bumped `DEFAULT_PROTOCOL_VERSION` from `2025-06-18` to `2025-11-25` in `AbstractMcpStreamableHttpController`
- Updated test expectations and documentation to reflect the new default version
- Added `2025-06-18` to the supported versions list (was previously implicit)

**Version Negotiation Improvements:**
- Changed `SUPPORTED_PROTOCOL_VERSIONS` from an unordered `Set` to an ordered `LinkedHashSet` to preserve version order in error messages
- Added `SUPPORTED_VERSIONS_SENTENCE` constant that builds a comma-separated list of supported versions once at startup
- Enhanced error messages when clients request unsupported versions to include the full list of supported versions (e.g., "This server implements 2024-11-05, 2025-03-26, 2025-06-18, 2025-11-25")
- Changed error code from `-32022` (UnsupportedProtocolVersionError, modern era) to `-32600` (InvalidRequest, handshake era) to signal to dual-era clients that this is a handshake-only server
- Updated logging from `warn` to `info` level for unsupported version requests, as this is routine fallback behavior

**Test Coverage:**
- Added `refusesTheCurrentRevisionAsAServerFromTheHandshakeEra()` to verify the server returns `-32600` (not `-32022`) for unsupported versions
- Added `namesWhatItDoesImplementInTheRefusal()` to verify all supported versions appear in error messages
- Added `servesEveryHandshakeRevision()` to pin all supported handshake revisions
- Added `refusesTheCurrentRevisionInTheHeaderAndSaysWhatItSpeaks()` integration test
- Added `servesTheNewestRevisionItImplements()` integration test
- Added `recognisesTheAddressItIsAlreadyPointedAt()` test for `MicroscopeClient.isPointedAt()`

**Client Connection Optimization:**
- Added `MicroscopeClient.isPointedAt(String url)` method to check if a client is already connected to a given address (with trailing slash normalization)
- Refactored `RecordingPanel.refresh()` to call new `adoptConfiguredAddress()` method that only replaces the client if the configured address has actually changed, avoiding unnecessary connection pool churn on tab switches

**Documentation:**
- Updated MCP documentation page to reflect the new default version and explain the handshake vs. modern era protocol difference
- Added explanation of how dual-era clients use error codes to determine server capabilities and fall back appropriately
- Included example of the version probe log message that appears when a modern-only client connects

## Implementation Details

The version negotiation strategy handles the protocol era transition gracefully:
- Clients that speak both eras try the newer protocol first (2026-07-28+)
- When Jeffrey responds with `-32600` (not the modern `-32022`), dual-era clients recognize this as a handshake-only server
- The error message lists all supported versions, giving clients the information needed to retry with `initialize`
- Modern-only clients will fail, but the server logs this clearly so operators understand the limitation

The ordered set ensures version lists in error messages are consistent and human-readable, improving debuggability when clients fail to negotiate.

https://claude.ai/code/session_01RhPy8MEUweeBtAc278CCqj