### PR TITLE
Fix Microscope MCP request validation and result contracts

### DIFF
--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/configuration/McpConfiguration.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/configuration/McpConfiguration.java
@@ -78,11 +78,12 @@ public class McpConfiguration {
     }
 
     /**
-     * The origin check the external endpoint applies before it serves anything.
+     * The trusted-host and origin checks the external endpoint applies before it serves anything.
      */
     @Bean
-    public McpRequestGuard mcpRequestGuard() {
-        return new McpRequestGuard();
+    public McpRequestGuard mcpRequestGuard(
+            @Value("${jeffrey.microscope.mcp.allowed-hosts:localhost,127.0.0.1,::1}") Set<String> allowedHosts) {
+        return new McpRequestGuard(allowedHosts);
     }
 
     /**

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/ExternalMcpController.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/ExternalMcpController.java
@@ -24,6 +24,8 @@ import cafe.jeffrey.shared.common.Json;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -116,6 +118,20 @@ public class ExternalMcpController extends AbstractMcpStreamableHttpController {
     public ResponseEntity<JsonNode> handle(
             @RequestBody JsonNode request,
             HttpServletRequest httpRequest) {
+        ResponseEntity<JsonNode> refusal = refuseRequest(httpRequest);
+        if (refusal != null) {
+            return refusal;
+        }
+        return dispatch(request, httpRequest.getHeader(PROTOCOL_VERSION_HEADER), features);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<JsonNode> malformedJson(HttpServletRequest httpRequest) {
+        ResponseEntity<JsonNode> refusal = refuseRequest(httpRequest);
+        return refusal == null ? parseErrorResponse() : refusal;
+    }
+
+    private ResponseEntity<JsonNode> refuseRequest(HttpServletRequest httpRequest) {
         if (!properties.enabled()) {
             return ResponseEntity.notFound().build();
         }
@@ -127,6 +143,6 @@ public class ExternalMcpController extends AbstractMcpStreamableHttpController {
             return ResponseEntity.status(HttpStatus.FORBIDDEN)
                     .body(Json.createObject().put(REFUSAL_FIELD, refusal));
         }
-        return dispatch(request, httpRequest.getHeader(PROTOCOL_VERSION_HEADER), features);
+        return null;
     }
 }

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/McpRequestGuard.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/McpRequestGuard.java
@@ -22,19 +22,24 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URI;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Decides whether one request to the external MCP endpoint may be served.
  * <p>
- * One check, and it is the one the MCP specification asks of every local HTTP server: a page in the
- * user's browser can post to {@code localhost} from any origin, so a server that ignores
- * {@code Origin} can be driven by a website the user merely visited — DNS rebinding, in the usual
- * telling. A coding agent sends no {@code Origin} header at all, so refusing a foreign one costs
- * every coding agent nothing and closes the browser path entirely.
+ * The trusted-host check prevents the caller from choosing both sides of the origin comparison with
+ * a forged {@code Host} header. The origin check is the one the MCP specification asks of every local
+ * HTTP server: a page in the user's browser can post to {@code localhost} from any origin, so a server
+ * that ignores {@code Origin} can be driven by a website the user merely visited — DNS rebinding, in
+ * the usual telling. A coding agent sends no {@code Origin} header at all, so refusing a foreign one
+ * costs every coding agent nothing and closes the browser path entirely.
  * <p>
  * It is not authentication and does not stand in for any. The endpoint has none, in common with
  * everything else under {@code /api/internal}: what decides who may reach it is the address Jeffrey
- * binds to and whatever sits in front of it, not this class.
+ * binds to, this class's hostname allowlist, and whatever sits in front of it.
  * <p>
  * This is a guard the endpoint consults rather than a servlet filter: the rule is the MCP endpoint's
  * own, and a filter would have to re-derive which requests it applies to.
@@ -44,15 +49,42 @@ public final class McpRequestGuard {
     private static final Logger LOG = LoggerFactory.getLogger(McpRequestGuard.class);
 
     private static final String ORIGIN_HEADER = "Origin";
+    private static final Set<String> DEFAULT_ALLOWED_HOSTS = Set.of("localhost", "127.0.0.1", "::1");
+    private static final Set<String> HTTP_SCHEMES = Set.of("http", "https");
+    private static final String UNTRUSTED_HOST_REASON =
+            "Requests to an untrusted host are not accepted by the MCP endpoint.";
+    private static final String CROSS_ORIGIN_REASON =
+            "Cross-origin requests are not accepted by the MCP endpoint.";
+
+    private final Set<String> allowedHosts;
+
+    public McpRequestGuard() {
+        this(DEFAULT_ALLOWED_HOSTS);
+    }
+
+    public McpRequestGuard(Set<String> allowedHosts) {
+        Objects.requireNonNull(allowedHosts, "allowedHosts");
+        this.allowedHosts = allowedHosts.stream()
+                .filter(Objects::nonNull)
+                .map(McpRequestGuard::normalizeHost)
+                .filter(host -> !host.isEmpty())
+                .collect(Collectors.toUnmodifiableSet());
+    }
 
     /**
      * @return why the request must be refused, or {@code null} when it may be served
      */
     public String refusalReason(HttpServletRequest request) {
+        String requestHost = normalizeHost(request.getServerName());
+        if (!allowedHosts.contains(requestHost)) {
+            LOG.warn("Refused an MCP request to an untrusted host: host={}", request.getServerName());
+            return UNTRUSTED_HOST_REASON;
+        }
+
         String origin = request.getHeader(ORIGIN_HEADER);
-        if (origin != null && !origin.isBlank() && !isSameHost(origin, request)) {
+        if (origin != null && !isSameOrigin(origin, request)) {
             LOG.warn("Refused an MCP request from a foreign origin: origin={}", origin);
-            return "Cross-origin requests are not accepted by the MCP endpoint.";
+            return CROSS_ORIGIN_REASON;
         }
         return null;
     }
@@ -61,22 +93,49 @@ public final class McpRequestGuard {
      * Whether the browser that sent this request already had the page Jeffrey serves. Anything Jeffrey
      * itself serves is same-origin; anything else is a site the user happened to be on.
      */
-    private static boolean isSameHost(String origin, HttpServletRequest request) {
+    private static boolean isSameOrigin(String origin, HttpServletRequest request) {
         try {
             URI originUri = URI.create(origin);
+            String scheme = normalizeScheme(originUri.getScheme());
             String host = originUri.getHost();
-            if (host == null) {
+            if (!HTTP_SCHEMES.contains(scheme)
+                    || host == null
+                    || originUri.getRawUserInfo() != null
+                    || hasText(originUri.getRawPath())
+                    || originUri.getRawQuery() != null
+                    || originUri.getRawFragment() != null) {
                 return false;
             }
-            int originPort = originUri.getPort() == -1 ? defaultPort(originUri.getScheme()) : originUri.getPort();
-            return host.equalsIgnoreCase(request.getServerName()) && originPort == request.getServerPort();
+            int originPort = originUri.getPort() == -1 ? defaultPort(scheme) : originUri.getPort();
+            return scheme.equals(normalizeScheme(request.getScheme()))
+                    && normalizeHost(host).equals(normalizeHost(request.getServerName()))
+                    && originPort == request.getServerPort();
         } catch (IllegalArgumentException e) {
             // An origin that is not a URI is not one Jeffrey served.
             return false;
         }
     }
 
+    private static String normalizeScheme(String scheme) {
+        return scheme == null ? "" : scheme.toLowerCase(Locale.ROOT);
+    }
+
+    private static String normalizeHost(String host) {
+        if (host == null) {
+            return "";
+        }
+        String normalized = host.trim().toLowerCase(Locale.ROOT);
+        if (normalized.startsWith("[") && normalized.endsWith("]")) {
+            return normalized.substring(1, normalized.length() - 1);
+        }
+        return normalized;
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isEmpty();
+    }
+
     private static int defaultPort(String scheme) {
-        return "https".equalsIgnoreCase(scheme) ? 443 : 80;
+        return "https".equals(scheme) ? 443 : 80;
     }
 }

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/McpResources.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/McpResources.java
@@ -91,8 +91,9 @@ public class McpResources implements McpResourceProvider {
         return List.of(new McpResource(
                 PROFILES_URI,
                 "Analysed profiles",
-                "Every profile in this Jeffrey installation, with what each one is and when it was "
-                        + "recorded. The starting point: every other resource takes a profile id from here.",
+                "The first 100 matching profiles in this Jeffrey installation by default, with what "
+                        + "each one is and when it was recorded. The catalogue reports when more match. "
+                        + "The starting point: every other resource takes a profile id from here.",
                 McpResource.TEXT_MARKDOWN));
     }
 

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/DuckDbMcpTools.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/DuckDbMcpTools.java
@@ -18,6 +18,7 @@
 
 package cafe.jeffrey.microscope.core.mcp.tools;
 
+import cafe.jeffrey.profile.mcp.ToolExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.tool.annotation.Tool;
@@ -75,7 +76,7 @@ public class DuckDbMcpTools {
             }
         } catch (SQLException e) {
             LOG.error("Failed to list tables: message={}", e.getMessage(), e);
-            return "Error: Failed to list tables: " + e.getMessage();
+            throw new ToolExecutionException("Failed to list tables: " + e.getMessage(), e);
         }
     }
 
@@ -85,7 +86,7 @@ public class DuckDbMcpTools {
             @ToolParam(required = true, description = "Name of the table to describe (e.g., 'events', 'threads', 'frames')")
             String tableName) {
         if (tableName == null || tableName.isBlank()) {
-            return "Error: Table name is required";
+            throw new ToolExecutionException("Table name is required");
         }
 
         try (Connection conn = dataSource.getConnection()) {
@@ -105,7 +106,7 @@ public class DuckDbMcpTools {
                 }
 
                 if (!hasColumns) {
-                    return "Error: Table '" + tableName + "' not found";
+                    throw new ToolExecutionException("Table '" + tableName + "' not found");
                 }
 
                 // Add helpful notes for specific tables
@@ -119,7 +120,7 @@ public class DuckDbMcpTools {
             }
         } catch (SQLException e) {
             LOG.error("Failed to describe table: table={} message={}", tableName, e.getMessage(), e);
-            return "Error: Failed to describe table: " + e.getMessage();
+            throw new ToolExecutionException("Failed to describe table: " + e.getMessage(), e);
         }
     }
 
@@ -132,7 +133,7 @@ public class DuckDbMcpTools {
             @ToolParam(required = true, description = "SQL SELECT query to execute. Must be a read-only query.")
             String query) {
         if (query == null || query.isBlank()) {
-            return "Error: Query is required";
+            throw new ToolExecutionException("Query is required");
         }
 
         // Defence in depth, and deliberately not the boundary. What confines this query is the
@@ -143,7 +144,7 @@ public class DuckDbMcpTools {
         // a clear message instead of an engine error.
         String normalizedQuery = query.trim().toLowerCase();
         if (!normalizedQuery.startsWith("select") && !normalizedQuery.startsWith("with")) {
-            return "Error: Only SELECT and WITH queries are allowed";
+            throw new ToolExecutionException("Only SELECT and WITH queries are allowed");
         }
 
         // prepareStatement, not createStatement, for three reasons. DuckDB refuses a prepared
@@ -156,7 +157,7 @@ public class DuckDbMcpTools {
         // engine's real message: the missing column, or the permission error from the sandbox above.
         // That message is the only thing the caller can act on.
         if (carriesMultipleStatements(query)) {
-            return "Error: " + MULTIPLE_STATEMENTS_MESSAGE;
+            throw new ToolExecutionException(MULTIPLE_STATEMENTS_MESSAGE);
         }
 
         // prepareStatement, not createStatement, for the error messages: Statement.executeQuery
@@ -177,7 +178,7 @@ public class DuckDbMcpTools {
             }
         } catch (SQLException e) {
             LOG.error("Failed to execute query: query={} message={}", query, e.getMessage(), e);
-            return "Error: Query execution failed: " + e.getMessage();
+            throw new ToolExecutionException("Query execution failed: " + e.getMessage(), e);
         }
     }
 
@@ -231,7 +232,7 @@ public class DuckDbMcpTools {
             return result.toString();
         } catch (SQLException e) {
             LOG.error("Failed to list event types: message={}", e.getMessage(), e);
-            return "Error: Failed to list event types: " + e.getMessage();
+            throw new ToolExecutionException("Failed to list event types: " + e.getMessage(), e);
         }
     }
 
@@ -248,7 +249,7 @@ public class DuckDbMcpTools {
             String whereClause) {
 
         if (eventType == null || eventType.isBlank()) {
-            return "Error: Event type is required";
+            throw new ToolExecutionException("Event type is required");
         }
 
         int effectiveLimit = limit != null ? limit : 100;
@@ -270,7 +271,7 @@ public class DuckDbMcpTools {
                 """);
 
         if (whereClause != null && !whereClause.isBlank() && carriesMultipleStatements(whereClause)) {
-            return "Error: " + MULTIPLE_STATEMENTS_MESSAGE;
+            throw new ToolExecutionException(MULTIPLE_STATEMENTS_MESSAGE);
         }
 
         if (whereClause != null && !whereClause.isBlank()) {
@@ -298,7 +299,7 @@ public class DuckDbMcpTools {
             }
         } catch (SQLException e) {
             LOG.error("Failed to query events: eventType={} message={}", eventType, e.getMessage(), e);
-            return "Error: Failed to query events: " + e.getMessage();
+            throw new ToolExecutionException("Failed to query events: " + e.getMessage(), e);
         }
     }
 
@@ -330,11 +331,11 @@ public class DuckDbMcpTools {
                         projectId != null ? "regular" : "Recordings"
                 );
             } else {
-                return "Error: No profile information found";
+                throw new ToolExecutionException("No profile information found");
             }
         } catch (SQLException e) {
             LOG.error("Failed to get profile info: message={}", e.getMessage(), e);
-            return "Error: Failed to get profile info: " + e.getMessage();
+            throw new ToolExecutionException("Failed to get profile info: " + e.getMessage(), e);
         }
     }
 

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/HeapDumpMcpTools.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/HeapDumpMcpTools.java
@@ -18,6 +18,7 @@
 
 package cafe.jeffrey.microscope.core.mcp.tools;
 
+import cafe.jeffrey.profile.mcp.ToolExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.tool.annotation.Tool;
@@ -89,7 +90,7 @@ public class HeapDumpMcpTools {
             );
         } catch (Exception e) {
             LOG.error("Failed to get heap summary: message={}", e.getMessage(), e);
-            return "Error: Failed to get heap summary: " + e.getMessage();
+            throw new ToolExecutionException("Failed to get heap summary: " + e.getMessage(), e);
         }
     }
 
@@ -128,7 +129,7 @@ public class HeapDumpMcpTools {
             return withNextSteps(result.toString(), STEP_INSTANCES, STEP_GC_ROOT_PATH);
         } catch (Exception e) {
             LOG.error("Failed to get class histogram: message={}", e.getMessage(), e);
-            return "Error: Failed to get class histogram: " + e.getMessage();
+            throw new ToolExecutionException("Failed to get class histogram: " + e.getMessage(), e);
         }
     }
 
@@ -168,7 +169,7 @@ public class HeapDumpMcpTools {
             return withNextSteps(result.toString(), STEP_GC_ROOT_PATH, STEP_DOMINATOR_FIRST);
         } catch (Exception e) {
             LOG.error("Failed to get biggest objects: message={}", e.getMessage(), e);
-            return "Error: Failed to get biggest objects: " + e.getMessage();
+            throw new ToolExecutionException("Failed to get biggest objects: " + e.getMessage(), e);
         }
     }
 
@@ -238,7 +239,7 @@ public class HeapDumpMcpTools {
             return withNextSteps(result.toString(), STEP_GC_ROOT_PATH, STEP_DOMINATOR_FIRST);
         } catch (Exception e) {
             LOG.error("Failed to get leak suspects: message={}", e.getMessage(), e);
-            return "Error: Failed to get leak suspects: " + e.getMessage();
+            throw new ToolExecutionException("Failed to get leak suspects: " + e.getMessage(), e);
         }
     }
 
@@ -286,7 +287,7 @@ public class HeapDumpMcpTools {
             return result.toString();
         } catch (Exception e) {
             LOG.error("Failed to get class-loader leak chains: message={}", e.getMessage(), e);
-            return "Error: Failed to get class-loader leak chains: " + e.getMessage();
+            throw new ToolExecutionException("Failed to get class-loader leak chains: " + e.getMessage(), e);
         }
     }
 
@@ -325,7 +326,7 @@ public class HeapDumpMcpTools {
             return result.toString();
         } catch (Exception e) {
             LOG.error("Failed to get top consumers: message={}", e.getMessage(), e);
-            return "Error: Failed to get top consumers: " + e.getMessage();
+            throw new ToolExecutionException("Failed to get top consumers: " + e.getMessage(), e);
         }
     }
 
@@ -369,7 +370,7 @@ public class HeapDumpMcpTools {
             return result.toString();
         } catch (Exception e) {
             LOG.error("Failed to get string analysis: message={}", e.getMessage(), e);
-            return "Error: Failed to get string analysis: " + e.getMessage();
+            throw new ToolExecutionException("Failed to get string analysis: " + e.getMessage(), e);
         }
     }
 
@@ -402,7 +403,7 @@ public class HeapDumpMcpTools {
             return result.toString();
         } catch (Exception e) {
             LOG.error("Failed to get collection analysis: message={}", e.getMessage(), e);
-            return "Error: Failed to get collection analysis: " + e.getMessage();
+            throw new ToolExecutionException("Failed to get collection analysis: " + e.getMessage(), e);
         }
     }
 
@@ -430,7 +431,7 @@ public class HeapDumpMcpTools {
             return result.toString();
         } catch (Exception e) {
             LOG.error("Failed to get threads: message={}", e.getMessage(), e);
-            return "Error: Failed to get threads: " + e.getMessage();
+            throw new ToolExecutionException("Failed to get threads: " + e.getMessage(), e);
         }
     }
 
@@ -452,7 +453,7 @@ public class HeapDumpMcpTools {
             return result.toString();
         } catch (Exception e) {
             LOG.error("Failed to get GC root summary: message={}", e.getMessage(), e);
-            return "Error: Failed to get GC root summary: " + e.getMessage();
+            throw new ToolExecutionException("Failed to get GC root summary: " + e.getMessage(), e);
         }
     }
 
@@ -467,7 +468,7 @@ public class HeapDumpMcpTools {
             Integer offset) {
         try {
             if (className == null || className.isBlank()) {
-                return "Error: Class name is required";
+                throw new ToolExecutionException("Class name is required");
             }
 
             int effectiveLimit = limit != null ? Math.min(Math.max(1, limit), 50) : 20;
@@ -498,7 +499,7 @@ public class HeapDumpMcpTools {
             return result.toString();
         } catch (Exception e) {
             LOG.error("Failed to browse class instances: className={} message={}", className, e.getMessage(), e);
-            return "Error: Failed to browse class instances: " + e.getMessage();
+            throw toolFailure("Failed to browse class instances: ", e);
         }
     }
 
@@ -510,7 +511,7 @@ public class HeapDumpMcpTools {
         try {
             InstanceDetail detail = delegate.getInstanceDetail(requireObjectId(objectId), false);
             if (detail == null) {
-                return "Error: Instance not found for object ID: " + objectId;
+                throw new ToolExecutionException("Instance not found for object ID: " + objectId);
             }
 
             StringBuilder result = new StringBuilder();
@@ -538,7 +539,7 @@ public class HeapDumpMcpTools {
             return result.toString();
         } catch (Exception e) {
             LOG.error("Failed to get instance detail: objectId={} message={}", objectId, e.getMessage(), e);
-            return "Error: Failed to get instance detail: " + e.getMessage();
+            throw toolFailure("Failed to get instance detail: ", e);
         }
     }
 
@@ -572,7 +573,7 @@ public class HeapDumpMcpTools {
             return result.toString();
         } catch (Exception e) {
             LOG.error("Failed to get dominator tree roots: message={}", e.getMessage(), e);
-            return "Error: Failed to get dominator tree roots: " + e.getMessage();
+            throw new ToolExecutionException("Failed to get dominator tree roots: " + e.getMessage(), e);
         }
     }
 
@@ -608,7 +609,7 @@ public class HeapDumpMcpTools {
             return result.toString();
         } catch (Exception e) {
             LOG.error("Failed to get dominator tree children: objectId={} message={}", objectId, e.getMessage(), e);
-            return "Error: Failed to get dominator tree children: " + e.getMessage();
+            throw new ToolExecutionException("Failed to get dominator tree children: " + e.getMessage(), e);
         }
     }
 
@@ -658,7 +659,7 @@ public class HeapDumpMcpTools {
             return result.toString();
         } catch (Exception e) {
             LOG.error("Failed to get path to GC root: objectId={} message={}", objectId, e.getMessage(), e);
-            return "Error: Failed to get path to GC root: " + e.getMessage();
+            throw new ToolExecutionException("Failed to get path to GC root: " + e.getMessage(), e);
         }
     }
 
@@ -698,7 +699,7 @@ public class HeapDumpMcpTools {
             return result.toString();
         } catch (Exception e) {
             LOG.error("Failed to get referrers: objectId={} message={}", objectId, e.getMessage(), e);
-            return "Error: Failed to get referrers: " + e.getMessage();
+            throw new ToolExecutionException("Failed to get referrers: " + e.getMessage(), e);
         }
     }
 
@@ -727,7 +728,7 @@ public class HeapDumpMcpTools {
             @ToolParam(required = true, description = "Name of the table to describe (e.g. 'instance', 'class', 'outbound_ref')")
             String tableName) {
         if (tableName == null || tableName.isBlank()) {
-            return "Error: A table name is required. Call heap_listTables to see them.";
+            throw new ToolExecutionException("A table name is required. Call heap_listTables to see them.");
         }
         // The name is compared as a string against information_schema rather than interpolated into a
         // FROM clause, so it can only ever match a table or match nothing.
@@ -741,10 +742,11 @@ public class HeapDumpMcpTools {
                             + "ORDER BY ordinal_position",
                     DESCRIBE_TABLE_ROW_CAP);
         } catch (RuntimeException e) {
-            return "Error: " + e.getMessage();
+            throw toolFailure("", e);
         }
         if (result.rows().isEmpty()) {
-            return "Error: Table '" + tableName + "' not found. Call heap_listTables to see them.";
+            throw new ToolExecutionException(
+                    "Table '" + tableName + "' not found. Call heap_listTables to see them.");
         }
         return render(result, "Schema for table '" + tableName + "'", null);
     }
@@ -761,7 +763,7 @@ public class HeapDumpMcpTools {
                     + "Add an explicit LIMIT to control how much you fetch; an implicit 100-row cap is applied otherwise.")
             String query) {
         if (query == null || query.isBlank()) {
-            return "Error: Query is required";
+            throw new ToolExecutionException("Query is required");
         }
         return sqlAnswer(query, EXECUTE_QUERY_ROW_CAP, "Query result", null);
     }
@@ -838,8 +840,15 @@ public class HeapDumpMcpTools {
         try {
             return render(delegate.executeSql(sql, rowCap), title, footer);
         } catch (RuntimeException e) {
-            return "Error: " + e.getMessage();
+            throw toolFailure("", e);
         }
+    }
+
+    private static ToolExecutionException toolFailure(String prefix, Exception cause) {
+        if (cause instanceof ToolExecutionException toolError) {
+            return toolError;
+        }
+        return new ToolExecutionException(prefix + cause.getMessage(), cause);
     }
 
     /**

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/ProfilesMcpTools.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/ProfilesMcpTools.java
@@ -19,6 +19,7 @@
 package cafe.jeffrey.microscope.core.mcp.tools;
 
 import cafe.jeffrey.microscope.persistence.api.MicroscopeCoreRepositories;
+import cafe.jeffrey.profile.mcp.McpToolOutput;
 import cafe.jeffrey.shared.common.model.ProfileInfo;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
@@ -49,27 +50,67 @@ public class ProfilesMcpTools {
         this.coreRepositories = coreRepositories;
     }
 
-    @Tool(description = "List every profile analysed in this Jeffrey installation. Start here: every "
-            + "other tool takes one of the profile ids this returns. A profile is one analysed "
-            + "recording (JFR) or heap dump. A row whose `ready` column reads 'building' is still "
-            + "being parsed and cannot be analysed yet - recordings_status reports how far it has "
-            + "got.")
+    @Tool(description = "List analysed profiles in this Jeffrey installation, returning the first 100 "
+            + "matches by default and at most 1000. Start here: every other tool takes one of the "
+            + "profile ids this returns. A profile is one analysed recording (JFR) or heap dump. A "
+            + "row whose `ready` column reads 'building' is still being parsed and cannot be analysed "
+            + "yet - recordings_status reports how far it has got.")
     public String list(
             @ToolParam(required = false, description = "Optional case-insensitive substring matched against the profile name")
             String search,
             @ToolParam(required = false, description = "Maximum number of profiles to return (default 100)")
             Integer limit) {
 
-        List<ProfileInfo> profiles = coreRepositories.findAllProfiles().stream()
+        List<ProfileInfo> matchingProfiles = coreRepositories.findAllProfiles().stream()
                 .filter(profile -> matches(profile, search))
-                .limit(ToolArguments.boundedLimit(limit, DEFAULT_LIST_LIMIT, MAX_LIST_LIMIT))
+                .toList();
+        int effectiveLimit = ToolArguments.boundedLimit(limit, DEFAULT_LIST_LIMIT, MAX_LIST_LIMIT);
+        List<ProfileInfo> selectedProfiles = matchingProfiles.stream()
+                .limit(effectiveLimit)
                 .toList();
 
-        if (profiles.isEmpty()) {
-            return search == null || search.isBlank()
+        if (selectedProfiles.isEmpty()) {
+            String empty = search == null || search.isBlank()
                     ? NO_PROFILES
                     : "No profile matches: " + search;
+            return empty + "\n\n" + returnedCount(0, 0);
         }
+
+        String selectedOutput = renderCatalogue(
+                selectedProfiles, selectedProfiles.size(), matchingProfiles.size(), effectiveLimit);
+        if (selectedOutput.length() <= McpToolOutput.MAX_CHARS) {
+            return selectedOutput;
+        }
+
+        // A limit controls rows, while the shared output cap controls characters. Long names can make
+        // the latter the tighter bound, so find the largest complete prefix that fits rather than let
+        // the cap cut a row and still claim that every selected row was returned.
+        int low = 0;
+        int high = selectedProfiles.size() - 1;
+        String fittingOutput = renderCatalogue(
+                List.of(), selectedProfiles.size(), matchingProfiles.size(), effectiveLimit);
+        while (low <= high) {
+            int candidateSize = low + (high - low) / 2;
+            String candidate = renderCatalogue(
+                    selectedProfiles.subList(0, candidateSize),
+                    selectedProfiles.size(),
+                    matchingProfiles.size(),
+                    effectiveLimit);
+            if (candidate.length() <= McpToolOutput.MAX_CHARS) {
+                fittingOutput = candidate;
+                low = candidateSize + 1;
+            } else {
+                high = candidateSize - 1;
+            }
+        }
+        return fittingOutput;
+    }
+
+    private static String renderCatalogue(
+            List<ProfileInfo> profiles,
+            int selectedCount,
+            int matchingCount,
+            int effectiveLimit) {
 
         MarkdownTable table = MarkdownTable.withColumns(
                 "profile_id", "name", "project", "event source", "recorded", "duration", "ready",
@@ -85,13 +126,35 @@ public class ProfilesMcpTools {
                     readiness(profile),
                     profile.modified() ? "yes" : "no");
         }
-        return table
+        String preamble = returnedCount(profiles.size(), matchingCount);
+        if (profiles.size() < selectedCount) {
+            preamble += "\n\nThe output size limit omitted " + (selectedCount - profiles.size())
+                    + " selected profiles; narrow `search` to retrieve the profiles you need.";
+        }
+        if (selectedCount < matchingCount) {
+            preamble += "\n\n" + limitRecovery(effectiveLimit);
+        }
+        String renderedTable = table
                 .note("A `modified` profile has had frames renamed or collapsed, so its frame names may "
                         + "differ from the source code.")
                 .note("A profile listed as `building` has a row but not yet its events: its recording is "
                         + "still being parsed. Its id is real, and every analysis tool will answer "
                         + "emptily until it is `yes` - recordings_status says when.")
                 .render();
+        return McpToolOutput.capped(preamble + "\n\n" + renderedTable);
+    }
+
+    private static String returnedCount(int returned, int matching) {
+        return "Returned " + returned + " of " + matching + " matching profiles.";
+    }
+
+    private static String limitRecovery(int effectiveLimit) {
+        if (effectiveLimit < MAX_LIST_LIMIT) {
+            return "Increase `limit` (maximum " + MAX_LIST_LIMIT + ") or narrow `search` to retrieve "
+                    + "the profiles you need.";
+        }
+        return "The maximum `limit` is " + MAX_LIST_LIMIT + "; narrow `search` to retrieve the "
+                + "profiles you need.";
     }
 
     /**

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/TracesMcpTools.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/TracesMcpTools.java
@@ -316,7 +316,7 @@ public class TracesMcpTools {
         List<SpanInterval> intervals = traceManager().spanIntervals(
                 parseId(traceId, "traceId"), parseId(spanId, "spanId"), Boolean.TRUE.equals(selfOnly));
         if (intervals.isEmpty()) {
-            return McpToolOutput.error("Span has no samples to show: " + spanId);
+            return "Span has no samples to show: " + spanId;
         }
         return exportScoped(SpanScope.of(intervals), eventType, threadMode, useWeight, traceUrl(traceId));
     }

--- a/jeffrey-microscope/core-microscope/src/main/resources/application.properties
+++ b/jeffrey-microscope/core-microscope/src/main/resources/application.properties
@@ -63,6 +63,14 @@ jeffrey.microscope.temp.dir=${jeffrey.microscope.home.dir}/temp
 # tunnel/proxy. Set to false to make the endpoint answer 404 (takes a restart).
 # jeffrey.microscope.mcp.enabled=true
 
+# Hostnames accepted in the effective request authority for the MCP endpoint, comma-separated. The
+# default admits only IPv4/IPv6 loopback. Set this list to the public hostname when exposing Jeffrey
+# remotely or behind a reverse proxy, retaining any loopback names that clients still use. When a
+# trusted proxy terminates TLS or rewrites Host, configure Spring Boot's server.forward-headers-strategy
+# so the servlet request exposes the public scheme, host and port; the MCP guard deliberately does not
+# interpret X-Forwarded-* headers itself (takes a restart).
+# jeffrey.microscope.mcp.allowed-hosts=localhost,127.0.0.1,::1
+
 # The hubs_ family, which lets that session list the recording sessions on the connected Jeffrey Hubs
 # below and pull one into this Jeffrey to analyse. Its own switch because it is the one family that
 # leaves this machine: everything else reads what is already here, while this reaches out to remote

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/DuckDbMcpToolErrorIntegrationTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/DuckDbMcpToolErrorIntegrationTest.java
@@ -1,0 +1,85 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.microscope.core.mcp;
+
+import cafe.jeffrey.microscope.core.mcp.tools.DuckDbMcpTools;
+import cafe.jeffrey.jfr.events.trace.TraceSpanEvent;
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordingFile;
+import cafe.jeffrey.profile.mcp.ReflectiveToolset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+
+import javax.sql.DataSource;
+import java.sql.SQLException;
+import java.nio.file.Path;
+import java.util.Set;
+
+import static cafe.jeffrey.microscope.core.web.MockMvcSupport.mockMvcTesterFor;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DuckDbMcpToolErrorIntegrationTest {
+
+    @Mock
+    McpToolsetAssembler assembler;
+
+    @Mock
+    DataSource dataSource;
+
+    @Test
+    void databaseFailureCrossesTheReflectiveAdapterAsAnMcpToolError(@TempDir Path directory) throws Exception {
+        when(dataSource.getConnection()).thenThrow(new SQLException("database unavailable"));
+        when(assembler.toolset()).thenReturn(new ReflectiveToolset(new DuckDbMcpTools(dataSource), "jfr"));
+        MockMvcTester mvc = mockMvcTesterFor(new ExternalMcpController(
+                assembler,
+                new ExternalMcpProperties(true, true, true, Set.of()),
+                new McpRequestGuard(),
+                new McpPromptRegistry()));
+
+        String request = """
+                {"jsonrpc":"2.0","id":1,"method":"tools/call",
+                 "params":{"name":"jfr_listTables","arguments":{}}}""";
+
+        Path recordingPath = directory.resolve("tool-failure.jfr");
+        try (Recording recording = new Recording()) {
+            recording.enable(TraceSpanEvent.class);
+            recording.start();
+            assertThat(mvc.post().uri(ExternalMcpController.PATH)
+                    .contentType(MediaType.APPLICATION_JSON).content(request))
+                    .hasStatusOk()
+                    .bodyJson()
+                    .extractingPath("$.result.isError").isEqualTo(true);
+            recording.stop();
+            recording.dump(recordingPath);
+        }
+        var toolSpans = RecordingFile.readAllEvents(recordingPath).stream()
+                .filter(event -> event.getEventType().getName().equals(TraceSpanEvent.NAME))
+                .filter(event -> event.getString("name").equals("jfr_listTables"))
+                .toList();
+        assertThat(toolSpans).hasSize(1);
+        assertThat(toolSpans.getFirst().getString("status")).isEqualTo("ERROR");
+    }
+}

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/ExternalMcpControllerTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/ExternalMcpControllerTest.java
@@ -100,6 +100,26 @@ class ExternalMcpControllerTest {
     }
 
     @Nested
+    class MalformedJson {
+
+        @Test
+        void reportsAJsonRpcParseErrorWithoutInvokingTools() {
+            assertThat(mvcWith(true).post().uri(URI).contentType(APPLICATION_JSON).content("{invalid"))
+                    .hasStatus(400)
+                    .bodyJson()
+                    .extractingPath("$.error.code").asNumber().isEqualTo(-32700);
+            verifyNoInteractions(assembler);
+        }
+
+        @Test
+        void keepsADisabledEndpointHiddenForMalformedJson() {
+            assertThat(mvcWith(false).post().uri(URI).contentType(APPLICATION_JSON).content("{invalid"))
+                    .hasStatus(404);
+            verifyNoInteractions(assembler);
+        }
+    }
+
+    @Nested
     class Enabled {
 
         @Test

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/McpRequestGuardTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/McpRequestGuardTest.java
@@ -19,7 +19,11 @@ package cafe.jeffrey.microscope.core.mcp;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -37,9 +41,14 @@ class McpRequestGuardTest {
     private final McpRequestGuard guard = new McpRequestGuard();
 
     private static MockHttpServletRequest request(String origin) {
+        return request("http", SERVER_NAME, SERVER_PORT, origin);
+    }
+
+    private static MockHttpServletRequest request(String scheme, String serverName, int serverPort, String origin) {
         MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setServerName(SERVER_NAME);
-        request.setServerPort(SERVER_PORT);
+        request.setScheme(scheme);
+        request.setServerName(serverName);
+        request.setServerPort(serverPort);
         if (origin != null) {
             request.addHeader("Origin", origin);
         }
@@ -59,11 +68,6 @@ class McpRequestGuardTest {
         }
 
         @Test
-        void servesARequestWithABlankOrigin() {
-            assertNull(guard.refusalReason(request("  ")));
-        }
-
-        @Test
         void servesAPageJeffreyItselfServed() {
             assertNull(guard.refusalReason(request("http://localhost:8585")));
         }
@@ -71,6 +75,19 @@ class McpRequestGuardTest {
         @Test
         void comparesTheHostCaseInsensitively() {
             assertNull(guard.refusalReason(request("http://LOCALHOST:8585")));
+        }
+
+        @Test
+        void servesTheIpv6LoopbackAddress() {
+            assertNull(guard.refusalReason(request("http", "[::1]", SERVER_PORT, "http://[::1]:8585")));
+        }
+
+        @Test
+        void servesAConfiguredRemoteHost() {
+            McpRequestGuard remoteGuard = new McpRequestGuard(Set.of("jeffrey.example"));
+
+            assertNull(remoteGuard.refusalReason(
+                    request("https", "jeffrey.example", 443, "https://jeffrey.example")));
         }
     }
 
@@ -82,6 +99,27 @@ class McpRequestGuardTest {
             assertNotNull(guard.refusalReason(request("https://evil.example")));
         }
 
+        @Test
+        void refusesARequestWhoseUntrustedHostMatchesItsOrigin() {
+            assertNotNull(guard.refusalReason(
+                    request("http", "audit.invalid", SERVER_PORT, "http://audit.invalid:8585")));
+        }
+
+        @Test
+        void refusesARequestWithNoOriginWhenItsHostIsUntrusted() {
+            assertNotNull(guard.refusalReason(request("http", "audit.invalid", SERVER_PORT, null)));
+        }
+
+        @Test
+        void doesNotTrustForwardedHeadersDirectly() {
+            MockHttpServletRequest request = request(
+                    "http", "audit.invalid", SERVER_PORT, "http://localhost:8585");
+            request.addHeader("X-Forwarded-Host", "localhost:8585");
+            request.addHeader("X-Forwarded-Proto", "http");
+
+            assertNotNull(guard.refusalReason(request));
+        }
+
         /**
          * A different port on the same host is a different origin, and on a developer's machine it is
          * very often a different application.
@@ -89,6 +127,12 @@ class McpRequestGuardTest {
         @Test
         void refusesTheSameHostOnAnotherPort() {
             assertNotNull(guard.refusalReason(request("http://localhost:3000")));
+        }
+
+        @Test
+        void refusesTheSameHostAndPortWithAnotherScheme() {
+            assertNotNull(guard.refusalReason(
+                    request("https", SERVER_NAME, SERVER_PORT, "http://localhost:8585")));
         }
 
         /**
@@ -110,6 +154,18 @@ class McpRequestGuardTest {
             assertNotNull(guard.refusalReason(request("http://[not a uri")));
         }
 
+        @ParameterizedTest
+        @ValueSource(strings = {
+                " ",
+                "http://user@localhost:8585",
+                "http://localhost:8585/path",
+                "http://localhost:8585?query",
+                "http://localhost:8585#fragment"
+        })
+        void refusesAnOriginThatIsNotAPlainOrigin(String origin) {
+            assertNotNull(guard.refusalReason(request(origin)));
+        }
+
         /**
          * A default port is the port, so an origin that omits it still has to match.
          */
@@ -125,11 +181,10 @@ class McpRequestGuardTest {
      */
     @Test
     void servesAnOriginOnTheDefaultPortWhenJeffreyIsThere() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setServerName("jeffrey.example");
-        request.setServerPort(443);
-        request.addHeader("Origin", "https://jeffrey.example");
+        McpRequestGuard remoteGuard = new McpRequestGuard(Set.of("jeffrey.example"));
+        MockHttpServletRequest request = request(
+                "https", "jeffrey.example", 443, "https://jeffrey.example");
 
-        assertNull(guard.refusalReason(request));
+        assertNull(remoteGuard.refusalReason(request));
     }
 }

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/McpResourcesTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/McpResourcesTest.java
@@ -58,6 +58,7 @@ class McpResourcesTest {
 
             assertEquals(1, offered.size());
             assertEquals("jeffrey://profiles", offered.getFirst().uri());
+            assertTrue(offered.getFirst().description().contains("first 100 matching profiles"));
         }
 
         /**

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/DuckDbMcpToolsTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/DuckDbMcpToolsTest.java
@@ -18,6 +18,7 @@
 
 package cafe.jeffrey.microscope.core.mcp.tools;
 
+import cafe.jeffrey.profile.mcp.ToolExecutionException;
 import cafe.jeffrey.test.DuckDBTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -30,6 +31,7 @@ import java.sql.Statement;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -148,19 +150,22 @@ class DuckDbMcpToolsTest {
         void surfacesTheRealBinderError(DataSource dataSource) throws SQLException {
             seedRows(dataSource, 1);
 
-            String out = new DuckDbMcpTools(dataSource).executeQuery("SELECT nope FROM big");
+            ToolExecutionException error = assertThrows(ToolExecutionException.class,
+                    () -> new DuckDbMcpTools(dataSource).executeQuery("SELECT nope FROM big"));
 
-            assertTrue(out.contains("nope"), "the caller has to be told which column: " + out);
-            assertFalse(out.contains("pending query result"), out);
+            assertTrue(error.getMessage().contains("nope"),
+                    "the caller has to be told which column: " + error.getMessage());
+            assertFalse(error.getMessage().contains("pending query result"), error.getMessage());
         }
 
         @Test
         @DisplayName("an unknown table comes back named")
         void surfacesTheRealCatalogError(DataSource dataSource) {
-            String out = new DuckDbMcpTools(dataSource).executeQuery("SELECT * FROM no_such_table");
+            ToolExecutionException error = assertThrows(ToolExecutionException.class,
+                    () -> new DuckDbMcpTools(dataSource).executeQuery("SELECT * FROM no_such_table"));
 
-            assertTrue(out.contains("no_such_table"), out);
-            assertFalse(out.contains("pending query result"), out);
+            assertTrue(error.getMessage().contains("no_such_table"), error.getMessage());
+            assertFalse(error.getMessage().contains("pending query result"), error.getMessage());
         }
     }
 
@@ -179,9 +184,11 @@ class DuckDbMcpToolsTest {
         void refusesStackedStatements(DataSource dataSource) throws SQLException {
             seedRows(dataSource, 1);
 
-            String out = new DuckDbMcpTools(dataSource).executeQuery("SELECT i FROM big; DROP TABLE big");
+            ToolExecutionException error = assertThrows(ToolExecutionException.class,
+                    () -> new DuckDbMcpTools(dataSource)
+                            .executeQuery("SELECT i FROM big; DROP TABLE big"));
 
-            assertTrue(out.startsWith("Error:"), out);
+            assertTrue(error.getMessage().contains("Only one statement"), error.getMessage());
             assertTrue(tableExists(dataSource), "the DROP must not have run");
         }
 
@@ -233,10 +240,11 @@ class DuckDbMcpToolsTest {
         void guardsTheWhereClause(DataSource dataSource) throws SQLException {
             seedRows(dataSource, 1);
 
-            String out = new DuckDbMcpTools(dataSource)
-                    .queryEvents("jdk.ExecutionSample", 10, "1=1); DROP TABLE big; --");
+            ToolExecutionException error = assertThrows(ToolExecutionException.class,
+                    () -> new DuckDbMcpTools(dataSource)
+                            .queryEvents("jdk.ExecutionSample", 10, "1=1); DROP TABLE big; --"));
 
-            assertTrue(out.startsWith("Error:"), out);
+            assertTrue(error.getMessage().contains("Only one statement"), error.getMessage());
             assertTrue(tableExists(dataSource), "the DROP must not have run");
         }
 
@@ -260,9 +268,9 @@ class DuckDbMcpToolsTest {
         void refusesNonSelect(DataSource dataSource) {
             DuckDbMcpTools tools = new DuckDbMcpTools(dataSource);
 
-            assertTrue(tools.executeQuery("DELETE FROM big").startsWith("Error:"));
-            assertTrue(tools.executeQuery("ATTACH 'other.db' AS other").startsWith("Error:"));
-            assertTrue(tools.executeQuery("COPY big TO '/tmp/out.csv'").startsWith("Error:"));
+            assertThrows(ToolExecutionException.class, () -> tools.executeQuery("DELETE FROM big"));
+            assertThrows(ToolExecutionException.class, () -> tools.executeQuery("ATTACH 'other.db' AS other"));
+            assertThrows(ToolExecutionException.class, () -> tools.executeQuery("COPY big TO '/tmp/out.csv'"));
         }
 
         @Test

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/EventTypeMcpToolsTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/EventTypeMcpToolsTest.java
@@ -21,6 +21,7 @@ package cafe.jeffrey.microscope.core.mcp.tools;
 import cafe.jeffrey.profile.common.treetable.EventViewerData;
 import cafe.jeffrey.profile.manager.EventViewerManager;
 import cafe.jeffrey.profile.manager.ProfileManager;
+import cafe.jeffrey.profile.mcp.ToolExecutionException;
 import cafe.jeffrey.provider.profile.api.FieldDescription;
 import cafe.jeffrey.shared.common.model.EventTypeName;
 import cafe.jeffrey.shared.common.model.ProfileInfo;
@@ -149,10 +150,13 @@ class EventTypeMcpToolsTest {
         void refusesAnUnrecordedTypeWithoutAskingForItsColumns() {
             recorded(RECORDED_TYPE);
 
-            String out = tools().describeEventType(UNRECORDED_TYPE);
+            ToolExecutionException error = assertThrows(
+                    ToolExecutionException.class,
+                    () -> tools().describeEventType(UNRECORDED_TYPE));
 
-            assertTrue(out.contains("recorded no event type called '" + UNRECORDED_TYPE + "'"), out);
-            assertTrue(out.contains("jfr_listEventTypes"), out);
+            assertTrue(error.getMessage().contains("recorded no event type called '" + UNRECORDED_TYPE + "'"),
+                    error.getMessage());
+            assertTrue(error.getMessage().contains("jfr_listEventTypes"), error.getMessage());
             verify(eventViewerManager, never()).eventColumns(Type.fromCode(UNRECORDED_TYPE));
         }
 

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/GrpcMcpToolsTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/GrpcMcpToolsTest.java
@@ -36,6 +36,7 @@ import cafe.jeffrey.profile.manager.custom.model.grpc.GrpcStatusStats;
 import cafe.jeffrey.profile.manager.custom.model.grpc.GrpcTrafficData;
 import cafe.jeffrey.profile.mcp.ReflectiveToolset;
 import cafe.jeffrey.profile.mcp.ToolDispatchException;
+import cafe.jeffrey.profile.mcp.ToolExecutionException;
 import cafe.jeffrey.shared.common.Json;
 import cafe.jeffrey.shared.common.model.ProfileInfo;
 import cafe.jeffrey.shared.common.model.RecordingEventSource;
@@ -262,12 +263,15 @@ class GrpcMcpToolsTest {
         }
 
         @Test
-        void reportsAnUnknownServiceInsteadOfFailing() {
+        void reportsAnUnknownServiceAsAToolError() {
             when(grpcManager.serviceDetailData(UNKNOWN_SERVICE)).thenReturn(serviceDetail(List.of()));
 
-            String out = tools().service(UNKNOWN_SERVICE, null);
+            ToolExecutionException error = assertThrows(
+                    ToolExecutionException.class,
+                    () -> tools().service(UNKNOWN_SERVICE, null));
 
-            assertTrue(out.contains("No calls were recorded for service '" + UNKNOWN_SERVICE + "'"), out);
+            assertTrue(error.getMessage().contains("No calls were recorded for service '" + UNKNOWN_SERVICE + "'"),
+                    error.getMessage());
         }
     }
 

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/HeapDumpMcpToolsTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/HeapDumpMcpToolsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.microscope.core.mcp.tools;
+
+import cafe.jeffrey.profile.mcp.ToolExecutionException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HeapDumpMcpToolsTest {
+
+    @Mock
+    HeapDumpToolsDelegate delegate;
+
+    @Test
+    void propagatesDelegateFailuresAsToolErrors() {
+        when(delegate.getSummary()).thenThrow(new IllegalStateException("broken heap index"));
+
+        ToolExecutionException error = assertThrows(ToolExecutionException.class,
+                () -> new HeapDumpMcpTools(delegate).getHeapSummary());
+
+        assertTrue(error.getMessage().contains("broken heap index"), error.getMessage());
+    }
+
+    @Test
+    void reportsAMissingInstanceAsAToolError() {
+        when(delegate.getInstanceDetail(42, false)).thenReturn(null);
+
+        ToolExecutionException error = assertThrows(ToolExecutionException.class,
+                () -> new HeapDumpMcpTools(delegate).getInstanceDetail(42L));
+
+        assertTrue(error.getMessage().contains("42"), error.getMessage());
+    }
+
+    @Test
+    void keepsAnEmptyGcRootPathResultAsAnOrdinaryAnswer() {
+        when(delegate.getPathsToGCRoot(42, true, 3)).thenReturn(List.of());
+
+        String result = new HeapDumpMcpTools(delegate).getPathToGCRoot(42L, 3);
+
+        assertTrue(result.startsWith("No paths to GC root found"), result);
+    }
+}

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/HeapOqlMcpToolsTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/HeapOqlMcpToolsTest.java
@@ -18,6 +18,7 @@
 
 package cafe.jeffrey.microscope.core.mcp.tools;
 
+import cafe.jeffrey.profile.mcp.ToolExecutionException;
 import cafe.jeffrey.profile.heapdump.model.OQLQueryRequest;
 import cafe.jeffrey.profile.heapdump.model.OQLQueryResult;
 import cafe.jeffrey.profile.heapdump.model.OQLResultEntry;
@@ -153,11 +154,12 @@ class HeapOqlMcpToolsTest {
         void handsBackTheEnginesOwnParseFailure() {
             answers(OQLQueryResult.error("Unexpected token at position 14", 2));
 
-            String out = tools().oql("SELECT * FRM x", null, null);
+            ToolExecutionException error = assertThrows(
+                    ToolExecutionException.class,
+                    () -> tools().oql("SELECT * FRM x", null, null));
 
-            assertTrue(out.startsWith("Error: "), out);
-            assertTrue(out.contains("position 14"), out);
-            assertFalse(out.contains("\"rows\""), out);
+            assertTrue(error.getMessage().contains("position 14"), error.getMessage());
+            assertFalse(error.getMessage().contains("\"rows\""), error.getMessage());
         }
     }
 

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/HttpMcpToolsTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/HttpMcpToolsTest.java
@@ -32,6 +32,7 @@ import cafe.jeffrey.profile.manager.custom.model.http.HttpStatusStats;
 import cafe.jeffrey.profile.manager.custom.model.http.HttpUriInfo;
 import cafe.jeffrey.profile.mcp.ReflectiveToolset;
 import cafe.jeffrey.profile.mcp.ToolDispatchException;
+import cafe.jeffrey.profile.mcp.ToolExecutionException;
 import cafe.jeffrey.shared.common.Json;
 import cafe.jeffrey.shared.common.model.ProfileInfo;
 import cafe.jeffrey.shared.common.model.RecordingEventSource;
@@ -183,12 +184,14 @@ class HttpMcpToolsTest {
          * error - and the controller's equivalent would throw on getFirst().
          */
         @Test
-        void reportsAnUnknownUriInsteadOfFailing() {
+        void reportsAnUnknownUriAsAToolError() {
             when(httpManager.overviewData("/nope")).thenReturn(data(List.of()));
 
-            String out = tools().endpoint("/nope", null);
+            ToolExecutionException error = assertThrows(
+                    ToolExecutionException.class,
+                    () -> tools().endpoint("/nope", null));
 
-            assertTrue(out.contains("No requests were recorded for '/nope'"), out);
+            assertTrue(error.getMessage().contains("No requests were recorded for '/nope'"), error.getMessage());
         }
 
         /**

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/IdeMcpToolsTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/IdeMcpToolsTest.java
@@ -29,6 +29,7 @@ import cafe.jeffrey.microscope.core.manager.ide.IdeTargetsResult.IdeInstanceView
 import cafe.jeffrey.microscope.core.manager.ide.IdeTargetsResult.IdeProjectView;
 import cafe.jeffrey.microscope.core.manager.recordings.RecordingCommitResolver;
 import cafe.jeffrey.profile.manager.ProfileManager;
+import cafe.jeffrey.profile.mcp.ToolExecutionException;
 import cafe.jeffrey.shared.common.model.ProfileInfo;
 import cafe.jeffrey.shared.common.model.RecordingEventSource;
 import org.junit.jupiter.api.BeforeEach;
@@ -241,10 +242,12 @@ class IdeMcpToolsTest {
         void linkRefusesAProjectIdThatIsNotOpen() {
             windowsOpen(project("a", "service", true));
 
-            String answer = tools.link("gone");
+            ToolExecutionException error = assertThrows(
+                    ToolExecutionException.class,
+                    () -> tools.link("gone"));
 
             verify(ideBridge, never()).selectTarget(any(), any());
-            assertTrue(answer.contains("gone"));
+            assertTrue(error.getMessage().contains("gone"), error.getMessage());
         }
     }
 
@@ -306,7 +309,11 @@ class IdeMcpToolsTest {
             when(ideBridge.fetchSource(any()))
                     .thenReturn(IdeSourceResult.failed("Source is not available for this class"));
 
-            assertTrue(tools.source(FQN).contains("Source is not available"));
+            ToolExecutionException error = assertThrows(
+                    ToolExecutionException.class,
+                    () -> tools.source(FQN));
+
+            assertTrue(error.getMessage().contains("Source is not available"), error.getMessage());
         }
 
         @Test

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/JdbcMcpToolsTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/JdbcMcpToolsTest.java
@@ -32,6 +32,7 @@ import cafe.jeffrey.profile.manager.custom.model.jdbc.statement.JdbcHeader;
 import cafe.jeffrey.profile.manager.custom.model.jdbc.statement.JdbcOperationStats;
 import cafe.jeffrey.profile.manager.custom.model.jdbc.statement.JdbcOverviewData;
 import cafe.jeffrey.profile.manager.custom.model.jdbc.statement.JdbcSlowStatement;
+import cafe.jeffrey.profile.mcp.ToolExecutionException;
 import cafe.jeffrey.shared.common.model.ProfileInfo;
 import cafe.jeffrey.shared.common.model.RecordingEventSource;
 import cafe.jeffrey.timeseries.SingleSerie;
@@ -262,12 +263,15 @@ class JdbcMcpToolsTest {
         }
 
         @Test
-        void reportsAnUnknownGroupInsteadOfFailing() {
+        void reportsAnUnknownGroupAsAToolError() {
             when(statementManager.overviewData(UNKNOWN_GROUP)).thenReturn(empty());
 
-            String out = tools().statementGroup(UNKNOWN_GROUP);
+            ToolExecutionException error = assertThrows(
+                    ToolExecutionException.class,
+                    () -> tools().statementGroup(UNKNOWN_GROUP));
 
-            assertTrue(out.contains("No statements were recorded for group '" + UNKNOWN_GROUP + "'"), out);
+            assertTrue(error.getMessage().contains("No statements were recorded for group '" + UNKNOWN_GROUP + "'"),
+                    error.getMessage());
         }
     }
 

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/JvmMcpToolsTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/JvmMcpToolsTest.java
@@ -21,6 +21,8 @@ package cafe.jeffrey.microscope.core.mcp.tools;
 import cafe.jeffrey.profile.common.analysis.AnalysisResult;
 import cafe.jeffrey.profile.common.analysis.AutoAnalysisResult;
 import cafe.jeffrey.profile.common.event.GarbageCollectorType;
+import cafe.jeffrey.profile.mcp.ReflectiveToolset;
+import cafe.jeffrey.profile.mcp.ToolExecutionException;
 import cafe.jeffrey.profile.manager.AutoAnalysisManager;
 import cafe.jeffrey.profile.manager.FlamegraphManager;
 import cafe.jeffrey.profile.manager.ProfileConfigurationManager;
@@ -41,6 +43,7 @@ import cafe.jeffrey.profile.manager.model.gc.GCHeader;
 import cafe.jeffrey.profile.manager.model.gc.GCOverviewData;
 import cafe.jeffrey.profile.manager.model.gc.GCPauseDistribution;
 import cafe.jeffrey.profile.manager.model.gc.ManualGCCalls;
+import cafe.jeffrey.profile.manager.model.gc.tuning.TenuringData;
 import cafe.jeffrey.profile.manager.model.vmoperation.SafepointLatencyData;
 import cafe.jeffrey.profile.manager.model.vmoperation.SafepointOffender;
 import cafe.jeffrey.profile.manager.model.vmoperation.VmOperationStat;
@@ -67,7 +70,9 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -529,9 +534,12 @@ class JvmMcpToolsTest {
             recorded(EventTypeName.JVM_INFORMATION);
             when(configurationManager.configuration()).thenReturn(configuration());
 
-            String result = tools().configuration("Nonexistent");
+            ToolExecutionException error = assertThrows(
+                    ToolExecutionException.class,
+                    () -> tools().configuration("Nonexistent"));
 
-            assertTrue(result.contains("no configuration section named 'Nonexistent'"));
+            assertTrue(error.getMessage().contains("no configuration section named 'Nonexistent'"),
+                    error.getMessage());
         }
 
         static JsonNode configuration() {
@@ -604,10 +612,24 @@ class JvmMcpToolsTest {
         void refusesAPageThatDoesNotExistNamingTheOnesThatDo() {
             recorded("jdk.GarbageCollection");
 
-            String result = tools().gcDetail("nonsense");
+            ToolExecutionException error = assertThrows(
+                    ToolExecutionException.class,
+                    () -> tools().gcDetail("nonsense"));
 
-            assertTrue(result.startsWith("Error: "));
-            assertTrue(result.contains("tenuring"));
+            assertTrue(error.getMessage().contains("tenuring"), error.getMessage());
+        }
+
+        @Test
+        void acceptsAnUppercaseEnumValueThroughTheReflectiveAdapter() {
+            recorded("jdk.GarbageCollection");
+            when(gcManager.tenuring()).thenReturn(new TenuringData(List.of()));
+            JvmMcpTools target = tools();
+            String lowercase = target.gcDetail("tenuring");
+
+            String uppercase = new ReflectiveToolset(target, "jvm").call(
+                    "jvm_gcDetail", Json.readTree("{\"page\":\"TENURING\"}"));
+
+            assertEquals(lowercase, uppercase);
         }
 
         @Test

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/ProfilesMcpToolsTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/ProfilesMcpToolsTest.java
@@ -30,6 +30,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -123,7 +124,7 @@ class ProfilesMcpToolsTest {
         }
 
         @Test
-        void appliesTheLimit() {
+        void reportsWhenTheLimitOmitsMatchingProfiles() {
             when(coreRepositories.findAllProfiles()).thenReturn(List.of(
                     profile("p-1", "One", "proj-1"),
                     profile("p-2", "Two", "proj-1")));
@@ -132,6 +133,63 @@ class ProfilesMcpToolsTest {
 
             assertTrue(result.contains("p-1"));
             assertFalse(result.contains("p-2"));
+            assertTrue(result.contains("Returned 1 of 2 matching profiles."), result);
+            assertTrue(result.contains("Increase `limit` (maximum 1000) or narrow `search`"), result);
+        }
+
+        @Test
+        void reportsWhenTheLimitReturnsEveryMatchingProfile() {
+            when(coreRepositories.findAllProfiles()).thenReturn(List.of(
+                    profile("p-1", "One", "proj-1"),
+                    profile("p-2", "Two", "proj-1")));
+
+            String result = tools.list(null, 2);
+
+            assertTrue(result.contains("Returned 2 of 2 matching profiles."), result);
+            assertFalse(result.contains("narrow `search`"), result);
+        }
+
+        @Test
+        void countsMatchesBeforeApplyingTheLimit() {
+            when(coreRepositories.findAllProfiles()).thenReturn(List.of(
+                    profile("p-1", "Checkout before", "proj-1"),
+                    profile("p-2", "Unrelated", "proj-1"),
+                    profile("p-3", "Checkout after", "proj-1")));
+
+            String result = tools.list("checkout", 1);
+
+            assertTrue(result.contains("Returned 1 of 2 matching profiles."), result);
+        }
+
+        @Test
+        void reportsWhenTheDefaultLimitOmitsMatchingProfiles() {
+            List<ProfileInfo> profiles = IntStream.rangeClosed(1, 101)
+                    .mapToObj(index -> profile("p-" + index, "Profile " + index, "proj-1"))
+                    .toList();
+            when(coreRepositories.findAllProfiles()).thenReturn(profiles);
+
+            String result = tools.list(null, null);
+
+            assertTrue(result.contains("Returned 100 of 101 matching profiles."), result);
+            assertTrue(result.contains("Increase `limit` (maximum 1000)"), result);
+        }
+
+        @Test
+        void reportsOnlyCompleteRowsWhenTheMaximumLimitAlsoHitsTheOutputCap() {
+            List<ProfileInfo> profiles = IntStream.rangeClosed(1, 1001)
+                    .mapToObj(index -> profile(
+                            "p-" + index,
+                            index == 1 ? "x".repeat(120_001) : "Profile " + index,
+                            "proj-1"))
+                    .toList();
+            when(coreRepositories.findAllProfiles()).thenReturn(profiles);
+
+            String result = tools.list(null, 1000);
+
+            assertTrue(result.startsWith("Returned 0 of 1001 matching profiles."), result);
+            assertFalse(result.contains("p-1"), result);
+            assertTrue(result.contains("output size limit omitted 1000 selected profiles"), result);
+            assertTrue(result.contains("The maximum `limit` is 1000; narrow `search`"), result);
         }
 
         /**
@@ -142,7 +200,10 @@ class ProfilesMcpToolsTest {
         void explainsAnEmptyInstallation() {
             when(coreRepositories.findAllProfiles()).thenReturn(List.of());
 
-            assertTrue(tools.list(null, null).contains("No profiles"));
+            String result = tools.list(null, null);
+
+            assertTrue(result.contains("No profiles"), result);
+            assertTrue(result.contains("Returned 0 of 0 matching profiles."), result);
         }
 
         @Test

--- a/jeffrey-microscope/profiles/mcp-server/src/main/java/cafe/jeffrey/profile/mcp/AbstractMcpStreamableHttpController.java
+++ b/jeffrey-microscope/profiles/mcp-server/src/main/java/cafe/jeffrey/profile/mcp/AbstractMcpStreamableHttpController.java
@@ -74,7 +74,6 @@ public abstract class AbstractMcpStreamableHttpController {
     private static final String METHOD_RESOURCES_LIST = "resources/list";
     private static final String METHOD_RESOURCES_TEMPLATES_LIST = "resources/templates/list";
     private static final String METHOD_RESOURCES_READ = "resources/read";
-    private static final String NOTIFICATION_PREFIX = "notifications/";
 
     private static final String FIELD_JSONRPC = "jsonrpc";
     private static final String FIELD_ID = "id";
@@ -225,15 +224,24 @@ public abstract class AbstractMcpStreamableHttpController {
      * @return the response to send, or null when the request was a notification and needs none
      */
     private JsonNode dispatchOne(JsonNode request, McpServerFeatures features) {
-        String method = request.path(FIELD_METHOD).asString();
         JsonNode id = request.get(FIELD_ID);
-
-        // JSON-RPC notifications (no id) require no response body.
-        if (method.startsWith(NOTIFICATION_PREFIX) || id == null) {
+        if (id != null && !id.isString() && !id.isIntegralNumber()) {
+            return error(null, ERROR_INVALID_REQUEST, "A JSON-RPC id must be a string or integer");
+        }
+        JsonNode version = request.get(FIELD_JSONRPC);
+        JsonNode methodNode = request.get(FIELD_METHOD);
+        if (version == null || !version.isString() || !JSONRPC_VERSION.equals(version.asString())
+                || methodNode == null || !methodNode.isString() || methodNode.asString().isBlank()) {
+            return error(id, ERROR_INVALID_REQUEST, "A JSON-RPC request must declare jsonrpc 2.0 and a string method");
+        }
+        String method = methodNode.asString();
+        // Only an absent id makes a notification; its method name does not.
+        if (id == null) {
             return null;
         }
-        if (method.isBlank()) {
-            return error(id, ERROR_INVALID_REQUEST, "A JSON-RPC request must name a method");
+        JsonNode params = request.get(FIELD_PARAMS);
+        if (params != null && !params.isObject()) {
+            return error(id, ERROR_INVALID_PARAMS, "MCP params must be an object");
         }
 
         try {
@@ -351,7 +359,7 @@ public abstract class AbstractMcpStreamableHttpController {
         result.put(FIELD_DESCRIPTION, prompt.description());
         ObjectNode message = result.putArray(FIELD_MESSAGES).addObject();
         message.put(FIELD_ROLE, ROLE_USER);
-        message.putObject(FIELD_CONTENT).put(FIELD_TYPE, CONTENT_TYPE_TEXT).put(FIELD_TEXT, prompt.text());
+        message.putObject(FIELD_CONTENT).put(FIELD_TYPE, CONTENT_TYPE_TEXT).put(FIELD_TEXT, prompt.render(params.get(FIELD_ARGUMENTS)));
         return success(id, result);
     }
 
@@ -395,6 +403,10 @@ public abstract class AbstractMcpStreamableHttpController {
                     .put(FIELD_MIME_TYPE, resource.mimeType());
         }
         return result;
+    }
+
+    protected final ResponseEntity<JsonNode> parseErrorResponse() {
+        return ResponseEntity.badRequest().body(error(null, -32700, "Parse error: invalid JSON"));
     }
 
     private JsonNode success(JsonNode id, JsonNode result) {

--- a/jeffrey-microscope/profiles/mcp-server/src/main/java/cafe/jeffrey/profile/mcp/McpPrompt.java
+++ b/jeffrey-microscope/profiles/mcp-server/src/main/java/cafe/jeffrey/profile/mcp/McpPrompt.java
@@ -17,7 +17,13 @@
  */
 package cafe.jeffrey.profile.mcp;
 
+import cafe.jeffrey.shared.common.Json;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ObjectNode;
+
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * A workflow the server offers by name, which a client can insert into a conversation.
@@ -44,6 +50,36 @@ public record McpPrompt(
 
     public McpPrompt {
         arguments = List.copyOf(arguments);
+    }
+
+    /** Adds caller-supplied context without interpreting it as a template or changing the workflow. */
+    public String render(JsonNode supplied) {
+        if (supplied != null && !supplied.isObject()) {
+            throw new IllegalArgumentException("Prompt arguments must be an object");
+        }
+        Set<String> declared = arguments.stream().map(Argument::name).collect(Collectors.toSet());
+        if (supplied != null) {
+            for (String name : supplied.propertyNames()) {
+                if (!declared.contains(name)) {
+                    throw new IllegalArgumentException("Unknown prompt argument: " + name);
+                }
+            }
+        }
+        ObjectNode context = Json.createObject();
+        for (Argument argument : arguments) {
+            JsonNode value = supplied == null ? null : supplied.get(argument.name());
+            if (value == null) {
+                if (argument.required()) {
+                    throw new IllegalArgumentException("Missing required prompt argument: " + argument.name());
+                }
+                continue;
+            }
+            if (!value.isString()) {
+                throw new IllegalArgumentException("Prompt argument '" + argument.name() + "' must be a string");
+            }
+            context.set(argument.name(), value);
+        }
+        return context.isEmpty() ? text : text + "\n\nCaller-provided workflow context (JSON):\n" + context;
     }
 
     public record Argument(String name, String description, boolean required) {

--- a/jeffrey-microscope/profiles/mcp-server/src/main/java/cafe/jeffrey/profile/mcp/McpToolOutput.java
+++ b/jeffrey-microscope/profiles/mcp-server/src/main/java/cafe/jeffrey/profile/mcp/McpToolOutput.java
@@ -47,8 +47,6 @@ public final class McpToolOutput {
             "\n\n_TRUNCATED: the result exceeded %d characters and was cut here. "
                     + "Narrow the query — a smaller limit, a time range, or a more specific filter._";
 
-    private static final String ERROR_PREFIX = "Error: ";
-
     /** Where the record of what was trimmed is attached on a JSON answer that had to lose rows. */
     private static final String TRUNCATED_FIELD = "_truncated";
 
@@ -60,6 +58,10 @@ public final class McpToolOutput {
     private static final String WRAPPED_ARRAY_FIELD = "items";
     private static final String TRUNCATED_KEPT = "kept";
     private static final String TRUNCATED_ORIGINAL = "original";
+    private static final String TRUNCATED_LIMIT = "limit";
+    private static final String TRUNCATED_REASON = "reason";
+    private static final String UNTRIMMABLE_JSON_REASON =
+            "JSON result exceeded the character limit and could not be trimmed structurally";
     private static final String ARRAY_LABEL_PREFIX = "array";
 
     /** How much of an oversized array survives one pass. */
@@ -109,10 +111,9 @@ public final class McpToolOutput {
         }
         JsonNode tree = Json.toTree(value);
         if (!tree.isObject() && !tree.isArray()) {
-            // A bare scalar cannot be trimmed structurally; it can only be cut.
-            return capped(rendered);
+            return overflowJson(rendered.length());
         }
-        return trimToFit(tree);
+        return trimToFit(tree, rendered.length());
     }
 
     /**
@@ -126,7 +127,7 @@ public final class McpToolOutput {
      * A bare array is answered as an object wrapping it, for the same reason. The record can only hang
      * off an object, and a list silently returned short is exactly the failure this class is for.
      */
-    private static String trimToFit(JsonNode tree) {
+    private static String trimToFit(JsonNode tree, int originalChars) {
         ObjectNode truncated = Json.createObject();
         for (int pass = 0; pass < MAX_TRIM_PASSES; pass++) {
             String rendered = render(tree, truncated);
@@ -145,9 +146,19 @@ public final class McpToolOutput {
             }
             recordTrim(truncated, largest, before);
         }
-        // Out of passes, or a tree of scalars no array trimming could reclaim room from. Cutting is all
-        // that is left, and the cut form says so in the note it carries.
-        return capped(render(tree, truncated));
+        // A scalar-heavy tree, or an array whose last element is itself too large, cannot be shortened
+        // by dropping rows. Return a compact JSON record rather than cutting a JSON token and appending
+        // the Markdown truncation note used by capped(String).
+        return overflowJson(originalChars);
+    }
+
+    private static String overflowJson(int originalChars) {
+        ObjectNode root = Json.createObject();
+        ObjectNode truncated = root.putObject(TRUNCATED_FIELD);
+        truncated.put(TRUNCATED_REASON, UNTRIMMABLE_JSON_REASON);
+        truncated.put(TRUNCATED_ORIGINAL, originalChars);
+        truncated.put(TRUNCATED_LIMIT, MAX_CHARS);
+        return Json.toString(root);
     }
 
     /**
@@ -169,17 +180,16 @@ public final class McpToolOutput {
     }
 
     /**
-     * Notes one trimmed array under the name of the field holding it, falling back to a counter when the
-     * array is nested somewhere without a name of its own.
+     * Notes one trimmed array under its path from the root, falling back to a counter for the root array.
      * <p>
      * The name is what makes the record worth carrying. "slowRequests: kept 20 of 500" tells a reader
      * which of the answer's lists they are seeing part of; a bare counter tells them only that
      * something was cut, which they could already see from the field being there at all.
      */
     private static void recordTrim(ObjectNode truncated, NamedArray trimmed, int originalSize) {
-        String label = trimmed.name() == null
-                ? ARRAY_LABEL_PREFIX + (truncated.size() + 1)
-                : trimmed.name();
+        String label = trimmed.path() == null
+                ? ARRAY_LABEL_PREFIX + 1
+                : trimmed.path();
 
         // The same list can be the biggest one twice over. Its record is then updated rather than
         // written again: two entries for one field would read as two lists having been cut, and the
@@ -192,7 +202,7 @@ public final class McpToolOutput {
 
     /**
      * The array holding the most elements anywhere in the tree — the one whose loss buys the most room
-     * — together with the field name it sits under, where it has one.
+     * — together with its path from the root, where it has one.
      */
     private static NamedArray largestArray(JsonNode root) {
         NamedArray largest = null;
@@ -205,21 +215,51 @@ public final class McpToolOutput {
                 largest = current;
             }
             if (value.isObject()) {
-                // An object names its children; an array does not, so its elements inherit its own
-                // name and a trimmed one is still reported under the field a reader can find.
                 value.propertyStream()
                         .filter(property -> isContainer(property.getValue()))
                         .forEach(property ->
-                                pending.push(new NamedArray(property.getKey(), property.getValue())));
+                                pending.push(new NamedArray(
+                                        appendProperty(current.path(), property.getKey()),
+                                        property.getValue())));
             } else {
+                int index = 0;
                 for (JsonNode child : value) {
                     if (isContainer(child)) {
-                        pending.push(new NamedArray(current.name(), child));
+                        pending.push(new NamedArray(appendIndex(current.path(), index), child));
                     }
+                    index++;
                 }
             }
         }
         return largest;
+    }
+
+    private static String appendProperty(String path, String property) {
+        String segment = isPlainPathSegment(property)
+                ? property
+                : "[" + Json.toString(property) + "]";
+        if (path == null) {
+            return segment;
+        }
+        return segment.startsWith("[") ? path + segment : path + "." + segment;
+    }
+
+    private static String appendIndex(String path, int index) {
+        return (path == null ? "" : path) + "[" + index + "]";
+    }
+
+    private static boolean isPlainPathSegment(String property) {
+        if (property.isEmpty()
+                || !(Character.isLetter(property.charAt(0)) || property.charAt(0) == '_')) {
+            return false;
+        }
+        for (int i = 1; i < property.length(); i++) {
+            char c = property.charAt(i);
+            if (!(Character.isLetterOrDigit(c) || c == '_')) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static boolean isContainer(JsonNode node) {
@@ -227,20 +267,17 @@ public final class McpToolOutput {
     }
 
     /**
-     * A node in the tree, with the object field it hangs off — {@code null} at the root and anywhere
-     * an array's own elements are being walked.
+     * A node in the tree, with its unambiguous path from the root ({@code null} for the root itself).
      */
-    private record NamedArray(String name, JsonNode value) {
+    private record NamedArray(String path, JsonNode value) {
 
         ArrayNode node() {
             return (ArrayNode) value;
         }
     }
 
-    /**
-     * A domain answer of "there is nothing here", as opposed to a bad argument — which throws.
-     */
+    /** A tool failure that the MCP envelope must mark with {@code isError=true}. */
     public static String error(String message) {
-        return ERROR_PREFIX + message;
+        throw new ToolExecutionException(message);
     }
 }

--- a/jeffrey-microscope/profiles/mcp-server/src/main/java/cafe/jeffrey/profile/mcp/ProfileScopedToolset.java
+++ b/jeffrey-microscope/profiles/mcp-server/src/main/java/cafe/jeffrey/profile/mcp/ProfileScopedToolset.java
@@ -92,9 +92,13 @@ public final class ProfileScopedToolset<T> implements McpToolProvider {
     }
 
     private static String readProfileId(JsonNode arguments) {
+        ToolMethodIndex.validateArgumentsObject(arguments);
         JsonNode node = arguments == null ? null : arguments.get(PROFILE_ID_ARGUMENT);
         if (node == null || node.isNull()) {
             throw new ToolDispatchException(PROFILE_ID_ARGUMENT + " is required");
+        }
+        if (!node.isString()) {
+            throw new ToolDispatchException(PROFILE_ID_ARGUMENT + " must be a string");
         }
         String profileId = node.asString();
         if (profileId == null || profileId.isBlank()) {

--- a/jeffrey-microscope/profiles/mcp-server/src/main/java/cafe/jeffrey/profile/mcp/ToolExecutionException.java
+++ b/jeffrey-microscope/profiles/mcp-server/src/main/java/cafe/jeffrey/profile/mcp/ToolExecutionException.java
@@ -1,0 +1,36 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.profile.mcp;
+
+/**
+ * A tool was dispatched successfully but could not produce its promised result.
+ *
+ * <p>The MCP envelope turns this exception into a tool result with {@code isError=true}, so callers
+ * can distinguish failures from ordinary textual answers without guessing from an "Error:" prefix.
+ */
+public class ToolExecutionException extends RuntimeException {
+
+    public ToolExecutionException(String message) {
+        super(message);
+    }
+
+    public ToolExecutionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/jeffrey-microscope/profiles/mcp-server/src/main/java/cafe/jeffrey/profile/mcp/ToolMethodIndex.java
+++ b/jeffrey-microscope/profiles/mcp-server/src/main/java/cafe/jeffrey/profile/mcp/ToolMethodIndex.java
@@ -163,6 +163,7 @@ final class ToolMethodIndex {
      * @throws ToolDispatchException if a required argument is missing or a value does not fit its type
      */
     Object[] bindArguments(Method method, JsonNode arguments) {
+        validateArgumentsObject(arguments);
         Parameter[] parameters = method.getParameters();
         Set<String> required = requiredParamsByMethod.getOrDefault(method, Set.of());
         Object[] args = new Object[parameters.length];
@@ -173,9 +174,30 @@ final class ToolMethodIndex {
             if (required.contains(name) && (value == null || value.isNull())) {
                 throw new ToolDispatchException("Missing required argument: " + name);
             }
-            args[i] = ToolParamTypes.convert(value, parameter.getType());
+            try {
+                args[i] = ToolParamTypes.convert(value, parameter.getType());
+                List<String> allowed = allowedValues(parameter);
+                if (value != null && !value.isNull() && !allowed.isEmpty()) {
+                    String canonical = allowed.stream()
+                            .filter(candidate -> candidate.equalsIgnoreCase(value.asString()))
+                            .findFirst()
+                            .orElseThrow(() -> new ToolDispatchException("Expected one of: " + String.join(", ", allowed)));
+                    // Preserve case-insensitive calls, but pass the spelling downstream tools declare.
+                    if (parameter.getType() == String.class) {
+                        args[i] = canonical;
+                    }
+                }
+            } catch (ToolDispatchException e) {
+                throw new ToolDispatchException("Invalid argument '" + name + "': " + e.getMessage());
+            }
         }
         return args;
+    }
+
+    static void validateArgumentsObject(JsonNode arguments) {
+        if (arguments != null && !arguments.isObject()) {
+            throw new ToolDispatchException("Tool arguments must be an object");
+        }
     }
 
     /**

--- a/jeffrey-microscope/profiles/mcp-server/src/main/java/cafe/jeffrey/profile/mcp/ToolMethodIndex.java
+++ b/jeffrey-microscope/profiles/mcp-server/src/main/java/cafe/jeffrey/profile/mcp/ToolMethodIndex.java
@@ -177,7 +177,11 @@ final class ToolMethodIndex {
             try {
                 args[i] = ToolParamTypes.convert(value, parameter.getType());
                 List<String> allowed = allowedValues(parameter);
-                if (value != null && !value.isNull() && !allowed.isEmpty()) {
+                // A blank string is how a model spells "I am not setting this", and every tool taking
+                // an enumerated argument already reads it that way: jvm_gcDetail answers with the list
+                // of pages, heap_prepare runs the whole pipeline, heap_classHistogram sorts by size.
+                // Refusing it here would turn each of those defaults into a protocol error.
+                if (!allowed.isEmpty() && !isOmitted(value)) {
                     String canonical = allowed.stream()
                             .filter(candidate -> candidate.equalsIgnoreCase(value.asString()))
                             .findFirst()
@@ -192,6 +196,14 @@ final class ToolMethodIndex {
             }
         }
         return args;
+    }
+
+    /**
+     * Whether the caller left this argument out — a blank string included, because that is what the
+     * tools themselves treat as absent, and the argument check is not the place to disagree with them.
+     */
+    private static boolean isOmitted(JsonNode value) {
+        return value == null || value.isNull() || (value.isString() && value.asString().isBlank());
     }
 
     static void validateArgumentsObject(JsonNode arguments) {

--- a/jeffrey-microscope/profiles/mcp-server/src/main/java/cafe/jeffrey/profile/mcp/ToolParamTypes.java
+++ b/jeffrey-microscope/profiles/mcp-server/src/main/java/cafe/jeffrey/profile/mcp/ToolParamTypes.java
@@ -60,10 +60,10 @@ final class ToolParamTypes {
 
     private static final Map<Class<?>, Binding> BINDINGS = Map.ofEntries(
             Map.entry(String.class, new Binding(JSON_TYPE_STRING, JsonNode::asString, null)),
-            Map.entry(int.class, new Binding(JSON_TYPE_INTEGER, JsonNode::asInt, 0)),
-            Map.entry(Integer.class, new Binding(JSON_TYPE_INTEGER, JsonNode::asInt, null)),
-            Map.entry(long.class, new Binding(JSON_TYPE_INTEGER, JsonNode::asLong, 0L)),
-            Map.entry(Long.class, new Binding(JSON_TYPE_INTEGER, JsonNode::asLong, null)),
+            Map.entry(int.class, new Binding(JSON_TYPE_INTEGER, node -> node.decimalValue().intValueExact(), 0)),
+            Map.entry(Integer.class, new Binding(JSON_TYPE_INTEGER, node -> node.decimalValue().intValueExact(), null)),
+            Map.entry(long.class, new Binding(JSON_TYPE_INTEGER, node -> node.decimalValue().longValueExact(), 0L)),
+            Map.entry(Long.class, new Binding(JSON_TYPE_INTEGER, node -> node.decimalValue().longValueExact(), null)),
             Map.entry(boolean.class, new Binding(JSON_TYPE_BOOLEAN, JsonNode::asBoolean, Boolean.FALSE)),
             Map.entry(Boolean.class, new Binding(JSON_TYPE_BOOLEAN, JsonNode::asBoolean, null)),
             Map.entry(double.class, new Binding(JSON_TYPE_NUMBER, JsonNode::asDouble, 0d)),
@@ -103,6 +103,9 @@ final class ToolParamTypes {
     static Object convert(JsonNode value, Class<?> type) {
         boolean missing = value == null || value.isNull();
         if (type.isEnum()) {
+            if (!missing && !value.isString()) {
+                throw new ToolDispatchException("Expected a string");
+            }
             return missing ? null : enumConstant(type, value.asString());
         }
 
@@ -112,7 +115,28 @@ final class ToolParamTypes {
             // family. Stated rather than assumed, so a future caller that skips the index is told.
             throw new IllegalStateException("Unsupported tool parameter type: " + type.getName());
         }
-        return missing ? binding.absent() : binding.read().apply(value);
+        if (missing) {
+            return binding.absent();
+        }
+        boolean validType = switch (binding.jsonType()) {
+            case JSON_TYPE_STRING -> value.isString();
+            case JSON_TYPE_INTEGER, JSON_TYPE_NUMBER -> value.isNumber();
+            case JSON_TYPE_BOOLEAN -> value.isBoolean();
+            default -> false;
+        };
+        if (!validType) {
+            throw new ToolDispatchException("Expected " + binding.jsonType());
+        }
+        try {
+            Object converted = binding.read().apply(value);
+            if (converted instanceof Double number && !Double.isFinite(number)
+                    || converted instanceof Float floatNumber && !Float.isFinite(floatNumber)) {
+                throw new ArithmeticException("Non-finite number");
+            }
+            return converted;
+        } catch (ArithmeticException e) {
+            throw new ToolDispatchException("Expected " + binding.jsonType() + " in the range of " + type.getSimpleName());
+        }
     }
 
     /**

--- a/jeffrey-microscope/profiles/mcp-server/src/test/java/cafe/jeffrey/profile/mcp/AbstractMcpStreamableHttpControllerTest.java
+++ b/jeffrey-microscope/profiles/mcp-server/src/test/java/cafe/jeffrey/profile/mcp/AbstractMcpStreamableHttpControllerTest.java
@@ -339,7 +339,7 @@ class AbstractMcpStreamableHttpControllerTest {
 
         @Tool(description = "A tool that ran and could not answer")
         public String fail() {
-            throw new IllegalStateException("nothing to report");
+            return McpToolOutput.error("nothing to report");
         }
 
         @Tool(description = "List what this fixture knows")

--- a/jeffrey-microscope/profiles/mcp-server/src/test/java/cafe/jeffrey/profile/mcp/McpRequestContractTest.java
+++ b/jeffrey-microscope/profiles/mcp-server/src/test/java/cafe/jeffrey/profile/mcp/McpRequestContractTest.java
@@ -1,0 +1,155 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package cafe.jeffrey.profile.mcp;
+
+import cafe.jeffrey.shared.common.Json;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import tools.jackson.databind.JsonNode;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class McpRequestContractTest {
+
+    private final ContractTools target = new ContractTools();
+    private final McpPrompt prompt = new McpPrompt("analyze", "Analyze", "Analyze a profile",
+            List.of(new McpPrompt.Argument("profileId", "Profile to analyze", true)), "Read the profile.");
+    private final McpServerFeatures features = new McpServerFeatures(
+            () -> new ReflectiveToolset(target, "test"),
+            () -> new McpPromptProvider() {
+                @Override
+                public List<McpPrompt> prompts() {
+                    return List.of(prompt);
+                }
+
+                @Override
+                public McpPrompt prompt(String name) {
+                    return prompt;
+                }
+            }, () -> null);
+    private final AbstractMcpStreamableHttpController controller = new AbstractMcpStreamableHttpController() {};
+
+    private JsonNode dispatch(String body) {
+        return controller.dispatch(Json.readTree(body), null, features).getBody();
+    }
+
+    private void assertError(String body, int code) {
+        JsonNode response = dispatch(body);
+        assertNotNull(response, body);
+        assertEquals(code, response.path("error").path("code").asInt(), response.toString());
+    }
+
+    @Test
+    void rejectsMalformedEnvelopesBeforeTreatingThemAsNotifications() {
+        for (String body : List.of("{}", "{\"id\":1,\"method\":\"ping\"}",
+                "{\"jsonrpc\":\"1.0\",\"id\":1,\"method\":\"ping\"}",
+                "{\"jsonrpc\":\"2.0\",\"id\":{},\"method\":\"ping\"}",
+                "{\"jsonrpc\":\"2.0\",\"id\":true,\"method\":\"ping\"}",
+                "{\"jsonrpc\":\"2.0\",\"method\":42}")) {
+            assertError(body, -32600);
+        }
+    }
+
+    @Test
+    void answersRequestsEvenWhenTheirMethodLooksLikeANotification() {
+        assertError("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"notifications/initialized\"}", -32601);
+    }
+
+    @Test
+    void refusesNonObjectParams() {
+        assertError("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\",\"params\":[]}", -32602);
+    }
+
+    @Test
+    void refusesIncorrectToolTypesAndRangesBeforeInvocation() {
+        for (String args : List.of("[]", "null", "{\"limit\":1.9}", "{\"limit\":\"1\"}",
+                "{\"limit\":2147483648}", "{\"limit\":true}", "{\"limit\":{}}",
+                "{\"label\":12}", "{\"enabled\":\"true\"}", "{\"direction\":\"invalid\"}",
+                "{\"sequence\":9223372036854775808}", "{\"ratio\":1e100}", "{\"measured\":1e400}")) {
+            assertError("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"test_check\",\"arguments\":" + args + "}}", -32602);
+        }
+        assertEquals(0, target.calls);
+    }
+
+    @Test
+    void acceptsValidTypesAndOptionalOmissions() {
+        JsonNode response = dispatch("""
+                {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"test_check",
+                "arguments":{"limit":2,"label":"x","enabled":true,"direction":"server"}}}
+                """);
+        assertFalse(response.path("result").path("isError").asBoolean());
+        assertEquals(1, target.calls);
+        assertEquals("SERVER", target.direction);
+        assertFalse(dispatch("""
+                {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"test_check"}}
+                """).path("result").path("isError").asBoolean());
+        assertEquals(2, target.calls);
+    }
+
+    @Test
+    void rejectsNonStringProfileIdsBeforeResolvingAProfile() {
+        AtomicInteger resolutions = new AtomicInteger();
+        var tools = new ProfileScopedToolset<>(ContractTools.class, "test", id -> {
+            resolutions.incrementAndGet();
+            return target;
+        });
+        assertThrows(ToolDispatchException.class,
+                () -> tools.call("test_check", Json.readTree("{\"profileId\":123}")));
+        assertEquals(0, resolutions.get());
+    }
+
+    @Test
+    void preservesPromptContextAndRejectsInvalidArguments() {
+        for (String id : List.of("profile-a", "profile-b")) {
+            String body = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"prompts/get\",\"params\":{\"name\":\"analyze\",\"arguments\":{\"profileId\":\"" + id + "\"}}}";
+            String text = dispatch(body).path("result").path("messages").get(0).path("content").path("text").asString();
+            assertTrue(text.contains(id));
+            assertTrue(text.contains(prompt.text()));
+        }
+        for (String args : List.of("{}", "[]", "{\"profileId\":123}",
+                "{\"profileId\":\"p\",\"unknown\":\"x\"}")) {
+            assertError("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"prompts/get\",\"params\":{\"name\":\"analyze\",\"arguments\":" + args + "}}", -32602);
+        }
+    }
+
+    public static class ContractTools {
+        int calls;
+        String direction;
+
+        @Tool(description = "Check arguments")
+        public String check(@ToolParam(required = false) Integer limit,
+                            @ToolParam(required = false) String label,
+                            @ToolParam(required = false) Boolean enabled,
+                            @ToolParam(required = false) @ToolParamValues({"SERVER", "CLIENT"}) String direction,
+                            @ToolParam(required = false) Long sequence,
+                            @ToolParam(required = false) Float ratio,
+                            @ToolParam(required = false) Double measured) {
+            calls++;
+            this.direction = direction;
+            return "ok";
+        }
+    }
+}

--- a/jeffrey-microscope/profiles/mcp-server/src/test/java/cafe/jeffrey/profile/mcp/McpRequestContractTest.java
+++ b/jeffrey-microscope/profiles/mcp-server/src/test/java/cafe/jeffrey/profile/mcp/McpRequestContractTest.java
@@ -110,6 +110,17 @@ class McpRequestContractTest {
     }
 
     @Test
+    void readsABlankEnumeratedArgumentAsOmitted() {
+        JsonNode response = dispatch("""
+                {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"test_check",
+                "arguments":{"direction":""}}}
+                """);
+
+        assertFalse(response.path("result").path("isError").asBoolean(), response.toString());
+        assertEquals(1, target.calls);
+    }
+
+    @Test
     void rejectsNonStringProfileIdsBeforeResolvingAProfile() {
         AtomicInteger resolutions = new AtomicInteger();
         var tools = new ProfileScopedToolset<>(ContractTools.class, "test", id -> {

--- a/jeffrey-microscope/profiles/mcp-server/src/test/java/cafe/jeffrey/profile/mcp/McpToolOutputTest.java
+++ b/jeffrey-microscope/profiles/mcp-server/src/test/java/cafe/jeffrey/profile/mcp/McpToolOutputTest.java
@@ -22,16 +22,25 @@ import org.junit.jupiter.api.Test;
 import cafe.jeffrey.shared.common.Json;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import tools.jackson.databind.JsonNode;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class McpToolOutputTest {
 
     private record Dashboard(String title, List<String> rows) {
+    }
+
+    private record NestedRows(List<String> rows) {
+    }
+
+    private record TwinLists(NestedRows left, NestedRows right) {
     }
 
 
@@ -123,6 +132,36 @@ class McpToolOutputTest {
     }
 
     @Test
+    void distinguishesTrimmedArraysWithTheSameFieldName() {
+        List<String> rows = new ArrayList<>();
+        for (int i = 0; i < 5_000; i++) {
+            rows.add("row-" + i + "-" + "x".repeat(60));
+        }
+
+        JsonNode truncated = Json.readTree(McpToolOutput.json(
+                new TwinLists(new NestedRows(rows), new NestedRows(rows)))).get("_truncated");
+
+        assertTrue(truncated.has("left.rows"), "the left array needs its own truncation record");
+        assertTrue(truncated.has("right.rows"), "the right array needs its own truncation record");
+    }
+
+    @Test
+    void escapesPropertyNamesThatWouldCollideWithAPath() {
+        List<String> rows = new ArrayList<>();
+        for (int i = 0; i < 5_000; i++) {
+            rows.add("row-" + i + "-" + "x".repeat(60));
+        }
+        Map<String, Object> value = new LinkedHashMap<>();
+        value.put("left", Map.of("rows", rows));
+        value.put("left.rows", rows);
+
+        JsonNode truncated = Json.readTree(McpToolOutput.json(value)).get("_truncated");
+
+        assertTrue(truncated.has("left.rows"), "the nested array keeps the readable dotted path");
+        assertTrue(truncated.has("[\"left.rows\"]"), "the dotted property name must be escaped");
+    }
+
+    @Test
     void aJsonResultThatFitsIsLeftExactlyAsItWas() {
         String rendered = McpToolOutput.json(new Dashboard("cpu", List.of("a", "b")));
         assertEquals("{\"title\":\"cpu\",\"rows\":[\"a\",\"b\"]}", rendered);
@@ -167,6 +206,9 @@ class McpToolOutputTest {
         assertTrue(parsed.isObject(), "a trimmed list is wrapped so the record has somewhere to hang");
         assertTrue(parsed.get("items").size() < rows.size());
         assertNotNull(parsed.get("_truncated"));
+        assertEquals(1, parsed.get("_truncated").size(),
+                "repeated passes over the root array must update one record");
+        assertTrue(parsed.get("_truncated").has("array1"));
         assertTrue(json.length() <= McpToolOutput.MAX_CHARS);
     }
 
@@ -178,10 +220,57 @@ class McpToolOutputTest {
     }
 
     @Test
-    void marksErrorsSoTheModelCanTellThemFromData() {
-        assertTrue(McpToolOutput.error("nothing here").startsWith("Error: "));
+    void keepsAScalarHeavyObjectBoundedAndParseable() {
+        Map<String, String> value = Map.of(
+                "largeField", "x".repeat(McpToolOutput.MAX_CHARS + 1));
+        String original = Json.toString(value);
+
+        String rendered = McpToolOutput.json(value);
+
+        JsonNode parsed = assertBoundedJson(rendered);
+        assertEquals(original.length(), parsed.get("_truncated").get("original").asInt());
+    }
+
+    @Test
+    void keepsAnOversizedBareScalarBoundedAndParseable() {
+        assertBoundedJson(McpToolOutput.json("x".repeat(McpToolOutput.MAX_CHARS + 1)));
+    }
+
+    @Test
+    void keepsAnArrayWithOneOversizedElementBoundedAndParseable() {
+        assertBoundedJson(McpToolOutput.json(List.of(
+                "x".repeat(McpToolOutput.MAX_CHARS + 1))));
+    }
+
+    @Test
+    void keepsJsonParseableWhenArrayTrimmingCannotReclaimEnoughSpace() {
+        assertBoundedJson(McpToolOutput.json(Map.of(
+                "rows", List.of("x".repeat(McpToolOutput.MAX_CHARS + 1)))));
+    }
+
+    @Test
+    void keepsOversizedUnicodeJsonBoundedAndParseable() {
+        assertBoundedJson(McpToolOutput.json(Map.of(
+                "largeField", "🧪".repeat(McpToolOutput.MAX_CHARS))));
+    }
+
+    @Test
+    void raisesErrorsSoTheProtocolCanTellThemFromData() {
+        ToolExecutionException error = assertThrows(
+                ToolExecutionException.class,
+                () -> McpToolOutput.error("nothing here"));
+
+        assertEquals("nothing here", error.getMessage());
     }
 
     private record Sample(int value) {
+    }
+
+    private static JsonNode assertBoundedJson(String json) {
+        assertTrue(json.length() <= McpToolOutput.MAX_CHARS, "length=" + json.length());
+        JsonNode parsed = Json.readTree(json);
+        assertNotNull(parsed);
+        assertTrue(parsed.has("_truncated"), "an overflow fallback must explain that data was omitted");
+        return parsed;
     }
 }

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpEnablingPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpEnablingPage.vue
@@ -56,6 +56,9 @@ const defaultEndpoint = `http://localhost:8585/api/mcp`;
 const loopback = `# application.properties -- reachable from this machine and nowhere else
 server.address=127.0.0.1`;
 
+const allowedHosts = `# Replace microscope.example.com with the hostname your clients use
+jeffrey.microscope.mcp.allowed-hosts=localhost,127.0.0.1,::1,microscope.example.com`;
+
 const tunnel = `ssh -N -L 8585:localhost:8585 you@the-host-running-jeffrey`;
 
 const serverProbe = `curl -s -X POST http://localhost:8585/api/mcp \\
@@ -146,7 +149,11 @@ const disabledProbe = `curl -s -o /dev/null -w '%{http_code}\\n' \\
         The MCP endpoint carries the same trust assumption as the rest of Jeffrey&rsquo;s API: anyone who can reach the address can read every profile in that installation &mdash; the recordings, their stack traces, their SQL statements, and the contents of any heap dump you have indexed. Jeffrey has no authentication to switch on, here or anywhere else, so what decides who can read all of that is the address Jeffrey binds to and whatever sits in front of it.
       </DocsCallout>
 
-      <p>One thing it does refuse on its own: a request carrying an <code>Origin</code> header naming somewhere other than the address it served. That is the check the MCP specification asks of every local HTTP server, and it closes a path that has nothing to do with your network &mdash; a page in a browser you merely visited can post to <code>localhost</code>, and without the check the server would answer it. A CLI client sends no <code>Origin</code> at all, so Claude Code and Codex never notice.</p>
+      <p>The MCP endpoint checks the request hostname against an independent allowlist. By default it accepts <code>localhost</code>, <code>127.0.0.1</code>, and IPv6 loopback <code>::1</code>. Other hostnames receive <code>403</code>, even when the request carries no <code>Origin</code> header. If an <code>Origin</code> is present, its scheme, hostname and port must also match the effective request address. This prevents a caller from bypassing the origin check by choosing matching, arbitrary <code>Host</code> and <code>Origin</code> headers.</p>
+
+      <p>For remote clients or a reverse proxy, configure the hostname they use and restart Microscope. The property replaces the default list, so retain any loopback names still in use:</p>
+      <DocsCodeBlock :code="allowedHosts" language="properties" />
+      <p>If a trusted proxy terminates TLS or rewrites the host, configure Spring Boot&rsquo;s <code>server.forward-headers-strategy</code> so the effective servlet request contains the public scheme, hostname and port. The MCP guard does not interpret raw <code>X-Forwarded-*</code> headers itself. The hostname allowlist does not authenticate clients; the network and proxy controls below still determine who can reach the installation.</p>
 
       <p>So decide what can reach the address:</p>
       <ul>

--- a/jeffrey-pages/src/views/docs/microscope/configuration/MicroscopeConfigApplicationPropertiesPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope/configuration/MicroscopeConfigApplicationPropertiesPage.vue
@@ -262,6 +262,23 @@ onMounted(() => {
             </td>
           </tr>
           <tr>
+            <td><code>jeffrey.microscope.mcp.allowed-hosts</code></td>
+            <td><code>localhost,127.0.0.1,::1</code></td>
+            <td>
+              The hostnames the endpoint will answer to, comma-separated, checked against the host the
+              request was actually addressed to. Anything else gets <code>403</code>, with or without an
+              <code>Origin</code> header. It is what stops a page in a browser from choosing both sides
+              of the origin comparison: rebind a name you control to <code>127.0.0.1</code> and the
+              <code>Host</code> and <code>Origin</code> it sends match each other perfectly. The list
+              replaces the default rather than adding to it, so keep the loopback names any client still
+              uses. Behind a reverse proxy, name the hostname clients dial and set Spring Boot's
+              <code>server.forward-headers-strategy</code> so the request carries the public scheme, host
+              and port &mdash; the check reads the servlet request, never <code>X-Forwarded-*</code>
+              directly. Read at startup. See
+              <router-link to="/docs/microscope-mcp/enabling">Enabling the Server</router-link>.
+            </td>
+          </tr>
+          <tr>
             <td><code>jeffrey.microscope.mcp.hubs.enabled</code></td>
             <td><code>true</code></td>
             <td>


### PR DESCRIPTION
MCP clients could receive successful results for failed tools, invalid JSON when output was truncated, and incomplete catalogues without an omission count. Requests also accepted invalid argument types and malformed JSON-RPC envelopes, ignored prompt arguments, and allowed matching arbitrary Host/Origin headers to bypass the request guard.

This change fixes those contracts:

- Validate request hosts against a configurable allowlist and enforce matching Origin scheme, host, and port.
- Report tool execution failures through `isError=true` and ERROR trace spans while preserving valid no-data results.
- Keep oversized JSON parseable and within its character budget, with accurate truncation metadata.
- Include validated caller arguments in prompt context.
- Validate argument shapes, types, numeric ranges, profile IDs, and enum values before invocation; normalize accepted enum spelling.
- Reject malformed JSON-RPC envelopes and return JSON-RPC parse errors at the HTTP boundary.
- Report complete emitted profile rows and explain omissions caused by row or character limits.

Validation: 1,419 tests passed with Java 25, including real DuckDB tests, HTTP error responses, and recorded JFR error spans:

```sh
mvn -pl jeffrey-microscope/core-microscope -am test -Dtest='*Mcp*,*Tool*' -Dsurefire.failIfNoSpecifiedTests=false -Dexec.skip=true
```

Documentation type-check: `cd jeffrey-pages && npm run type-check`. `git diff --check` passes.

Deployment: `jeffrey.microscope.mcp.allowed-hosts` defaults to `localhost,127.0.0.1,::1`. Remote/proxy deployments must configure their client-facing hostname and restart Microscope. The enabling-server documentation explains the setting and proxy handling.
