### PR TITLE
Correct the Gemini docs against the real CLI, and shorten the client pages

### DIFF
--- a/jeffrey-claude-plugin/README.md
+++ b/jeffrey-claude-plugin/README.md
@@ -110,9 +110,11 @@ checkout's `.gemini/settings.json` for one:
 }
 ```
 
-`httpUrl` is Gemini's key for streamable HTTP; `url` there means SSE, which this server does not
-speak. Keep the name `jeffrey`: the skills name tools by the part after the prefix, and the prefix is
-built from the server's name.
+`httpUrl` is one of three spellings Gemini accepts for the same server: `url` with `"type": "http"`
+is identical, and is what `gemini mcp add jeffrey <url> --transport http` writes; a bare `url` works
+too, because Gemini tries HTTP first and falls back to SSE only when that fails. Only `"type": "sse"`
+is wrong here. Keep the name `jeffrey`: the skills name tools by the part after the prefix, and the
+prefix is built from the server's name.
 
 ## What you get
 
@@ -320,9 +322,11 @@ probe bounds itself at three seconds anyway.
 
 **Three agent directories, one set of agents.** `agents/` is Claude Code's, and the only one a plugin
 carries; `codex/` and `gemini/` hold the same analyst and heap specialist in the dialect each of those
-clients validates, to be copied by hand. Gemini does read an installed extension's `agents/`, and logs
-a load error for each of the three Claude files, whose frontmatter its strict schema rejects — the
-errors are debug-level, and nothing else follows from them.
+clients validates, to be copied by hand. Gemini does read an installed extension's `agents/`, and
+prints a validation error for each of the three Claude files, whose frontmatter its strict schema
+rejects — on ordinary commands, not only in debug mode. Nothing else follows from it: the extension
+loads, the server connects and the skills work. It is the cost of one directory that has to satisfy
+Claude Code, whose plugins read `agents/` and nothing else.
 
 In both hand-copied sets the read-only promise rests on the *No writing* rule in the agent's own
 instructions rather than on a deny-list the client does not have.

--- a/jeffrey-pages/src/views/docs/docs-page.css
+++ b/jeffrey-pages/src/views/docs/docs-page.css
@@ -609,11 +609,16 @@
  * <th scope="row">, so a screen reader still pairs "Tool prefix" with the column it was read
  * under, which a grid of divs would lose.
  *
- * Each column carries an accent under its heading and the second one a faint tint, so the eye can
- * follow one client down the page without counting cells. Below 720px the columns would be three
- * words wide, so the whole thing stacks into labelled pairs instead of scrolling sideways — which
- * is why every cell needs a data-client attribute: it is the column heading, once there is no
- * heading row to read.
+ * The two columns are named for their roles rather than their vendors — is-primary is the client
+ * whose page this is, is-baseline is Claude Code, which the others are described against — so one
+ * scheme serves the Codex page, the Gemini page and whatever comes next. A vendor's own colour
+ * would have to be picked again per page, and would say something about branding that a docs table
+ * has no business saying. The accent under each heading and the tint down the primary column are
+ * what let the eye follow one client without counting cells.
+ *
+ * Below 720px the columns would be three words wide, so the whole thing stacks into labelled pairs
+ * instead of scrolling sideways — which is why every cell needs a data-client attribute: it is the
+ * column heading, once there is no heading row to read.
  */
 .docs-compare-wrap {
   margin: 1.5rem 0;
@@ -673,20 +678,20 @@
 }
 
 /* Inset rather than border-bottom: a border would move the text and double the row's own line. */
-.docs-content .docs-compare thead th.is-primary-client {
-  box-shadow: inset 0 -3px 0 #d97757;
+.docs-content .docs-compare thead th.is-baseline {
+  box-shadow: inset 0 -3px 0 #a9b2c3;
 }
 
-.docs-content .docs-compare thead th.is-secondary-client {
-  box-shadow: inset 0 -3px 0 #1a73e8;
+.docs-content .docs-compare thead th.is-primary {
+  box-shadow: inset 0 -3px 0 #5e64ff;
 }
 
-.docs-compare-client.is-primary-client {
-  color: #b45309;
+.docs-compare-client.is-baseline {
+  color: #6c7689;
 }
 
-.docs-compare-client.is-secondary-client {
-  color: #1a73e8;
+.docs-compare-client.is-primary {
+  color: #4c52db;
 }
 
 .docs-content .docs-compare tbody th {
@@ -702,8 +707,8 @@
   color: #495057;
 }
 
-.docs-content .docs-compare tbody td.is-secondary-client {
-  background: rgba(26, 115, 232, 0.03);
+.docs-content .docs-compare tbody td.is-primary {
+  background: rgba(94, 100, 255, 0.03);
 }
 
 .docs-content .docs-compare tbody tr:last-child th,
@@ -766,12 +771,12 @@
     color: #8a94a6;
   }
 
-  .docs-content .docs-compare tbody td.is-primary-client::before {
-    color: #b45309;
+  .docs-content .docs-compare tbody td.is-baseline::before {
+    color: #6c7689;
   }
 
-  .docs-content .docs-compare tbody td.is-secondary-client::before {
-    color: #1a73e8;
+  .docs-content .docs-compare tbody td.is-primary::before {
+    color: #4c52db;
   }
 
   .docs-content .docs-compare tbody tr {

--- a/jeffrey-pages/src/views/docs/docs-page.css
+++ b/jeffrey-pages/src/views/docs/docs-page.css
@@ -601,3 +601,185 @@
 .text-muted {
   color: #6c757d;
 }
+
+/* Client Comparison Table
+ *
+ * For a table whose columns are *things being compared* rather than more fields of one thing —
+ * one client per column, one difference per row. It stays a real <table>: the row label is a
+ * <th scope="row">, so a screen reader still pairs "Tool prefix" with the column it was read
+ * under, which a grid of divs would lose.
+ *
+ * Each column carries an accent under its heading and the second one a faint tint, so the eye can
+ * follow one client down the page without counting cells. Below 720px the columns would be three
+ * words wide, so the whole thing stacks into labelled pairs instead of scrolling sideways — which
+ * is why every cell needs a data-client attribute: it is the column heading, once there is no
+ * heading row to read.
+ */
+.docs-compare-wrap {
+  margin: 1.5rem 0;
+  border: 1px solid #eaedf1;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
+  background: #fff;
+}
+
+.docs-content .docs-compare {
+  width: 100%;
+  margin: 0;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 0.9rem;
+}
+
+.docs-content .docs-compare th,
+.docs-content .docs-compare td {
+  border: 0;
+  border-bottom: 1px solid #eaedf1;
+  padding: 0.85rem 1.1rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.docs-content .docs-compare thead th {
+  background: #f9fafd;
+  font-weight: 600;
+  color: #0b1727;
+  white-space: nowrap;
+}
+
+/* The corner cell names the column of row labels rather than sitting empty. */
+.docs-content .docs-compare thead th:first-child {
+  font-size: 0.72rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #8a94a6;
+}
+
+.docs-compare-client {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.docs-compare-client::before {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: currentColor;
+  flex: none;
+}
+
+/* Inset rather than border-bottom: a border would move the text and double the row's own line. */
+.docs-content .docs-compare thead th.is-primary-client {
+  box-shadow: inset 0 -3px 0 #d97757;
+}
+
+.docs-content .docs-compare thead th.is-secondary-client {
+  box-shadow: inset 0 -3px 0 #1a73e8;
+}
+
+.docs-compare-client.is-primary-client {
+  color: #b45309;
+}
+
+.docs-compare-client.is-secondary-client {
+  color: #1a73e8;
+}
+
+.docs-content .docs-compare tbody th {
+  background: #fcfcfd;
+  font-weight: 600;
+  color: #343a40;
+  width: 1%;
+  white-space: nowrap;
+}
+
+.docs-content .docs-compare tbody td {
+  border-left: 1px solid #f4f6f9;
+  color: #495057;
+}
+
+.docs-content .docs-compare tbody td.is-secondary-client {
+  background: rgba(26, 115, 232, 0.03);
+}
+
+.docs-content .docs-compare tbody tr:last-child th,
+.docs-content .docs-compare tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+/* A value, not prose: quieter than the pink inline <code> so six of them in a column do not shout. */
+.docs-compare-value {
+  display: inline-block;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  padding: 0.15rem 0.45rem;
+  border-radius: 4px;
+  background: #edf2f9;
+  border: 1px solid #eaedf1;
+  color: #3d4756;
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 720px) {
+  .docs-content .docs-compare thead {
+    display: none;
+  }
+
+  .docs-content .docs-compare,
+  .docs-content .docs-compare tbody,
+  .docs-content .docs-compare tr,
+  .docs-content .docs-compare th,
+  .docs-content .docs-compare td {
+    display: block;
+    width: auto;
+  }
+
+  .docs-content .docs-compare tbody th {
+    /* width and nowrap are the desktop rule's, and outrank the block above on specificity;
+       left alone the label shrink-wraps to one word per line. */
+    width: auto;
+    border-bottom: 0;
+    padding-bottom: 0.35rem;
+    white-space: normal;
+  }
+
+  .docs-content .docs-compare tbody td {
+    border-left: 0;
+    border-bottom: 0;
+    padding-top: 0.2rem;
+    padding-bottom: 0.6rem;
+  }
+
+  .docs-content .docs-compare tbody td::before {
+    content: attr(data-client);
+    display: block;
+    margin-bottom: 0.2rem;
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: #8a94a6;
+  }
+
+  .docs-content .docs-compare tbody td.is-primary-client::before {
+    color: #b45309;
+  }
+
+  .docs-content .docs-compare tbody td.is-secondary-client::before {
+    color: #1a73e8;
+  }
+
+  .docs-content .docs-compare tbody tr {
+    border-bottom: 1px solid #eaedf1;
+    padding-bottom: 0.35rem;
+  }
+
+  .docs-content .docs-compare tbody tr:last-child {
+    border-bottom: 0;
+  }
+}

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpClaudeCodePage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpClaudeCodePage.vue
@@ -106,29 +106,9 @@ const removal = `/plugin uninstall microscope@jeffrey`;
 
       <p><strong>A startup check</strong>, which says so when Jeffrey is not answering rather than letting the first tool call find out. <a href="#the-startup-check">Below.</a></p>
 
-      <p><strong>Ten skills</strong>, which Claude picks up on its own when a question calls for them, and which you can also invoke directly:</p>
-      <ul>
-        <li><code>/microscope:analyze-jfr</code> &mdash; where to start and which family answers which question</li>
-        <li><code>/microscope:analyze-heap</code> &mdash; a heap dump end to end: what is holding the memory, what is leaking, and the order the twenty-four heap tools have to be run in</li>
-        <li><code>/microscope:analyze-hub</code> &mdash; the recordings that never reached this machine: finds the session across the connected Jeffrey Hubs, pulls it in, and hands off to <code>analyze-jfr</code> or <code>analyze-heap</code></li>
-        <li><code>/microscope:compare-jfr</code> &mdash; before against after: whether a change made it slower, which methods moved, and whether the two recordings were comparable in the first place</li>
-        <li><code>/microscope:profile-run</code> &mdash; a workload with no recording yet: what to run it under, for how long, and where the file has to land for Jeffrey to open it</li>
-        <li><code>/microscope:regression-check</code> &mdash; the same before-and-after question starting from two revisions rather than two profiles: build and record each, then weigh them</li>
-        <li><code>/microscope:advise-jfr</code> &mdash; from a profile to a code change: hot frames mapped to your checkout, a recommendation, then the edit and a re-profile on request</li>
-        <li><code>/microscope:jfr-sql</code> &mdash; the JFR schema and the DuckDB idioms that go with it</li>
-        <li><code>/microscope:heap-sql</code> &mdash; the heap-dump index schema</li>
-        <li><code>/microscope:report</code> &mdash; the evidence discipline the other nine write to: what a finding must carry before it is worth writing down, how a figure is quoted and against what denominator, and how the questions a recording cannot answer are reported apart from the findings</li>
-      </ul>
+      <p><strong>Ten skills</strong>, which Claude picks up on its own when a question calls for them and which you can also invoke directly, as <code>/microscope:analyze-jfr</code>: <code>analyze-jfr</code>, <code>analyze-heap</code>, <code>analyze-hub</code>, <code>compare-jfr</code>, <code>profile-run</code>, <code>regression-check</code>, <code>advise-jfr</code>, <code>jfr-sql</code>, <code>heap-sql</code>, <code>report</code>. What each one carries is on the <router-link to="/docs/microscope-mcp/skills">Skills</router-link> page.</p>
 
-      <p>The <router-link to="/docs/microscope-mcp/skills">Skills</router-link> page covers what each one carries and why it exists.</p>
-
-      <p><strong>Three subagents.</strong> <code>microscope:profile-analyst</code> is the general one. A single <code>flamegraph_export</code> can run to 120,000 characters &mdash; the cap a tool result is truncated at &mdash; and answering a question properly often takes several of them. The analyst runs a sequence and returns only the findings: the hot frames with their <code>total</code> and <code>self</code> shares, or the retaining classes with their retained bytes and GC-root paths. Everything it read stays in its own context window rather than crowding out the conversation you are having.</p>
-
-      <p>The skills hand it the reading and keep what actually needs your session: mapping frames onto the checkout, the recommendation, and every question put to you. <code>advise-jfr</code> uses it hardest, sending CPU, wall-clock, allocation and blocking out as four parallel delegations instead of pulling four documents into one context. Its tools are the read-only MCP families and nothing else &mdash; no file access, no <code>recordings_</code>, no <code>hubs_</code> &mdash; so it can neither touch your repository nor create a profile. <router-link to="/docs/microscope-mcp/agent">The agent reference</router-link> covers what it returns and when to read an export yourself instead.</p>
-
-      <p><code>microscope:heap-triage</code> is the heap specialist. It carries <code>analyze-heap</code> and <code>heap-sql</code>, runs the whole leak route &mdash; histogram, dominator tree, GC-root path &mdash; and returns class names with retained bytes and the paths that make each claim checkable. The difference that matters: it will run <code>heap_prepare</code> when a report or a retained size has not been built, where the analyst would report the gap and stop.</p>
-
-      <p><code>microscope:profile-lead</code> is for the question that names no dimension &mdash; &ldquo;why is this service slow&rdquo;, &ldquo;review this recording&rdquo;. It triages from <code>profiles_summary</code> itself, reads the capability gaps first, dispatches the other two only for what the summary justifies, and merges what they return into one ranked report. It holds the orientation tools and the two specialists, and no export tool of its own; its model is inherited from the session. The <router-link to="/docs/microscope-mcp/agent#the-lead">agent reference</router-link> has the sequence.</p>
+      <p><strong>Three subagents</strong> &mdash; <code>microscope:profile-analyst</code>, <code>microscope:heap-triage</code> and <code>microscope:profile-lead</code> &mdash; which arrive with the plugin and need no install step. Claude Code is the only client that can carry them: its subagent definitions take a tool deny-list, so all three are held to reading a profile rather than told to. What each one does, and when to delegate to it, is on the <router-link to="/docs/microscope-mcp/agent">Agents</router-link> page.</p>
 
       <h2 id="permissions">Permissions</h2>
       <p>Claude Code asks before each tool the first time. Every tool here reads except the <code>recordings_</code> and <code>hubs_</code> families, which build a profile from a recording file on this machine or from a session on a connected hub, so approving the read-only families once is usually what you want &mdash; from the prompt, or up front with <code>/permissions</code>:</p>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpClaudeCodePage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpClaudeCodePage.vue
@@ -106,7 +106,7 @@ const removal = `/plugin uninstall microscope@jeffrey`;
 
       <p><strong>A startup check</strong>, which says so when Jeffrey is not answering rather than letting the first tool call find out. <a href="#the-startup-check">Below.</a></p>
 
-      <p><strong>Nine skills</strong>, which Claude picks up on its own when a question calls for them, and which you can also invoke directly:</p>
+      <p><strong>Ten skills</strong>, which Claude picks up on its own when a question calls for them, and which you can also invoke directly:</p>
       <ul>
         <li><code>/microscope:analyze-jfr</code> &mdash; where to start and which family answers which question</li>
         <li><code>/microscope:analyze-heap</code> &mdash; a heap dump end to end: what is holding the memory, what is leaking, and the order the twenty-four heap tools have to be run in</li>
@@ -117,6 +117,7 @@ const removal = `/plugin uninstall microscope@jeffrey`;
         <li><code>/microscope:advise-jfr</code> &mdash; from a profile to a code change: hot frames mapped to your checkout, a recommendation, then the edit and a re-profile on request</li>
         <li><code>/microscope:jfr-sql</code> &mdash; the JFR schema and the DuckDB idioms that go with it</li>
         <li><code>/microscope:heap-sql</code> &mdash; the heap-dump index schema</li>
+        <li><code>/microscope:report</code> &mdash; the evidence discipline the other nine write to: what a finding must carry before it is worth writing down, how a figure is quoted and against what denominator, and how the questions a recording cannot answer are reported apart from the findings</li>
       </ul>
 
       <p>The <router-link to="/docs/microscope-mcp/skills">Skills</router-link> page covers what each one carries and why it exists.</p>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpCodexPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpCodexPage.vue
@@ -203,47 +203,53 @@ const removal = `codex plugin marketplace remove jeffrey`;
       <h2 id="what-differs-from-claude-code">What Differs from Claude Code</h2>
       <p>The tools and the skills are identical. Everything below is a property of the plugin formats, not of Jeffrey.</p>
 
-      <table>
-        <thead>
+      <div class="docs-compare-wrap">
+        <table class="docs-compare">
+          <thead>
+            <tr>
+              <th scope="col">Difference</th>
+              <th scope="col" class="is-baseline">
+                <span class="docs-compare-client is-baseline">Claude Code</span>
+              </th>
+              <th scope="col" class="is-primary">
+                <span class="docs-compare-client is-primary">Codex</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
           <tr>
-            <th></th>
-            <th>Claude Code</th>
-            <th>Codex</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Manifest</td>
-            <td><code>.claude-plugin/plugin.json</code></td>
-            <td>Agent Plugins <code>plugin.json</code> + <code>mcp.json</code></td>
-          </tr>
-          <tr>
-            <td>Install</td>
-            <td><code>/plugin install microscope@jeffrey</code></td>
-            <td><code>codex plugin marketplace add</code>, then <code>/plugins</code></td>
-          </tr>
-          <tr>
-            <td>Skills</td>
-            <td>Seven, invoked <code>/microscope:analyze-jfr</code></td>
-            <td>The same seven, invoked <code>$analyze-jfr</code></td>
+            <th scope="row">Manifest</th>
+            <td class="is-baseline" data-client="Claude Code"><span class="docs-compare-value">.claude-plugin/plugin.json</span></td>
+            <td class="is-primary" data-client="Codex">Agent Plugins <span class="docs-compare-value">plugin.json</span> + <span class="docs-compare-value">mcp.json</span></td>
           </tr>
           <tr>
-            <td>Endpoint</td>
-            <td>A per-machine setting</td>
-            <td>Fixed at <code>localhost:8585</code>; anything else is a <code>config.toml</code> block</td>
+            <th scope="row">Install</th>
+            <td class="is-baseline" data-client="Claude Code"><span class="docs-compare-value">/plugin install microscope@jeffrey</span></td>
+            <td class="is-primary" data-client="Codex"><span class="docs-compare-value">codex plugin marketplace add</span>, then <span class="docs-compare-value">/plugins</span></td>
           </tr>
           <tr>
-            <td>Analyst agent</td>
-            <td>Shipped, tool-restricted</td>
-            <td>Copied by hand, restricted by instruction</td>
+            <th scope="row">Skills</th>
+            <td class="is-baseline" data-client="Claude Code">Ten, invoked <span class="docs-compare-value">/microscope:analyze-jfr</span></td>
+            <td class="is-primary" data-client="Codex">The same ten, invoked <span class="docs-compare-value">$analyze-jfr</span></td>
           </tr>
           <tr>
-            <td>Tool prefix</td>
-            <td><code>mcp__plugin_microscope_jeffrey__</code></td>
-            <td><code>mcp__jeffrey__</code></td>
+            <th scope="row">Endpoint</th>
+            <td class="is-baseline" data-client="Claude Code">A per-machine setting</td>
+            <td class="is-primary" data-client="Codex">Fixed at <span class="docs-compare-value">localhost:8585</span>; anything else is a <span class="docs-compare-value">config.toml</span> block</td>
           </tr>
-        </tbody>
-      </table>
+          <tr>
+            <th scope="row">Agents</th>
+            <td class="is-baseline" data-client="Claude Code">All three, shipped and tool-restricted</td>
+            <td class="is-primary" data-client="Codex">The same three, copied by hand and restricted by instruction</td>
+          </tr>
+          <tr>
+            <th scope="row">Tool prefix</th>
+            <td class="is-baseline" data-client="Claude Code"><span class="docs-compare-value">mcp__plugin_microscope_jeffrey__</span></td>
+            <td class="is-primary" data-client="Codex"><span class="docs-compare-value">mcp__jeffrey__</span></td>
+          </tr>
+          </tbody>
+        </table>
+      </div>
 
       <p>The two that bite are the endpoint and the agent. Neither has a workaround inside the plugin: they are the price of a format that six vendors agreed on, and both are one file away from being solved by hand.</p>
     </div>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpCodexPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpCodexPage.vue
@@ -128,24 +128,12 @@ const removal = `codex plugin marketplace remove jeffrey`;
       <p>The skills keep working either way &mdash; they name tools by the part after the prefix, and the server is still called <code>jeffrey</code>. Only the registration moves.</p>
 
       <h2 id="what-the-plugin-adds">What the Plugin Adds</h2>
-      <p>Registering the server by hand gives you every tool. The plugin adds the endpoint already configured, and <strong>ten skills</strong>, which Codex picks up on its own when a question calls for them and which you can also invoke directly with <code>$</code>:</p>
-      <ul>
-        <li><code>$analyze-jfr</code> &mdash; where to start and which family answers which question</li>
-        <li><code>$analyze-heap</code> &mdash; a heap dump end to end: what is holding the memory, what is leaking, and the order the twenty-four heap tools have to be run in</li>
-        <li><code>$analyze-hub</code> &mdash; the recordings that never reached this machine: finds the session across the connected Jeffrey Hubs, pulls it in, and hands off to <code>analyze-jfr</code> or <code>analyze-heap</code></li>
-        <li><code>$compare-jfr</code> &mdash; before against after: whether a change made it slower, which methods moved, and whether the two recordings were comparable in the first place</li>
-        <li><code>$profile-run</code> &mdash; a workload that has not been recorded yet: what to run it under, for how long, and where the file has to land for Jeffrey to open it</li>
-        <li><code>$regression-check</code> &mdash; the same before-and-after question starting from two revisions rather than two profiles: build and record both, then weigh them</li>
-        <li><code>$advise-jfr</code> &mdash; from a profile to a code change: hot frames mapped to your checkout, a recommendation, then the edit and a re-profile on request</li>
-        <li><code>$jfr-sql</code> &mdash; the JFR schema and the DuckDB idioms that go with it</li>
-        <li><code>$heap-sql</code> &mdash; the heap-dump index schema</li>
-        <li><code>$report</code> &mdash; the evidence discipline the other nine write to: what a finding must carry before it is worth writing down, how a figure is quoted and against what denominator, and how the questions a recording cannot answer are reported apart from the findings</li>
-      </ul>
+      <p>Registering the server by hand gives you every tool. The plugin adds the endpoint already configured and <strong>ten skills</strong>, which Codex picks up on its own when a question calls for them and which you can also invoke directly with <code>$</code>, as <code>$analyze-jfr</code>: <code>analyze-jfr</code>, <code>analyze-heap</code>, <code>analyze-hub</code>, <code>compare-jfr</code>, <code>profile-run</code>, <code>regression-check</code>, <code>advise-jfr</code>, <code>jfr-sql</code>, <code>heap-sql</code>, <code>report</code>. What each one carries is on the <router-link to="/docs/microscope-mcp/skills">Skills</router-link> page; <code>/skills</code> lists what the session actually loaded.</p>
 
-      <p>They are the same files Claude Code loads &mdash; both clients read the <a href="https://agentskills.io/specification" target="_blank" rel="noopener">Agent Skills</a> format, so the skill directory is shared rather than duplicated. The <router-link to="/docs/microscope-mcp/skills">Skills</router-link> page covers what each one carries and why it exists. <code>/skills</code> lists what the session actually loaded.</p>
+      <p>They are the same files Claude Code loads &mdash; both clients read the <a href="https://agentskills.io/specification" target="_blank" rel="noopener">Agent Skills</a> format, so the skill directory is shared rather than duplicated.</p>
 
       <h2 id="the-analyst-agent">The Agents</h2>
-      <p>A single <code>flamegraph_export</code> can run to 120,000 characters, and answering a question properly often takes several. The <router-link to="/docs/microscope-mcp/agent">three agents</router-link> &mdash; <code>profile-analyst</code> for a profile, <code>heap-triage</code> for a heap dump, <code>profile-lead</code> to triage an open-ended question and dispatch those two &mdash; run a sequence and return only the findings &mdash; the hot frames with their <code>total</code> and <code>self</code> shares, or the retaining classes with their retained bytes and GC-root paths &mdash; leaving everything they read in their own context.</p>
+      <p>The <router-link to="/docs/microscope-mcp/agent">three agents</router-link> &mdash; <code>profile-analyst</code>, <code>heap-triage</code> and <code>profile-lead</code> &mdash; read an export end to end and return only the findings. What each one is for is on that page; what follows is how Codex gets them.</p>
 
       <p><strong>A Codex plugin cannot carry them.</strong> Agent Plugins defines exactly two component types, skills and MCP servers; agents are not among them. So the plugin ships both as files to copy:</p>
       <DocsCodeBlock :code="agentInstall" language="bash" />

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpCodexPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpCodexPage.vue
@@ -139,6 +139,7 @@ const removal = `codex plugin marketplace remove jeffrey`;
         <li><code>$advise-jfr</code> &mdash; from a profile to a code change: hot frames mapped to your checkout, a recommendation, then the edit and a re-profile on request</li>
         <li><code>$jfr-sql</code> &mdash; the JFR schema and the DuckDB idioms that go with it</li>
         <li><code>$heap-sql</code> &mdash; the heap-dump index schema</li>
+        <li><code>$report</code> &mdash; the evidence discipline the other nine write to: what a finding must carry before it is worth writing down, how a figure is quoted and against what denominator, and how the questions a recording cannot answer are reported apart from the findings</li>
       </ul>
 
       <p>They are the same files Claude Code loads &mdash; both clients read the <a href="https://agentskills.io/specification" target="_blank" rel="noopener">Agent Skills</a> format, so the skill directory is shared rather than duplicated. The <router-link to="/docs/microscope-mcp/skills">Skills</router-link> page covers what each one carries and why it exists. <code>/skills</code> lists what the session actually loaded.</p>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpGeminiPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpGeminiPage.vue
@@ -132,7 +132,7 @@ const update = `gemini extensions update microscope`;
       <p>Gemini installs an extension from a directory holding a <code>gemini-extension.json</code>, which is <code>jeffrey-claude-plugin/</code> in a clone:</p>
       <DocsCodeBlock :code="installLocal" language="bash" />
 
-      <p>Start a new session afterwards &mdash; an extension's servers, skills and agents are loaded when the session begins, not mid-conversation. <code>/extensions</code> lists what loaded.</p>
+      <p>Start a new session afterwards &mdash; an extension's servers and skills are loaded when the session begins, not mid-conversation. <code>/extensions</code> lists what loaded.</p>
 
       <p>The GitHub-URL form of that command does not work here: Gemini looks for the manifest at the root of whatever it clones, and in this repository it lives one directory down.</p>
 

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpGeminiPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpGeminiPage.vue
@@ -248,44 +248,44 @@ const update = `gemini extensions update microscope`;
           <thead>
             <tr>
               <th scope="col">Difference</th>
-              <th scope="col" class="is-primary-client">
-                <span class="docs-compare-client is-primary-client">Claude Code</span>
+              <th scope="col" class="is-baseline">
+                <span class="docs-compare-client is-baseline">Claude Code</span>
               </th>
-              <th scope="col" class="is-secondary-client">
-                <span class="docs-compare-client is-secondary-client">Gemini CLI</span>
+              <th scope="col" class="is-primary">
+                <span class="docs-compare-client is-primary">Gemini CLI</span>
               </th>
             </tr>
           </thead>
           <tbody>
           <tr>
             <th scope="row">Manifest</th>
-            <td class="is-primary-client" data-client="Claude Code"><span class="docs-compare-value">.claude-plugin/plugin.json</span></td>
-            <td class="is-secondary-client" data-client="Gemini CLI"><span class="docs-compare-value">gemini-extension.json</span></td>
+            <td class="is-baseline" data-client="Claude Code"><span class="docs-compare-value">.claude-plugin/plugin.json</span></td>
+            <td class="is-primary" data-client="Gemini CLI"><span class="docs-compare-value">gemini-extension.json</span></td>
           </tr>
           <tr>
             <th scope="row">Install</th>
-            <td class="is-primary-client" data-client="Claude Code"><span class="docs-compare-value">/plugin install microscope@jeffrey</span></td>
-            <td class="is-secondary-client" data-client="Gemini CLI"><span class="docs-compare-value">gemini extensions install &lt;path&gt;</span></td>
+            <td class="is-baseline" data-client="Claude Code"><span class="docs-compare-value">/plugin install microscope@jeffrey</span></td>
+            <td class="is-primary" data-client="Gemini CLI"><span class="docs-compare-value">gemini extensions install &lt;path&gt;</span></td>
           </tr>
           <tr>
             <th scope="row">Endpoint</th>
-            <td class="is-primary-client" data-client="Claude Code">A per-machine setting</td>
-            <td class="is-secondary-client" data-client="Gemini CLI">A setting too, asked at install or read from the environment</td>
+            <td class="is-baseline" data-client="Claude Code">A per-machine setting</td>
+            <td class="is-primary" data-client="Gemini CLI">A setting too, asked at install or read from the environment</td>
           </tr>
           <tr>
             <th scope="row">Tool prefix</th>
-            <td class="is-primary-client" data-client="Claude Code"><span class="docs-compare-value">mcp__plugin_microscope_jeffrey__</span></td>
-            <td class="is-secondary-client" data-client="Gemini CLI"><span class="docs-compare-value">mcp_jeffrey_</span></td>
+            <td class="is-baseline" data-client="Claude Code"><span class="docs-compare-value">mcp__plugin_microscope_jeffrey__</span></td>
+            <td class="is-primary" data-client="Gemini CLI"><span class="docs-compare-value">mcp_jeffrey_</span></td>
           </tr>
           <tr>
             <th scope="row">Agents</th>
-            <td class="is-primary-client" data-client="Claude Code">All three, from the plugin</td>
-            <td class="is-secondary-client" data-client="Gemini CLI">Two, copied by hand &mdash; no subagent may dispatch another</td>
+            <td class="is-baseline" data-client="Claude Code">All three, from the plugin</td>
+            <td class="is-primary" data-client="Gemini CLI">Two, copied by hand &mdash; no subagent may dispatch another</td>
           </tr>
           <tr>
             <th scope="row">Read-only agents</th>
-            <td class="is-primary-client" data-client="Claude Code">Enforced by a deny-list</td>
-            <td class="is-secondary-client" data-client="Gemini CLI">Instructed, or enforced with <span class="docs-compare-value">excludeTools</span></td>
+            <td class="is-baseline" data-client="Claude Code">Enforced by a deny-list</td>
+            <td class="is-primary" data-client="Gemini CLI">Instructed, or enforced with <span class="docs-compare-value">excludeTools</span></td>
           </tr>
           </tbody>
         </table>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpGeminiPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpGeminiPage.vue
@@ -243,47 +243,53 @@ const update = `gemini extensions update microscope`;
       <h2 id="what-differs">What Differs from Claude Code</h2>
       <p>The tools and the skills are identical. Everything below is a property of the clients, not of Jeffrey.</p>
 
-      <table>
-        <thead>
+      <div class="docs-compare-wrap">
+        <table class="docs-compare">
+          <thead>
+            <tr>
+              <th scope="col">Difference</th>
+              <th scope="col" class="is-primary-client">
+                <span class="docs-compare-client is-primary-client">Claude Code</span>
+              </th>
+              <th scope="col" class="is-secondary-client">
+                <span class="docs-compare-client is-secondary-client">Gemini CLI</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
           <tr>
-            <th></th>
-            <th>Claude Code</th>
-            <th>Gemini CLI</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Manifest</td>
-            <td><code>.claude-plugin/plugin.json</code></td>
-            <td><code>gemini-extension.json</code></td>
-          </tr>
-          <tr>
-            <td>Install</td>
-            <td><code>/plugin install microscope@jeffrey</code></td>
-            <td><code>gemini extensions install &lt;path&gt;</code></td>
-          </tr>
-          <tr>
-            <td>Endpoint</td>
-            <td>A per-machine setting</td>
-            <td>A setting too, asked at install or read from the environment</td>
+            <th scope="row">Manifest</th>
+            <td class="is-primary-client" data-client="Claude Code"><span class="docs-compare-value">.claude-plugin/plugin.json</span></td>
+            <td class="is-secondary-client" data-client="Gemini CLI"><span class="docs-compare-value">gemini-extension.json</span></td>
           </tr>
           <tr>
-            <td>Tool prefix</td>
-            <td><code>mcp__plugin_microscope_jeffrey__</code></td>
-            <td><code>mcp_jeffrey_</code></td>
+            <th scope="row">Install</th>
+            <td class="is-primary-client" data-client="Claude Code"><span class="docs-compare-value">/plugin install microscope@jeffrey</span></td>
+            <td class="is-secondary-client" data-client="Gemini CLI"><span class="docs-compare-value">gemini extensions install &lt;path&gt;</span></td>
           </tr>
           <tr>
-            <td>Agents</td>
-            <td>All three, from the plugin</td>
-            <td>Two, copied by hand: no subagent may dispatch another</td>
+            <th scope="row">Endpoint</th>
+            <td class="is-primary-client" data-client="Claude Code">A per-machine setting</td>
+            <td class="is-secondary-client" data-client="Gemini CLI">A setting too, asked at install or read from the environment</td>
           </tr>
           <tr>
-            <td>Read-only agents</td>
-            <td>Enforced by a deny-list</td>
-            <td>Instructed, or enforced with <code>excludeTools</code></td>
+            <th scope="row">Tool prefix</th>
+            <td class="is-primary-client" data-client="Claude Code"><span class="docs-compare-value">mcp__plugin_microscope_jeffrey__</span></td>
+            <td class="is-secondary-client" data-client="Gemini CLI"><span class="docs-compare-value">mcp_jeffrey_</span></td>
           </tr>
-        </tbody>
-      </table>
+          <tr>
+            <th scope="row">Agents</th>
+            <td class="is-primary-client" data-client="Claude Code">All three, from the plugin</td>
+            <td class="is-secondary-client" data-client="Gemini CLI">Two, copied by hand &mdash; no subagent may dispatch another</td>
+          </tr>
+          <tr>
+            <th scope="row">Read-only agents</th>
+            <td class="is-primary-client" data-client="Claude Code">Enforced by a deny-list</td>
+            <td class="is-secondary-client" data-client="Gemini CLI">Instructed, or enforced with <span class="docs-compare-value">excludeTools</span></td>
+          </tr>
+          </tbody>
+        </table>
+      </div>
 
       <DocsCallout type="tip" title="From the IDE">
         The <router-link to="/docs/intellij-plugin">IntelliJ plugin</router-link>'s recording panel hands a profile straight to Gemini, alongside Claude Code and Codex &mdash; one button opens a terminal with the profile already identified and the matching skill triggered.

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpGeminiPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpGeminiPage.vue
@@ -159,23 +159,12 @@ const update = `gemini extensions update microscope`;
       <p>Keep the name <code>jeffrey</code>: the skills name tools by the part after the prefix, and the prefix is built from the server's name. Then remove the extension, or accept that the same tools are registered twice.</p>
 
       <h2 id="what-the-extension-adds">What the Extension Adds</h2>
-      <p>Registering the server by hand gives you every tool. The extension adds the endpoint already configured, a check that Jeffrey is serving when a session starts, and <strong>ten skills</strong>, which Gemini loads on its own when a question calls for one:</p>
-      <ul>
-        <li><code>analyze-jfr</code> &mdash; where to start and which family answers which question</li>
-        <li><code>analyze-heap</code> &mdash; a heap dump end to end: what is holding the memory, what is leaking, and the order the heap tools have to be run in</li>
-        <li><code>analyze-hub</code> &mdash; the recordings that never reached this machine: finds the session across the connected Jeffrey Hubs, pulls it in, and hands off</li>
-        <li><code>compare-jfr</code> &mdash; before against after: which methods moved, and whether the two recordings were comparable in the first place</li>
-        <li><code>profile-run</code> &mdash; a workload that has not been recorded yet: what to run it under, for how long, and where the file has to land</li>
-        <li><code>regression-check</code> &mdash; the same before-and-after question starting from two revisions rather than two profiles</li>
-        <li><code>advise-jfr</code> &mdash; from a profile to a code change: hot frames mapped to your checkout, a recommendation, then the edit</li>
-        <li><code>jfr-sql</code> and <code>heap-sql</code> &mdash; the two database schemas and the DuckDB idioms that go with them</li>
-        <li><code>report</code> &mdash; the evidence discipline the other nine write to</li>
-      </ul>
+      <p>Registering the server by hand gives you every tool. The extension adds the endpoint already configured, a check that Jeffrey is serving when a session starts, and <strong>ten skills</strong>, which Gemini loads on its own when a question calls for one: <code>analyze-jfr</code>, <code>analyze-heap</code>, <code>analyze-hub</code>, <code>compare-jfr</code>, <code>profile-run</code>, <code>regression-check</code>, <code>advise-jfr</code>, <code>jfr-sql</code>, <code>heap-sql</code>, <code>report</code>. What each one carries is on the <router-link to="/docs/microscope-mcp/skills">Skills</router-link> page; <code>/skills</code> lists what a session actually loaded, and <code>gemini extensions list</code> prints them with the server and the endpoint setting from outside one.</p>
 
-      <p><code>/skills</code> lists what a session actually loaded, and <code>gemini extensions list</code> prints them with the server and the endpoint setting from outside one. They are the same files Claude Code and Codex load &mdash; all three read the <a href="https://agentskills.io/specification" target="_blank" rel="noopener">Agent Skills</a> format, so the directory is shared rather than duplicated. The <router-link to="/docs/microscope-mcp/skills">Skills</router-link> page covers what each one carries and why it exists.</p>
+      <p>They are the same files Claude Code and Codex load &mdash; all three read the <a href="https://agentskills.io/specification" target="_blank" rel="noopener">Agent Skills</a> format, so the directory is shared rather than duplicated.</p>
 
       <h2 id="the-agents">The Agents</h2>
-      <p>A single <code>flamegraph_export</code> can run to 120,000 characters, and answering a question properly often takes several. The <router-link to="/docs/microscope-mcp/agent">agents</router-link> run a sequence and return only the findings, leaving everything they read in their own context.</p>
+      <p>The <router-link to="/docs/microscope-mcp/agent">agents</router-link> read an export end to end and return only the findings. What each one is for is on that page; what follows is how Gemini gets them, and which of them it can run at all.</p>
 
       <p>Gemini gets <strong>two of the three</strong>, and they are files to copy:</p>
       <DocsCodeBlock :code="agentInstall" language="bash" />

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpGeminiPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpGeminiPage.vue
@@ -107,6 +107,11 @@ cp jeffrey/jeffrey-claude-plugin/gemini/agents/heap-triage.md ~/.gemini/agents/`
 
 const endpointEnv = `export JEFFREY_MCP_ENDPOINT=http://localhost:9000/api/mcp`;
 
+const manualAdd = `gemini mcp add jeffrey http://localhost:8585/api/mcp \\
+  --transport http --scope user --timeout 900000`;
+
+const reconfigure = `gemini extensions config microscope`;
+
 const removal = `gemini extensions uninstall microscope`;
 
 const update = `gemini extensions update microscope`;
@@ -139,13 +144,16 @@ const update = `gemini extensions update microscope`;
       <p>Gemini asks for the endpoint while installing &mdash; keep the default unless your Jeffrey is elsewhere. <code>--skip-settings</code> skips the question. The manifest behind it:</p>
       <DocsCodeBlock :code="manifest" language="json" />
 
-      <p><code>httpUrl</code> is Gemini's key for <strong>Streamable HTTP</strong>. Its neighbour <code>url</code> means an SSE endpoint, which this server does not offer &mdash; using it is the one configuration mistake that produces a server which looks registered and never connects.</p>
+      <p><code>httpUrl</code> is one of <strong>three spellings Gemini accepts</strong> for the same Streamable HTTP server, and the shorthand for &ldquo;this is HTTP, do not guess&rdquo;. <code>url</code> with <code>&quot;type&quot;: &quot;http&quot;</code> is the same thing &mdash; it is what <code>gemini mcp add --transport http</code> writes &mdash; and a bare <code>url</code> with no <code>type</code> also works, because Gemini tries HTTP first and only falls back to SSE when that fails. Only <code>&quot;type&quot;: &quot;sse&quot;</code> is wrong here, since this server offers no SSE stream. <code>/mcp</code> prints the transport it settled on.</p>
 
       <h2 id="pointing-it-elsewhere">Pointing It Elsewhere</h2>
       <p><strong>Gemini has a setting, as Claude Code does</strong> &mdash; unlike Codex, where the endpoint really is fixed. The extension declares one, and the manifest reads it with a default, so <code>localhost:8585</code> stands until you give it something else. Answer the question at install time, or export the variable the setting is named after:</p>
       <DocsCodeBlock :code="endpointEnv" language="bash" />
 
-      <p>That is the same variable the session-start check reads, so the probe and the tools cannot end up pointed at different machines. To skip the extension's server altogether, register your own in <code>~/.gemini/settings.json</code> for every project, or a checkout's <code>.gemini/settings.json</code> for one:</p>
+      <p>That is the same variable the session-start check reads, so the probe and the tools cannot end up pointed at different machines. To change the answer you gave at install time:</p>
+      <DocsCodeBlock :code="reconfigure" language="bash" />
+
+      <p>To skip the extension's server altogether, register your own in <code>~/.gemini/settings.json</code> for every project, or a checkout's <code>.gemini/settings.json</code> for one:</p>
       <DocsCodeBlock :code="customUrl" language="json" />
 
       <p>Keep the name <code>jeffrey</code>: the skills name tools by the part after the prefix, and the prefix is built from the server's name. Then remove the extension, or accept that the same tools are registered twice.</p>
@@ -164,7 +172,7 @@ const update = `gemini extensions update microscope`;
         <li><code>report</code> &mdash; the evidence discipline the other nine write to</li>
       </ul>
 
-      <p>They are the same files Claude Code and Codex load &mdash; all three read the <a href="https://agentskills.io/specification" target="_blank" rel="noopener">Agent Skills</a> format, so the directory is shared rather than duplicated. The <router-link to="/docs/microscope-mcp/skills">Skills</router-link> page covers what each one carries and why it exists.</p>
+      <p><code>/skills</code> lists what a session actually loaded, and <code>gemini extensions list</code> prints them with the server and the endpoint setting from outside one. They are the same files Claude Code and Codex load &mdash; all three read the <a href="https://agentskills.io/specification" target="_blank" rel="noopener">Agent Skills</a> format, so the directory is shared rather than duplicated. The <router-link to="/docs/microscope-mcp/skills">Skills</router-link> page covers what each one carries and why it exists.</p>
 
       <h2 id="the-agents">The Agents</h2>
       <p>A single <code>flamegraph_export</code> can run to 120,000 characters, and answering a question properly often takes several. The <router-link to="/docs/microscope-mcp/agent">agents</router-link> run a sequence and return only the findings, leaving everything they read in their own context.</p>
@@ -174,7 +182,11 @@ const update = `gemini extensions update microscope`;
 
       <p><code>~/.gemini/agents/</code> makes them available in every repository; <code>.gemini/agents/</code> inside a checkout scopes them to that one, and <code>/agents</code> lists what loaded. The skills delegate to an agent of that name when the client has one and read the exports themselves when it does not, so skipping this costs context rather than correctness.</p>
 
-      <p><strong>The extension cannot carry them</strong>, even though Gemini does read an installed extension's <code>agents/</code> directory. It validates that frontmatter against a strict schema and rejects any key it does not define, and the plugin's own agents carry Claude Code's <code>disallowedTools</code>, <code>skills</code> and <code>color</code>. Gemini logs a debug-level load error for each and carries on; the copies above are the same agents written in the dialect it accepts.</p>
+      <p><strong>The extension cannot carry them</strong>, even though Gemini does read an installed extension's <code>agents/</code> directory. It validates that frontmatter against a strict schema and rejects any key it does not define, and the plugin's own agents carry Claude Code's <code>disallowedTools</code>, <code>skills</code> and <code>color</code>; their tool patterns are not names Gemini accepts either. The copies above are the same agents written in the dialect it does accept.</p>
+
+      <DocsCallout type="warning" title="Those three files are noisy">
+        Gemini prints a validation error for each of them &mdash; <em>Unrecognized key(s)</em>, then a line per tool pattern &mdash; and it prints them on ordinary commands, not only in debug mode. Nothing else follows from it: the extension loads, the server connects, the skills work. It is the cost of one directory that has to satisfy Claude Code, whose plugins read <code>agents/</code> and nothing else.
+      </DocsCallout>
 
       <p>There is <strong>no <code>profile-lead</code> for Gemini at all</strong>, and that is a property of the client rather than an omission: <strong>a Gemini subagent may not dispatch another subagent</strong>, and dispatching the other two is the whole of what the lead does. Ask an open-ended question in the main conversation instead; <code>analyze-jfr</code> carries the same triage order, and the two specialists work beneath it.</p>
 
@@ -207,7 +219,7 @@ const update = `gemini extensions update microscope`;
       <p>On the Gemini side, <code>includeTools</code> or <code>excludeTools</code> on the server entry narrows what this client sees without touching what Jeffrey serves to anything else. Leave both alone unless you have a reason &mdash; the skills route between families freely, and one that is not advertised is one their advice sends the model to in vain.</p>
 
       <h2 id="check-it-is-connected">Check It Is Connected</h2>
-      <p>Run <code>/mcp</code> inside a session. The <code>jeffrey</code> server should be listed with its tools. If it is not, in order of likelihood: the session predates the install and needs restarting, the entry says <code>url</code> where it should say <code>httpUrl</code>, this installation set <code>jeffrey.microscope.mcp.enabled=false</code>, Jeffrey is not on <code>localhost:8585</code>, or Jeffrey is not running.</p>
+      <p>Run <code>/mcp</code> inside a session, or <code>gemini mcp list</code> outside one. The <code>jeffrey</code> server should be listed with its tools. If it is listed but <strong>Disabled</strong>, the directory is untrusted &mdash; Gemini disables every MCP server in an untrusted folder, user-level ones included, and says so above the list; trust the folder and start again. If it is not listed at all, in order of likelihood: the session predates the install and needs restarting, this installation set <code>jeffrey.microscope.mcp.enabled=false</code>, Jeffrey is not on <code>localhost:8585</code>, or Jeffrey is not running.</p>
 
       <p><code>curl</code> against the endpoint settles which side is at fault; <router-link to="/docs/microscope-mcp/other-clients">Other Clients</router-link> has the exact request.</p>
 
@@ -221,7 +233,10 @@ const update = `gemini extensions update microscope`;
       <p>Uninstalling takes the skills and the session-start check with it. It does not change anything inside Jeffrey &mdash; the MCP server keeps serving &mdash; and it touches neither a server you registered yourself in <code>settings.json</code> nor an agent you copied into <code>~/.gemini/agents/</code>.</p>
 
       <h2 id="without-the-extension">Without the Extension</h2>
-      <p>The endpoint is an ordinary MCP server, so the <code>mcpServers</code> block from <a href="#pointing-it-elsewhere">above</a> in <code>~/.gemini/settings.json</code> is the whole of it. Use the address you actually reach Jeffrey on &mdash; behind a container, a proxy or a non-default port, <code>localhost:8585</code> is not it.</p>
+      <p>The endpoint is an ordinary MCP server, and one command registers it with no extension involved:</p>
+      <DocsCodeBlock :code="manualAdd" language="bash" />
+
+      <p><code>--scope user</code> writes <code>~/.gemini/settings.json</code> and serves every project; the default, <code>project</code>, writes the checkout's <code>.gemini/settings.json</code> instead. Or write the <code>mcpServers</code> block from <a href="#pointing-it-elsewhere">above</a> by hand. Either way, use the address you actually reach Jeffrey on &mdash; behind a container, a proxy or a non-default port, <code>localhost:8585</code> is not it.</p>
 
       <p>What you give up is the skills and the session-start check: the entry sequence, the two database schemas, and being told when Jeffrey is not answering. The tools still work; the model just starts colder, and is more likely to guess a column name than to call <code>jfr_describeTable</code> first. The server also offers the skills as MCP <strong>prompts</strong>, so they are not lost &mdash; somebody has to ask for one rather than the client loading it. The agents were never part of the extension anyway.</p>
 

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpGeminiPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpGeminiPage.vue
@@ -293,3 +293,7 @@ const update = `gemini extensions update microscope`;
     <DocsNavFooter />
   </article>
 </template>
+
+<style scoped>
+@import '@/views/docs/docs-page.css';
+</style>

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpOtherClientsPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpOtherClientsPage.vue
@@ -156,7 +156,7 @@ const protocolError = `{
       <p>None of them can carry the three agents, for the reason that page gives: Agent Plugins defines skills and MCP servers, and nothing else. And in all of them the endpoint is fixed at <code>localhost:8585</code>, because the format forbids placeholder expansion in a server URL &mdash; a Jeffrey anywhere else is registered by hand, as below.</p>
 
       <DocsCallout type="info" title="Gemini CLI is not one of them">
-        It reads its own extension format rather than this manifest, and takes more from the package than these clients can &mdash; the skills, the session-start check, and an endpoint you can point elsewhere. It has a <router-link to="/docs/microscope-mcp/gemini">page of its own</router-link>. Its <code>mcpServers</code> entry also differs in one key that matters: <code>httpUrl</code> for Streamable HTTP, where <code>url</code> would mean SSE.
+        It reads its own extension format rather than this manifest, and takes more from the package than these clients can &mdash; the skills, the session-start check, and an endpoint you can point elsewhere. It has a <router-link to="/docs/microscope-mcp/gemini">page of its own</router-link>. Its <code>mcpServers</code> entry also spells the endpoint its own way: <code>httpUrl</code>, or <code>url</code> with <code>&quot;type&quot;: &quot;http&quot;</code> &mdash; which is what its own <code>gemini mcp add --transport http</code> writes.
       </DocsCallout>
 
       <h3 id="cursor">Cursor</h3>


### PR DESCRIPTION
Follow-up to #282, which shipped Gemini support written from its documentation. This checks that work against **gemini-cli 0.59.0 itself** — installed here, the extension loaded, its bundle read — and four claims turned out to be wrong. The rest is the docs cleanup that came out of looking at those pages closely.

## What the CLI proved wrong

**`url` is not a mistake.** The page said `httpUrl` was the only correct key and that `url` "means an SSE endpoint… the one configuration mistake that produces a server which looks registered and never connects", and told anyone troubleshooting to change it. All three spellings resolve to the same HTTP server:

```
○ literal:   http://localhost:8585/api/mcp (http)   ← httpUrl with ${VAR:-default}
○ urlnotype: http://localhost:8585/api/mcp (http)   ← bare url, tries HTTP first
○ urlhttp:   http://localhost:8585/api/mcp (http)   ← url + "type": "http"
```

`gemini mcp add --transport http` writes the very shape the page called wrong, so a reader following it would have broken a working config. Only `"type": "sse"` is actually wrong here.

**The agent errors are not debug-level.** The three Claude agents in `agents/` fail Gemini's strict frontmatter schema, and it prints `Unrecognized key(s)` plus a line per tool pattern on ordinary commands, not only under `-d`. Both the page and the README claimed otherwise; they now say so plainly, as the cost of one directory that has to satisfy Claude Code.

**`gemini mcp add` was missing**, though the Claude Code and Codex pages both document their client's equivalent. Added, with `gemini extensions config` for changing the endpoint after install.

**An untrusted folder disables every MCP server**, user-level ones included — the likeliest reason the server is listed but `Disabled`, and the first thing that happened here. It replaces the `url`/`httpUrl` line in the troubleshooting list.

## The page was rendering unstyled

`McpGeminiPage.vue` was the only one of the ten MCP pages missing `<style scoped>@import '@/views/docs/docs-page.css';</style>`. That CSS is not global — each page imports it — so the whole page had no cell borders or padding, which is why the comparison table's columns collided.

## The comparison tables

Both client comparisons now share one layout (`docs-compare` in `docs-page.css`): an accent under each column heading, a faint tint down the subject column, values in quiet monospace chips, and below 720px it stacks into labelled pairs rather than scrolling sideways. It stays a real `<table>` with the row label as `<th scope="row">`, so a screen reader still pairs "Tool prefix" with the column it was read under.

The columns are named for their roles — `is-baseline` is Claude Code, `is-primary` is the page's own client — rather than their vendors, so the scheme serves the Codex page, the Gemini page and whatever comes next.

Tables that are **not** comparisons keep the ordinary docs table: the wire-protocol methods on Other Clients, and the tool families on the overview.

## Shorter client pages

Each of the three carried the ten skills with a blurb each and a paragraph per agent — content the Skills and Agents pages already own in full, and the reason two of the three lists had drifted (both were missing `report`; Claude Code also said "Nine skills"). What stays is what changes per client: the invocation form (`/microscope:`, `$`, or by name), whether the client can carry an agent and how it gets one, and the restriction it can actually enforce. The names are still listed, so the pages still say what you get without a second click. **53 lines out, 10 in.**

## Verified

- `gemini extensions validate` passes on the plugin directory; installed, it loads the server, all ten skills and the endpoint setting.
- `${JEFFREY_MCP_ENDPOINT:-…}` resolves through the CLI's own resolver, with and without the setting.
- The comparison tables rendered in Chromium from the real CSS and markup at 980px and 390px.
- `npm run build` (`vue-tsc` + `vite build`) clean; the IntelliJ plugin suite untouched by this PR and still green from #282.

No backend or plugin behaviour changes here — the only non-docs edit is the `README.md` correction to match the two findings above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GgjC681vRiSePyQ31Nzdh

---
_Generated by [Claude Code](https://claude.ai/code/session_016GgjC681vRiSePyQ31Nzdh)_