### PR TITLE
Allow configurable event limits in Hub MCP queries

### DIFF
--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/HubsReplayMcpTools.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/HubsReplayMcpTools.java
@@ -70,7 +70,10 @@ public final class HubsReplayMcpTools {
 
     @McpToolHints(readOnly = true, openWorld = true)
     @Tool(description = "Query selected JFR events from a Hub session without downloading or analysing it. "
-            + "Bounded to 15 seconds, at most 1000 rows and 100000 UTF-8 bytes. "
+            + "Returns the first matching events in replay order, not ranked by duration: default 100 rows. "
+            + "Set a positive limit for more rows or 0 for no row limit. "
+            + "The 15-second deadline and maxBytes budget still apply (at most 100000 UTF-8 bytes). "
+            + "Narrow eventTypes and the time window when a limit is reached. "
             + "Coverage is finished files visible when replay starts; inspect complete and termination.")
     @McpOutputSchema("""
             {"type":"object","properties":{
@@ -79,7 +82,8 @@ public final class HubsReplayMcpTools {
               "complete":{"type":"boolean"},"partial":{"type":"boolean"},"termination":{"type":"string"},
               "coverageKnown":{"type":"boolean"},"sourceErrors":{"type":"integer"},
               "rows":{"type":"integer"},"resultBytes":{"type":"integer"},
-              "limit":{"type":"integer"},"maxBytes":{"type":"integer"}
+              "limit":{"type":"integer","minimum":0,"description":"Requested row limit; 0 means no row limit"},
+              "maxBytes":{"type":"integer"}
             },"required":["sessionRef","events","eventTypes","complete","partial","termination",
               "coverageKnown","sourceErrors","rows","resultBytes","limit","maxBytes"]}
             """)
@@ -88,7 +92,7 @@ public final class HubsReplayMcpTools {
             @ToolParam(description = "Comma-separated exact JFR event type names") String eventTypes,
             @ToolParam(description = "Inclusive start epoch milliseconds", required = false) Long startTime,
             @ToolParam(description = "Inclusive end epoch milliseconds", required = false) Long endTime,
-            @ToolParam(description = "Maximum rows, 1–1000; default 100", required = false) Integer limit,
+            @ToolParam(description = "Maximum rows; default 100. Any positive integer, or 0 for no row limit. Byte and time limits still apply", required = false) Integer limit,
             @ToolParam(description = "Maximum UTF-8 JSON object bytes (excluding duplicated MCP text/structured envelope), 4096–100000; default 65536", required = false) Integer maxBytes) {
         if (sessionRef == null || sessionRef.length() > 2048) {
             throw new IllegalArgumentException("Pass a complete session_ref from hubs_sessions (at most 2048 characters)");
@@ -108,8 +112,11 @@ public final class HubsReplayMcpTools {
         }
         int rows = limit == null ? 100 : limit;
         int bytes = maxBytes == null ? 65536 : maxBytes;
-        if (rows < 1 || rows > 1000 || bytes < 4096 || bytes > 100000) {
-            throw new IllegalArgumentException("limit must be 1–1000 and maxBytes must be 4096–100000");
+        if (rows < 0) {
+            throw new IllegalArgumentException("limit must be nonnegative; 0 means no row limit");
+        }
+        if (bytes < 4096 || bytes > 100000) {
+            throw new IllegalArgumentException("maxBytes must be 4096–100000");
         }
         HubReplayCollector collector = new HubReplayCollector(ref, rows, bytes);
         collector.filters(types, startTime, endTime);

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/hubs/HubReplayCollector.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/hubs/HubReplayCollector.java
@@ -124,10 +124,9 @@ public final class HubReplayCollector {
             }
             ObjectNode row = eventJson(event);
             // What this row costs, rather than what the whole answer now weighs. Re-serialising the
-            // document once per event is quadratic in the row count, and at the limits this tool
-            // accepts -- a thousand rows inside a hundred kilobytes -- that is most of the work the
-            // call does. Rows are independent elements of one array, so the delta is exact: the row
-            // itself, the comma before it, and any digit the row counter grows by.
+            // document once per event is quadratic in the row count, including when the caller
+            // disables the row limit. Rows are independent array elements, so the delta is exact:
+            // the row itself, the comma before it, and any digit the row counter grows by.
             int delta = utf8Length(Json.toString(row))
                     + (events.isEmpty() ? 0 : 1)
                     + digits(events.size() + 1) - digits(events.size());
@@ -138,7 +137,7 @@ public final class HubReplayCollector {
             events.add(row);
             accumulated += delta;
             output.put("rows", events.size());
-            if (events.size() >= limit) {
+            if (limit > 0 && events.size() >= limit) {
                 stop("row_limit");
                 return;
             }

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/HubsReplayMcpEndpointTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/HubsReplayMcpEndpointTest.java
@@ -1,0 +1,149 @@
+/*
+ * Jeffrey
+ * Copyright (C) 2026 Petr Bouda
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cafe.jeffrey.microscope.core.mcp;
+
+import cafe.jeffrey.hub.api.v1.EventBatch;
+import cafe.jeffrey.hub.api.v1.ReplayStatus;
+import cafe.jeffrey.hub.api.v1.StreamingEvent;
+import cafe.jeffrey.microscope.core.manager.EventStreamingManager;
+import cafe.jeffrey.microscope.core.manager.project.ProjectManager;
+import cafe.jeffrey.microscope.core.mcp.tools.HubsReplayMcpTools;
+import cafe.jeffrey.microscope.core.mcp.tools.McpOperationRegistry;
+import cafe.jeffrey.microscope.core.mcp.tools.hubs.HubSessionRef;
+import cafe.jeffrey.microscope.core.web.ProjectManagerResolver;
+import cafe.jeffrey.microscope.grpc.client.EventStreamingClient.EventStreamingSubscription;
+import cafe.jeffrey.microscope.grpc.client.ReplaySubscriptionRequest;
+import cafe.jeffrey.microscope.grpc.client.StreamingCallbacks;
+import cafe.jeffrey.profile.mcp.ReflectiveToolset;
+import cafe.jeffrey.shared.common.Json;
+import io.grpc.Context;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.http.MediaType;
+import tools.jackson.databind.node.ObjectNode;
+
+import java.util.Set;
+
+import static cafe.jeffrey.microscope.core.web.MockMvcSupport.mockMvcTesterFor;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class HubsReplayMcpEndpointTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            ", 1500, 65536, 100, row_limit",
+            "500, 1500, 65536, 500, row_limit",
+            "2000, 1001, 100000, 1001, completed",
+            "0, 150, 65536, 150, completed",
+            "0, 1500, 4096, -1, byte_limit"
+    })
+    void mcpHonorsTheRequestedRowLimitAndAlwaysBoundsTheResponse(
+            Integer limit,
+            int inputRows,
+            int maxBytes,
+            int expectedRows,
+            String termination) throws Exception {
+        var resolver = mock(ProjectManagerResolver.class);
+        var project = mock(ProjectManager.class);
+        var streaming = mock(EventStreamingManager.class);
+        when(resolver.resolveStrict("hub", "workspace", "project"))
+                .thenReturn(new ProjectManagerResolver.ProjectContext(null, null, project));
+        when(project.eventStreamingManager()).thenReturn(streaming);
+
+        try (var context = Context.ROOT.withCancellation()) {
+            when(streaming.subscribeReplayRaw(any(), any())).thenAnswer(invocation -> {
+                StreamingCallbacks callbacks = invocation.getArgument(1);
+                callbacks.onNext().accept(EventBatch.newBuilder()
+                        .setReplayStatus(ReplayStatus.newBuilder()
+                                .setWorkspaceId("workspace")
+                                .setProjectId("project"))
+                        .build());
+                var batch = EventBatch.newBuilder();
+                for (int index = 0; index < inputRows; index++) {
+                    batch.addEvents(StreamingEvent.newBuilder()
+                            .setSessionId("session")
+                            .setEventType("jdk.GarbageCollection")
+                            .setTimestamp(1789293600000L + index));
+                }
+                callbacks.onNext().accept(batch.build());
+                // A late completion must not erase the fact that the result was truncated.
+                callbacks.onNext().accept(EventBatch.newBuilder()
+                        .setReplayStatus(ReplayStatus.newBuilder().setTerminal(true))
+                        .build());
+                callbacks.onComplete().run();
+                return new EventStreamingSubscription(context, "session");
+            });
+
+            var assembler = mock(McpToolsetAssembler.class);
+            when(assembler.toolset()).thenReturn(new ReflectiveToolset(new HubsReplayMcpTools(resolver, new McpOperationRegistry()), "hubs"));
+            var mvc = mockMvcTesterFor(new ExternalMcpController(
+                    assembler,
+                    new ExternalMcpProperties(true, true, true, Set.of()),
+                    new McpRequestGuard(),
+                    new McpPromptRegistry(),
+                    mock(McpDiagnostics.class)));
+            String sessionRef = new HubSessionRef("hub", "workspace", "project", "session").encode();
+            String request = """
+                    {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{
+                      "name":"hubs_queryEvents","arguments":{
+                        "sessionRef":"%s","eventTypes":"jdk.GarbageCollection",
+                        "startTime":1789293600000,"endTime":1789300800000
+                      }}}
+                    """.formatted(sessionRef);
+            var requestJson = (ObjectNode) Json.mapper().readTree(request);
+            var arguments = (ObjectNode) requestJson.path("params").path("arguments");
+            if (limit != null) {
+                arguments.put("limit", limit);
+            }
+            arguments.put("maxBytes", maxBytes);
+            var response = mvc.post()
+                    .uri(ExternalMcpController.PATH)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("MCP-Protocol-Version", "2025-06-18")
+                    .content(Json.toString(requestJson))
+                    .exchange();
+
+            assertThat(response).hasStatusOk();
+            var envelope = Json.mapper().readTree(response.getResponse().getContentAsString());
+            assertThat(envelope.has("error")).isFalse();
+            var result = envelope.path("result").path("structuredContent");
+            int actualRows = result.path("events").size();
+            if (expectedRows >= 0) {
+                assertThat(actualRows).isEqualTo(expectedRows);
+            } else {
+                assertThat(actualRows).isBetween(1, inputRows - 1);
+            }
+            assertThat(result.path("rows").asInt()).isEqualTo(actualRows);
+            assertThat(result.path("limit").asInt()).isEqualTo(limit == null ? 100 : limit);
+            assertThat(result.path("termination").asString()).isEqualTo(termination);
+            assertThat(result.path("partial").asBoolean()).isEqualTo(!termination.equals("completed"));
+            assertThat(result.path("complete").asBoolean()).isEqualTo(termination.equals("completed"));
+            assertThat(result.path("resultBytes").asInt()).isLessThanOrEqualTo(maxBytes);
+            assertThat(context.isCancelled()).isTrue();
+            verify(streaming).subscribeReplayRaw(eq(new ReplaySubscriptionRequest(
+                    "session", Set.of("jdk.GarbageCollection"),
+                    1789293600000L, 1789300800000L, "workspace", "project")), any());
+        }
+    }
+}

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/HubsReplayMcpToolsTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/HubsReplayMcpToolsTest.java
@@ -31,6 +31,9 @@ import cafe.jeffrey.microscope.grpc.client.EventStreamingClient.EventStreamingSu
 import cafe.jeffrey.microscope.grpc.client.StreamingCallbacks;
 import io.grpc.Context;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -49,8 +52,10 @@ import static org.mockito.Mockito.when;
 class HubsReplayMcpToolsTest {
     private static final String REF = new HubSessionRef("hub", "workspace", "project", "session").encode();
 
-    @Test
-    void noResponseHasFiniteTimeoutAndCancelsSubscription() {
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(ints = 0)
+    void noResponseHasFiniteTimeoutAndCancelsSubscription(Integer limit) {
         ProjectManagerResolver resolver = mock(ProjectManagerResolver.class);
         ProjectManager project = mock(ProjectManager.class);
         EventStreamingManager streaming = mock(EventStreamingManager.class);
@@ -61,7 +66,7 @@ class HubsReplayMcpToolsTest {
         when(streaming.subscribeReplayRaw(any(), any())).thenReturn(new EventStreamingSubscription(context, "session"));
         HubsReplayMcpTools tools = new HubsReplayMcpTools(resolver, new McpOperationRegistry(), Duration.ofMillis(40));
         long before = System.nanoTime();
-        var result = tools.queryEvents(REF, "jdk.CPULoad", null, null, null, null).structuredContent();
+        var result = tools.queryEvents(REF, "jdk.CPULoad", null, null, limit, null).structuredContent();
         assertTrue(Duration.ofNanos(System.nanoTime() - before).compareTo(Duration.ofSeconds(2)) < 0);
         assertEquals("timeout", result.path("termination").asText());
         assertFalse(result.path("complete").asBoolean());
@@ -100,7 +105,7 @@ class HubsReplayMcpToolsTest {
     void invalidLimitsAndTimeWindowNeverContactHub() {
         ProjectManagerResolver resolver = mock(ProjectManagerResolver.class);
         HubsReplayMcpTools tools = new HubsReplayMcpTools(resolver, new McpOperationRegistry());
-        assertThrows(IllegalArgumentException.class, () -> tools.queryEvents(REF, "jdk.CPULoad", null, null, 1001, null));
+        assertThrows(IllegalArgumentException.class, () -> tools.queryEvents(REF, "jdk.CPULoad", null, null, -1, null));
         assertThrows(IllegalArgumentException.class, () -> tools.queryEvents(REF, "jdk.CPULoad", 2L, 1L, null, null));
         assertThrows(IllegalArgumentException.class, () -> tools.queryEvents(REF, "", null, null, null, null));
         verifyNoInteractions(resolver);

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpToolsPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpToolsPage.vue
@@ -304,6 +304,23 @@ hubs_download { "sessionRef": "h1Y2ZnLX..." }
 
       <p><strong>Bounded remote events.</strong> <code>hubs_queryEvents(sessionRef, eventTypes, startTime?, endTime?, limit?, maxBytes?)</code> reads finished recording files directly from a Hub. Event types are comma-separated; timestamps are epoch milliseconds. It returns complete event rows within the limits, then cancels the replay. Inspect source coverage and the termination reason before interpreting an empty or partial response. It requires a Hub that acknowledges the full workspace/project/session identity; an older Hub is not treated as a complete empty result. This is a finite query, with a deadline, rather than a live subscription.</p>
 
+      <p>The default is <strong>100 matching events</strong>, with a 15-second deadline and a 65,536-byte result budget. Set <code>limit</code> to any positive integer for a different event-count limit, or <code>0</code> to disable the event-count limit. Set <code>maxBytes</code> between 4,096 and 100,000. These are the first matches in replay order; they are not ranked by duration and do not represent the whole time window when <code>partial</code> is true. A byte or time limit can return fewer events than requested.</p>
+
+      <p>For example, call this tool through Microscope's MCP endpoint to inspect GC events between 10:00 and 12:00 UTC on 13 September 2026. Copy <code>sessionRef</code> from <code>hubs_sessions</code>. Both time bounds are inclusive.</p>
+      <pre><code>{
+  "name": "hubs_queryEvents",
+  "arguments": {
+    "sessionRef": "&lt;session_ref from hubs_sessions&gt;",
+    "eventTypes": "jdk.GarbageCollection,jdk.GCPhasePause",
+    "startTime": 1789293600000,
+    "endTime": 1789300800000,
+    "limit": 100
+  }
+}</code></pre>
+      <p>For more events, use <code>"limit": 500</code> or <code>"limit": 2000</code>. To remove the event-count limit, use <code>"limit": 0</code>; optionally raise <code>"maxBytes": 100000</code>. The byte budget and 15-second deadline still apply with <code>limit: 0</code>, so it does not guarantee that every matching event fits into one MCP response. Omitting <code>limit</code> keeps the default of 100.</p>
+
+      <p>If <code>termination</code> is <code>row_limit</code>, <code>byte_limit</code>, or <code>timeout</code>, narrow the time window or event types for a smaller sample. Do not infer total counts, the busiest period, or the slowest events from this truncated result.</p>
+
       <p><strong>Remote event summaries.</strong> <code>hubs_eventActivity(sessionRef, startTime, endTime, bucketSeconds?, eventTypes?)</code>
         starts an aggregation on Hub through gRPC. The agent connects to Microscope’s existing MCP endpoint.
         Hub reads the recordings and keeps the counters; only compact summaries travel to Microscope.</p>


### PR DESCRIPTION
`hubs_queryEvents` previously rejected row limits above 1,000 and could not disable the row cap. It now accepts any positive row limit or `limit: 0` to disable the event-count limit, while keeping 100 as the default.

The existing 15-second deadline and byte budget still apply, including with `limit: 0`. Results report partial coverage and the termination reason when either bound is reached. The tool description and Jeffrey Pages document the limits and include a GC query for a UTC time window.

Validation: 86 focused MCP/replay tests passed, including requests through `/api/mcp` for the default 100 rows, larger explicit limits, no row limit, byte-limit cancellation, and timeout cancellation. Jeffrey Pages type-check passed.
