### PR TITLE
Add violet badge styling for duration measurements

### DIFF
--- a/shared/ui/common/src/components/Badge.vue
+++ b/shared/ui/common/src/components/Badge.vue
@@ -410,6 +410,17 @@ const uppercaseClass = computed(() => (props.uppercase ? '' : 'badge-no-uppercas
   border: 1px solid var(--color-secondary-border);
 }
 
+/* Violet reads as a measured quantity rather than a timestamp — the key-value
+   base fill above wins over the plain .badge-violet rule, so it is restated here. */
+.badge.badge-key-value.badge-violet {
+  background: var(--color-violet-lightest-bg);
+  border: 1px solid var(--color-violet-border-medium);
+}
+
+.badge.badge-key-value.badge-violet .badge-value {
+  color: var(--color-violet-text);
+}
+
 /* Icon styling */
 .badge-icon {
   margin-right: 0.25rem;

--- a/shared/ui/instances/src/InstancesTimeline.vue
+++ b/shared/ui/instances/src/InstancesTimeline.vue
@@ -96,7 +96,6 @@
                 :value="FormattingService.formatTimestampUTC(instanceEnd(instance))"
                 size="xs"
               />
-              <Badge v-else key-label="Status" value="Running" variant="warning" size="xs" />
               <Badge
                 key-label="Duration"
                 :value="FormattingService.formatDurationInMillis2Units(instance.duration)"

--- a/shared/ui/instances/src/InstancesTimeline.vue
+++ b/shared/ui/instances/src/InstancesTimeline.vue
@@ -99,6 +99,7 @@
               <Badge
                 key-label="Duration"
                 :value="FormattingService.formatDurationInMillis2Units(instance.duration)"
+                variant="violet"
                 size="xs"
               />
             </span>


### PR DESCRIPTION
## Summary
Adds CSS styling for the violet badge variant when used in key-value mode, and updates the instances timeline to display duration as a violet badge instead of a warning badge for running instances.

## Key Changes
- **Badge.vue**: Added `.badge.badge-key-value.badge-violet` CSS rules to properly style violet badges in key-value context, ensuring the background and border colors are applied correctly and the value text uses the violet color scheme
- **InstancesTimeline.vue**: Changed the duration badge variant from default to `violet` to better semantically represent duration as a measured quantity rather than a status indicator; removed the redundant "Status: Running" badge that was displayed alongside duration

## Implementation Details
The violet badge styling required explicit CSS rules in the key-value context because the base key-value fill rules take precedence over the plain `.badge-violet` rule. The new rules ensure consistent color application using the violet color variables (`--color-violet-lightest-bg`, `--color-violet-border-medium`, `--color-violet-text`).

https://claude.ai/code/session_01BDq8BHhFVfUBTNz3spDenf