### PR TITLE
Preserve Hub replay coverage at the exact row limit

### DIFF
--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/HubsReplayMcpTools.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/HubsReplayMcpTools.java
@@ -72,7 +72,8 @@ public final class HubsReplayMcpTools {
     @Tool(description = "Query selected JFR events from a Hub session without downloading or analysing it. "
             + "Returns the first matching events in replay order, not ranked by duration: default 100 rows. "
             + "Set a positive limit for more rows or 0 for no row limit. "
-            + "The 15-second deadline and maxBytes budget still apply (at most 100000 UTF-8 bytes). "
+            + "The 15-second deadline and maxBytes budget still apply: default 65536, maximum 100000 UTF-8 bytes. "
+            + "How many events fit depends on their serialized size; raising limit does not raise maxBytes. "
             + "Narrow eventTypes and the time window when a limit is reached. "
             + "Coverage is finished files visible when replay starts; inspect complete and termination.")
     @McpOutputSchema("""

--- a/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/hubs/HubReplayCollector.java
+++ b/jeffrey-microscope/core-microscope/src/main/java/cafe/jeffrey/microscope/core/mcp/tools/hubs/HubReplayCollector.java
@@ -37,6 +37,8 @@ import java.util.concurrent.TimeoutException;
 /** Bounds one replay and preserves the first terminal reason, including cancellation races. */
 public final class HubReplayCollector {
     private static final int TERMINAL_RESERVE = 512;
+    /** The caller asked for every matching event; only the byte budget and the deadline bound it. */
+    private static final int NO_ROW_LIMIT = 0;
     private final HubSessionRef ref;
     private final int limit;
     private final int maxBytes;
@@ -122,6 +124,15 @@ public final class HubReplayCollector {
                 stop("scope_mismatch");
                 return;
             }
+            // Truncation is declared by the event that does not fit, never by the last one that did.
+            // Stopping on the limit-th row instead would report a query whose every match was
+            // returned as partial, and would skip the coverage summary that completed() records --
+            // so a caller asking for exactly as many rows as the session holds would be told, with
+            // coverageKnown false, to narrow a window that has nothing left to give.
+            if (limit != NO_ROW_LIMIT && events.size() == limit) {
+                stop("row_limit");
+                return;
+            }
             ObjectNode row = eventJson(event);
             // What this row costs, rather than what the whole answer now weighs. Re-serialising the
             // document once per event is quadratic in the row count, including when the caller
@@ -137,10 +148,6 @@ public final class HubReplayCollector {
             events.add(row);
             accumulated += delta;
             output.put("rows", events.size());
-            if (limit > 0 && events.size() >= limit) {
-                stop("row_limit");
-                return;
-            }
         }
     }
 

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/HubsReplayMcpEndpointTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/HubsReplayMcpEndpointTest.java
@@ -33,9 +33,11 @@ import cafe.jeffrey.microscope.grpc.client.StreamingCallbacks;
 import cafe.jeffrey.profile.mcp.ReflectiveToolset;
 import cafe.jeffrey.shared.common.Json;
 import io.grpc.Context;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.http.MediaType;
+import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ObjectNode;
 
 import java.util.Set;
@@ -49,25 +51,81 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class HubsReplayMcpEndpointTest {
+    private static final String HUB_ID = "hub";
+    private static final String WORKSPACE_ID = "workspace";
+    private static final String PROJECT_ID = "project";
+    private static final String SESSION_ID = "session";
+    private static final String EVENT_TYPE = "jdk.GarbageCollection";
+    private static final long WINDOW_START = 1789293600000L;
+    private static final long WINDOW_END = 1789300800000L;
+    private static final int DEFAULT_ROWS = 100;
+    private static final int NO_ROW_LIMIT = 0;
+    private static final int SMALLEST_MAX_BYTES = 4096;
 
+    /**
+     * Row counts here stay well inside the byte budget on purpose. A case tuned to the last row the
+     * budget can hold passes only for these field-less synthetic events, and would then be reddened
+     * by an unrelated edit -- one more sentence in the collector's coverage blurb, or a realistic
+     * UUID session ref, costs a row or two of headroom. Each case pins the row limit, so the byte
+     * limit is given room to stay out of the way; {@link #theByteBudgetBoundsAnAnswerNoRowLimitDoes}
+     * pins the other one.
+     */
     @ParameterizedTest
     @CsvSource({
+            // limit, input rows, maxBytes, expected rows, termination
             ", 1500, 65536, 100, row_limit",
             "500, 1500, 65536, 500, row_limit",
-            "2000, 1001, 100000, 1001, completed",
-            "0, 150, 65536, 150, completed",
-            "0, 1500, 4096, -1, byte_limit"
+            // A limit above the retired 1000-row cap is accepted and never clamped back to it.
+            "2000, 400, 100000, 400, completed",
+            // Exactly as many matches as rows asked for is a complete answer, not a truncated one:
+            // the limit-th row does not declare truncation, the event that does not fit does.
+            "150, 150, 65536, 150, completed",
+            "0, 150, 65536, 150, completed"
     })
-    void mcpHonorsTheRequestedRowLimitAndAlwaysBoundsTheResponse(
+    void mcpHonorsTheRequestedRowLimit(
             Integer limit,
             int inputRows,
             int maxBytes,
             int expectedRows,
             String termination) throws Exception {
+        JsonNode result = queryEvents(limit, inputRows, maxBytes);
+
+        assertThat(result.path("events").size()).isEqualTo(expectedRows);
+        assertThat(result.path("rows").asInt()).isEqualTo(expectedRows);
+        assertThat(result.path("limit").asInt()).isEqualTo(limit == null ? DEFAULT_ROWS : limit);
+        assertThat(result.path("termination").asString()).isEqualTo(termination);
+        assertThat(result.path("partial").asBoolean()).isEqualTo(!termination.equals("completed"));
+        assertThat(result.path("complete").asBoolean()).isEqualTo(termination.equals("completed"));
+        // Only a run that reached the hub's own summary can speak for coverage; a truncated one
+        // stops before it, so the two flags move together.
+        assertThat(result.path("coverageKnown").asBoolean()).isEqualTo(termination.equals("completed"));
+        assertThat(result.path("resultBytes").asInt()).isLessThanOrEqualTo(maxBytes);
+    }
+
+    @Test
+    void theByteBudgetBoundsAnAnswerNoRowLimitDoes() throws Exception {
+        int inputRows = 1500;
+        JsonNode result = queryEvents(NO_ROW_LIMIT, inputRows, SMALLEST_MAX_BYTES);
+
+        assertThat(result.path("termination").asString()).isEqualTo("byte_limit");
+        assertThat(result.path("partial").asBoolean()).isTrue();
+        assertThat(result.path("limit").asInt()).isEqualTo(NO_ROW_LIMIT);
+        // Some events came back and some did not: the budget, not the row limit, is what stopped it.
+        assertThat(result.path("events").size()).isBetween(1, inputRows - 1);
+        // The budget bounds the document that is actually sent, not just the figure reporting it.
+        assertThat(Json.toByteArray(result).length).isLessThanOrEqualTo(SMALLEST_MAX_BYTES);
+        assertThat(result.path("resultBytes").asInt()).isLessThanOrEqualTo(SMALLEST_MAX_BYTES);
+    }
+
+    /**
+     * One {@code tools/call} through {@code /api/mcp}, answered by a hub that acknowledges the
+     * scope, delivers {@code inputRows} matching events in a single batch and then completes.
+     */
+    private JsonNode queryEvents(Integer limit, int inputRows, int maxBytes) throws Exception {
         var resolver = mock(ProjectManagerResolver.class);
         var project = mock(ProjectManager.class);
         var streaming = mock(EventStreamingManager.class);
-        when(resolver.resolveStrict("hub", "workspace", "project"))
+        when(resolver.resolveStrict(HUB_ID, WORKSPACE_ID, PROJECT_ID))
                 .thenReturn(new ProjectManagerResolver.ProjectContext(null, null, project));
         when(project.eventStreamingManager()).thenReturn(streaming);
 
@@ -76,15 +134,15 @@ class HubsReplayMcpEndpointTest {
                 StreamingCallbacks callbacks = invocation.getArgument(1);
                 callbacks.onNext().accept(EventBatch.newBuilder()
                         .setReplayStatus(ReplayStatus.newBuilder()
-                                .setWorkspaceId("workspace")
-                                .setProjectId("project"))
+                                .setWorkspaceId(WORKSPACE_ID)
+                                .setProjectId(PROJECT_ID))
                         .build());
                 var batch = EventBatch.newBuilder();
                 for (int index = 0; index < inputRows; index++) {
                     batch.addEvents(StreamingEvent.newBuilder()
-                            .setSessionId("session")
-                            .setEventType("jdk.GarbageCollection")
-                            .setTimestamp(1789293600000L + index));
+                            .setSessionId(SESSION_ID)
+                            .setEventType(EVENT_TYPE)
+                            .setTimestamp(WINDOW_START + index));
                 }
                 callbacks.onNext().accept(batch.build());
                 // A late completion must not erase the fact that the result was truncated.
@@ -92,7 +150,7 @@ class HubsReplayMcpEndpointTest {
                         .setReplayStatus(ReplayStatus.newBuilder().setTerminal(true))
                         .build());
                 callbacks.onComplete().run();
-                return new EventStreamingSubscription(context, "session");
+                return new EventStreamingSubscription(context, SESSION_ID);
             });
 
             var assembler = mock(McpToolsetAssembler.class);
@@ -103,14 +161,14 @@ class HubsReplayMcpEndpointTest {
                     new McpRequestGuard(),
                     new McpPromptRegistry(),
                     mock(McpDiagnostics.class)));
-            String sessionRef = new HubSessionRef("hub", "workspace", "project", "session").encode();
+            String sessionRef = new HubSessionRef(HUB_ID, WORKSPACE_ID, PROJECT_ID, SESSION_ID).encode();
             String request = """
                     {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{
                       "name":"hubs_queryEvents","arguments":{
-                        "sessionRef":"%s","eventTypes":"jdk.GarbageCollection",
-                        "startTime":1789293600000,"endTime":1789300800000
+                        "sessionRef":"%s","eventTypes":"%s",
+                        "startTime":%d,"endTime":%d
                       }}}
-                    """.formatted(sessionRef);
+                    """.formatted(sessionRef, EVENT_TYPE, WINDOW_START, WINDOW_END);
             var requestJson = (ObjectNode) Json.mapper().readTree(request);
             var arguments = (ObjectNode) requestJson.path("params").path("arguments");
             if (limit != null) {
@@ -127,23 +185,11 @@ class HubsReplayMcpEndpointTest {
             assertThat(response).hasStatusOk();
             var envelope = Json.mapper().readTree(response.getResponse().getContentAsString());
             assertThat(envelope.has("error")).isFalse();
-            var result = envelope.path("result").path("structuredContent");
-            int actualRows = result.path("events").size();
-            if (expectedRows >= 0) {
-                assertThat(actualRows).isEqualTo(expectedRows);
-            } else {
-                assertThat(actualRows).isBetween(1, inputRows - 1);
-            }
-            assertThat(result.path("rows").asInt()).isEqualTo(actualRows);
-            assertThat(result.path("limit").asInt()).isEqualTo(limit == null ? 100 : limit);
-            assertThat(result.path("termination").asString()).isEqualTo(termination);
-            assertThat(result.path("partial").asBoolean()).isEqualTo(!termination.equals("completed"));
-            assertThat(result.path("complete").asBoolean()).isEqualTo(termination.equals("completed"));
-            assertThat(result.path("resultBytes").asInt()).isLessThanOrEqualTo(maxBytes);
             assertThat(context.isCancelled()).isTrue();
             verify(streaming).subscribeReplayRaw(eq(new ReplaySubscriptionRequest(
-                    "session", Set.of("jdk.GarbageCollection"),
-                    1789293600000L, 1789300800000L, "workspace", "project")), any());
+                    SESSION_ID, Set.of(EVENT_TYPE), WINDOW_START, WINDOW_END,
+                    WORKSPACE_ID, PROJECT_ID)), any());
+            return envelope.path("result").path("structuredContent");
         }
     }
 }

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/HubsReplayMcpToolsTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/HubsReplayMcpToolsTest.java
@@ -52,9 +52,10 @@ import static org.mockito.Mockito.when;
 class HubsReplayMcpToolsTest {
     private static final String REF = new HubSessionRef("hub", "workspace", "project", "session").encode();
 
+    /** 5000 is past the retired 1000-row cap: it is accepted, echoed back, and never clamped. */
     @ParameterizedTest
     @NullSource
-    @ValueSource(ints = 0)
+    @ValueSource(ints = {0, 5000})
     void noResponseHasFiniteTimeoutAndCancelsSubscription(Integer limit) {
         ProjectManagerResolver resolver = mock(ProjectManagerResolver.class);
         ProjectManager project = mock(ProjectManager.class);
@@ -69,6 +70,7 @@ class HubsReplayMcpToolsTest {
         var result = tools.queryEvents(REF, "jdk.CPULoad", null, null, limit, null).structuredContent();
         assertTrue(Duration.ofNanos(System.nanoTime() - before).compareTo(Duration.ofSeconds(2)) < 0);
         assertEquals("timeout", result.path("termination").asText());
+        assertEquals(limit == null ? 100 : limit, result.path("limit").asInt());
         assertFalse(result.path("complete").asBoolean());
         assertTrue(context.isCancelled());
     }

--- a/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/hubs/HubReplayCollectorTest.java
+++ b/jeffrey-microscope/core-microscope/src/test/java/cafe/jeffrey/microscope/core/mcp/tools/hubs/HubReplayCollectorTest.java
@@ -53,6 +53,46 @@ class HubReplayCollectorTest {
         assertFalse(collector.result().path("complete").asBoolean());
     }
 
+    @ParameterizedTest
+    @CsvSource({"0, completed, true", "2, source_errors, false"})
+    void exactRowLimitWaitsForCoverage(long sourceErrors, String termination, boolean complete) {
+        var collector = new HubReplayCollector(REF, 1, 4096);
+        var cancels = new AtomicInteger();
+        collector.acknowledge("workspace", "project");
+        collector.cancellation(cancels::incrementAndGet);
+        collector.accept(batch("only event"));
+
+        assertEquals(0, cancels.get());
+        assertEquals("running", collector.result().path("termination").asText());
+        collector.completed(sourceErrors);
+
+        var result = collector.result();
+        assertEquals(1, result.path("rows").asInt());
+        assertEquals(termination, result.path("termination").asText());
+        assertEquals(complete, result.path("complete").asBoolean());
+        assertTrue(result.path("coverageKnown").asBoolean());
+        assertEquals(sourceErrors, result.path("sourceErrors").asLong());
+        assertEquals(1, cancels.get());
+    }
+
+    @Test
+    void anExtraEventInALaterBatchConfirmsTruncation() {
+        var collector = new HubReplayCollector(REF, 1, 4096);
+        var cancels = new AtomicInteger();
+        collector.acknowledge("workspace", "project");
+        collector.cancellation(cancels::incrementAndGet);
+        collector.accept(batch("first"));
+        assertEquals(0, cancels.get());
+
+        collector.accept(batch("second"));
+        collector.completed(0);
+
+        assertEquals(1, cancels.get());
+        assertEquals(1, collector.result().path("rows").asInt());
+        assertEquals("row_limit", collector.result().path("termination").asText());
+        assertFalse(collector.result().path("complete").asBoolean());
+    }
+
     @Test
     void unacknowledgedLegacyHubCannotReturnUnscopedRows() {
         HubReplayCollector collector = new HubReplayCollector(REF, 10, 4096);

--- a/jeffrey-pages/src/views/docs/microscope-mcp/McpToolsPage.vue
+++ b/jeffrey-pages/src/views/docs/microscope-mcp/McpToolsPage.vue
@@ -306,6 +306,8 @@ hubs_download { "sessionRef": "h1Y2ZnLX..." }
 
       <p>The default is <strong>100 matching events</strong>, with a 15-second deadline and a 65,536-byte result budget. Set <code>limit</code> to any positive integer for a different event-count limit, or <code>0</code> to disable the event-count limit. Set <code>maxBytes</code> between 4,096 and 100,000. These are the first matches in replay order; they are not ranked by duration and do not represent the whole time window when <code>partial</code> is true. A byte or time limit can return fewer events than requested.</p>
 
+      <p><strong>Row and byte limits apply independently.</strong> Raising <code>limit</code> can return more events until the byte budget or deadline is reached. The number that fits depends on event fields, string lengths and response metadata. For illustration, rows averaging 250 bytes leave room for roughly 250 rows under the default budget or 400 under the maximum, before accounting for metadata. These are estimates, not fixed row capacities.</p>
+
       <p>For example, call this tool through Microscope's MCP endpoint to inspect GC events between 10:00 and 12:00 UTC on 13 September 2026. Copy <code>sessionRef</code> from <code>hubs_sessions</code>. Both time bounds are inclusive.</p>
       <pre><code>{
   "name": "hubs_queryEvents",
@@ -317,9 +319,9 @@ hubs_download { "sessionRef": "h1Y2ZnLX..." }
     "limit": 100
   }
 }</code></pre>
-      <p>For more events, use <code>"limit": 500</code> or <code>"limit": 2000</code>. To remove the event-count limit, use <code>"limit": 0</code>; optionally raise <code>"maxBytes": 100000</code>. The byte budget and 15-second deadline still apply with <code>limit: 0</code>, so it does not guarantee that every matching event fits into one MCP response. Omitting <code>limit</code> keeps the default of 100.</p>
+      <p>Omitting <code>limit</code> keeps the default of 100. For more events, try <code>"limit": 500</code> and <code>"maxBytes": 100000</code>. Use <code>"limit": 0</code> to remove the row cap. Neither setting guarantees that all matches fit: the byte budget and 15-second deadline still apply.</p>
 
-      <p>If <code>termination</code> is <code>row_limit</code>, <code>byte_limit</code>, or <code>timeout</code>, narrow the time window or event types for a smaller sample. Do not infer total counts, the busiest period, or the slowest events from this truncated result.</p>
+      <p><code>termination</code> explains why the query ended. <code>completed</code> means all matching events from the finished files in scope were returned with known coverage and no source errors. Exactly as many events as the row limit can still be complete: the query waits for another match or the Hub&rsquo;s completion report, subject to the deadline. <code>row_limit</code> means an additional matching event was omitted; <code>byte_limit</code> means the next event did not fit. <code>timeout</code> means completion could not be confirmed before the deadline. Narrow the window or event types when a result is partial. Results follow replay order, with no global chronological ordering or deduplication guarantee; do not infer total counts, the busiest period, or the slowest events from a partial result.</p>
 
       <p><strong>Remote event summaries.</strong> <code>hubs_eventActivity(sessionRef, startTime, endTime, bucketSeconds?, eventTypes?)</code>
         starts an aggregation on Hub through gRPC. The agent connects to Microscope’s existing MCP endpoint.


### PR DESCRIPTION
A query returning exactly its requested row limit previously reported `row_limit` and unknown coverage, even when it returned every matching event. The collector now reports `row_limit` only when an additional matching event is omitted. For example, 100 matches with `limit: 100` can finish as `completed` after Hub confirms coverage.

At the exact limit, the query waits for another matching event or Hub completion, subject to the existing 15-second deadline. The byte budget still applies. Documentation clarifies replay ordering, completion semantics, and how event size affects the number of rows that fit.

Validation:
- 1,898 Microscope tests passed, including endpoint coverage, source errors at the exact limit, cancellation across batches, byte bounds, and timeouts.
- Four regression cases reproduced the old behavior before applying the fix.
- Jeffrey Pages type-check passed.
